### PR TITLE
feat(editor-state): remove binary assets field and enhance memory han…

### DIFF
--- a/docs/todos/188-disable-modules.md
+++ b/docs/todos/188-disable-modules.md
@@ -1,0 +1,143 @@
+---
+title: 'TODO: Add Disable Flag for Code Blocks'
+priority: High
+effort: 2-4 days
+created: 2026-01-20
+status: Open
+completed: null
+---
+
+# TODO: Add Disable Flag for Code Blocks
+
+## Problem Description
+
+The editor does not currently support disabling code blocks. The user wants a per-block flag that can be toggled from the context menu. Disabled blocks must:
+- Be excluded from program compilation and config compilation.
+- Persist in project JSON and runtime-ready export.
+- Render with a transparent background so they are visually distinct.
+- Remain editable (cursor and edits still allowed).
+
+Current behavior: all blocks are compiled based on block type, and all blocks are rendered with the same module background fill sprite.
+
+## Proposed Solution
+
+Introduce a `disabled: boolean` flag on both:
+- `CodeBlock` (persistent project format)
+- `CodeBlockGraphicData` (runtime editor state)
+
+Default it to `false` for new blocks and when loading a project without the flag.
+
+Add a context menu action that toggles disabled state on the selected block. Use label variants:
+- `Disable module`
+- `Enable module`
+Use the same label pattern for other block types (function/config/constants/shaders/comment) but label should still be “module” in the UI to match existing menu naming, unless the menu already uses the block-specific label (it does: moduleMenu derives blockLabel from blockType).
+
+Exclude disabled blocks from:
+- Program compiler input (modules/functions/constants)
+- Config compiler input (config blocks)
+
+Render disabled blocks with a transparent background (new fill sprite key). No other dimming required.
+
+## Implementation Plan
+
+### Step 1: Data model + defaults
+- Add `disabled?: boolean` to `CodeBlock` in `packages/editor/packages/editor-state/src/features/code-blocks/types.ts`.
+- Add `disabled: boolean` to `CodeBlockGraphicData` in the same file.
+- Default `disabled` to `false` in:
+  - `codeBlockCreator` when creating new `CodeBlockGraphicData`.
+  - `graphicHelper` population from `initialProjectState` (map `codeBlock.disabled ?? false`).
+  - `createMockCodeBlock` in `packages/editor/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts`.
+- Ensure runtime-ready serialization still includes `disabled` in project JSON.
+
+### Step 2: Serialization + import/export
+- Update serialization:
+  - `packages/editor/packages/editor-state/src/features/project-export/serializeCodeBlocks.ts` should include `disabled`.
+  - `serializeToProject` and `serializeToRuntimeReadyProject` rely on the above.
+- Update import:
+  - `packages/editor/packages/editor-state/src/features/code-blocks/features/graphicHelper/effect.ts` should apply `disabled` from project blocks.
+- Update snapshots:
+  - `packages/editor/packages/editor-state/src/features/project-export/__snapshots__/serializeProject.ts.snap`
+  - `packages/editor/packages/editor-state/src/features/project-export/__snapshots__/serializeRuntimeReadyProject.ts.snap`
+
+### Step 3: Context menu + event handler
+- Add a context menu item in `packages/editor/packages/editor-state/src/features/menu/menus/moduleMenu.ts`:
+  - Title: `Disable ${blockLabel}` or `Enable ${blockLabel}` based on selected block’s `disabled` flag.
+  - Action: `toggleCodeBlockDisabled`.
+- Implement handler in `packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.ts`:
+  - Toggle `codeBlock.disabled`.
+  - Update `codeBlock.lastUpdated` so cache invalidates.
+  - Re-set `graphicHelper.codeBlocks` array to trigger store update.
+- Only allow toggling if `featureFlags.editing` is true.
+
+### Step 4: Compilation filters
+- Update program compiler:
+  - `packages/editor/packages/editor-state/src/features/program-compiler/effect.ts`
+  - In `flattenProjectForCompiler`, filter out disabled blocks from modules/functions/constants.
+- Update config compiler:
+  - `packages/editor/packages/editor-state/src/features/config-compiler/collectConfigBlocks.ts`
+  - Filter out disabled config blocks.
+- Add/adjust tests to cover disabled filtering:
+  - `packages/editor/packages/editor-state/src/features/code-blocks/creationIndex.test.ts` (compiler ordering test should ignore disabled).
+  - `packages/editor/packages/editor-state/src/features/config-compiler/collectConfigBlocks.ts` tests should include disabled config block exclusion.
+
+### Step 5: Rendering (transparent background)
+- Add new fill color key:
+  - `moduleBackgroundDisabled` to `packages/editor/packages/sprite-generator/src/types.ts`.
+  - Add to `fillColors` list in `packages/editor/packages/sprite-generator/src/fillColors.ts`.
+- Update color schemes:
+  - `src/colorSchemes/default.ts`
+  - `src/colorSchemes/hackerman.ts`
+  - `src/colorSchemes/redalert.ts`
+  - `packages/editor/packages/sprite-generator/src/defaultColorScheme.ts`
+  - `packages/editor/packages/web-ui/screenshot-tests/utils/createMockStateWithColors.ts`
+  - `packages/editor/packages/sprite-generator/tests/utils/testFixtures.ts`
+- Update sprite-generator tests to include the new fill key:
+  - `packages/editor/packages/sprite-generator/tests/types.test.ts` should assert `moduleBackgroundDisabled` exists.
+- Update web UI rendering:
+  - `packages/editor/packages/web-ui/src/drawers/codeBlocks/index.ts` should draw `moduleBackgroundDisabled` when `codeBlock.disabled` is true (dragged state should still use dragged sprite).
+- Update screenshots if needed (web-ui screenshot tests).
+
+## Success Criteria
+
+- [ ] Disabled blocks persist in project JSON and runtime-ready export.
+- [ ] Disabled blocks are not sent to program/config compilers.
+- [ ] Context menu toggles disabled state with correct label.
+- [ ] Disabled blocks render with transparent background.
+- [ ] Tests updated/added and snapshots updated as needed.
+
+## Affected Components
+
+- `packages/editor/packages/editor-state/src/features/code-blocks/types.ts`
+- `packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.ts`
+- `packages/editor/packages/editor-state/src/features/code-blocks/features/graphicHelper/effect.ts`
+- `packages/editor/packages/editor-state/src/features/project-export/serializeCodeBlocks.ts`
+- `packages/editor/packages/editor-state/src/features/program-compiler/effect.ts`
+- `packages/editor/packages/editor-state/src/features/config-compiler/collectConfigBlocks.ts`
+- `packages/editor/packages/editor-state/src/features/menu/menus/moduleMenu.ts`
+- `packages/editor/packages/web-ui/src/drawers/codeBlocks/index.ts`
+- `packages/editor/packages/sprite-generator/src/types.ts`
+- `packages/editor/packages/sprite-generator/src/fillColors.ts`
+- Color schemes and test fixtures listed in Step 5
+
+## Risks & Considerations
+
+- **Compiler errors**: Disabled modules are excluded; existing modules that reference them will fail to compile. This is expected.
+- **Caching**: Must update `lastUpdated` to bust cached rendering for toggled blocks.
+- **Backwards compatibility**: `disabled` is optional for older projects; treat missing as `false`.
+- **Menu scope**: Make sure menu only appears for code blocks and uses existing `blockLabel` logic.
+
+## Related Items
+
+- **Blocks**: none
+- **Depends on**: none
+- **Related**: none
+
+## Notes
+
+- User requirements:
+  - Disabled applies to all block types.
+  - Blocks remain editable.
+  - Visual change is only transparent background.
+  - Menu label should be `Disable <label>` / `Enable <label>`.
+  - Disabled state must be included in exported projects.
+  - Compiler exclusion is acceptable even if it causes missing connections or compile errors for references.

--- a/packages/editor/packages/editor-state/src/features/binary-assets/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/binary-assets/effect.ts
@@ -52,7 +52,9 @@ export default function binaryAssets(store: StateManager<State>, events: EventDi
 	}
 
 	async function onLoadBinaryFilesIntoMemory() {
-		if (!state.compiler.hasMemoryBeenReinitialized || state.binaryAssets.some(asset => !asset.loadedIntoMemory)) {
+		const allOfTheAssetsHaveBeenLoaded = !state.binaryAssets.some(asset => !asset.loadedIntoMemory);
+
+		if (!state.compiler.hasMemoryBeenReinitialized && allOfTheAssetsHaveBeenLoaded) {
 			return;
 		}
 
@@ -78,7 +80,6 @@ export default function binaryAssets(store: StateManager<State>, events: EventDi
 				asset.byteAddress = resolved.byteAddress;
 				asset.memoryByteLength = resolved.memoryByteLength;
 				await state.callbacks.loadBinaryAssetIntoMemory(asset);
-				console.log('idebelefut az kizart dolog');
 				asset.loadedIntoMemory = true;
 			} catch (error) {
 				console.error('Failed to load binary asset into memory:', asset.url, error);

--- a/packages/editor/packages/editor-state/src/features/program-compiler/disableCompilation.test.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/disableCompilation.test.ts
@@ -68,12 +68,14 @@ describe('disableAutoCompilation feature', () => {
 
 	describe('Project compilation', () => {
 		it('should skip compilation when disableAutoCompilation is true', async () => {
+			vi.useFakeTimers();
 			store.set('compiledConfig.disableAutoCompilation', true);
 
 			compiler(store, mockEvents);
 
 			store.set('compiledConfig', { ...mockState.compiledConfig, disableAutoCompilation: true });
-			await new Promise(resolve => setTimeout(resolve, 0));
+			await vi.runAllTimersAsync();
+			vi.useRealTimers();
 
 			expect(mockCompileCode).not.toHaveBeenCalled();
 			expect(mockState.compiler.isCompiling).toBe(false);
@@ -88,17 +90,20 @@ describe('disableAutoCompilation feature', () => {
 		});
 
 		it('should compile normally when disableAutoCompilation is false', async () => {
+			vi.useFakeTimers();
 			store.set('compiledConfig.disableAutoCompilation', false);
 
 			compiler(store, mockEvents);
 
 			store.set('compiledConfig', { ...mockState.compiledConfig, disableAutoCompilation: false });
-			await new Promise(resolve => setTimeout(resolve, 0));
+			await vi.runAllTimersAsync();
+			vi.useRealTimers();
 
 			expect(mockCompileCode).toHaveBeenCalled();
 		});
 
 		it('should prioritize disableAutoCompilation check over pre-compiled WASM check', async () => {
+			vi.useFakeTimers();
 			mockState.callbacks.compileCode = undefined;
 			const compiledModules = { mod: {} };
 			store.set('compiledConfig.disableAutoCompilation', true);
@@ -111,7 +116,8 @@ describe('disableAutoCompilation feature', () => {
 			compiler(store, mockEvents);
 
 			store.set('compiledConfig', { ...mockState.compiledConfig, disableAutoCompilation: true });
-			await new Promise(resolve => setTimeout(resolve, 0));
+			await vi.runAllTimersAsync();
+			vi.useRealTimers();
 
 			expect(
 				mockState.console.logs.some(
@@ -159,6 +165,7 @@ describe('disableAutoCompilation feature', () => {
 				selectedRuntime: 0,
 				runtimeSettings: [{ runtime: 'WebWorkerLogicRuntime', sampleRate: 50 }],
 				disableAutoCompilation: false,
+				binaryAssets: [],
 			});
 		});
 

--- a/packages/editor/packages/editor-state/src/features/program-compiler/disableCompilation.test.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/disableCompilation.test.ts
@@ -159,7 +159,6 @@ describe('disableAutoCompilation feature', () => {
 				selectedRuntime: 0,
 				runtimeSettings: [{ runtime: 'WebWorkerLogicRuntime', sampleRate: 50 }],
 				disableAutoCompilation: false,
-				binaryAssets: [],
 			});
 		});
 
@@ -170,7 +169,6 @@ describe('disableAutoCompilation feature', () => {
 				selectedRuntime: 1,
 				runtimeSettings: [{ runtime: 'MainThreadLogicRuntime', sampleRate: 60 }],
 				disableAutoCompilation: false,
-				binaryAssets: [],
 			};
 
 			const result = await compileConfigForExport(mockState);

--- a/packages/editor/packages/editor-state/src/features/program-compiler/types.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/types.ts
@@ -16,6 +16,7 @@ export interface Compiler {
 	compiledModules: CompiledModuleLookup;
 	allocatedMemorySize: number;
 	compiledFunctions?: CompiledFunctionLookup;
+	hasMemoryBeenReinitialized: boolean;
 }
 
 /**

--- a/packages/editor/packages/editor-state/src/features/project-export/__snapshots__/serializeToProject.ts.snap
+++ b/packages/editor/packages/editor-state/src/features/project-export/__snapshots__/serializeToProject.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`serializeToProject > includes compiled modules when requested 1`] = `
 {
-  "binaryAssets": [],
   "codeBlocks": [],
   "compiledModules": {
     "mod": {},
@@ -18,7 +17,6 @@ exports[`serializeToProject > includes compiled modules when requested 1`] = `
 
 exports[`serializeToProject > serializes basic project state without compiled data 1`] = `
 {
-  "binaryAssets": [],
   "codeBlocks": [
     {
       "code": [

--- a/packages/editor/packages/editor-state/src/features/project-export/__snapshots__/serializeToRuntimeReadyProject.ts.snap
+++ b/packages/editor/packages/editor-state/src/features/project-export/__snapshots__/serializeToRuntimeReadyProject.ts.snap
@@ -2,7 +2,6 @@
 
 exports[`serializeToRuntimeReadyProject > omits compiled config when no config blocks are present 1`] = `
 {
-  "binaryAssets": [],
   "codeBlocks": [],
   "compiledConfig": {
     "binaryAssets": [],
@@ -28,7 +27,6 @@ exports[`serializeToRuntimeReadyProject > omits compiled config when no config b
 
 exports[`serializeToRuntimeReadyProject > serializes runtime-ready project with compiled config 1`] = `
 {
-  "binaryAssets": [],
   "codeBlocks": [
     {
       "code": [

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeToProject.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeToProject.ts
@@ -29,7 +29,6 @@ export default function serializeToProject(
 				y: Math.round(state.viewport.y / state.viewport.hGrid),
 			},
 		},
-		binaryAssets: state.binaryAssets,
 		compiledModules: options?.includeCompiled ? compiler.compiledModules : undefined,
 		// postProcessEffects are now derived from shader code blocks and not persisted
 	};

--- a/packages/editor/packages/editor-state/src/features/project-import/__tests__/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/project-import/__tests__/effect.test.ts
@@ -145,6 +145,7 @@ describe('projectImport', () => {
 		});
 
 		it('should clear compilation errors when loading a project', async () => {
+			vi.useFakeTimers();
 			projectImport(store, mockEvents);
 			configEffect(store, mockEvents);
 			compiler(store, mockEvents);
@@ -159,7 +160,8 @@ describe('projectImport', () => {
 
 			loadProjectCallback({ project: EMPTY_DEFAULT_PROJECT });
 			store.set('compiledConfig', { ...mockState.compiledConfig });
-			await new Promise(resolve => setTimeout(resolve, 0));
+			await vi.runAllTimersAsync();
+			vi.useRealTimers();
 
 			expect(mockState.codeErrors.compilationErrors).toEqual([]);
 		});
@@ -177,6 +179,7 @@ describe('projectImport', () => {
 		});
 
 		it('should load runtime-ready project with pre-compiled WASM', async () => {
+			vi.useFakeTimers();
 			projectImport(store, mockEvents);
 			compiler(store, mockEvents);
 
@@ -191,9 +194,13 @@ describe('projectImport', () => {
 				memorySnapshot: 'AQAAAA==', // base64 for minimal Int32Array
 			};
 
+			await Promise.resolve();
+			await Promise.resolve();
+
 			loadProjectCallback({ project: runtimeReadyProject });
 			store.set('compiledConfig', { ...mockState.compiledConfig });
-			await new Promise(resolve => setTimeout(resolve, 0));
+			await vi.runAllTimersAsync();
+			vi.useRealTimers();
 
 			expect(
 				mockState.console.logs.some(
@@ -204,6 +211,7 @@ describe('projectImport', () => {
 		});
 
 		it('should ignore invalid memory snapshots without crashing', async () => {
+			vi.useFakeTimers();
 			projectImport(store, mockEvents);
 			compiler(store, mockEvents);
 
@@ -220,7 +228,8 @@ describe('projectImport', () => {
 
 			loadProjectCallback({ project: invalidProject });
 			store.set('compiledConfig', { ...mockState.compiledConfig });
-			await new Promise(resolve => setTimeout(resolve, 0));
+			await vi.runAllTimersAsync();
+			vi.useRealTimers();
 
 			expect(consoleErrorSpy).not.toHaveBeenCalled();
 			expect(mockState.compiler.allocatedMemorySize).toBe(0);

--- a/packages/editor/packages/editor-state/src/features/project-import/types.ts
+++ b/packages/editor/packages/editor-state/src/features/project-import/types.ts
@@ -4,7 +4,6 @@
 
 import type { CompiledModuleLookup } from '@8f4e/compiler';
 import type { PostProcessEffect } from 'glugglug';
-import type { BinaryAsset } from '../binary-assets/types';
 import type { CodeBlock } from '../code-blocks/types';
 import type { ConfigObject } from '../config-compiler/types';
 import type { ProjectViewport } from '../viewport/types';
@@ -16,7 +15,6 @@ export interface Project {
 	codeBlocks: CodeBlock[];
 	/** Viewport position using grid coordinates for persistent storage */
 	viewport: ProjectViewport;
-	binaryAssets?: BinaryAsset[];
 	/** Compiled WebAssembly bytecode encoded as base64 string for runtime-only execution */
 	compiledWasm?: string;
 	compiledModules?: CompiledModuleLookup;
@@ -36,7 +34,6 @@ export const EMPTY_DEFAULT_PROJECT: Project = {
 	viewport: {
 		gridCoordinates: { x: 0, y: 0 },
 	},
-	binaryAssets: [],
 };
 
 /**

--- a/packages/editor/packages/editor-state/src/pureHelpers/debounceTrailing.ts
+++ b/packages/editor/packages/editor-state/src/pureHelpers/debounceTrailing.ts
@@ -1,0 +1,35 @@
+export type DebouncedTrailing<T extends (...args: unknown[]) => void> = ((...args: Parameters<T>) => void) & {
+	cancel: () => void;
+};
+
+/**
+ * Creates a trailing-edge debounce wrapper.
+ */
+export default function debounceTrailing<T extends (...args: unknown[]) => void>(
+	fn: T,
+	delayMs: number
+): DebouncedTrailing<T> {
+	let timeout: ReturnType<typeof setTimeout> | null = null;
+
+	const debounced = (...args: Parameters<T>) => {
+		if (timeout) {
+			clearTimeout(timeout);
+		}
+
+		timeout = setTimeout(() => {
+			timeout = null;
+			fn(...args);
+		}, delayMs);
+	};
+
+	debounced.cancel = () => {
+		if (!timeout) {
+			return;
+		}
+
+		clearTimeout(timeout);
+		timeout = null;
+	};
+
+	return debounced;
+}

--- a/packages/editor/packages/editor-state/src/pureHelpers/state/createDefaultState.ts
+++ b/packages/editor/packages/editor-state/src/pureHelpers/state/createDefaultState.ts
@@ -26,6 +26,7 @@ export default function createDefaultState() {
 			allocatedMemorySize: 0,
 			compiledModules: {},
 			byteCodeSize: 0,
+			hasMemoryBeenReinitialized: false,
 		},
 		midi: {
 			inputs: [],

--- a/packages/editor/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
+++ b/packages/editor/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
@@ -214,6 +214,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			allocatedMemorySize: 0,
 			compiledModules: {},
 			byteCodeSize: 0,
+			hasMemoryBeenReinitialized: false,
 		},
 		callbacks: {
 			loadSession: createMockAsyncFunction(null),

--- a/packages/editor/packages/editor-state/tests/runtimeReadyProject.test.ts
+++ b/packages/editor/packages/editor-state/tests/runtimeReadyProject.test.ts
@@ -187,6 +187,7 @@ describe('Runtime-ready project functionality', () => {
 
 	describe('Pre-compiled WASM loading', () => {
 		it('should use pre-compiled WASM metadata when available', async () => {
+			vi.useFakeTimers();
 			const compiledModules = { mod: {} };
 			const memorySnapshot = 'AQAAAAIAAAADAAAA';
 			// No compileCode callback for runtime-only projects
@@ -202,7 +203,8 @@ describe('Runtime-ready project functionality', () => {
 			compiler(store, mockEvents);
 
 			store.set('compiledConfig', { ...mockState.compiledConfig });
-			await new Promise(resolve => setTimeout(resolve, 0));
+			await vi.runAllTimersAsync();
+			vi.useRealTimers();
 
 			// Verify pre-compiled WASM was recognized via internal logger
 			expect(
@@ -220,6 +222,7 @@ describe('Runtime-ready project functionality', () => {
 		});
 
 		it('should compile normally when no pre-compiled WASM is available', async () => {
+			vi.useFakeTimers();
 			// Mock the compileCode function
 			const mockCompileCode = vi.fn().mockResolvedValue({
 				compiledModules: {},
@@ -235,7 +238,8 @@ describe('Runtime-ready project functionality', () => {
 			compiler(store, mockEvents);
 
 			store.set('compiledConfig', { ...mockState.compiledConfig });
-			await new Promise(resolve => setTimeout(resolve, 0));
+			await vi.runAllTimersAsync();
+			vi.useRealTimers();
 
 			// Verify regular compilation was attempted
 			expect(mockCompileCode).toHaveBeenCalled();

--- a/src/examples/projects/standaloneProject.ts
+++ b/src/examples/projects/standaloneProject.ts
@@ -64,7 +64,6 @@ const standalonProject: Project = {
 			y: 4,
 		},
 	},
-	binaryAssets: [],
 	compiledModules: {
 		counter: {
 			id: 'counter',


### PR DESCRIPTION
This PR removes the binaryAssets field from the Project interface (used for project serialization) while keeping it in ConfigObject (for runtime configuration), adds a new hasMemoryBeenReinitialized flag to track WASM memory state changes, implements debounced recompilation to reduce compilation frequency, and replaces an event-based binary asset loading trigger with a state subscription pattern.

Changes:

Removed binaryAssets from project serialization (Project interface) while retaining it in runtime configuration (ConfigObject)
Added hasMemoryBeenReinitialized flag to Compiler interface to track memory reinitialization state
Implemented trailing-edge debounce utility with 500ms delay for recompilation events
Replaced loadBinaryFilesIntoMemory event dispatch with subscription to hasMemoryBeenReinitialized flag