### PR TITLE
Add config schema

### DIFF
--- a/docs/todos/156-add-glsl-shader-code-blocks.md
+++ b/docs/todos/156-add-glsl-shader-code-blocks.md
@@ -1,0 +1,103 @@
+---
+title: 'TODO: Add GLSL Shader Code Blocks for Post-Process Effects'
+priority: Medium
+effort: 2-4d
+created: 2026-01-02
+status: Open
+completed: null
+---
+
+# TODO: Add GLSL Shader Code Blocks for Post-Process Effects
+
+## Problem Description
+
+Post-process shaders are currently defined via `postProcessEffects` on the project data model. This makes shader edits disconnected from the editor's code block workflows, prevents shader code from living alongside other project code, and keeps shader edits out of the standard code block tooling (creation, editing, highlighting, error reporting).
+
+## Proposed Solution
+
+Introduce two new code block types for shader sources:
+- `vertexShader <id>` ... `vertexShaderEnd`
+- `fragmentShader <id>` ... `fragmentShaderEnd`
+
+Shader blocks become the sole source of `postProcessEffects`. The editor derives `postProcessEffects` by pairing vertex and fragment blocks with the same `<id>`. On duplicate IDs, the last block in creation order wins. Paired effects default to `enabled: true`.
+
+## Implementation Plan
+
+### Step 1: Extend block-type detection and types
+- Update `packages/compiler/src/syntax/getBlockType.ts` to recognize `vertexShader` and `fragmentShader` marker pairs.
+- Extend `CodeBlockType` unions in compiler syntax and editor-state types.
+- Add in-source tests for new block types and mixed-marker cases.
+
+### Step 2: Add editor creation + menu entries
+- Update `packages/editor/packages/editor-state/src/effects/menu/menus.ts` to add “New Vertex Shader” and “New Fragment Shader”.
+- Update `packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockCreator.ts` to seed new shader blocks with markers and unique IDs.
+- Add ID parsing helpers for shader blocks (similar to `getModuleId` / `getFunctionId`).
+
+### Step 3: Update rendering and highlighting
+- Add shader markers to `instructionsToHighlight` in `packages/editor/packages/editor-state/src/effects/codeBlocks/graphicHelper.ts`.
+- Decide whether to add GLSL keyword highlighting (optional but improves readability).
+- Update context menu labels so shader blocks are not labeled as module/function.
+
+### Step 4: Derive post-process effects from shader blocks
+- Add helpers to collect shader blocks and extract bodies between markers.
+- Build `postProcessEffects` by pairing blocks with the same ID using last-wins resolution.
+- Default `enabled: true` for paired effects.
+- Surface errors for missing pairs via `codeErrors`.
+- Recompute shader effects when shader block code changes and dispatch `loadPostProcessEffects`.
+
+### Step 5: Update project import/export and examples
+- Remove or ignore `postProcessEffects` as a persisted project field.
+- Rebuild shader effects from code blocks on project load and code edits.
+- Update example projects (e.g., CRT effect) to use shader code blocks instead of `postProcessEffects`.
+- Add tests for pairing, last-wins behavior, and serialization round-trips.
+
+## Success Criteria
+
+- [ ] Shader blocks are recognized by `getBlockType` and editor-state.
+- [ ] Users can create vertex/fragment shader blocks from the UI.
+- [ ] `postProcessEffects` is derived solely from shader blocks with last-wins resolution.
+- [ ] Example projects render correctly with shader blocks and without `postProcessEffects` fields.
+- [ ] Tests cover pairing, missing pairs, and block extraction.
+
+## Affected Components
+
+- `packages/compiler/src/syntax/getBlockType.ts` - Block type detection for shaders
+- `packages/compiler/src/syntax/index.ts` - Export updated types
+- `packages/editor/packages/editor-state/src/types.ts` - Extend `CodeBlockType`
+- `packages/editor/packages/editor-state/src/effects/codeBlocks/codeBlockCreator.ts` - Shader block creation and ID handling
+- `packages/editor/packages/editor-state/src/effects/menu/menus.ts` - New shader block menu items
+- `packages/editor/packages/editor-state/src/effects/codeBlocks/graphicHelper.ts` - Highlight shader markers/keywords
+- `packages/editor/packages/editor-state/src/effects/projectImport.ts` - Recompute shader effects on load
+- `packages/editor/packages/editor-state/src/pureHelpers/projectSerializing/serializeToProject.ts` - Remove `postProcessEffects` persistence
+- `src/examples/projects/crtEffect.ts` - Example shader block usage
+
+## Risks & Considerations
+
+- **Pairing errors**: Missing vertex/fragment pairs could lead to silent failures; ensure errors are surfaced in editor UI.
+- **Breaking change**: Removing `postProcessEffects` from project schema may break older saved projects unless migration is handled.
+- **Duplicate IDs**: Last-wins behavior could surprise users; ensure predictable ordering and messaging.
+- **Shader compilation**: Invalid GLSL should surface clear errors when compiling effects.
+
+## Related Items
+
+- **Related**: `docs/todos/archived/054-make-post-process-shaders-project-scoped.md`
+
+## References
+
+- `src/examples/projects/crtEffect.ts`
+- `packages/editor/packages/glugglug/README.md`
+
+## Notes
+
+- Pairing rule: matching `<id>` in `vertexShader` and `fragmentShader` markers.
+- Resolution rule: when duplicates exist, use the last block by creation order.
+- Post-process effects are derived from code blocks only; project fields should not store shader strings.
+
+## Archive Instructions
+
+When this TODO is completed:
+1. Update the front matter to set `status: Completed` and provide the `completed` date
+2. Move it to the `todo/archived/` folder to keep the main todo directory clean and organized
+3. Update the `todo/_index.md` file to:
+   - Move the TODO from the "Active TODOs" section to the "Completed TODOs" section
+   - Add the completion date to the TODO entry (use `date +%Y-%m-%d` command if current date is not provided in the context) 

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -30,6 +30,7 @@ This document provides a comprehensive index of all TODO items in the 8f4e proje
 | 153 | Add Constants Code Blocks to Compiler | 🟡 | 1-2d | 2025-12-30 | Add named `constants` / `constantsEnd` blocks to define shared constants namespaces consumed via `use` |
 | 154 | Split compiler utils and use syntax helpers | 🟡 | 1-2d | 2025-12-30 | Split `packages/compiler/src/utils.ts` into per-function modules with in-source tests and replace syntax checks with syntax helpers |
 | 155 | Add Framebuffer Memory Accounting in glugglug | 🟡 | 2-4h | 2025-12-30 | Track estimated render target and cache framebuffer memory usage for debugging and profiling |
+| 156 | Add GLSL Shader Code Blocks for Post-Process Effects | 🟡 | 2-4d | 2026-01-02 | Replace project `postProcessEffects` with vertex/fragment shader code blocks and derive effects from block pairs |
 | 002 | Enable Strict TypeScript in Editor Package | 🟡 | 2-3d | 2025-08-23 | Currently has 52 type errors when strict settings enabled, causing missing null checks and implicit any types that reduce type safety and developer experience |
 | 025 | Separate Editor View Layer into Standalone Package | 🟡 | 3-5d | 2025-08-26 | Extract Canvas-based rendering and sprite management into `@8f4e/browser-view` package to make core editor a pure state machine compatible with any renderer |
 | 026 | Separate Editor User Interactions into Standalone Package | 🟡 | 2-3d | 2025-08-26 | Extract DOM event handling and input logic into `@8f4e/browser-input` package to enable alternative input systems (touch, joystick, terminal) |

--- a/packages/editor/packages/editor-state/src/configSchema.ts
+++ b/packages/editor/packages/editor-state/src/configSchema.ts
@@ -8,7 +8,88 @@ const runtimeSettingsSchema: ConfigSchema = {
 			enum: ['WebWorkerLogicRuntime', 'MainThreadLogicRuntime', 'AudioWorkletRuntime', 'WebWorkerMIDIRuntime'],
 		},
 		sampleRate: { type: 'number' },
+		audioInputBuffers: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					memoryId: { type: 'string' },
+					channel: { type: 'number' },
+					input: { type: 'number' },
+				},
+				additionalProperties: false,
+			},
+		},
+		audioOutputBuffers: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					memoryId: { type: 'string' },
+					channel: { type: 'number' },
+					output: { type: 'number' },
+				},
+				additionalProperties: false,
+			},
+		},
+		midiNoteOutputs: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					moduleId: { type: 'string' },
+					channelMemoryId: { type: 'string' },
+					portMemoryId: { type: 'string' },
+					velocityMemoryId: { type: 'string' },
+					noteOnOffMemoryId: { type: 'string' },
+					noteMemoryId: { type: 'string' },
+				},
+				additionalProperties: false,
+			},
+		},
+		midiNoteInputs: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					moduleId: { type: 'string' },
+					channelMemoryId: { type: 'string' },
+					portMemoryId: { type: 'string' },
+					velocityMemoryId: { type: 'string' },
+					noteOnOffMemoryId: { type: 'string' },
+					noteMemoryId: { type: 'string' },
+				},
+				additionalProperties: false,
+			},
+		},
+		midiControlChangeOutputs: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					moduleId: { type: 'string' },
+					channelMemoryId: { type: 'string' },
+					selectedCCMemoryId: { type: 'string' },
+					valueMemoryId: { type: 'string' },
+				},
+				additionalProperties: false,
+			},
+		},
+		midiControlChangeInputs: {
+			type: 'array',
+			items: {
+				type: 'object',
+				properties: {
+					moduleId: { type: 'string' },
+					channelMemoryId: { type: 'string' },
+					selectedCCMemoryId: { type: 'string' },
+					valueMemoryId: { type: 'string' },
+				},
+				additionalProperties: false,
+			},
+		},
 	},
+	additionalProperties: false,
 };
 
 const configSchema: ConfigSchema = {
@@ -24,6 +105,7 @@ const configSchema: ConfigSchema = {
 			items: runtimeSettingsSchema,
 		},
 	},
+	additionalProperties: false,
 };
 
 export default configSchema;

--- a/packages/editor/packages/editor-state/src/configSchema.ts
+++ b/packages/editor/packages/editor-state/src/configSchema.ts
@@ -1,0 +1,29 @@
+import type { ConfigSchema } from './types';
+
+const runtimeSettingsSchema: ConfigSchema = {
+	type: 'object',
+	properties: {
+		runtime: {
+			type: 'string',
+			enum: ['WebWorkerLogicRuntime', 'MainThreadLogicRuntime', 'AudioWorkletRuntime', 'WebWorkerMIDIRuntime'],
+		},
+		sampleRate: { type: 'number' },
+	},
+};
+
+const configSchema: ConfigSchema = {
+	type: 'object',
+	properties: {
+		title: { type: 'string' },
+		author: { type: 'string' },
+		description: { type: 'string' },
+		memorySizeBytes: { type: 'number' },
+		selectedRuntime: { type: 'number' },
+		runtimeSettings: {
+			type: 'array',
+			items: runtimeSettingsSchema,
+		},
+	},
+};
+
+export default configSchema;

--- a/packages/editor/packages/editor-state/src/effects/config.ts
+++ b/packages/editor/packages/editor-state/src/effects/config.ts
@@ -5,6 +5,7 @@ import { applyConfigToState } from '../impureHelpers/config/applyConfigToState';
 import isPlainObject from '../pureHelpers/isPlainObject';
 import deepMergeConfig from '../pureHelpers/config/deepMergeConfig';
 import { collectConfigBlocks, ConfigBlockSource } from '../pureHelpers/config/collectConfigBlocks';
+import configSchema from '../configSchema';
 
 import type { ConfigObject } from '../impureHelpers/config/applyConfigToState';
 import type { CodeError, EventDispatcher, State } from '../types';
@@ -25,7 +26,7 @@ async function buildConfigFromBlocks(
 
 	for (const { block, source } of configBlocks) {
 		try {
-			const result = await compileConfig(source);
+			const result = await compileConfig(source, configSchema);
 
 			if (result.errors.length > 0) {
 				const blockErrors: CodeError[] = result.errors.map(error => ({

--- a/packages/editor/packages/editor-state/src/index.ts
+++ b/packages/editor/packages/editor-state/src/index.ts
@@ -83,6 +83,7 @@ export type {
 	Options,
 	EditorSettings,
 	CompilationResult,
+	ConfigSchema,
 	ConfigCompilationResult,
 	CodeBlock,
 	Viewport,

--- a/packages/editor/packages/editor-state/src/types.ts
+++ b/packages/editor/packages/editor-state/src/types.ts
@@ -563,9 +563,27 @@ export interface Callbacks {
 	 * Used by config blocks to generate runtime configuration.
 	 *
 	 * @param source - The config program source code (one command per line)
+	 * @param schema - JSON Schema describing the expected config structure
 	 * @returns Promise containing the compiled config object and any errors
 	 */
-	compileConfig?: (source: string) => Promise<ConfigCompilationResult>;
+	compileConfig?: (source: string, schema: ConfigSchema) => Promise<ConfigCompilationResult>;
+}
+
+/**
+ * Supported primitive types in config schema subset
+ */
+export type ConfigSchemaType = 'string' | 'number' | 'boolean' | 'null' | 'object' | 'array';
+
+/**
+ * A subset of JSON Schema used for config validation
+ */
+export interface ConfigSchema {
+	type?: ConfigSchemaType | ConfigSchemaType[];
+	enum?: readonly (string | number | boolean | null)[];
+	properties?: Record<string, ConfigSchema>;
+	required?: readonly string[];
+	items?: ConfigSchema;
+	additionalProperties?: boolean | ConfigSchema;
 }
 
 /**

--- a/src/config-callback.ts
+++ b/src/config-callback.ts
@@ -1,14 +1,15 @@
 import { compileConfig as compileStackConfig } from '@8f4e/stack-config-compiler';
 
-import type { ConfigCompilationResult } from '@8f4e/editor-state';
+import type { ConfigCompilationResult, ConfigSchema } from '@8f4e/editor-state';
 
 /**
  * Compiles a stack-config program source into a JSON configuration object.
  * This is a wrapper around the @8f4e/stack-config-compiler package.
  *
  * @param source - The config program source code (one command per line)
+ * @param schema - JSON Schema describing the expected config structure
  * @returns Promise containing the compiled config object and any errors
  */
-export default async function compileConfig(source: string): Promise<ConfigCompilationResult> {
-	return compileStackConfig(source);
+export default async function compileConfig(source: string, schema: ConfigSchema): Promise<ConfigCompilationResult> {
+	return compileStackConfig(source, { schema });
 }


### PR DESCRIPTION
This PR introduces a configuration schema validation system by adding a ConfigSchema type and passing it to the compileConfig function. This enables type-safe validation of configuration objects during compilation.

Adds a ConfigSchema TypeScript interface representing a subset of JSON Schema
Updates the compileConfig callback signature to accept a schema parameter
Creates a comprehensive configuration schema for the editor's runtime settings
Includes an unrelated documentation update adding a new TODO item for GLSL shader code blocks