### PR TITLE
chore: add missing README files for various packages to improve docum…

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,25 +13,25 @@ The 8f4e project is organized as an Nx monorepo with the following package hiera
 <pre>
 8f4e/
 └── packages/
-    ├── [cli](./packages/cli/README.md) (CLI for compiling 8f4e project JSON files)
-    ├── [compiler](./packages/compiler/README.md) (The core compiler that transforms 8f4e code into WebAssembly)
-    ├── [compiler-worker](./packages/compiler-worker/README.md) (Web Worker wrapper around the compiler for live coding)
-    ├── [config](./packages/config/README.md) (Shared tooling and configuration helpers for the workspace)
-    ├── [editor](./packages/editor/README.md) (The main editor package with UI components and state management)
+    ├── <a href="./packages/cli/README.md">cli</a> (CLI for compiling 8f4e project JSON files)
+    ├── <a href="./packages/compiler/README.md">compiler</a> (The core compiler that transforms 8f4e code into WebAssembly)
+    ├── <a href="./packages/compiler-worker/README.md">compiler-worker</a> (Web Worker wrapper around the compiler for live coding)
+    ├── <a href="./packages/config/README.md">config</a> (Shared tooling and configuration helpers for the workspace)
+    ├── <a href="./packages/editor/README.md">editor</a> (The main editor package with UI components and state management)
     │   └── packages/
-    │       ├── [editor-state](./packages/editor/packages/editor-state/README.md) (Editor state management)
-    │       ├── [glugglug](./packages/editor/packages/glugglug/README.md) (2D WebGL graphics utilities)
-    │       ├── [sprite-generator](./packages/editor/packages/sprite-generator/README.md) (All UI graphics are generative)
-    │       ├── [state-manager](./packages/editor/packages/state-manager/README.md) (State manager with subscriptions)
-    │       └── [web-ui](./packages/editor/packages/web-ui/README.md) (WebGL rendering for the editor interface)
-    ├── [examples](./packages/examples/README.md) (Example modules and projects)
-    ├── [pmml28f4e](./packages/pmml28f4e/README.md) (PMML neural network conversion to 8f4e projects)
-    ├── [runtime-audio-worklet](./packages/runtime-audio-worklet/README.md)     ┐ 
-    ├── [runtime-main-thread-logic](./packages/runtime-main-thread-logic/README.md) │ (Various runtime environments 
-    ├── [runtime-web-worker-logic](./packages/runtime-web-worker-logic/README.md)  │ for different execution contexts)
-    ├── [runtime-web-worker-midi](./packages/runtime-web-worker-midi/README.md)   ┘
-    ├── [stack-config-compiler](./packages/stack-config-compiler/README.md) (Stack-machine-inspired config language compiler)
-    └── [website-background](./packages/website-background/README.md) (Website background assets built from an editor project)
+    │       ├── <a href="./packages/editor/packages/editor-state/README.md">editor-state</a> (Editor state management)
+    │       ├── <a href="./packages/editor/packages/glugglug/README.md">glugglug</a> (2D WebGL graphics utilities)
+    │       ├── <a href="./packages/editor/packages/sprite-generator/README.md">sprite-generator</a> (All UI graphics are generative)
+    │       ├── <a href="./packages/editor/packages/state-manager/README.md">state-manager</a> (State manager with subscriptions)
+    │       └── <a href="./packages/editor/packages/web-ui/README.md">web-ui</a> (WebGL rendering for the editor interface)
+    ├── <a href="./packages/examples/README.md">examples</a> (Example modules and projects)
+    ├── <a href="./packages/pmml28f4e/README.md">pmml28f4e</a> (PMML neural network conversion to 8f4e projects)
+    ├── <a href="./packages/runtime-audio-worklet/README.md">runtime-audio-worklet</a>     ┐ 
+    ├── <a href="./packages/runtime-main-thread-logic/README.md">runtime-main-thread-logic</a> │ (Various runtime environments 
+    ├── <a href="./packages/runtime-web-worker-logic/README.md">runtime-web-worker-logic</a>  │ for different execution contexts)
+    ├── <a href="./packages/runtime-web-worker-midi/README.md">runtime-web-worker-midi</a>   ┘
+    ├── <a href="./packages/stack-config-compiler/README.md">stack-config-compiler</a> (Stack-machine-inspired config language compiler)
+    └── <a href="./packages/website-background/README.md">website-background</a> (Website background assets built from an editor project)
 </pre>
 
 You can use `npx nx graph` to explore the relationship between the packages.

--- a/README.md
+++ b/README.md
@@ -13,21 +13,25 @@ The 8f4e project is organized as an Nx monorepo with the following package hiera
 <pre>
 8f4e/
 └── packages/
-    ├── compiler (The core compiler that transforms 8f4e code into WebAssembly)
-    ├── compiler-worker (Web Worker wrapper around the compiler for live coding)
-    ├── <a href="./packages/config/README.md">config</a> (Shared tooling and configuration helpers for the workspace)
-    ├── editor (The main editor package with UI components and state management)
+    ├── [cli](./packages/cli/README.md) (CLI for compiling 8f4e project JSON files)
+    ├── [compiler](./packages/compiler/README.md) (The core compiler that transforms 8f4e code into WebAssembly)
+    ├── [compiler-worker](./packages/compiler-worker/README.md) (Web Worker wrapper around the compiler for live coding)
+    ├── [config](./packages/config/README.md) (Shared tooling and configuration helpers for the workspace)
+    ├── [editor](./packages/editor/README.md) (The main editor package with UI components and state management)
     │   └── packages/
-    │       ├── editor-state (Editor state management)
-    │       ├── <a href="./packages/editor/packages/glugglug/README.md">glugglug</a> (2D WebGL graphics utilities)
-    │       ├── <a href="./packages/editor/packages/sprite-generator/README.md">sprite-generator</a> (All UI graphics are generative)
-    │       ├── <a href="./packages/editor/packages/state-manager/README.md">state-manager</a> (State manager with subscriptions)
-    │       └── <a href="./packages/editor/packages/web-ui/README.md">web-ui</a> (WebGL rendering for the editor interface)
-    ├── runtime-audio-worklet     ┐ 
-    ├── runtime-main-thread-logic │ (Various runtime environments 
-    ├── runtime-web-worker-logic  │ for different execution contexts)
-    ├── runtime-web-worker-midi   ┘
-    └── <a href="./packages/stack-config-compiler/README.md">stack-config-compiler</a> (Stack-machine-inspired config language compiler)
+    │       ├── [editor-state](./packages/editor/packages/editor-state/README.md) (Editor state management)
+    │       ├── [glugglug](./packages/editor/packages/glugglug/README.md) (2D WebGL graphics utilities)
+    │       ├── [sprite-generator](./packages/editor/packages/sprite-generator/README.md) (All UI graphics are generative)
+    │       ├── [state-manager](./packages/editor/packages/state-manager/README.md) (State manager with subscriptions)
+    │       └── [web-ui](./packages/editor/packages/web-ui/README.md) (WebGL rendering for the editor interface)
+    ├── [examples](./packages/examples/README.md) (Example modules and projects)
+    ├── [pmml28f4e](./packages/pmml28f4e/README.md) (PMML neural network conversion to 8f4e projects)
+    ├── [runtime-audio-worklet](./packages/runtime-audio-worklet/README.md)     ┐ 
+    ├── [runtime-main-thread-logic](./packages/runtime-main-thread-logic/README.md) │ (Various runtime environments 
+    ├── [runtime-web-worker-logic](./packages/runtime-web-worker-logic/README.md)  │ for different execution contexts)
+    ├── [runtime-web-worker-midi](./packages/runtime-web-worker-midi/README.md)   ┘
+    ├── [stack-config-compiler](./packages/stack-config-compiler/README.md) (Stack-machine-inspired config language compiler)
+    └── [website-background](./packages/website-background/README.md) (Website background assets built from an editor project)
 </pre>
 
 You can use `npx nx graph` to explore the relationship between the packages.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The 8f4e project is organized as an Nx monorepo with the following package hiera
     │       ├── <a href="./packages/editor/packages/state-manager/README.md">state-manager</a> (State manager with subscriptions)
     │       └── <a href="./packages/editor/packages/web-ui/README.md">web-ui</a> (WebGL rendering for the editor interface)
     ├── <a href="./packages/examples/README.md">examples</a> (Example modules and projects)
-    ├── <a href="./packages/pmml28f4e/README.md">pmml28f4e</a> (PMML neural network conversion to 8f4e projects)
+    ├── <a href="./packages/pmml28f4e/README.md">pmml28f4e</a> (tool to convert PMML neural networks to 8f4e projects)
     ├── <a href="./packages/runtime-audio-worklet/README.md">runtime-audio-worklet</a>     ┐ 
     ├── <a href="./packages/runtime-main-thread-logic/README.md">runtime-main-thread-logic</a> │ (Various runtime environments 
     ├── <a href="./packages/runtime-web-worker-logic/README.md">runtime-web-worker-logic</a>  │ for different execution contexts)

--- a/packages/compiler-worker/README.md
+++ b/packages/compiler-worker/README.md
@@ -1,0 +1,9 @@
+# @8f4e/compiler-worker
+
+Web Worker wrapper around the 8f4e compiler for live coding. It orchestrates compilation, memory creation, and memory diffing so the editor can push incremental updates efficiently.
+
+## Responsibilities
+
+- Run compilation off the main thread.
+- Compare program and memory structure changes.
+- Produce memory diffs for runtime updates.

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -1,0 +1,9 @@
+# @8f4e/compiler
+
+Core compiler that transforms 8f4e source into WebAssembly plus runtime metadata. It exposes the main compiler API along with a `syntax` export used by editor tooling.
+
+## Responsibilities
+
+- Parse and validate 8f4e source.
+- Compile instructions into WebAssembly modules.
+- Provide syntax helpers for highlighting and tooling.

--- a/packages/examples/README.md
+++ b/packages/examples/README.md
@@ -1,0 +1,8 @@
+# @8f4e/examples
+
+Example modules and projects used by the editor and tooling. Exports example modules under `modules/` and full projects under `projects/`.
+
+## Contents
+
+- `modules/`: reusable example modules.
+- `projects/`: complete example projects.

--- a/packages/runtime-audio-worklet/README.md
+++ b/packages/runtime-audio-worklet/README.md
@@ -1,0 +1,8 @@
+# @8f4e/runtime-audio-worklet
+
+AudioWorklet runtime for executing 8f4e programs in the browser audio graph. Includes the worklet entry point and runtime definition metadata.
+
+## Responsibilities
+
+- Provide the AudioWorklet processor entry.
+- Expose runtime definitions used by the editor and host.

--- a/packages/runtime-main-thread-logic/README.md
+++ b/packages/runtime-main-thread-logic/README.md
@@ -1,0 +1,8 @@
+# @8f4e/runtime-main-thread-logic
+
+Main-thread runtime logic for hosting 8f4e programs. Used when execution happens on the UI thread (non-worker environments) and when coordinating editor state with runtime updates.
+
+## Responsibilities
+
+- Provide main-thread runtime behavior and utilities.
+- Expose runtime definitions used by hosts.

--- a/packages/runtime-web-worker-logic/README.md
+++ b/packages/runtime-web-worker-logic/README.md
@@ -1,0 +1,8 @@
+# @8f4e/runtime-web-worker-logic
+
+Web Worker runtime logic for executing 8f4e programs off the main thread. This package provides runtime definitions and worker-compatible logic used by hosts.
+
+## Responsibilities
+
+- Provide worker-safe runtime behavior.
+- Expose runtime definitions used by hosts.

--- a/packages/runtime-web-worker-midi/README.md
+++ b/packages/runtime-web-worker-midi/README.md
@@ -1,0 +1,8 @@
+# @8f4e/runtime-web-worker-midi
+
+Web Worker runtime focused on MIDI handling and 8f4e program execution. Intended for MIDI-driven workflows that benefit from background execution.
+
+## Responsibilities
+
+- Provide MIDI-capable runtime behavior in a worker.
+- Expose runtime definitions used by hosts.

--- a/packages/website-background/README.md
+++ b/packages/website-background/README.md
@@ -5,4 +5,3 @@ Website background assets built from an 8f4e editor project. This folder contain
 ## Contents
 
 - `src/editor.ts`: entry point for rendering or exporting the background.
-- `src/project-runtime-ready.json`: precompiled project data.

--- a/packages/website-background/README.md
+++ b/packages/website-background/README.md
@@ -1,0 +1,8 @@
+# Website Background
+
+Website background assets built from an 8f4e editor project. This folder contains the project and code used to generate or render the background visuals.
+
+## Contents
+
+- `src/editor.ts`: entry point for rendering or exporting the background.
+- `src/project-runtime-ready.json`: precompiled project data.


### PR DESCRIPTION
This PR adds missing README files for 8 packages in the monorepo and updates the root README to include links to all package READMEs for improved documentation and discoverability.

Changes:

Added README files for compiler, compiler-worker, runtime packages (audio-worklet, main-thread-logic, web-worker-logic, web-worker-midi), examples, and website-background
Updated root README to add hyperlinks to all package READMEs in the package hierarchy diagram
Standardized documentation structure across packages with brief descriptions and responsibilities sections