### PR TITLE
feat(compiler): add float support for edge detectors

### DIFF
--- a/packages/compiler/docs/instructions/signal-helpers.md
+++ b/packages/compiler/docs/instructions/signal-helpers.md
@@ -2,7 +2,7 @@
 
 ### risingEdge
 
-The risingEdge instruction returns 1 when the current integer value is greater than the previous value, otherwise 0.
+The risingEdge instruction returns 1 when the current value is greater than the previous value, otherwise 0. Supports `int` and `float`.
 
 #### Examples
 
@@ -13,7 +13,7 @@ risingEdge
 
 ### fallingEdge
 
-The fallingEdge instruction returns 1 when the current integer value is less than the previous value, otherwise 0.
+The fallingEdge instruction returns 1 when the current value is less than the previous value, otherwise 0. Supports `int` and `float`.
 
 #### Examples
 

--- a/packages/compiler/src/instructionCompilers/__snapshots__/risingEdge.ts.snap
+++ b/packages/compiler/src/instructionCompilers/__snapshots__/risingEdge.ts.snap
@@ -60,3 +60,64 @@ exports[`risingEdge instruction compiler > compiles the rising edge segment 1`] 
   ],
 }
 `;
+
+exports[`risingEdge instruction compiler > compiles the rising edge segment for float operands 1`] = `
+{
+  "locals": {
+    "__risingEdgeDetector_currentValue4": {
+      "index": 0,
+      "isInteger": false,
+    },
+  },
+  "loopSegmentByteCode": [
+    33,
+    0,
+    32,
+    0,
+    65,
+    0,
+    42,
+    2,
+    0,
+    94,
+    4,
+    127,
+    65,
+    1,
+    5,
+    65,
+    0,
+    11,
+    65,
+    0,
+    32,
+    0,
+    56,
+    2,
+    0,
+  ],
+  "memory": {
+    "__risingEdgeDetector_previousValue4": {
+      "byteAddress": 0,
+      "default": 0,
+      "elementWordSize": 4,
+      "id": "__risingEdgeDetector_previousValue4",
+      "isInteger": false,
+      "isPointer": false,
+      "isPointingToInteger": false,
+      "isPointingToPointer": false,
+      "isUnsigned": false,
+      "numberOfElements": 1,
+      "type": "float",
+      "wordAlignedAddress": 0,
+      "wordAlignedSize": 1,
+    },
+  },
+  "stack": [
+    {
+      "isInteger": true,
+      "isNonZero": false,
+    },
+  ],
+}
+`;

--- a/packages/compiler/src/instructionCompilers/fallingEdge.ts
+++ b/packages/compiler/src/instructionCompilers/fallingEdge.ts
@@ -15,21 +15,24 @@ const fallingEdge: InstructionCompiler = withValidation(
 	},
 	(line, context) => {
 		// Non-null assertion is safe: withValidation with minOperands: 1 guarantees at least 1 operand exists on the stack
-		context.stack.pop()!;
-
-		context.stack.push({ isInteger: true, isNonZero: false });
+		const operand = context.stack.pop()!;
 
 		const currentValueName = '__fallingEdgeDetector_currentValue' + line.lineNumber;
 		const previousValueName = '__fallingEdgeDetector_previousValue' + line.lineNumber;
+		const memoryType = operand.isInteger ? 'int' : 'float';
+		const loadInstruction = operand.isInteger ? 'load' : 'loadFloat';
+
+		// Restore the operand for the segment so type checks apply to the original value.
+		context.stack.push(operand);
 
 		return compileSegment(
 			[
-				`int ${previousValueName} 0`,
-				`local int ${currentValueName}`,
+				`${memoryType} ${previousValueName} 0`,
+				`local ${memoryType} ${currentValueName}`,
 				`localSet ${currentValueName}`,
 				`localGet ${currentValueName}`,
 				`push &${previousValueName}`,
-				'load',
+				loadInstruction,
 				'lessThan',
 				'if int',
 				'push 1',

--- a/packages/compiler/tests/instructions/__snapshots__/fallingEdge.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/fallingEdge.test.ts.snap
@@ -1,5 +1,199 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`fallingEdge (float) > if the generated AST, WAT and memory map match the snapshot 1`] = `
+[
+  {
+    "arguments": [
+      {
+        "type": "identifier",
+        "value": "fallingEdgeFloat",
+      },
+    ],
+    "instruction": "module",
+    "lineNumber": 0,
+  },
+  {
+    "arguments": [
+      {
+        "type": "identifier",
+        "value": "input",
+      },
+    ],
+    "instruction": "float",
+    "lineNumber": 2,
+  },
+  {
+    "arguments": [
+      {
+        "type": "identifier",
+        "value": "output",
+      },
+    ],
+    "instruction": "int",
+    "lineNumber": 3,
+  },
+  {
+    "arguments": [
+      {
+        "type": "identifier",
+        "value": "&output",
+      },
+    ],
+    "instruction": "push",
+    "lineNumber": 5,
+  },
+  {
+    "arguments": [
+      {
+        "type": "identifier",
+        "value": "input",
+      },
+    ],
+    "instruction": "push",
+    "lineNumber": 6,
+  },
+  {
+    "arguments": [],
+    "instruction": "fallingEdge",
+    "lineNumber": 7,
+  },
+  {
+    "arguments": [
+      {
+        "type": "identifier",
+        "value": "int",
+      },
+    ],
+    "instruction": "if",
+    "lineNumber": 8,
+  },
+  {
+    "arguments": [
+      {
+        "isInteger": true,
+        "type": "literal",
+        "value": 1,
+      },
+    ],
+    "instruction": "push",
+    "lineNumber": 9,
+  },
+  {
+    "arguments": [],
+    "instruction": "else",
+    "lineNumber": 10,
+  },
+  {
+    "arguments": [
+      {
+        "isInteger": true,
+        "type": "literal",
+        "value": 0,
+      },
+    ],
+    "instruction": "push",
+    "lineNumber": 11,
+  },
+  {
+    "arguments": [],
+    "instruction": "ifEnd",
+    "lineNumber": 12,
+  },
+  {
+    "arguments": [],
+    "instruction": "store",
+    "lineNumber": 13,
+  },
+  {
+    "arguments": [],
+    "instruction": "moduleEnd",
+    "lineNumber": 15,
+  },
+]
+`;
+
+exports[`fallingEdge (float) > if the generated AST, WAT and memory map match the snapshot 2`] = `
+"(module
+  (type (;0;) (func))
+  (import "js" "memory" (memory (;0;) 1))
+  (func (;0;) (type 0)
+    (local f32)
+    i32.const 4
+    i32.const 0
+    f32.load
+    local.set 0
+    local.get 0
+    i32.const 8
+    f32.load
+    f32.lt
+    if (result i32)  ;; label = @1
+      i32.const 1
+    else
+      i32.const 0
+    end
+    i32.const 8
+    local.get 0
+    f32.store
+    if (result i32)  ;; label = @1
+      i32.const 1
+    else
+      i32.const 0
+    end
+    i32.store)
+  (export "test" (func 0)))
+"
+`;
+
+exports[`fallingEdge (float) > if the generated AST, WAT and memory map match the snapshot 3`] = `
+{
+  "__fallingEdgeDetector_previousValue7": {
+    "byteAddress": 8,
+    "default": 0,
+    "elementWordSize": 4,
+    "id": "__fallingEdgeDetector_previousValue7",
+    "isInteger": false,
+    "isPointer": false,
+    "isPointingToInteger": false,
+    "isPointingToPointer": false,
+    "isUnsigned": false,
+    "numberOfElements": 1,
+    "type": "float",
+    "wordAlignedAddress": 2,
+    "wordAlignedSize": 1,
+  },
+  "input": {
+    "byteAddress": 0,
+    "default": 0,
+    "elementWordSize": 4,
+    "id": "input",
+    "isInteger": false,
+    "isPointer": false,
+    "isPointingToInteger": false,
+    "isPointingToPointer": false,
+    "isUnsigned": false,
+    "numberOfElements": 1,
+    "type": "float",
+    "wordAlignedAddress": 0,
+    "wordAlignedSize": 1,
+  },
+  "output": {
+    "byteAddress": 4,
+    "default": 0,
+    "elementWordSize": 4,
+    "id": "output",
+    "isInteger": true,
+    "isPointer": false,
+    "isPointingToInteger": false,
+    "isPointingToPointer": false,
+    "isUnsigned": false,
+    "numberOfElements": 1,
+    "type": "int",
+    "wordAlignedAddress": 1,
+    "wordAlignedSize": 1,
+  },
+}
+`;
+
 exports[`fallingEdge > if the generated AST, WAT and memory map match the snapshot 1`] = `
 [
   {

--- a/packages/compiler/tests/instructions/__snapshots__/risingEdge.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/risingEdge.test.ts.snap
@@ -1,5 +1,199 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`risingEdge (float) > if the generated AST, WAT and memory map match the snapshot 1`] = `
+[
+  {
+    "arguments": [
+      {
+        "type": "identifier",
+        "value": "risingEdgeFloat",
+      },
+    ],
+    "instruction": "module",
+    "lineNumber": 0,
+  },
+  {
+    "arguments": [
+      {
+        "type": "identifier",
+        "value": "input",
+      },
+    ],
+    "instruction": "float",
+    "lineNumber": 2,
+  },
+  {
+    "arguments": [
+      {
+        "type": "identifier",
+        "value": "output",
+      },
+    ],
+    "instruction": "int",
+    "lineNumber": 3,
+  },
+  {
+    "arguments": [
+      {
+        "type": "identifier",
+        "value": "&output",
+      },
+    ],
+    "instruction": "push",
+    "lineNumber": 5,
+  },
+  {
+    "arguments": [
+      {
+        "type": "identifier",
+        "value": "input",
+      },
+    ],
+    "instruction": "push",
+    "lineNumber": 6,
+  },
+  {
+    "arguments": [],
+    "instruction": "risingEdge",
+    "lineNumber": 7,
+  },
+  {
+    "arguments": [
+      {
+        "type": "identifier",
+        "value": "int",
+      },
+    ],
+    "instruction": "if",
+    "lineNumber": 8,
+  },
+  {
+    "arguments": [
+      {
+        "isInteger": true,
+        "type": "literal",
+        "value": 1,
+      },
+    ],
+    "instruction": "push",
+    "lineNumber": 9,
+  },
+  {
+    "arguments": [],
+    "instruction": "else",
+    "lineNumber": 10,
+  },
+  {
+    "arguments": [
+      {
+        "isInteger": true,
+        "type": "literal",
+        "value": 0,
+      },
+    ],
+    "instruction": "push",
+    "lineNumber": 11,
+  },
+  {
+    "arguments": [],
+    "instruction": "ifEnd",
+    "lineNumber": 12,
+  },
+  {
+    "arguments": [],
+    "instruction": "store",
+    "lineNumber": 13,
+  },
+  {
+    "arguments": [],
+    "instruction": "moduleEnd",
+    "lineNumber": 15,
+  },
+]
+`;
+
+exports[`risingEdge (float) > if the generated AST, WAT and memory map match the snapshot 2`] = `
+"(module
+  (type (;0;) (func))
+  (import "js" "memory" (memory (;0;) 1))
+  (func (;0;) (type 0)
+    (local f32)
+    i32.const 4
+    i32.const 0
+    f32.load
+    local.set 0
+    local.get 0
+    i32.const 8
+    f32.load
+    f32.gt
+    if (result i32)  ;; label = @1
+      i32.const 1
+    else
+      i32.const 0
+    end
+    i32.const 8
+    local.get 0
+    f32.store
+    if (result i32)  ;; label = @1
+      i32.const 1
+    else
+      i32.const 0
+    end
+    i32.store)
+  (export "test" (func 0)))
+"
+`;
+
+exports[`risingEdge (float) > if the generated AST, WAT and memory map match the snapshot 3`] = `
+{
+  "__risingEdgeDetector_previousValue7": {
+    "byteAddress": 8,
+    "default": 0,
+    "elementWordSize": 4,
+    "id": "__risingEdgeDetector_previousValue7",
+    "isInteger": false,
+    "isPointer": false,
+    "isPointingToInteger": false,
+    "isPointingToPointer": false,
+    "isUnsigned": false,
+    "numberOfElements": 1,
+    "type": "float",
+    "wordAlignedAddress": 2,
+    "wordAlignedSize": 1,
+  },
+  "input": {
+    "byteAddress": 0,
+    "default": 0,
+    "elementWordSize": 4,
+    "id": "input",
+    "isInteger": false,
+    "isPointer": false,
+    "isPointingToInteger": false,
+    "isPointingToPointer": false,
+    "isUnsigned": false,
+    "numberOfElements": 1,
+    "type": "float",
+    "wordAlignedAddress": 0,
+    "wordAlignedSize": 1,
+  },
+  "output": {
+    "byteAddress": 4,
+    "default": 0,
+    "elementWordSize": 4,
+    "id": "output",
+    "isInteger": true,
+    "isPointer": false,
+    "isPointingToInteger": false,
+    "isPointingToPointer": false,
+    "isUnsigned": false,
+    "numberOfElements": 1,
+    "type": "int",
+    "wordAlignedAddress": 1,
+    "wordAlignedSize": 1,
+  },
+}
+`;
+
 exports[`risingEdge > if the generated AST, WAT and memory map match the snapshot 1`] = `
 [
   {

--- a/packages/compiler/tests/instructions/fallingEdge.test.ts
+++ b/packages/compiler/tests/instructions/fallingEdge.test.ts
@@ -30,3 +30,34 @@ moduleEnd
 		[{ input: 10 }, { output: 0 }],
 	]
 );
+
+moduleTester(
+	'fallingEdge (float)',
+	`module fallingEdgeFloat
+
+float input
+int output
+
+push &output
+ push input
+ fallingEdge
+ if int
+  push 1
+ else
+  push 0
+ ifEnd
+store
+
+moduleEnd
+`,
+	[
+		[{ input: 10.1 }, { output: 0 }],
+		[{ input: 11.2 }, { output: 0 }],
+		[{ input: 12.3 }, { output: 0 }],
+		[{ input: 9.9 }, { output: 1 }],
+		[{ input: 12.2 }, { output: 0 }],
+		[{ input: 12.2 }, { output: 0 }],
+		[{ input: 10.8 }, { output: 1 }],
+		[{ input: 10.8 }, { output: 0 }],
+	]
+);

--- a/packages/compiler/tests/instructions/risingEdge.test.ts
+++ b/packages/compiler/tests/instructions/risingEdge.test.ts
@@ -30,3 +30,34 @@ moduleEnd
 		[{ input: 10 }, { output: 0 }],
 	]
 );
+
+moduleTester(
+	'risingEdge (float)',
+	`module risingEdgeFloat
+
+float input
+int output
+
+push &output
+ push input
+ risingEdge
+ if int
+  push 1
+ else
+  push 0
+ ifEnd
+store
+
+moduleEnd
+`,
+	[
+		[{ input: 12.01 }, { output: 1 }],
+		[{ input: 11.5 }, { output: 0 }],
+		[{ input: 11.5 }, { output: 0 }],
+		[{ input: 12.1 }, { output: 1 }],
+		[{ input: 12.1 }, { output: 0 }],
+		[{ input: 12.01 }, { output: 0 }],
+		[{ input: 12.2 }, { output: 1 }],
+		[{ input: 11.9 }, { output: 0 }],
+	]
+);


### PR DESCRIPTION
This pull request adds float support to the risingEdge and fallingEdge edge detector instructions in the compiler. Previously, these instructions only worked with integer values; now they support both int and float types.

Changes:

Modified risingEdge and fallingEdge instruction compilers to detect operand type and use appropriate memory types and load instructions
Added comprehensive test coverage for float operands in both edge detectors
Updated documentation to reflect that both instructions now support int and float types