### PR TITLE
Move memory management into worker

### DIFF
--- a/docs/brainstorming_notes/011-per-module-memory-headroom.md
+++ b/docs/brainstorming_notes/011-per-module-memory-headroom.md
@@ -100,7 +100,7 @@ After each compile, we can compare:
 
 If all modules’ base addresses and slot sizes are unchanged:
 
-- The recompile is **layout-compatible**.
+- The compile is **layout-compatible**.
 - The runtime can:
   - Reuse the existing `WebAssembly.Memory` instance.
   - Swap out the code buffer and optionally re-run only necessary init code.
@@ -108,7 +108,7 @@ If all modules’ base addresses and slot sizes are unchanged:
 
 If any module’s base address or `wordAlignedSize` changed:
 
-- The recompile is **layout-incompatible**.
+- The compile is **layout-incompatible**.
 - The runtime falls back to the current behaviour:
   - Rebuild and reinitialise memory.
   - A one-off audio hiccup is acceptable in this overflow case.

--- a/docs/brainstorming_notes/011-per-module-memory-sandboxes.md
+++ b/docs/brainstorming_notes/011-per-module-memory-sandboxes.md
@@ -1,0 +1,123 @@
+# Per-Module Memory Sandboxes for Live Coding
+
+## Overview
+
+This document captures brainstorming and planning notes for introducing per-module memory sandboxes in the compiler to support live coding / algorave scenarios without interrupting generative audio playback.
+
+## Current Memory Model
+
+- All modules compile into a single linear WebAssembly memory arena (`Int32Array` / `Float32Array` over `WebAssembly.Memory`).
+- Memory addresses are assigned in a strict global order:
+  - First by module order (topologically sorted via `sortModules` in `packages/compiler/src/index.ts`).
+  - Then by declaration order within each module (`packages/compiler/src/compiler.ts`).
+- For each module, `compileModule`:
+  - Receives a `startingByteAddress` (derived from a global `memoryAddress` word index).
+  - Compiles all `memory` declarations into a `memoryMap` of `DataStructure` entries.
+  - Each `DataStructure` includes:
+    - `byteAddress` and `wordAlignedAddress` (index into the global arena).
+    - `wordAlignedSize` (how many words the structure occupies).
+- After compilation, `calculateWordAlignedSizeOfMemory` sums a module’s declared data structures to get its total `wordAlignedSize`.
+- In `compileModules` (`packages/compiler/src/index.ts`):
+  - A global `memoryAddress` (in words) is maintained.
+  - For each module:
+    - `startingByteAddress = memoryAddress * GLOBAL_ALIGNMENT_BOUNDARY`.
+    - The module is compiled, yielding `module.wordAlignedSize`.
+    - `memoryAddress += module.wordAlignedSize`.
+- Result:
+  - Modules are tightly packed back-to-back; there are no gaps between modules.
+  - The base address and contents of any module depend on the sizes of all preceding modules.
+  - Adding or removing a memory declaration in an earlier module changes that module’s `wordAlignedSize`, shifts all later modules’ base addresses, and effectively requires rebuilding and reinitialising memory to stay consistent with the new layout.
+
+## Live-Coding Pain Point
+
+In live coding / algorave scenarios, performers edit code while audio is running. Today:
+
+- Adding a new array or variable to any earlier module changes the global memory layout.
+- The runtime must treat the program as structurally different and rebuild/reinitialise memory.
+- This can glitch audio or reset generative state, breaking the musical flow.
+
+We want a way for coders to make small, local changes (like adding a new variable) without forcing a global memory reset, as long as they stay within some pre-declared budget.
+
+## Goal: Per-Module Memory Sandboxes
+
+High-level objective:
+
+- Give each module its own “sandbox” area in memory where it can freely grow and shrink (within a budget) without disturbing others.
+- As long as a module’s total memory usage stays within its pre-allocated sandbox:
+  - Its own base address and size remain stable.
+  - The base addresses of all following modules remain stable.
+  - The runtime can reload code without resetting or shuffling the existing memory contents, preserving audio buffers and state.
+- If a module exceeds its sandbox:
+  - The system gracefully falls back to the current behaviour: modules are repacked and memory is reinitialised, which may cause an audible hiccup.
+  - This “overflow” should be rare and intentional, not the default live-coding path.
+
+## Planned Mechanism: `allocate` Instruction (Soft Sandbox)
+
+Introduce a new module-level instruction:
+
+- Syntax (proposed):
+  - `allocate N`
+  - `N` is a number of **words** to reserve for this module.
+- Semantics:
+  - The compiler still computes the actual required size of each module (`actualWordSize`) by summing its declared data structures (current behaviour).
+  - Each module may also specify a minimum reserved size (`reservedWordSize`) via `allocate N`.
+  - The effective “slot size” for the module becomes:
+    - `slotWordSize = max(actualWordSize, reservedWordSize)`.
+  - The module’s `wordAlignedSize` (which drives global layout) is set to `slotWordSize`.
+- Behaviour:
+  - If `actualWordSize <= reservedWordSize`:
+    - The module uses at most the reserved space.
+    - Its slot size is fixed at `reservedWordSize`, regardless of small changes in declarations.
+    - Later modules’ base addresses remain unchanged — the layout is stable and safe for live hot-swapping.
+  - If `actualWordSize > reservedWordSize`:
+    - The hint is exceeded; the module needs more space than its sandbox.
+    - We set `slotWordSize = actualWordSize` (no error) and repack modules exactly as today.
+    - The global layout may shift, and a full memory rebuild is acceptable in this “overflow” case.
+
+### Compiler Integration
+
+- `allocate` instruction:
+  - Parsed like other instructions, recognised in `instructionCompilers`.
+  - Emits no WASM code; it only records metadata, e.g. `context.namespace.minAllocatedWords`.
+- `compileModule`:
+  - After building `memoryMap` and computing `actualWordSize` via `calculateWordAlignedSizeOfMemory`:
+    - Read `minAllocatedWords` from the namespace, defaulting to `0`.
+    - Compute `slotWordSize = Math.max(actualWordSize, minAllocatedWords)`.
+  - Set `module.wordAlignedSize = slotWordSize`.
+  - Internal `DataStructure.byteAddress` / `wordAlignedAddress` remain contiguous within the module; the reserved slack is simply unused trailing space.
+- `compileModules`:
+  - Continues to use `module.wordAlignedSize` to advance the global `memoryAddress` as today.
+  - With `allocate` in place, `wordAlignedSize` may be larger than strictly necessary, effectively creating per-module “sandboxes”.
+- `allocatedMemorySize`:
+  - Still computed as “start of last module + its `wordAlignedSize`”, now including reserved slack.
+
+## Runtime Behaviour and Live Coding
+
+After each compile, we can compare:
+
+- The previous `compiledModules` layout (per-module `byteAddress`, `wordAlignedAddress`, `wordAlignedSize`).
+- The new layout produced with `allocate`.
+
+If all modules’ base addresses and slot sizes are unchanged:
+
+- The recompile is **layout-compatible**.
+- The runtime can:
+  - Reuse the existing `WebAssembly.Memory` instance.
+  - Swap out the code buffer and optionally re-run only necessary init code.
+  - Preserve existing memory content, keeping audio buffers and state intact (no glitch).
+
+If any module’s base address or `wordAlignedSize` changed:
+
+- The recompile is **layout-incompatible**.
+- The runtime falls back to the current behaviour:
+  - Rebuild and reinitialise memory.
+  - A one-off audio hiccup is acceptable in this overflow case.
+
+For performers:
+
+- Use `allocate N` per module to reserve enough space for the variables/arrays you expect to add live.
+- As long as you stay within that budget:
+  - You can add/remove declarations without interrupting generative music playback.
+- If you overflow the budget:
+  - The compiler still works, but the change may cause a one-off glitch as memory is rebuilt — similar to the current behaviour.
+

--- a/packages/compiler-worker/src/compileAndUpdateMemory.ts
+++ b/packages/compiler-worker/src/compileAndUpdateMemory.ts
@@ -2,10 +2,6 @@ import compile, { CompileOptions, CompiledModuleLookup, Module } from '@8f4e/com
 
 let previousCompiledModules: CompiledModuleLookup | undefined;
 
-export function resetCompiledModulesCache(): void {
-	previousCompiledModules = undefined;
-}
-
 function compareObject(obj1: Record<string, number>, obj2: Record<string, number>): boolean {
 	const keys1 = Object.keys(obj1);
 	const keys2 = Object.keys(obj2);
@@ -129,7 +125,7 @@ export function getOrCreateMemory(memorySizeBytes: number): WebAssembly.Memory {
 	return memoryRefCache;
 }
 
-export default async function testBuild(
+export default async function compileAndUpdateMemory(
 	modules: Module[],
 	compilerOptions: CompileOptions
 ): Promise<{

--- a/packages/compiler-worker/src/index.ts
+++ b/packages/compiler-worker/src/index.ts
@@ -2,19 +2,19 @@ import { CompileOptions, Module } from '@8f4e/compiler';
 
 import testBuild, { resetCompiledModulesCache } from './testBuild';
 
-async function recompile(memoryRef: WebAssembly.Memory, modules: Module[], compilerOptions: CompileOptions) {
+async function recompile(modules: Module[], compilerOptions: CompileOptions) {
 	try {
-		const { codeBuffer, compiledModules, allocatedMemorySize } = await testBuild(memoryRef, modules, compilerOptions);
+		const { codeBuffer, compiledModules, allocatedMemorySize, memoryRef } = await testBuild(modules, compilerOptions);
 		self.postMessage({
 			type: 'buildOk',
 			payload: {
 				codeBuffer,
 				compiledModules,
 				allocatedMemorySize,
+				wasmMemory: memoryRef,
 			},
 		});
 	} catch (error) {
-		console.log('testBuildError', error);
 		self.postMessage({
 			type: 'buildError',
 			payload: error,
@@ -25,7 +25,7 @@ async function recompile(memoryRef: WebAssembly.Memory, modules: Module[], compi
 self.onmessage = function (event) {
 	switch (event.data.type) {
 		case 'recompile':
-			recompile(event.data.payload.memoryRef, event.data.payload.modules, event.data.payload.compilerOptions);
+			recompile(event.data.payload.modules, event.data.payload.compilerOptions);
 			break;
 		case 'reset':
 			resetCompiledModulesCache();

--- a/packages/compiler-worker/src/index.ts
+++ b/packages/compiler-worker/src/index.ts
@@ -1,12 +1,15 @@
 import { CompileOptions, Module } from '@8f4e/compiler';
 
-import testBuild, { resetCompiledModulesCache } from './testBuild';
+import compileAndUpdateMemory from './compileAndUpdateMemory';
 
-async function recompile(modules: Module[], compilerOptions: CompileOptions) {
+async function compile(modules: Module[], compilerOptions: CompileOptions) {
 	try {
-		const { codeBuffer, compiledModules, allocatedMemorySize, memoryRef } = await testBuild(modules, compilerOptions);
+		const { codeBuffer, compiledModules, allocatedMemorySize, memoryRef } = await compileAndUpdateMemory(
+			modules,
+			compilerOptions
+		);
 		self.postMessage({
-			type: 'buildOk',
+			type: 'success',
 			payload: {
 				codeBuffer,
 				compiledModules,
@@ -16,7 +19,7 @@ async function recompile(modules: Module[], compilerOptions: CompileOptions) {
 		});
 	} catch (error) {
 		self.postMessage({
-			type: 'buildError',
+			type: 'compilationError',
 			payload: error,
 		});
 	}
@@ -24,11 +27,8 @@ async function recompile(modules: Module[], compilerOptions: CompileOptions) {
 
 self.onmessage = function (event) {
 	switch (event.data.type) {
-		case 'recompile':
-			recompile(event.data.payload.modules, event.data.payload.compilerOptions);
-			break;
-		case 'reset':
-			resetCompiledModulesCache();
+		case 'compile':
+			compile(event.data.payload.modules, event.data.payload.compilerOptions);
 			break;
 	}
 };

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/errorMessages/errorMessages.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/errorMessages/errorMessages.test.ts
@@ -24,7 +24,7 @@ describe('errorMessages', () => {
 				},
 			},
 			compiler: {
-				buildErrors: [
+				compilationErrors: [
 					{
 						moduleId: 'test-block',
 						lineNumber: 2,
@@ -52,7 +52,7 @@ describe('errorMessages', () => {
 	});
 
 	it('should handle multiple error messages', () => {
-		mockState.compiler.buildErrors = [
+		mockState.compiler.compilationErrors = [
 			{
 				moduleId: 'test-block',
 				lineNumber: 1,
@@ -74,7 +74,7 @@ describe('errorMessages', () => {
 	});
 
 	it('should ignore errors from different modules', () => {
-		mockState.compiler.buildErrors = [
+		mockState.compiler.compilationErrors = [
 			{
 				moduleId: 'test-block',
 				lineNumber: 1,
@@ -109,7 +109,7 @@ describe('errorMessages', () => {
 	});
 
 	it('should handle empty build errors', () => {
-		mockState.compiler.buildErrors = [];
+		mockState.compiler.compilationErrors = [];
 
 		errorMessages(mockGraphicData, mockState);
 
@@ -118,7 +118,7 @@ describe('errorMessages', () => {
 
 	it('should position errors correctly with gaps', () => {
 		mockGraphicData.gaps = new Map([[1, { size: 1 }]]); // Gap at line 1
-		mockState.compiler.buildErrors = [
+		mockState.compiler.compilationErrors = [
 			{
 				moduleId: 'test-block',
 				lineNumber: 2,

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/errorMessages/errorMessages.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockDecorators/errorMessages/errorMessages.ts
@@ -4,15 +4,15 @@ import type { CodeBlockGraphicData, State } from '../../../../types';
 
 export default function errorMessages(graphicData: CodeBlockGraphicData, state: State) {
 	graphicData.extras.errorMessages = [];
-	state.compiler.buildErrors.forEach(buildError => {
-		if (buildError.moduleId !== graphicData.id) {
+	state.compiler.compilationErrors.forEach(compilationError => {
+		if (compilationError.moduleId !== graphicData.id) {
 			return;
 		}
 		graphicData.extras.errorMessages.push({
 			x: 0,
-			y: (gapCalculator(buildError.lineNumber, graphicData.gaps) + 1) * state.graphicHelper.viewport.hGrid,
-			message: ['Error:', buildError.message],
-			lineNumber: buildError.lineNumber,
+			y: (gapCalculator(compilationError.lineNumber, graphicData.gaps) + 1) * state.graphicHelper.viewport.hGrid,
+			message: ['Error:', compilationError.message],
+			lineNumber: compilationError.lineNumber,
 		});
 	});
 }

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/gaps.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/gaps.ts
@@ -4,11 +4,11 @@ import type { CodeBlockGraphicData, State } from '../../types';
 
 export default function gaps(graphicData: CodeBlockGraphicData, state: State) {
 	graphicData.gaps.clear();
-	state.compiler.buildErrors.forEach(buildError => {
-		if (buildError.moduleId !== graphicData.id) {
+	state.compiler.compilationErrors.forEach(compilationError => {
+		if (compilationError.moduleId !== graphicData.id) {
 			return;
 		}
-		graphicData.gaps.set(buildError.lineNumber, { size: 2 });
+		graphicData.gaps.set(compilationError.lineNumber, { size: 2 });
 	});
 
 	graphicData.code.forEach((line, lineNumber) => {

--- a/packages/editor/packages/editor-state/src/effects/codeBlocks/graphicHelper.ts
+++ b/packages/editor/packages/editor-state/src/effects/codeBlocks/graphicHelper.ts
@@ -170,7 +170,7 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 		updateGraphics(state.graphicHelper.selectedCodeBlock);
 	};
 
-	events.on('buildError', updateGraphicsAll);
+	events.on('compilationError', updateGraphicsAll);
 	events.on<CodeBlockClickEvent>('codeBlockClick', onCodeBlockClick);
 	events.on<CodeBlockClickEvent>('codeBlockClick', ({ codeBlock }) => updateGraphics(codeBlock));
 	events.on('runtimeInitialized', updateGraphicsAll);

--- a/packages/editor/packages/editor-state/src/effects/compiler.ts
+++ b/packages/editor/packages/editor-state/src/effects/compiler.ts
@@ -22,7 +22,7 @@ export default async function compiler(store: StateManager<State>, events: Event
 		if (state.compiler.codeBuffer.length > 0 && !state.callbacks.compileProject) {
 			console.log('[Compiler] Using pre-compiled WASM from runtime-ready project');
 			state.compiler.isCompiling = false;
-			state.compiler.buildErrors = [];
+			state.compiler.compilationErrors = [];
 			events.dispatch('buildFinished');
 			return;
 		}
@@ -66,7 +66,7 @@ export default async function compiler(store: StateManager<State>, events: Event
 			state.compiler.isCompiling = false;
 			state.compiler.compilationTime = performance.now() - state.compiler.lastCompilationStart;
 
-			state.compiler.buildErrors = [];
+			state.compiler.compilationErrors = [];
 
 			events.dispatch('loadBinaryFilesIntoMemory');
 			events.dispatch('buildFinished');
@@ -78,7 +78,7 @@ export default async function compiler(store: StateManager<State>, events: Event
 				context?: { namespace?: { moduleName: string } };
 				errorCode?: number;
 			};
-			state.compiler.buildErrors = [
+			state.compiler.compilationErrors = [
 				{
 					lineNumber: errorObject?.line?.lineNumber || 1,
 					moduleId: errorObject?.context?.namespace?.moduleName || '',
@@ -86,7 +86,7 @@ export default async function compiler(store: StateManager<State>, events: Event
 					message: errorObject?.message || error?.toString() || 'Compilation failed',
 				},
 			];
-			events.dispatch('buildError');
+			events.dispatch('compilationError');
 		}
 	}
 

--- a/packages/editor/packages/editor-state/src/effects/projectImport.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/projectImport.test.ts
@@ -138,12 +138,12 @@ describe('projectImport', () => {
 			const loadProjectCallback = loadProjectCall![1];
 
 			// Set some existing state
-			mockState.compiler.buildErrors = [{ message: 'Error', line: 1, column: 1 }];
+			mockState.compiler.compilationErrors = [{ message: 'Error', line: 1, column: 1 }];
 			mockState.compiler.isCompiling = true;
 
 			loadProjectCallback({ project: EMPTY_DEFAULT_PROJECT });
 
-			expect(mockState.compiler.buildErrors).toEqual([]);
+			expect(mockState.compiler.compilationErrors).toEqual([]);
 			expect(mockState.compiler.isCompiling).toBe(false);
 			expect(mockState.compiler.codeBuffer).toEqual(new Uint8Array());
 		});

--- a/packages/editor/packages/editor-state/src/effects/projectImport.ts
+++ b/packages/editor/packages/editor-state/src/effects/projectImport.ts
@@ -51,7 +51,7 @@ export default function projectImport(store: StateManager<State>, events: EventD
 		state.compiler.codeBuffer = new Uint8Array();
 		state.compiler.compiledModules = {};
 		state.compiler.allocatedMemorySize = 0;
-		state.compiler.buildErrors = [];
+		state.compiler.compilationErrors = [];
 		state.compiler.isCompiling = false;
 
 		// Populate new state locations

--- a/packages/editor/packages/editor-state/src/effects/runtimeReadyProject.test.ts
+++ b/packages/editor/packages/editor-state/src/effects/runtimeReadyProject.test.ts
@@ -210,16 +210,16 @@ describe('Runtime-ready project functionality', () => {
 
 			// Get the onRecompile callback
 			const onCalls = (mockEvents.on as unknown as MockInstance).mock.calls;
-			const recompileCall = onCalls.find(
+			const compileCall = onCalls.find(
 				call =>
 					call[0] === 'createConnection' ||
 					call[0] === 'codeBlockAdded' ||
 					call[0] === 'deleteCodeBlock' ||
 					call[0] === 'projectLoaded'
 			);
-			expect(recompileCall).toBeDefined();
+			expect(compileCall).toBeDefined();
 
-			const onRecompileCallback = recompileCall![1];
+			const onRecompileCallback = compileCall![1];
 
 			// Trigger recompilation
 			await onRecompileCallback();
@@ -235,7 +235,7 @@ describe('Runtime-ready project functionality', () => {
 			expect(mockState.compiler.memoryBuffer).toEqual(expectedIntMemory);
 			expect(mockState.compiler.memoryBufferFloat).toEqual(expectedFloatMemory);
 			expect(mockState.compiler.isCompiling).toBe(false);
-			expect(mockState.compiler.buildErrors).toEqual([]);
+			expect(mockState.compiler.compilationErrors).toEqual([]);
 			expect(mockState.compiler.compilationTime).toBe(0);
 
 			consoleSpy.mockRestore();
@@ -258,14 +258,14 @@ describe('Runtime-ready project functionality', () => {
 
 			// Get the onRecompile callback
 			const onCalls = (mockEvents.on as unknown as MockInstance).mock.calls;
-			const recompileCall = onCalls.find(
+			const compileCall = onCalls.find(
 				call =>
 					call[0] === 'createConnection' ||
 					call[0] === 'codeBlockAdded' ||
 					call[0] === 'deleteCodeBlock' ||
 					call[0] === 'projectLoaded'
 			);
-			const onRecompileCallback = recompileCall![1];
+			const onRecompileCallback = compileCall![1];
 
 			// Trigger recompilation
 			await onRecompileCallback();

--- a/packages/editor/packages/editor-state/src/helpers/testUtils.ts
+++ b/packages/editor/packages/editor-state/src/helpers/testUtils.ts
@@ -204,7 +204,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 		compiler: {
 			codeBuffer: new Uint8Array(0),
 			isCompiling: false,
-			buildErrors: [],
+			compilationErrors: [],
 			compilationTime: 0,
 			lastCompilationStart: 0,
 			allocatedMemorySize: 0,

--- a/packages/editor/packages/editor-state/src/index.ts
+++ b/packages/editor/packages/editor-state/src/index.ts
@@ -89,7 +89,7 @@ function createDefaultState() {
 			memoryBufferFloat: new Float32Array(),
 			timerAccuracy: 0,
 			compiledModules: {},
-			buildErrors: [],
+			compilationErrors: [],
 			compilerOptions: {
 				memorySizeBytes,
 				startingMemoryWordAddress: 0,
@@ -185,7 +185,7 @@ export type {
 	Position,
 	ContextMenuItem,
 	MenuGenerator,
-	BuildError,
+	CompilationError,
 	Compiler,
 	Midi,
 	GraphicHelper,

--- a/packages/editor/packages/editor-state/src/types.ts
+++ b/packages/editor/packages/editor-state/src/types.ts
@@ -147,7 +147,7 @@ export interface ContextMenu extends Position {
 	menuStack: string[];
 }
 
-export interface BuildError {
+export interface CompilationError {
 	lineNumber: number;
 	code: number;
 	message: string;
@@ -164,7 +164,7 @@ export interface Compiler {
 	memoryBufferFloat: Float32Array;
 	timerAccuracy: number;
 	compiledModules: CompiledModuleLookup;
-	buildErrors: BuildError[];
+	compilationErrors: CompilationError[];
 	compilerOptions: CompileOptions;
 	allocatedMemorySize: number;
 	runtimeSettings: Runtimes[];

--- a/packages/runtime-main-thread-logic/src/index.ts
+++ b/packages/runtime-main-thread-logic/src/index.ts
@@ -51,7 +51,7 @@ export default function createMainThreadLogicRuntime(
 			isRunning = true;
 			onInitialized();
 		} catch (error) {
-			console.log('buildError', error);
+			console.log('compilationError', error);
 			onError(error);
 		}
 	}

--- a/packages/runtime-web-worker-logic/src/index.ts
+++ b/packages/runtime-web-worker-logic/src/index.ts
@@ -39,9 +39,9 @@ async function init(memoryRef: WebAssembly.Memory, sampleRate: number, codeBuffe
 			payload: {},
 		});
 	} catch (error) {
-		console.log('buildError', error);
+		console.log('compilationError', error);
 		self.postMessage({
-			type: 'buildError',
+			type: 'compilationError',
 			payload: error,
 		});
 	}

--- a/packages/runtime-web-worker-midi/src/index.ts
+++ b/packages/runtime-web-worker-midi/src/index.ts
@@ -65,9 +65,9 @@ async function init(
 			payload: {},
 		});
 	} catch (error) {
-		console.log('buildError', error);
+		console.log('compilationError', error);
 		self.postMessage({
-			type: 'buildError',
+			type: 'compilationError',
 			payload: error,
 		});
 	}

--- a/src/compiler-callback.ts
+++ b/src/compiler-callback.ts
@@ -12,7 +12,7 @@ export async function compileProject(modules: Module[], compilerOptions: Compile
 	return new Promise((resolve, reject) => {
 		const handleMessage = ({ data }: MessageEvent) => {
 			switch (data.type) {
-				case 'buildOk':
+				case 'success':
 					memoryRef = data.payload.wasmMemory;
 					resolve({
 						compiledModules: data.payload.compiledModules,
@@ -22,7 +22,7 @@ export async function compileProject(modules: Module[], compilerOptions: Compile
 						memoryBufferFloat: new Float32Array(data.payload.wasmMemory.buffer),
 					});
 					break;
-				case 'buildError': {
+				case 'compilationError': {
 					// Create an error object that matches the expected structure
 					const error = new Error(data.payload.message) as Error & {
 						line?: { lineNumber: number };
@@ -42,7 +42,7 @@ export async function compileProject(modules: Module[], compilerOptions: Compile
 		compilerWorker.addEventListener('message', handleMessage, { once: true });
 
 		compilerWorker.postMessage({
-			type: 'recompile',
+			type: 'compile',
 			payload: {
 				modules,
 				compilerOptions,

--- a/src/compiler-callback.ts
+++ b/src/compiler-callback.ts
@@ -6,44 +6,20 @@ import CompilerWorker from '@8f4e/compiler-worker?worker';
 // it will live for the entire application lifecycle
 const compilerWorker = new CompilerWorker();
 
-// Create WebAssembly memory for compilation
-// This memory is shared with the compiler worker and runtimes
 let memoryRef: WebAssembly.Memory | null = null;
-let currentMemorySize = 0;
-
-export function getOrCreateMemory(memorySizeBytes: number): WebAssembly.Memory {
-	const WASM_PAGE_SIZE = 65536; // 64KiB per page
-	const pages = Math.ceil(memorySizeBytes / WASM_PAGE_SIZE);
-
-	// Create new memory only if it doesn't exist or if the size differs
-	// We must recreate when size changes (even when shrinking) because the WASM module's
-	// declared maximum must match the memory's maximum exactly
-	if (!memoryRef || currentMemorySize !== memorySizeBytes) {
-		memoryRef = new WebAssembly.Memory({
-			initial: pages,
-			maximum: pages,
-			shared: true,
-		});
-		currentMemorySize = memorySizeBytes;
-	}
-
-	return memoryRef;
-}
 
 export async function compileProject(modules: Module[], compilerOptions: CompileOptions): Promise<CompilationResult> {
-	// Create or reuse memory
-	const memory = getOrCreateMemory(compilerOptions.memorySizeBytes);
-
 	return new Promise((resolve, reject) => {
 		const handleMessage = ({ data }: MessageEvent) => {
 			switch (data.type) {
 				case 'buildOk':
+					memoryRef = data.payload.wasmMemory;
 					resolve({
 						compiledModules: data.payload.compiledModules,
 						codeBuffer: data.payload.codeBuffer,
 						allocatedMemorySize: data.payload.allocatedMemorySize,
-						memoryBuffer: new Int32Array(memory.buffer),
-						memoryBufferFloat: new Float32Array(memory.buffer),
+						memoryBuffer: new Int32Array(data.payload.wasmMemory.buffer),
+						memoryBufferFloat: new Float32Array(data.payload.wasmMemory.buffer),
 					});
 					break;
 				case 'buildError': {
@@ -68,7 +44,6 @@ export async function compileProject(modules: Module[], compilerOptions: Compile
 		compilerWorker.postMessage({
 			type: 'recompile',
 			payload: {
-				memoryRef: memory,
 				modules,
 				compilerOptions,
 			},


### PR DESCRIPTION
This PR refactors WebAssembly memory management by moving memory creation and lifecycle handling from the main thread into the compiler worker. The worker now owns the memory instance and returns it as part of the compilation result, eliminating the need to pass memory references between threads.