### PR TITLE
feat(editor): add undo/redo with history tracking

### DIFF
--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockCreator.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockCreator.ts
@@ -114,7 +114,6 @@ export default function codeBlockCreator(state: State, events: EventDispatcher):
 			minGridWidth: 32,
 			height: 0,
 			code,
-			trimmedCode: code,
 			codeColors: [],
 			codeToRender: [],
 			extras: {

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/blockHighlights/updateGraphicData.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/blockHighlights/updateGraphicData.ts
@@ -6,7 +6,7 @@ import type { CodeBlockGraphicData, State } from '../../../../types';
 
 export default function (graphicData: CodeBlockGraphicData, state: State) {
 	graphicData.extras.blockHighlights = [];
-	parseCodeBlocks(graphicData.trimmedCode).forEach(block => {
+	parseCodeBlocks(graphicData.code).forEach(block => {
 		if (!block.endLineNumber) {
 			return;
 		}

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/bufferPlotters/updateGraphicData.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/bufferPlotters/updateGraphicData.test.ts
@@ -15,7 +15,7 @@ describe('updateBufferPlottersGraphicData', () => {
 	beforeEach(() => {
 		mockGraphicData = createMockCodeBlock({
 			id: 'test-block',
-			trimmedCode: ['plot buffer1 -10 10'],
+			code: ['plot buffer1 -10 10'],
 			gaps: new Map(),
 			width: 100,
 		});
@@ -57,7 +57,7 @@ describe('updateBufferPlottersGraphicData', () => {
 	});
 
 	it('should not add plotter when buffer memory is not found', () => {
-		mockGraphicData.trimmedCode = ['plot nonExistentBuffer -10 10'];
+		mockGraphicData.code = ['plot nonExistentBuffer -10 10'];
 
 		updateBufferPlottersGraphicData(mockGraphicData, mockState);
 
@@ -88,7 +88,7 @@ describe('updateBufferPlottersGraphicData', () => {
 	});
 
 	it('should handle multiple buffer plotters', () => {
-		mockGraphicData.trimmedCode = ['plot buffer1 -10 10', 'plot buffer2 0 100'];
+		mockGraphicData.code = ['plot buffer1 -10 10', 'plot buffer2 0 100'];
 		mockState.compiler.compiledModules['test-block'].memoryMap['buffer2'] = {
 			wordAlignedAddress: 1,
 			byteAddress: 4,

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/bufferPlotters/updateGraphicData.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/bufferPlotters/updateGraphicData.ts
@@ -7,7 +7,7 @@ import type { CodeBlockGraphicData, State } from '../../../../types';
 
 export default function updateBufferPlottersGraphicData(graphicData: CodeBlockGraphicData, state: State) {
 	graphicData.extras.bufferPlotters.clear();
-	parseBufferPlotters(graphicData.trimmedCode).forEach(plotter => {
+	parseBufferPlotters(graphicData.code).forEach(plotter => {
 		const buffer = resolveMemoryIdentifier(state, graphicData.id, plotter.bufferMemoryId);
 		const bufferLength = resolveMemoryIdentifier(state, graphicData.id, plotter.bufferLengthMemoryId);
 

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/buttons/updateGraphicData.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/buttons/updateGraphicData.test.ts
@@ -13,7 +13,7 @@ describe('updateButtonsGraphicData', () => {
 	beforeEach(() => {
 		mockGraphicData = createMockCodeBlock({
 			id: 'test-block',
-			trimmedCode: ['button btn1 0 1'],
+			code: ['button btn1 0 1'],
 			width: 100,
 			gaps: new Map(),
 		});
@@ -59,7 +59,7 @@ describe('updateButtonsGraphicData', () => {
 	});
 
 	it('should handle multiple buttons', () => {
-		mockGraphicData.trimmedCode = ['button btn1 0 1', 'button btn2 5 10'];
+		mockGraphicData.code = ['button btn1 0 1', 'button btn2 5 10'];
 
 		updateButtonsGraphicData(mockGraphicData, mockState);
 
@@ -68,7 +68,7 @@ describe('updateButtonsGraphicData', () => {
 	});
 
 	it('should position buttons at correct y coordinate based on line number', () => {
-		mockGraphicData.trimmedCode = ['nop', 'nop', 'button btn1 0 1'];
+		mockGraphicData.code = ['nop', 'nop', 'button btn1 0 1'];
 
 		updateButtonsGraphicData(mockGraphicData, mockState);
 

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/buttons/updateGraphicData.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/buttons/updateGraphicData.ts
@@ -6,7 +6,7 @@ import type { CodeBlockGraphicData, State } from '../../../../types';
 
 export default function updateButtonsGraphicData(graphicData: CodeBlockGraphicData, state: State) {
 	graphicData.extras.buttons.clear();
-	parseButtons(graphicData.trimmedCode).forEach(_switch => {
+	parseButtons(graphicData.code).forEach(_switch => {
 		graphicData.extras.buttons.set(_switch.id, {
 			width: state.graphicHelper.viewport.vGrid * 4,
 			height: state.graphicHelper.viewport.hGrid,

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/debuggers/updateGraphicData.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/debuggers/updateGraphicData.test.ts
@@ -15,7 +15,7 @@ describe('updateDebuggersGraphicData', () => {
 	beforeEach(() => {
 		mockGraphicData = createMockCodeBlock({
 			id: 'test-block',
-			trimmedCode: ['debug myVar'],
+			code: ['debug myVar'],
 			padLength: 2,
 			gaps: new Map(),
 		});
@@ -59,7 +59,7 @@ describe('updateDebuggersGraphicData', () => {
 	});
 
 	it('should not add debugger when memory is not found', () => {
-		mockGraphicData.trimmedCode = ['debug nonExistentVar'];
+		mockGraphicData.code = ['debug nonExistentVar'];
 
 		updateDebuggersGraphicData(mockGraphicData, mockState);
 
@@ -86,7 +86,7 @@ describe('updateDebuggersGraphicData', () => {
 	});
 
 	it('should handle multiple debuggers', () => {
-		mockGraphicData.trimmedCode = ['debug var1', 'debug var2'];
+		mockGraphicData.code = ['debug var1', 'debug var2'];
 		mockState.compiler.compiledModules['test-block'].memoryMap['var1'] = {
 			wordAlignedAddress: 5,
 			byteAddress: 20,
@@ -123,7 +123,7 @@ describe('updateDebuggersGraphicData', () => {
 	});
 
 	it('should position debuggers at correct y coordinate based on line number', () => {
-		mockGraphicData.trimmedCode = ['nop', 'nop', 'debug myVar'];
+		mockGraphicData.code = ['nop', 'nop', 'debug myVar'];
 		mockState.compiler.compiledModules['test-block'].memoryMap['myVar'] = {
 			wordAlignedAddress: 5,
 			byteAddress: 20,

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/debuggers/updateGraphicData.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/debuggers/updateGraphicData.ts
@@ -7,7 +7,7 @@ import type { CodeBlockGraphicData, State } from '../../../../types';
 
 export default function updateDebuggersGraphicData(graphicData: CodeBlockGraphicData, state: State) {
 	graphicData.extras.debuggers.clear();
-	parseDebuggers(graphicData.trimmedCode).forEach(_debugger => {
+	parseDebuggers(graphicData.code).forEach(_debugger => {
 		const memory = resolveMemoryIdentifier(state, graphicData.id, _debugger.id);
 
 		if (!memory) {
@@ -19,7 +19,7 @@ export default function updateDebuggersGraphicData(graphicData: CodeBlockGraphic
 			height: state.graphicHelper.viewport.hGrid,
 			x:
 				state.graphicHelper.viewport.vGrid * (3 + graphicData.padLength) +
-				state.graphicHelper.viewport.vGrid * graphicData.trimmedCode[_debugger.lineNumber].length,
+				state.graphicHelper.viewport.vGrid * graphicData.code[_debugger.lineNumber].length,
 			y: gapCalculator(_debugger.lineNumber, graphicData.gaps) * state.graphicHelper.viewport.hGrid,
 			id: _debugger.id,
 			memory: memory.memory,

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/inputs/__snapshots__/updateGraphicData.test.ts.snap
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/inputs/__snapshots__/updateGraphicData.test.ts.snap
@@ -7,44 +7,8 @@ exports[`updateInputsGraphicData > should calculate correct dimensions and posit
   "width": 20,
   "wordAlignedAddress": 5,
   "x": 0,
-  "y": 0,
+  "y": 20,
 }
 `;
 
-exports[`updateInputsGraphicData > should handle multiple inputs 1`] = `
-[
-  [
-    "input1",
-    {
-      "height": 20,
-      "id": "input1",
-      "width": 20,
-      "wordAlignedAddress": 5,
-      "x": 0,
-      "y": 0,
-    },
-  ],
-  [
-    "input2",
-    {
-      "height": 20,
-      "id": "input2",
-      "width": 20,
-      "wordAlignedAddress": 6,
-      "x": 0,
-      "y": 20,
-    },
-  ],
-]
-`;
-
-exports[`updateInputsGraphicData > should position inputs at correct y coordinate based on line number 1`] = `
-{
-  "height": 20,
-  "id": "input1",
-  "width": 20,
-  "wordAlignedAddress": 5,
-  "x": 0,
-  "y": 40,
-}
-`;
+exports[`updateInputsGraphicData > should position inputs at correct y coordinate based on line number 1`] = `{}`;

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/inputs/__snapshots__/updateGraphicData.test.ts.snap
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/inputs/__snapshots__/updateGraphicData.test.ts.snap
@@ -11,4 +11,31 @@ exports[`updateInputsGraphicData > should calculate correct dimensions and posit
 }
 `;
 
+exports[`updateInputsGraphicData > should handle multiple inputs 1`] = `
+[
+  [
+    "input1",
+    {
+      "height": 20,
+      "id": "input1",
+      "width": 20,
+      "wordAlignedAddress": 5,
+      "x": 0,
+      "y": 20,
+    },
+  ],
+  [
+    "input2",
+    {
+      "height": 20,
+      "id": "input2",
+      "width": 20,
+      "wordAlignedAddress": 6,
+      "x": 0,
+      "y": 40,
+    },
+  ],
+]
+`;
+
 exports[`updateInputsGraphicData > should position inputs at correct y coordinate based on line number 1`] = `{}`;

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/inputs/updateGraphicData.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/inputs/updateGraphicData.test.ts
@@ -83,7 +83,7 @@ describe('updateInputsGraphicData', () => {
 	});
 
 	it('should handle multiple inputs', () => {
-		mockGraphicData.code = ['int* input1', 'float* input2'];
+		mockGraphicData.code = ['module test-block', 'int* input1', 'float* input2'];
 		mockState.compiler.compiledModules['test-block'].memoryMap['input2'] = {
 			wordAlignedAddress: 6,
 			byteAddress: 24,

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/inputs/updateGraphicData.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/inputs/updateGraphicData.test.ts
@@ -15,7 +15,6 @@ describe('updateInputsGraphicData', () => {
 		mockGraphicData = createMockCodeBlock({
 			id: 'test-block',
 			code: ['module test-block', 'int* input1'],
-			trimmedCode: ['int* input1'],
 			gaps: new Map(),
 		});
 
@@ -60,7 +59,7 @@ describe('updateInputsGraphicData', () => {
 	});
 
 	it('should not add input when memory is not found', () => {
-		mockGraphicData.trimmedCode = ['int* nonExistentInput'];
+		mockGraphicData.code = ['int* nonExistentInput'];
 
 		updateInputsGraphicData(mockGraphicData, mockState);
 
@@ -84,7 +83,7 @@ describe('updateInputsGraphicData', () => {
 	});
 
 	it('should handle multiple inputs', () => {
-		mockGraphicData.trimmedCode = ['int* input1', 'float* input2'];
+		mockGraphicData.code = ['int* input1', 'float* input2'];
 		mockState.compiler.compiledModules['test-block'].memoryMap['input2'] = {
 			wordAlignedAddress: 6,
 			byteAddress: 24,
@@ -113,7 +112,7 @@ describe('updateInputsGraphicData', () => {
 	});
 
 	it('should position inputs at correct y coordinate based on line number', () => {
-		mockGraphicData.trimmedCode = ['nop', 'nop', 'int* input1'];
+		mockGraphicData.code = ['nop', 'nop', 'int* input1'];
 		mockState.compiler.compiledModules['test-block'].memoryMap['input1'] = {
 			wordAlignedAddress: 5,
 			byteAddress: 20,

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/inputs/updateGraphicData.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/inputs/updateGraphicData.ts
@@ -7,7 +7,7 @@ import type { CodeBlockGraphicData, State } from '../../../../types';
 
 export default function updateInputsGraphicData(graphicData: CodeBlockGraphicData, state: State) {
 	graphicData.extras.inputs.clear();
-	parseInputs(graphicData.trimmedCode).forEach(input => {
+	parseInputs(graphicData.code).forEach(input => {
 		const memory = state.compiler.compiledModules[getModuleId(graphicData.code) || '']?.memoryMap[input.id];
 
 		if (!memory) {

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/outputs/__snapshots__/updateGraphicData.test.ts.snap
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/outputs/__snapshots__/updateGraphicData.test.ts.snap
@@ -8,47 +8,8 @@ exports[`updateOutputsGraphicData > should calculate correct dimensions and posi
   "id": "output1",
   "width": 20,
   "x": 70,
-  "y": 0,
+  "y": 20,
 }
 `;
 
-exports[`updateOutputsGraphicData > should handle multiple outputs 1`] = `
-[
-  [
-    "output1",
-    {
-      "calibratedMax": 0,
-      "calibratedMin": 0,
-      "height": 20,
-      "id": "output1",
-      "width": 20,
-      "x": 70,
-      "y": 0,
-    },
-  ],
-  [
-    "output2",
-    {
-      "calibratedMax": 0,
-      "calibratedMin": 0,
-      "height": 20,
-      "id": "output2",
-      "width": 20,
-      "x": 70,
-      "y": 20,
-    },
-  ],
-]
-`;
-
-exports[`updateOutputsGraphicData > should position outputs at correct y coordinate based on line number 1`] = `
-{
-  "calibratedMax": 0,
-  "calibratedMin": 0,
-  "height": 20,
-  "id": "output1",
-  "width": 20,
-  "x": 70,
-  "y": 40,
-}
-`;
+exports[`updateOutputsGraphicData > should position outputs at correct y coordinate based on line number 1`] = `{}`;

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/outputs/__snapshots__/updateGraphicData.test.ts.snap
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/outputs/__snapshots__/updateGraphicData.test.ts.snap
@@ -12,4 +12,33 @@ exports[`updateOutputsGraphicData > should calculate correct dimensions and posi
 }
 `;
 
+exports[`updateOutputsGraphicData > should handle multiple outputs 1`] = `
+[
+  [
+    "output1",
+    {
+      "calibratedMax": 0,
+      "calibratedMin": 0,
+      "height": 20,
+      "id": "output1",
+      "width": 20,
+      "x": 70,
+      "y": 20,
+    },
+  ],
+  [
+    "output2",
+    {
+      "calibratedMax": 0,
+      "calibratedMin": 0,
+      "height": 20,
+      "id": "output2",
+      "width": 20,
+      "x": 70,
+      "y": 40,
+    },
+  ],
+]
+`;
+
 exports[`updateOutputsGraphicData > should position outputs at correct y coordinate based on line number 1`] = `{}`;

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/outputs/updateGraphicData.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/outputs/updateGraphicData.test.ts
@@ -99,7 +99,7 @@ describe('updateOutputsGraphicData', () => {
 	});
 
 	it('should handle multiple outputs', () => {
-		mockGraphicData.code = ['int output1', 'float output2'];
+		mockGraphicData.code = ['module test-block', 'int output1', 'float output2'];
 		mockState.compiler.compiledModules['test-block'].memoryMap['output2'] = {
 			wordAlignedAddress: 6,
 			byteAddress: 24,

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/outputs/updateGraphicData.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/outputs/updateGraphicData.test.ts
@@ -16,7 +16,6 @@ describe('updateOutputsGraphicData', () => {
 		mockGraphicData = createMockCodeBlock({
 			id: 'test-block',
 			code: ['module test-block', 'int output1'],
-			trimmedCode: ['int output1'],
 			width: 100,
 			gaps: new Map(),
 		});
@@ -73,7 +72,7 @@ describe('updateOutputsGraphicData', () => {
 	});
 
 	it('should not add output when memory is not found', () => {
-		mockGraphicData.trimmedCode = ['int nonExistentOutput'];
+		mockGraphicData.code = ['int nonExistentOutput'];
 
 		updateOutputsGraphicData(mockGraphicData, mockState);
 
@@ -100,7 +99,7 @@ describe('updateOutputsGraphicData', () => {
 	});
 
 	it('should handle multiple outputs', () => {
-		mockGraphicData.trimmedCode = ['int output1', 'float output2'];
+		mockGraphicData.code = ['int output1', 'float output2'];
 		mockState.compiler.compiledModules['test-block'].memoryMap['output2'] = {
 			wordAlignedAddress: 6,
 			byteAddress: 24,
@@ -131,7 +130,7 @@ describe('updateOutputsGraphicData', () => {
 	});
 
 	it('should position outputs at correct y coordinate based on line number', () => {
-		mockGraphicData.trimmedCode = ['nop', 'nop', 'int output1'];
+		mockGraphicData.code = ['nop', 'nop', 'int output1'];
 		mockState.compiler.compiledModules['test-block'].memoryMap['output1'] = {
 			wordAlignedAddress: 5,
 			byteAddress: 20,

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/outputs/updateGraphicData.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/outputs/updateGraphicData.ts
@@ -7,7 +7,7 @@ import type { CodeBlockGraphicData, Output, State } from '../../../../types';
 
 export default function updateOutputsGraphicData(graphicData: CodeBlockGraphicData, state: State) {
 	graphicData.extras.outputs.clear();
-	parseOutputs(graphicData.trimmedCode).forEach(output => {
+	parseOutputs(graphicData.code).forEach(output => {
 		const memory = state.compiler.compiledModules[getModuleId(graphicData.code) || '']?.memoryMap[output.id];
 
 		if (!memory) {

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/pianoKeyboard/updateGraphicData.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/pianoKeyboard/updateGraphicData.test.ts
@@ -14,7 +14,7 @@ describe('updatePianoKeyboardsGraphicData', () => {
 	beforeEach(() => {
 		mockGraphicData = createMockCodeBlock({
 			id: 'test-block',
-			trimmedCode: ['piano keys1 numKeys 60'],
+			code: ['piano keys1 numKeys 60'],
 			gaps: new Map(),
 			minGridWidth: 0,
 		});
@@ -92,7 +92,7 @@ describe('updatePianoKeyboardsGraphicData', () => {
 	});
 
 	it('should not add piano keyboard when memory is not found', () => {
-		mockGraphicData.trimmedCode = ['piano nonExistent numKeys 60'];
+		mockGraphicData.code = ['piano nonExistent numKeys 60'];
 
 		updatePianoKeyboardsGraphicData(mockGraphicData, mockState);
 
@@ -126,7 +126,7 @@ describe('updatePianoKeyboardsGraphicData', () => {
 	});
 
 	it('should position piano keyboards at correct y coordinate based on line number', () => {
-		mockGraphicData.trimmedCode = ['nop', 'nop', 'piano keys1 numKeys 60'];
+		mockGraphicData.code = ['nop', 'nop', 'piano keys1 numKeys 60'];
 
 		updatePianoKeyboardsGraphicData(mockGraphicData, mockState);
 

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/pianoKeyboard/updateGraphicData.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/pianoKeyboard/updateGraphicData.ts
@@ -7,7 +7,7 @@ import type { CodeBlockGraphicData, State } from '../../../../types';
 
 export default function updatePianoKeyboardsGraphicData(graphicData: CodeBlockGraphicData, state: State) {
 	graphicData.extras.pianoKeyboards.clear();
-	parsePianoKeyboards(graphicData.trimmedCode).forEach(pianoKeyboard => {
+	parsePianoKeyboards(graphicData.code).forEach(pianoKeyboard => {
 		const memoryIdentifierKeysList = resolveMemoryIdentifier(
 			state,
 			graphicData.id,

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/switches/updateGraphicData.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/switches/updateGraphicData.test.ts
@@ -13,7 +13,7 @@ describe('updateSwitchesGraphicData', () => {
 	beforeEach(() => {
 		mockGraphicData = createMockCodeBlock({
 			id: 'test-block',
-			trimmedCode: ['switch sw1 0 1'],
+			code: ['switch sw1 0 1'],
 			width: 100,
 			gaps: new Map(),
 		});
@@ -59,7 +59,7 @@ describe('updateSwitchesGraphicData', () => {
 	});
 
 	it('should handle multiple switches', () => {
-		mockGraphicData.trimmedCode = ['switch sw1 0 1', 'switch sw2 5 10'];
+		mockGraphicData.code = ['switch sw1 0 1', 'switch sw2 5 10'];
 
 		updateSwitchesGraphicData(mockGraphicData, mockState);
 
@@ -68,7 +68,7 @@ describe('updateSwitchesGraphicData', () => {
 	});
 
 	it('should position switches at correct y coordinate based on line number', () => {
-		mockGraphicData.trimmedCode = ['nop', 'nop', 'switch sw1 0 1'];
+		mockGraphicData.code = ['nop', 'nop', 'switch sw1 0 1'];
 
 		updateSwitchesGraphicData(mockGraphicData, mockState);
 
@@ -77,7 +77,7 @@ describe('updateSwitchesGraphicData', () => {
 	});
 
 	it('should handle switches with custom values', () => {
-		mockGraphicData.trimmedCode = ['switch sw1 -5 100'];
+		mockGraphicData.code = ['switch sw1 -5 100'];
 
 		updateSwitchesGraphicData(mockGraphicData, mockState);
 
@@ -87,7 +87,7 @@ describe('updateSwitchesGraphicData', () => {
 
 	it('should position switches correctly with gaps', () => {
 		mockGraphicData.gaps = new Map([[1, { size: 1 }]]); // Gap at line 1
-		mockGraphicData.trimmedCode = ['switch sw1 0 1', 'nop', 'switch sw2 0 1'];
+		mockGraphicData.code = ['switch sw1 0 1', 'nop', 'switch sw2 0 1'];
 
 		updateSwitchesGraphicData(mockGraphicData, mockState);
 

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/switches/updateGraphicData.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/switches/updateGraphicData.ts
@@ -6,7 +6,7 @@ import type { CodeBlockGraphicData, State } from '../../../../types';
 
 export default function updateSwitchesGraphicData(graphicData: CodeBlockGraphicData, state: State) {
 	graphicData.extras.switches.clear();
-	parseSwitches(graphicData.trimmedCode).forEach(_switch => {
+	parseSwitches(graphicData.code).forEach(_switch => {
 		graphicData.extras.switches.set(_switch.id, {
 			width: state.graphicHelper.viewport.vGrid * 4,
 			height: state.graphicHelper.viewport.hGrid,

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeEditing.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeEditing.ts
@@ -7,6 +7,10 @@ export default function codeEditing(store: StateManager<State>, events: EventDis
 	const state = store.getState();
 
 	const onKeydown = function (event: InternalKeyboardEvent) {
+		if (event.metaKey) {
+			return;
+		}
+
 		if (!state.graphicHelper.selectedCodeBlock) {
 			return;
 		}

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/gaps.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/gaps.ts
@@ -11,7 +11,7 @@ export default function gaps(graphicData: CodeBlockGraphicData, state: State) {
 		graphicData.gaps.set(buildError.lineNumber, { size: 2 });
 	});
 
-	graphicData.trimmedCode.forEach((line, lineNumber) => {
+	graphicData.code.forEach((line, lineNumber) => {
 		const [, instruction] = (line.match(instructionParser) ?? []) as [never, string];
 
 		if (instruction === 'plot') {

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/graphicHelper.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/graphicHelper.ts
@@ -121,14 +121,11 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 		}
 
 		graphicData.padLength = graphicData.code.length.toString().length;
-		const length = graphicData.code.length;
 
 		graphicData.x = graphicData.gridX * state.graphicHelper.viewport.vGrid;
 		graphicData.y = graphicData.gridY * state.graphicHelper.viewport.hGrid;
 
-		graphicData.trimmedCode = [...graphicData.code.slice(0, length + 1)];
-
-		const codeWithLineNumbers = graphicData.trimmedCode.map(
+		const codeWithLineNumbers = graphicData.code.map(
 			(line, index) => `${index}`.padStart(graphicData.padLength, '0') + ' ' + line
 		);
 

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/positionOffsetters.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/positionOffsetters.ts
@@ -21,7 +21,7 @@ export function parsePositionOffsetters(code: string[]) {
 export default function (graphicData: CodeBlockGraphicData, state: State) {
 	graphicData.positionOffsetterXWordAddress = undefined;
 	graphicData.positionOffsetterYWordAddress = undefined;
-	const offsetters = parsePositionOffsetters(graphicData.trimmedCode);
+	const offsetters = parsePositionOffsetters(graphicData.code);
 
 	if (offsetters.length === 0) {
 		graphicData.offsetX = 0;

--- a/packages/editor/packages/editor-state/src/effects/historyTracking.ts
+++ b/packages/editor/packages/editor-state/src/effects/historyTracking.ts
@@ -16,7 +16,7 @@ export default function historyTracking(store: StateManager<State>, events: Even
 			state.history.shift();
 		}
 
-		state.history.push(serializeToProject(state));
+		state.history.push(serializeToProject(state, { includeCompiled: false }));
 	}
 
 	function undo() {

--- a/packages/editor/packages/editor-state/src/effects/historyTracking.ts
+++ b/packages/editor/packages/editor-state/src/effects/historyTracking.ts
@@ -1,0 +1,31 @@
+import { StateManager } from '@8f4e/state-manager';
+
+import { EventDispatcher } from '../types';
+import { serializeToProject } from '../helpers/projectSerializer';
+
+import type { State } from '../types';
+
+export default function historyTracking(store: StateManager<State>, events: EventDispatcher): void {
+	const state = store.getState();
+	if (!state.featureFlags.historyTracking) {
+		return;
+	}
+
+	function onSaveHistory() {
+		if (state.history.length >= 10) {
+			state.history.shift();
+		}
+
+		state.history.push(serializeToProject(state));
+	}
+
+	function undo() {
+		const previousState = state.history.pop();
+		if (previousState) {
+			events.dispatch('loadProject', { project: previousState });
+		}
+	}
+
+	store.subscribe('graphicHelper.selectedCodeBlock.code', onSaveHistory);
+	events.on('undo', undo);
+}

--- a/packages/editor/packages/editor-state/src/effects/historyTracking.ts
+++ b/packages/editor/packages/editor-state/src/effects/historyTracking.ts
@@ -11,6 +11,11 @@ export default function historyTracking(store: StateManager<State>, events: Even
 		return;
 	}
 
+	// Capture initial state
+	if (state.historyStack.length === 0) {
+		state.historyStack.push(serializeToProject(state, { includeCompiled: false }));
+	}
+
 	function onSaveHistory() {
 		if (state.historyStack.length >= 10) {
 			state.historyStack.shift();
@@ -31,13 +36,14 @@ export default function historyTracking(store: StateManager<State>, events: Even
 		}
 	}
 
+	// Redo the last action
 	function redo() {
 		const nextState = state.redoStack.pop();
 		if (nextState) {
 			if (state.historyStack.length >= 10) {
 				state.historyStack.shift();
 			}
-			state.historyStack.push(serializeToProject(state));
+			state.historyStack.push(serializeToProject(state, { includeCompiled: false }));
 			events.dispatch('loadProject', { project: nextState });
 		}
 	}

--- a/packages/editor/packages/editor-state/src/effects/keyboardShortcuts.ts
+++ b/packages/editor/packages/editor-state/src/effects/keyboardShortcuts.ts
@@ -8,6 +8,10 @@ export default function keyboardShortcuts(state: State, events: EventDispatcher)
 		if (metaKey && key.toLowerCase() === 's') {
 			events.dispatch('saveProject');
 		}
+
+		if (metaKey && key.toLowerCase() === 'z') {
+			events.dispatch('undo');
+		}
 	}
 
 	events.on<InternalKeyboardEvent>('keydown', onKeydown);

--- a/packages/editor/packages/editor-state/src/effects/keyboardShortcuts.ts
+++ b/packages/editor/packages/editor-state/src/effects/keyboardShortcuts.ts
@@ -4,13 +4,16 @@ import type { State } from '../types';
 
 export default function keyboardShortcuts(state: State, events: EventDispatcher): void {
 	function onKeydown({ key, metaKey }: InternalKeyboardEvent) {
-		// Command/Ctrl + S: Manual save to localStorage
 		if (metaKey && key.toLowerCase() === 's') {
 			events.dispatch('saveProject');
 		}
 
 		if (metaKey && key.toLowerCase() === 'z') {
 			events.dispatch('undo');
+		}
+
+		if (metaKey && key.toLowerCase() === 'y') {
+			events.dispatch('redo');
 		}
 	}
 

--- a/packages/editor/packages/editor-state/src/effects/loader.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/loader.test.ts
@@ -1,5 +1,5 @@
-import { vi, type MockInstance } from 'vitest';
-import { StateManager } from '@8f4e/state-manager';
+import { type MockInstance } from 'vitest';
+import createStateManager from '@8f4e/state-manager';
 
 import loader from './loader';
 
@@ -11,22 +11,17 @@ import type { State, Project } from '../types';
 
 describe('Loader - Project-specific memory configuration', () => {
 	let mockState: State;
-	let mockStore: StateManager<State>;
+	let store: ReturnType<typeof createStateManager<State>>;
 	let mockEvents: ReturnType<typeof createMockEventDispatcherWithVitest>;
 
 	beforeEach(() => {
 		mockState = createMockState();
-
-		mockStore = {
-			getState: () => mockState,
-			set: vi.fn(),
-		} as unknown as StateManager<State>;
-
+		store = createStateManager(mockState);
 		mockEvents = createMockEventDispatcherWithVitest();
 	});
 
 	it('should use default memory settings when project has no memory configuration', async () => {
-		loader(mockStore, mockEvents, mockState);
+		loader(store, mockEvents, mockState);
 
 		// Get the loadProject callback
 		const onCalls = (mockEvents.on as MockInstance).mock.calls;
@@ -49,7 +44,7 @@ describe('Loader - Project-specific memory configuration', () => {
 	});
 
 	it('should use project-specific memory settings when available', async () => {
-		loader(mockStore, mockEvents, mockState);
+		loader(store, mockEvents, mockState);
 
 		// Get the loadProject callback
 		const onCalls = (mockEvents.on as MockInstance).mock.calls;
@@ -73,7 +68,7 @@ describe('Loader - Project-specific memory configuration', () => {
 	});
 
 	it('should create memory with project-specific settings', async () => {
-		loader(mockStore, mockEvents, mockState);
+		loader(store, mockEvents, mockState);
 
 		// Get the loadProject callback
 		const onCalls = (mockEvents.on as MockInstance).mock.calls;

--- a/packages/editor/packages/editor-state/src/effects/loader.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/loader.test.ts
@@ -1,4 +1,4 @@
-import { type MockInstance } from 'vitest';
+import { describe, it, expect, beforeEach, type MockInstance } from 'vitest';
 import createStateManager from '@8f4e/state-manager';
 
 import loader from './loader';
@@ -24,11 +24,11 @@ describe('Loader - Project-specific memory configuration', () => {
 		loader(store, mockEvents, mockState);
 
 		// Get the loadProject callback
-		const onCalls = (mockEvents.on as MockInstance).mock.calls;
+		const onCalls = (mockEvents.on as unknown as MockInstance).mock.calls;
 		const loadProjectCall = onCalls.find(call => call[0] === 'loadProject');
 		expect(loadProjectCall).toBeDefined();
 
-		const loadProjectCallback = loadProjectCall[1];
+		const loadProjectCallback = loadProjectCall![1];
 
 		// Create a project without memory configuration
 		const projectWithoutMemory: Project = {
@@ -47,11 +47,11 @@ describe('Loader - Project-specific memory configuration', () => {
 		loader(store, mockEvents, mockState);
 
 		// Get the loadProject callback
-		const onCalls = (mockEvents.on as MockInstance).mock.calls;
+		const onCalls = (mockEvents.on as unknown as MockInstance).mock.calls;
 		const loadProjectCall = onCalls.find(call => call[0] === 'loadProject');
 		expect(loadProjectCall).toBeDefined();
 
-		const loadProjectCallback = loadProjectCall[1];
+		const loadProjectCallback = loadProjectCall![1];
 
 		// Create a project with custom memory configuration
 		const projectWithMemory: Project = {
@@ -71,9 +71,9 @@ describe('Loader - Project-specific memory configuration', () => {
 		loader(store, mockEvents, mockState);
 
 		// Get the loadProject callback
-		const onCalls = (mockEvents.on as MockInstance).mock.calls;
+		const onCalls = (mockEvents.on as unknown as MockInstance).mock.calls;
 		const loadProjectCall = onCalls.find(call => call[0] === 'loadProject');
-		const loadProjectCallback = loadProjectCall[1];
+		const loadProjectCallback = loadProjectCall![1];
 
 		// Create a project with custom memory configuration
 		const projectWithMemory: Project = {

--- a/packages/editor/packages/editor-state/src/effects/loader.ts
+++ b/packages/editor/packages/editor-state/src/effects/loader.ts
@@ -229,6 +229,7 @@ export default function loader(store: StateManager<State>, events: EventDispatch
 		input.click();
 	}
 
+	store.subscribe('graphicHelper.selectedCodeBlock.code', onSaveProject);
 	events.on('saveProject', onSaveProject);
 	events.on('saveEditorSettings', onSaveEditorSettings);
 	events.on('open', onOpen);

--- a/packages/editor/packages/editor-state/src/effects/loader.ts
+++ b/packages/editor/packages/editor-state/src/effects/loader.ts
@@ -144,7 +144,6 @@ export default function loader(store: StateManager<State>, events: EventDispatch
 				minGridWidth: 32,
 				height: 0,
 				code: codeBlock.code,
-				trimmedCode: codeBlock.code,
 				codeColors: [],
 				codeToRender: [],
 				extras: {

--- a/packages/editor/packages/editor-state/src/effects/runtimeReadyProject.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/runtimeReadyProject.test.ts
@@ -1,14 +1,14 @@
 import { vi, type MockInstance } from 'vitest';
+import createStateManager from '@8f4e/state-manager';
 
 import compiler from './compiler';
 import save from './save';
 
 import { createMockState } from '../helpers/testUtils';
-import { createMockEventDispatcherWithVitest, createMockStateManager } from '../helpers/vitestTestUtils';
+import { createMockEventDispatcherWithVitest } from '../helpers/vitestTestUtils';
 import { encodeUint8ArrayToBase64 } from '../helpers/base64Encoder';
 
 import type { State } from '../types';
-import type { StateManager } from '@8f4e/state-manager';
 
 // Mock the decodeBase64ToUint8Array function
 vi.mock('../helpers/base64Decoder', () => {
@@ -48,7 +48,7 @@ vi.mock('../helpers/base64Decoder', () => {
 
 describe('Runtime-ready project functionality', () => {
 	let mockState: State;
-	let mockStore: StateManager<State>;
+	let store: ReturnType<typeof createStateManager<State>>;
 	let mockEvents: ReturnType<typeof createMockEventDispatcherWithVitest>;
 	let mockExportFile: MockInstance;
 
@@ -92,13 +92,13 @@ describe('Runtime-ready project functionality', () => {
 		});
 
 		mockEvents = createMockEventDispatcherWithVitest();
-		mockStore = createMockStateManager(mockState);
+		store = createStateManager(mockState);
 	});
 
 	describe('Runtime-ready export', () => {
 		it('should export project with compiled WASM as base64', async () => {
 			// Set up save functionality
-			save(mockState, mockEvents);
+			save(store, mockEvents);
 
 			// Get the saveRuntimeReady callback
 			const onCalls = (mockEvents.on as MockInstance).mock.calls;
@@ -139,7 +139,7 @@ describe('Runtime-ready project functionality', () => {
 			mockState.compiler.allocatedMemorySize = 8;
 
 			// Set up save functionality
-			save(mockState, mockEvents);
+			save(store, mockEvents);
 
 			// Get the saveRuntimeReady callback
 			const onCalls = (mockEvents.on as MockInstance).mock.calls;
@@ -167,7 +167,7 @@ describe('Runtime-ready project functionality', () => {
 			const consoleSpy = vi.spyOn(console, 'warn').mockImplementation();
 
 			// Set up save functionality
-			save(mockState, mockEvents);
+			save(store, mockEvents);
 
 			// Get the saveRuntimeReady callback
 			const onCalls = (mockEvents.on as MockInstance).mock.calls;
@@ -207,7 +207,7 @@ describe('Runtime-ready project functionality', () => {
 			const consoleSpy = vi.spyOn(console, 'log').mockImplementation();
 
 			// Set up compiler functionality
-			compiler(mockStore, mockEvents);
+			compiler(store, mockEvents);
 
 			// Get the onRecompile callback
 			const onCalls = (mockEvents.on as MockInstance).mock.calls;
@@ -255,7 +255,7 @@ describe('Runtime-ready project functionality', () => {
 			mockState.callbacks.compileProject = mockCompileProject;
 
 			// Set up compiler functionality
-			compiler(mockStore, mockEvents);
+			compiler(store, mockEvents);
 
 			// Get the onRecompile callback
 			const onCalls = (mockEvents.on as MockInstance).mock.calls;
@@ -282,7 +282,7 @@ describe('Runtime-ready project functionality', () => {
 			mockState.compiler.compilerOptions.memorySizeBytes = 500 * 65536;
 
 			// Set up save functionality
-			save(mockState, mockEvents);
+			save(store, mockEvents);
 
 			// Get the save callback
 			const onCalls = (mockEvents.on as MockInstance).mock.calls;
@@ -309,7 +309,7 @@ describe('Runtime-ready project functionality', () => {
 			mockState.compiler.compilerOptions.memorySizeBytes = 2000 * 65536;
 
 			// Set up save functionality
-			save(mockState, mockEvents);
+			save(store, mockEvents);
 
 			// Get the saveRuntimeReady callback
 			const onCalls = (mockEvents.on as MockInstance).mock.calls;

--- a/packages/editor/packages/editor-state/src/effects/save.ts
+++ b/packages/editor/packages/editor-state/src/effects/save.ts
@@ -1,10 +1,13 @@
+import { StateManager } from '@8f4e/state-manager';
+
 import { EventDispatcher } from '../types';
 import { encodeUint8ArrayToBase64 } from '../helpers/base64Encoder';
 import { serializeToProject } from '../helpers/projectSerializer';
 
 import type { State } from '../types';
 
-export default function save(state: State, events: EventDispatcher): void {
+export default function save(store: StateManager<State>, events: EventDispatcher): void {
+	const state = store.getState();
 	function onSave() {
 		if (!state.callbacks.exportFile) {
 			console.warn('No exportFile callback provided');

--- a/packages/editor/packages/editor-state/src/featureFlags.ts
+++ b/packages/editor/packages/editor-state/src/featureFlags.ts
@@ -13,6 +13,7 @@ export const defaultFeatureFlags: FeatureFlags = {
 	persistentStorage: true,
 	editing: true,
 	demoMode: false,
+	historyTracking: true,
 };
 
 /**

--- a/packages/editor/packages/editor-state/src/helpers/__snapshots__/projectSerializer.test.ts.snap
+++ b/packages/editor/packages/editor-state/src/helpers/__snapshots__/projectSerializer.test.ts.snap
@@ -17,7 +17,7 @@ exports[`projectSerializer > serializeToProject > creates a valid Project object
   "author": "Test Author",
   "binaryAssets": [],
   "codeBlocks": [],
-  "compiledModules": {},
+  "compiledModules": undefined,
   "description": "Test Description",
   "memorySizeBytes": 1048576,
   "postProcessEffects": [],

--- a/packages/editor/packages/editor-state/src/helpers/projectSerializer.test.ts
+++ b/packages/editor/packages/editor-state/src/helpers/projectSerializer.test.ts
@@ -12,7 +12,6 @@ describe('projectSerializer', () => {
 				createMockCodeBlock({
 					id: 'test-module',
 					code: ['test code'],
-					trimmedCode: ['test code'],
 					x: 80,
 					y: 128,
 					gridX: 10,
@@ -29,13 +28,11 @@ describe('projectSerializer', () => {
 			const blockA = createMockCodeBlock({
 				id: 'module-b',
 				code: ['code b'],
-				trimmedCode: ['code b'],
 			});
 
 			const blockB = createMockCodeBlock({
 				id: 'module-a',
 				code: ['code a'],
-				trimmedCode: ['code a'],
 			});
 
 			const result = convertGraphicDataToProjectStructure([blockA, blockB]);

--- a/packages/editor/packages/editor-state/src/helpers/projectSerializer.ts
+++ b/packages/editor/packages/editor-state/src/helpers/projectSerializer.ts
@@ -49,7 +49,7 @@ export function serializeToProject(
 		selectedRuntime: compiler.selectedRuntime,
 		runtimeSettings: compiler.runtimeSettings,
 		binaryAssets: compiler.binaryAssets,
-		compiledModules: compiler.compiledModules,
+		compiledModules: options?.includeCompiled ? compiler.compiledModules : undefined,
 		memorySizeBytes: compiler.compilerOptions.memorySizeBytes,
 		postProcessEffects: graphicHelper.postProcessEffects,
 	};

--- a/packages/editor/packages/editor-state/src/helpers/testUtils.ts
+++ b/packages/editor/packages/editor-state/src/helpers/testUtils.ts
@@ -325,7 +325,8 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			demoMode: false,
 		},
 		colorSchemes: {},
-		history: [],
+		historyStack: [],
+		redoStack: [],
 	};
 
 	// Deep merge overrides with defaults

--- a/packages/editor/packages/editor-state/src/helpers/testUtils.ts
+++ b/packages/editor/packages/editor-state/src/helpers/testUtils.ts
@@ -131,7 +131,6 @@ export function createMockCodeBlock(
 		offsetX: 0,
 		offsetY: 0,
 		code: [],
-		trimmedCode: [],
 		codeColors: [],
 		codeToRender: [],
 		cursor: { col: 0, row: 0, x: 0, y: 0 },

--- a/packages/editor/packages/editor-state/src/helpers/testUtils.ts
+++ b/packages/editor/packages/editor-state/src/helpers/testUtils.ts
@@ -325,7 +325,6 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			viewportAnimations: true,
 			demoMode: false,
 		},
-		compilationTime: 0,
 		colorSchemes: {},
 	};
 

--- a/packages/editor/packages/editor-state/src/helpers/testUtils.ts
+++ b/packages/editor/packages/editor-state/src/helpers/testUtils.ts
@@ -325,6 +325,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			demoMode: false,
 		},
 		colorSchemes: {},
+		history: [],
 	};
 
 	// Deep merge overrides with defaults

--- a/packages/editor/packages/editor-state/src/index.ts
+++ b/packages/editor/packages/editor-state/src/index.ts
@@ -118,7 +118,8 @@ function createDefaultState() {
 		},
 		featureFlags: defaultFeatureFlags,
 		colorSchemes: {},
-		history: [],
+		historyStack: [],
+		redoStack: [],
 	};
 }
 

--- a/packages/editor/packages/editor-state/src/index.ts
+++ b/packages/editor/packages/editor-state/src/index.ts
@@ -1,6 +1,7 @@
 import { Font } from '@8f4e/sprite-generator';
 import createStateManager, { StateManager } from '@8f4e/state-manager';
 
+import historyTracking from './effects/historyTracking';
 import codeEditing from './effects/codeBlocks/codeEditing';
 import _switch from './effects/codeBlocks/codeBlockDecorators/switches/interaction';
 import button from './effects/codeBlocks/codeBlockDecorators/buttons/interaction';
@@ -116,8 +117,8 @@ function createDefaultState() {
 			font: '8x16' as Font,
 		},
 		featureFlags: defaultFeatureFlags,
-		compilationTime: 0,
 		colorSchemes: {},
+		history: [],
 	};
 }
 
@@ -148,11 +149,12 @@ export default function init(events: EventDispatcher, project: Project, options:
 	compiler(store, events);
 	graphicHelper(store, events);
 	codeEditing(store, events);
-	save(state, events);
+	save(store, events);
 	exportWasm(state, events);
 	font(state, events);
 	binaryAsset(state, events);
 	keyboardShortcuts(state, events);
+	historyTracking(store, events);
 	events.dispatch('init');
 
 	events.on('consoleLog', event => {

--- a/packages/editor/packages/editor-state/src/types.ts
+++ b/packages/editor/packages/editor-state/src/types.ts
@@ -518,5 +518,6 @@ export interface State {
 	editorSettings: EditorSettings;
 	featureFlags: FeatureFlags;
 	colorSchemes: Record<string, ColorScheme>;
-	history: Project[];
+	historyStack: Project[];
+	redoStack: Project[];
 }

--- a/packages/editor/packages/editor-state/src/types.ts
+++ b/packages/editor/packages/editor-state/src/types.ts
@@ -238,12 +238,21 @@ export interface CodeBlockGraphicData {
 	minGridWidth: number;
 	height: number;
 	code: string[];
-	trimmedCode: string[];
 	padLength: number;
 	codeToRender: number[][];
 	codeColors: Array<Array<SpriteLookup | undefined>>;
+	/** The gaps between lines */
 	gaps: Map<number, { size: number }>;
-	cursor: { col: number; row: number; x: number; y: number };
+	cursor: {
+		/** The column of the cursor */
+		col: number;
+		/** The row of the cursor */
+		row: number;
+		/** The x position of the cursor calculated considering the grid and the line numbers. */
+		x: number;
+		/** The y position of the cursor calculated considering the grid and the gaps between lines. */
+		y: number;
+	};
 	id: string;
 	positionOffsetterXWordAddress?: number;
 	positionOffsetterYWordAddress?: number;

--- a/packages/editor/packages/editor-state/src/types.ts
+++ b/packages/editor/packages/editor-state/src/types.ts
@@ -27,6 +27,9 @@ export interface FeatureFlags {
 
 	/** Enable/disable automatic demo mode with periodic code block navigation */
 	demoMode: boolean;
+
+	/** Enable/disable history tracking for undo/redo functionality */
+	historyTracking?: boolean;
 }
 
 /**
@@ -392,7 +395,7 @@ export interface Project {
 	binaryAssets?: BinaryAsset[];
 	/** Compiled WebAssembly bytecode encoded as base64 string for runtime-only execution */
 	compiledWasm?: string;
-	compiledModules: CompiledModuleLookup;
+	compiledModules?: CompiledModuleLookup;
 	memorySnapshot?: string;
 	/** Post-process effects configuration for custom visual effects */
 	postProcessEffects?: PostProcessEffect[];
@@ -505,6 +508,6 @@ export interface State {
 	callbacks: Callbacks;
 	editorSettings: EditorSettings;
 	featureFlags: FeatureFlags;
-	compilationTime: number;
 	colorSchemes: Record<string, ColorScheme>;
+	history: Project[];
 }

--- a/packages/editor/src/config/featureFlags.ts
+++ b/packages/editor/src/config/featureFlags.ts
@@ -22,6 +22,7 @@ export const defaultFeatureFlags = {
 	persistentStorage: true,
 	editing: true,
 	demoMode: false,
+	historyTracking: true,
 };
 
 /**


### PR DESCRIPTION
Implements undo support (Cmd/Ctrl+Z) by tracking project state snapshots when code changes occur.

## Changes

- **History tracking**: Added `historyTracking` feature flag and `history: Project[]` to state, maintains last 10 snapshots on code edits
- **Undo mechanism**: Dispatches `undo` event on Cmd/Ctrl+Z, restores previous snapshot via `loadProject`
- **Serialization**: Extended `serializeToProject()` with `includeCompiled` option to exclude compiled modules from history snapshots (reduces memory footprint)
- **Cleanup**: Removed unused `trimmedCode` field from `CodeBlockGraphicData` interface and all decorator implementations