### PR TITLE
chore(editor-state): remove persistent storage feature flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,13 +7,16 @@
 - Docs and assets: `docs/`, selected files copied via Vite static-copy.
 - Nested `AGENTS.md` files exist in some packages to provide package-specific guidance; they extend (and may override) this root file for their scope.
 
-## Build, Test, and Development Commands
-- `npm run dev`: Watches `packages/editor` and starts Vite on `http://localhost:3000`.
-- `npm run build`: Builds all Nx packages, then Vite production build to `dist/`.
-- `npm run test`: Runs Vitest for all packages via Nx.
-- `npm run typecheck`: Type-checks all packages. Runs on pre-commit via Husky/lint-staged and in CI on push/PR to main and staging.
-- `npm run lint`: ESLint with autofix; also runs on pre-commit via Husky/lint-staged.
-- `npm run graph`: Opens Nx project dependency graph.
+## Build, Test, and Development Commands (Nx-first)
+- `npx nx run app:dev`: Builds packages (watch) and starts Vite dev server on `http://localhost:3000`.
+- `npx nx run app:serve`: Serves the production build via `vite preview`.
+- `npx nx run app:build`: Vite production build to `dist/` for the root app.
+- `npx nx run-many --target=build --all`: Build all packages/libs.
+- `npx nx run-many --target=test --all`: Run Vitest across all packages.
+- `npx nx run-many --target=typecheck --all`: Type-check all packages; also run on pre-commit via Husky/lint-staged.
+- `npx nx run app:lint`: ESLint for the root app. Use `run-many --target=lint --all` to lint all projects if needed.
+- `npx nx graph`: Open Nx project dependency graph.
+- `npx nx run app:kill-dev`: Kill any dev server on port 3000.
 
 ## Coding Style & Naming Conventions
 - Language: TypeScript (ES modules). Target: modern browsers/node.

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -9,7 +9,6 @@ The feature flags system allows you to enable/disable specific editor functional
 - `consoleOverlay: boolean` - Enable/disable console overlay display (internal logging) (default: false)
 - `moduleDragging: boolean` - Enable/disable dragging and repositioning of code block modules
 - `viewportDragging: boolean` - Enable/disable panning/scrolling of the editor viewport
- - Storage persistence is controlled by providing or omitting storage callbacks (`loadSession`, `saveSession`, `loadEditorConfigBlocks`, `saveEditorConfigBlocks`). No dedicated flag is required.
 - `editing: boolean` - Enable/disable all editing functionality (create, edit, delete, save)
 - `demoMode: boolean` - Enable/disable automatic demo mode with periodic code block navigation (default: false)
 
@@ -153,27 +152,6 @@ const state = init(events, project, {
     infoOverlay: false,
     moduleDragging: false,
     viewportDragging: false,
-  }
-});
-```
-
-## Backward Compatibility
-
-The system maintains full backward compatibility with existing options:
-
-```typescript
-// Legacy usage still works
-const state = init(events, project, {
-  showInfoOverlay: false,
-  // Storage behavior depends on provided callbacks
-});
-
-// Feature flags take precedence over legacy options
-const state = init(events, project, {
-  showInfoOverlay: true,         // Legacy option
-  // Storage behavior depends on provided callbacks
-  featureFlags: {
-    infoOverlay: false           // This overrides showInfoOverlay
   }
 });
 ```

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -9,7 +9,7 @@ The feature flags system allows you to enable/disable specific editor functional
 - `consoleOverlay: boolean` - Enable/disable console overlay display (internal logging) (default: false)
 - `moduleDragging: boolean` - Enable/disable dragging and repositioning of code block modules
 - `viewportDragging: boolean` - Enable/disable panning/scrolling of the editor viewport
-- `localStorage: boolean` - Enable/disable localStorage functionality
+ - Storage persistence is controlled by providing or omitting storage callbacks (`loadSession`, `saveSession`, `loadEditorConfigBlocks`, `saveEditorConfigBlocks`). No dedicated flag is required.
 - `editing: boolean` - Enable/disable all editing functionality (create, edit, delete, save)
 - `demoMode: boolean` - Enable/disable automatic demo mode with periodic code block navigation (default: false)
 
@@ -61,7 +61,7 @@ const state = init(events, project, {
     editing: false,             // Disable all editing functionality
     contextMenu: false,         // Disable context menus
     moduleDragging: false,      // Disable module dragging
-    // viewportDragging, infoOverlay and localStorage remain enabled for navigation
+    // viewportDragging and infoOverlay remain enabled for navigation
   }
 });
 ```
@@ -77,7 +77,7 @@ const state = init(events, project, {
     contextMenu: false,         // Disable context menus
     moduleDragging: false,      // Disable module dragging
     viewportDragging: false,    // Disable viewport panning
-    // infoOverlay and localStorage remain enabled
+    // infoOverlay remains enabled
   }
 });
 ```
@@ -153,7 +153,6 @@ const state = init(events, project, {
     infoOverlay: false,
     moduleDragging: false,
     viewportDragging: false,
-    localStorage: false,
   }
 });
 ```
@@ -166,16 +165,15 @@ The system maintains full backward compatibility with existing options:
 // Legacy usage still works
 const state = init(events, project, {
   showInfoOverlay: false,
-  isLocalStorageEnabled: false,
+  // Storage behavior depends on provided callbacks
 });
 
 // Feature flags take precedence over legacy options
 const state = init(events, project, {
   showInfoOverlay: true,         // Legacy option
-  isLocalStorageEnabled: true,   // Legacy option
+  // Storage behavior depends on provided callbacks
   featureFlags: {
-    infoOverlay: false,          // This overrides showInfoOverlay
-    localStorage: false,         // This overrides isLocalStorageEnabled
+    infoOverlay: false           // This overrides showInfoOverlay
   }
 });
 ```

--- a/packages/compiler/AGENTS.md
+++ b/packages/compiler/AGENTS.md
@@ -28,6 +28,7 @@
 - Vitest (via Nx). Place tests in `tests/`, `__tests__/`, or `*.test.ts`.
 - Focus on deterministic, fast unit tests for parsing, IR, and transforms.
 - In-source tests (`import.meta.vitest`) are enabled for `src/syntax/**/*.ts` via Vitest config.
+- To update snapshots after intentional changes, use `npx nx run compiler:test -- --update`.
 
 ## Pure Function Feature
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockNavigation/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockNavigation/effect.test.ts
@@ -37,7 +37,6 @@ describe('codeBlockNavigation', () => {
 				moduleDragging: true,
 				viewportDragging: true,
 				viewportAnimations: false,
-				persistentStorage: true,
 				editing: true,
 				demoMode: false,
 			},

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/graphicHelper/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/graphicHelper/effect.ts
@@ -176,7 +176,7 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 			});
 		});
 
-		if (state.featureFlags.persistentStorage && state.callbacks.loadEditorConfigBlocks) {
+		if (state.callbacks.loadEditorConfigBlocks) {
 			try {
 				const loadedBlocks = (await state.callbacks.loadEditorConfigBlocks()) ?? [];
 				const validBlocks = loadedBlocks.filter(block => isEditorConfigCode(block.code));

--- a/packages/editor/packages/editor-state/src/features/demo-mode/demoModeNavigation.test.ts
+++ b/packages/editor/packages/editor-state/src/features/demo-mode/demoModeNavigation.test.ts
@@ -47,7 +47,6 @@ describe('demoModeNavigation', () => {
 				moduleDragging: true,
 				viewportDragging: true,
 				viewportAnimations: false,
-				persistentStorage: true,
 				editing: true,
 				demoMode: true,
 			},

--- a/packages/editor/packages/editor-state/src/features/editor-config/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/editor-config/effect.ts
@@ -64,7 +64,7 @@ export default function editorConfigEffect(store: StateManager<State>, events: E
 	}
 
 	function saveEditorConfigBlocks() {
-		if (!state.featureFlags.persistentStorage || !state.callbacks.saveEditorConfigBlocks) {
+		if (!state.callbacks.saveEditorConfigBlocks) {
 			return;
 		}
 

--- a/packages/editor/packages/editor-state/src/features/project-export/__tests__/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/__tests__/effect.test.ts
@@ -187,11 +187,9 @@ describe('projectExport', () => {
 	});
 
 	describe('saveSession', () => {
-		it('should save session when persistentStorage is enabled', async () => {
+		it('should save session when saveSession callback is provided', async () => {
 			const mockSaveSession = vi.fn().mockResolvedValue(undefined);
 			const mockGetStorageQuota = vi.fn().mockResolvedValue({ usedBytes: 1024, totalBytes: 10240 });
-
-			mockState.featureFlags.persistentStorage = true;
 			mockState.callbacks.saveSession = mockSaveSession;
 			mockState.callbacks.getStorageQuota = mockGetStorageQuota;
 
@@ -208,11 +206,10 @@ describe('projectExport', () => {
 			expect(mockState.storageQuota.usedBytes).toBe(1024);
 		});
 
-		it('should not save session when persistentStorage is disabled', async () => {
+		it('should not save session when saveSession callback is absent', async () => {
 			const mockSaveSession = vi.fn().mockResolvedValue(undefined);
 
-			mockState.featureFlags.persistentStorage = false;
-			mockState.callbacks.saveSession = mockSaveSession;
+			mockState.callbacks.saveSession = undefined;
 
 			projectExport(store, mockEvents);
 
@@ -226,7 +223,6 @@ describe('projectExport', () => {
 		});
 
 		it('should not save session when callback is not provided', async () => {
-			mockState.featureFlags.persistentStorage = true;
 			mockState.callbacks.saveSession = undefined;
 
 			projectExport(store, mockEvents);
@@ -243,7 +239,6 @@ describe('projectExport', () => {
 			const mockSaveSession = vi.fn().mockResolvedValue(undefined);
 			const mockGetStorageQuota = vi.fn().mockResolvedValue({ usedBytes: 1024, totalBytes: 10240 });
 
-			mockState.featureFlags.persistentStorage = true;
 			mockState.callbacks.saveSession = mockSaveSession;
 			mockState.callbacks.getStorageQuota = mockGetStorageQuota;
 

--- a/packages/editor/packages/editor-state/src/features/project-export/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/effect.ts
@@ -44,7 +44,7 @@ export default function projectExport(store: StateManager<State>, events: EventD
 	}
 
 	async function onSaveSession() {
-		if (!state.featureFlags.persistentStorage || !state.callbacks.saveSession) {
+		if (!state.callbacks.saveSession) {
 			return;
 		}
 

--- a/packages/editor/packages/editor-state/src/features/project-import/__tests__/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/project-import/__tests__/effect.test.ts
@@ -52,8 +52,7 @@ describe('projectImport', () => {
 	});
 
 	describe('Initial session loading', () => {
-		it('should load empty project when persistentStorage is disabled', async () => {
-			mockState.featureFlags.persistentStorage = false;
+		it('should load empty project when loadSession callback is absent', async () => {
 			projectImport(store, mockEvents);
 
 			// Give time for promises to resolve
@@ -62,12 +61,10 @@ describe('projectImport', () => {
 			expect(mockState.initialProjectState).toEqual(EMPTY_DEFAULT_PROJECT);
 		});
 
-		it('should load session from callback when persistentStorage is enabled', async () => {
+		it('should load session from callback when provided', async () => {
 			const mockProject: Project = {
 				...EMPTY_DEFAULT_PROJECT,
 			};
-
-			mockState.featureFlags.persistentStorage = true;
 			mockState.callbacks.loadSession = vi.fn().mockResolvedValue(mockProject);
 
 			projectImport(store, mockEvents);
@@ -80,8 +77,6 @@ describe('projectImport', () => {
 
 		it('should handle loadSession errors gracefully', async () => {
 			const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
-
-			mockState.featureFlags.persistentStorage = true;
 			mockState.callbacks.loadSession = vi.fn().mockRejectedValue(new Error('Storage error'));
 
 			projectImport(store, mockEvents);

--- a/packages/editor/packages/editor-state/src/features/project-import/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/project-import/effect.ts
@@ -10,7 +10,7 @@ export default function projectImport(store: StateManager<State>, events: EventD
 	const state = store.getState();
 
 	const projectPromise = Promise.resolve().then(() => {
-		if (!state.featureFlags.persistentStorage || !state.callbacks.loadSession) {
+		if (!state.callbacks.loadSession) {
 			return Promise.resolve().then(() => loadProject({ project: EMPTY_DEFAULT_PROJECT }));
 		}
 

--- a/packages/editor/packages/editor-state/src/pureHelpers/state/featureFlags.ts
+++ b/packages/editor/packages/editor-state/src/pureHelpers/state/featureFlags.ts
@@ -10,7 +10,6 @@ export const defaultFeatureFlags: FeatureFlags = {
 	moduleDragging: true,
 	viewportDragging: true,
 	viewportAnimations: true,
-	persistentStorage: true,
 	editing: true,
 	demoMode: false,
 	historyTracking: true,

--- a/packages/editor/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
+++ b/packages/editor/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
@@ -252,7 +252,6 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			infoOverlay: true,
 			moduleDragging: true,
 			viewportDragging: true,
-			persistentStorage: false,
 			editing: true,
 			viewportAnimations: true,
 			demoMode: false,

--- a/packages/editor/packages/editor-state/src/types.ts
+++ b/packages/editor/packages/editor-state/src/types.ts
@@ -133,9 +133,6 @@ export interface FeatureFlags {
 	/** Enable/disable viewport animations for programmatic viewport changes */
 	viewportAnimations: boolean;
 
-	/** Enable/disable persistent storage functionality */
-	persistentStorage: boolean;
-
 	/** Enable/disable all editing functionality (create, edit, delete, save) */
 	editing: boolean;
 

--- a/packages/editor/packages/editor-state/tests/runtimeReadyProject.test.ts
+++ b/packages/editor/packages/editor-state/tests/runtimeReadyProject.test.ts
@@ -91,7 +91,6 @@ describe('Runtime-ready project functionality', () => {
 				infoOverlay: true,
 				moduleDragging: true,
 				viewportDragging: true,
-				persistentStorage: true,
 				editing: true,
 				demoMode: false,
 				viewportAnimations: true,

--- a/packages/editor/packages/sprite-generator/AGENTS.md
+++ b/packages/editor/packages/sprite-generator/AGENTS.md
@@ -14,6 +14,7 @@
 
 ## Testing
 - Vitest (via Nx). Prefer unit tests and golden/snapshot tests for outputs.
+- To update snapshots after intentional changes, use `npx nx run sprite-generator:test -- --update` (or the `:update` variant for screenshot tests).
 
 ## Commits & PRs
 - Commits: `sprite-generator: <change>`; PRs include rationale and test notes.

--- a/packages/editor/packages/web-ui/screenshot-tests/utils/createMockStateWithColors.ts
+++ b/packages/editor/packages/web-ui/screenshot-tests/utils/createMockStateWithColors.ts
@@ -97,7 +97,6 @@ export default function createMockStateWithColors(overrides: Partial<State> = {}
 			infoOverlay: false,
 			moduleDragging: false,
 			viewportDragging: false,
-			persistentStorage: false,
 			editing: false,
 			demoMode: false,
 			viewportAnimations: false,

--- a/packages/editor/src/config/featureFlags.test.ts
+++ b/packages/editor/src/config/featureFlags.test.ts
@@ -32,7 +32,6 @@ describe('Feature Flags Configuration', () => {
 		expect(defaultFeatureFlags.infoOverlay).toBe(true);
 		expect(defaultFeatureFlags.moduleDragging).toBe(true);
 		expect(defaultFeatureFlags.viewportDragging).toBe(true);
-		expect(defaultFeatureFlags.persistentStorage).toBe(true);
 		expect(defaultFeatureFlags.editing).toBe(true);
 		expect(defaultFeatureFlags.demoMode).toBe(false);
 	});
@@ -47,7 +46,6 @@ describe('Feature Flags Configuration', () => {
 		expect(result.infoOverlay).toBe(true);
 		expect(result.moduleDragging).toBe(true);
 		expect(result.viewportDragging).toBe(true);
-		expect(result.persistentStorage).toBe(true);
 		expect(result.editing).toBe(true);
 		expect(result.demoMode).toBe(false);
 	});
@@ -63,7 +61,6 @@ describe('Feature Flags Configuration', () => {
 		expect(result.infoOverlay).toBe(true);
 		expect(result.moduleDragging).toBe(true);
 		expect(result.viewportDragging).toBe(true);
-		expect(result.persistentStorage).toBe(true);
 	});
 
 	test('validateFeatureFlags should allow combining editing flag with other flags', () => {
@@ -79,7 +76,6 @@ describe('Feature Flags Configuration', () => {
 		expect(result.moduleDragging).toBe(false);
 		expect(result.infoOverlay).toBe(true);
 		expect(result.viewportDragging).toBe(true);
-		expect(result.persistentStorage).toBe(true);
 	});
 
 	test('validateFeatureFlags should allow enabling demo mode', () => {
@@ -93,7 +89,6 @@ describe('Feature Flags Configuration', () => {
 		expect(result.infoOverlay).toBe(true);
 		expect(result.moduleDragging).toBe(true);
 		expect(result.viewportDragging).toBe(true);
-		expect(result.persistentStorage).toBe(true);
 		expect(result.editing).toBe(true);
 	});
 });

--- a/packages/editor/src/config/featureFlags.ts
+++ b/packages/editor/src/config/featureFlags.ts
@@ -19,7 +19,6 @@ export const defaultFeatureFlags = {
 	moduleDragging: true,
 	viewportDragging: true,
 	viewportAnimations: false,
-	persistentStorage: true,
 	editing: true,
 	demoMode: false,
 	historyTracking: true,

--- a/packages/editor/src/integration/featureFlags.test.ts
+++ b/packages/editor/src/integration/featureFlags.test.ts
@@ -20,20 +20,17 @@ describe('Feature Flags Integration', () => {
 		// Other flags should remain at defaults
 		expect(featureFlags.infoOverlay).toBe(true);
 		expect(featureFlags.viewportDragging).toBe(true);
-		expect(featureFlags.persistentStorage).toBe(true);
 	});
 
 	test('should handle feature flags override correctly', () => {
 		const options: Partial<Options> = {
 			featureFlags: {
-				persistentStorage: false,
 				infoOverlay: true, // Override default
 			},
 		};
 
 		const featureFlags = validateFeatureFlags(options.featureFlags);
 
-		expect(featureFlags.persistentStorage).toBe(false);
 		expect(featureFlags.infoOverlay).toBe(true);
 	});
 
@@ -49,7 +46,6 @@ describe('Feature Flags Integration', () => {
 		expect(result).toHaveProperty('infoOverlay');
 		expect(result).toHaveProperty('moduleDragging');
 		expect(result).toHaveProperty('viewportDragging');
-		expect(result).toHaveProperty('persistentStorage');
 		expect(result).toHaveProperty('editing');
 
 		// Should merge correctly
@@ -57,7 +53,6 @@ describe('Feature Flags Integration', () => {
 		expect(result.infoOverlay).toBe(true);
 		expect(result.moduleDragging).toBe(true);
 		expect(result.viewportDragging).toBe(true);
-		expect(result.persistentStorage).toBe(true);
 		expect(result.editing).toBe(true);
 	});
 
@@ -76,7 +71,6 @@ describe('Feature Flags Integration', () => {
 		expect(featureFlags.infoOverlay).toBe(true);
 		expect(featureFlags.moduleDragging).toBe(true);
 		expect(featureFlags.viewportDragging).toBe(true);
-		expect(featureFlags.persistentStorage).toBe(true);
 	});
 
 	test('should support view-only mode with editing and contextMenu disabled', () => {
@@ -96,6 +90,5 @@ describe('Feature Flags Integration', () => {
 		// Navigation and info should remain enabled
 		expect(featureFlags.viewportDragging).toBe(true);
 		expect(featureFlags.infoOverlay).toBe(true);
-		expect(featureFlags.persistentStorage).toBe(true);
 	});
 });

--- a/packages/website-background/src/editor.ts
+++ b/packages/website-background/src/editor.ts
@@ -1,28 +1,10 @@
 import initEditor from '@8f4e/editor';
-import { ColorScheme } from '@8f4e/sprite-generator';
-import { compileConfig, JSONSchemaLike } from '@8f4e/stack-config-compiler';
 
-import { getListOfModules, getModule, getListOfProjects, getProject } from './examples/registry';
 import { runtimeRegistry, DEFAULT_RUNTIME_ID } from './runtime-registry';
-import {
-	loadSession,
-	saveSession,
-	loadEditorConfigBlocks,
-	saveEditorConfigBlocks,
-	importProject,
-	exportProject,
-	exportBinaryCode,
-} from './storage-callbacks';
+import { loadSession, loadEditorConfigBlocks } from './storage-callbacks';
 import { compileCode } from './compiler-callback';
-
-async function getListOfColorSchemes(): Promise<string[]> {
-	return ['hackerman', 'redalert', 'default'];
-}
-
-async function getColorScheme(name: string): Promise<ColorScheme> {
-	const module = await import(`./colorSchemes/${name}.ts`);
-	return module.default;
-}
+import compileConfig from './config-callback';
+import defaultColorScheme from './defaultColorScheme';
 
 async function init() {
 	const canvas = <HTMLCanvasElement>document.getElementById('glcanvas');
@@ -35,21 +17,12 @@ async function init() {
 		runtimeRegistry,
 		defaultRuntimeId: DEFAULT_RUNTIME_ID,
 		callbacks: {
-			getListOfModules,
-			getModule,
-			getListOfProjects,
-			getProject,
 			compileCode: (modules, compilerOptions, functions) => compileCode(modules, compilerOptions, functions, editor),
-			compileConfig: async (source: string, schema: JSONSchemaLike) => compileConfig(source, { schema }),
+			compileConfig,
 			loadSession,
-			saveSession,
 			loadEditorConfigBlocks,
-			saveEditorConfigBlocks,
-			importProject,
-			exportProject,
-			exportBinaryCode,
-			getListOfColorSchemes,
-			getColorScheme,
+			getListOfColorSchemes: async () => ['default'],
+			getColorScheme: async () => defaultColorScheme,
 		},
 	});
 


### PR DESCRIPTION
This PR removes the persistentStorage feature flag from the editor-state package, simplifying the codebase by relying solely on the presence of storage callbacks to determine storage behavior. The flag was redundant since storage functionality was already controlled by whether callbacks (loadSession, saveSession, loadEditorConfigBlocks, saveEditorConfigBlocks) were provided.

Changes:

Removed persistentStorage from the FeatureFlags interface and all default configurations
Updated conditional logic in storage-related effects to check only for callback existence instead of checking both the flag and callbacks
Updated all tests to reflect callback-based behavior instead of flag-based behavior
Updated feature flags documentation to remove references to the removed flag