### PR TITLE
fix(compiler): split macro line numbers before and after expansion

### DIFF
--- a/docs/agent_failure_notes/019-compatibility-shim-instead-of-finishing-repo-wide-rename.md
+++ b/docs/agent_failure_notes/019-compatibility-shim-instead-of-finishing-repo-wide-rename.md
@@ -1,0 +1,58 @@
+---
+title: Agent Failure Note – Compatibility shim added instead of completing repo-wide rename
+agent: Codex App Version 26.305.950 (863)
+model: gpt-5.4 (medium)
+date: 2026-03-14
+---
+
+# Agent Failure Note – Compatibility shim added instead of completing repo-wide rename
+
+## Short Summary
+
+The agent introduced a compatibility shim to preserve old field access during an internal rename, even though the repository fully owned all affected code and tests. That made the model less explicit and delayed the real migration work instead of completing it.
+
+## Original Problem
+
+The task was to rename macro-related AST line number fields so the compiler clearly distinguished:
+
+- `lineNumberBeforeMacroExpansion`
+- `lineNumberAfterMacroExpansion`
+
+Instead of updating all source, tests, and snapshots immediately, the agent first added fallback helper logic that still accepted the old `lineNumber` field.
+
+That let partially migrated code continue to work, but it was the wrong choice.
+
+## Anti-Patterns
+
+1. Adding a backward-compatibility layer to avoid fixing all call sites during a repo-wide rename.
+2. Using fallback logic to keep old tests passing instead of updating fixtures and snapshots explicitly.
+3. Preserving an obsolete field shape in helper functions after deciding on better names.
+
+Why this is wrong:
+- It blurs the new domain model right after it was clarified.
+- It hides incomplete migration work behind permissive helper behavior.
+- It increases the chance of old and new naming schemes coexisting indefinitely.
+- It optimizes for short-term test stability instead of architectural clarity.
+
+```ts
+export function getLineNumberBeforeMacroExpansion(line: LineNumberCarrier): number {
+	return line.lineNumberBeforeMacroExpansion ?? line.lineNumberAfterMacroExpansion ?? line.lineNumber ?? 0;
+}
+```
+
+The fallback to `lineNumber` was the mistake. Once the rename was chosen, all internal references should have been migrated.
+
+## Failure Pattern
+
+Treating a fully owned internal rename like a public API migration.
+
+## Correct Solution
+
+When the repository owns all code and the rename is intentional:
+
+- rename the fields everywhere,
+- update all source call sites,
+- update test fixtures and snapshots,
+- and remove the old names completely in the same change.
+
+Do not add compatibility shims just to reduce migration work or avoid temporary test breakage. In this case the correct path was to complete the rename end to end and let any missed references fail loudly until fixed.

--- a/packages/cli/src/traceInstructionFlow.ts
+++ b/packages/cli/src/traceInstructionFlow.ts
@@ -89,7 +89,7 @@ function traceAst(id: string, kind: BlockTrace['kind'], ast: AST, context: Compi
 		compiler(line, context);
 
 		entries.push({
-			lineNumber: line.lineNumber + 1,
+			lineNumber: line.lineNumberBeforeMacroExpansion + 1,
 			instruction: line.instruction,
 			arguments: serializeArguments(line),
 			stackBefore,

--- a/packages/compiler/src/astUtils/collectConstants.ts
+++ b/packages/compiler/src/astUtils/collectConstants.ts
@@ -35,7 +35,8 @@ if (import.meta.vitest) {
 						{ type: ArgumentType.IDENTIFIER, value: 'MAX_VALUE' },
 						{ type: ArgumentType.LITERAL, value: 100, isInteger: true },
 					],
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 				},
 			];
 
@@ -53,7 +54,8 @@ if (import.meta.vitest) {
 						{ type: ArgumentType.IDENTIFIER, value: 'PI' },
 						{ type: ArgumentType.LITERAL, value: 3.14159, isInteger: false },
 					],
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 				},
 			];
 
@@ -71,7 +73,8 @@ if (import.meta.vitest) {
 						{ type: ArgumentType.IDENTIFIER, value: 'PI64' },
 						{ type: ArgumentType.LITERAL, value: 3.141592653589793, isInteger: false, isFloat64: true },
 					],
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 				},
 			];
 
@@ -89,7 +92,8 @@ if (import.meta.vitest) {
 						{ type: ArgumentType.IDENTIFIER, value: 'PI' },
 						{ type: ArgumentType.LITERAL, value: 3.14159, isInteger: false },
 					],
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 				},
 				{
 					instruction: 'const',
@@ -97,7 +101,8 @@ if (import.meta.vitest) {
 						{ type: ArgumentType.IDENTIFIER, value: 'TAU' },
 						{ type: ArgumentType.LITERAL, value: 6.28318, isInteger: false },
 					],
-					lineNumber: 2,
+					lineNumberBeforeMacroExpansion: 2,
+					lineNumberAfterMacroExpansion: 2,
 				},
 			];
 
@@ -113,7 +118,8 @@ if (import.meta.vitest) {
 				{
 					instruction: 'module',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'test' }],
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 				},
 				{
 					instruction: 'const',
@@ -121,7 +127,8 @@ if (import.meta.vitest) {
 						{ type: ArgumentType.IDENTIFIER, value: 'VALUE' },
 						{ type: ArgumentType.LITERAL, value: 42, isInteger: true },
 					],
-					lineNumber: 2,
+					lineNumberBeforeMacroExpansion: 2,
+					lineNumberAfterMacroExpansion: 2,
 				},
 			];
 
@@ -136,7 +143,8 @@ if (import.meta.vitest) {
 				{
 					instruction: 'module',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'test' }],
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 				},
 			];
 

--- a/packages/compiler/src/astUtils/getConstantsName.ts
+++ b/packages/compiler/src/astUtils/getConstantsName.ts
@@ -36,7 +36,8 @@ if (import.meta.vitest) {
 				{
 					instruction: 'constants',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'math' }],
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 				},
 			];
 
@@ -53,7 +54,8 @@ if (import.meta.vitest) {
 				{
 					instruction: 'constants',
 					arguments: [],
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 				},
 			];
 
@@ -65,7 +67,8 @@ if (import.meta.vitest) {
 				{
 					instruction: 'constants',
 					arguments: [{ type: ArgumentType.LITERAL, value: 123, isInteger: true }],
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 				},
 			];
 

--- a/packages/compiler/src/astUtils/getModuleName.ts
+++ b/packages/compiler/src/astUtils/getModuleName.ts
@@ -36,7 +36,8 @@ if (import.meta.vitest) {
 				{
 					instruction: 'module',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'testModule' }],
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 				},
 			];
 
@@ -53,7 +54,8 @@ if (import.meta.vitest) {
 				{
 					instruction: 'module',
 					arguments: [],
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 				},
 			];
 
@@ -65,7 +67,8 @@ if (import.meta.vitest) {
 				{
 					instruction: 'module',
 					arguments: [{ type: ArgumentType.LITERAL, value: 123, isInteger: true }],
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 				},
 			];
 

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -8,6 +8,7 @@ import createLocalDeclaration from './wasmUtils/codeSection/createLocalDeclarati
 import instructions, { Instruction } from './instructionCompilers';
 import {
 	AST,
+	type ASTLine,
 	CompilationContext,
 	CompiledModule,
 	CompiledFunction,
@@ -76,12 +77,17 @@ function tokenizeInstruction(line: string): string[] {
 	return tokens;
 }
 
-export function parseLine(line: string, lineNumber: number): AST[number] {
+export function parseLine(
+	line: string,
+	lineNumberBeforeMacroExpansion: number,
+	lineNumberAfterMacroExpansion = lineNumberBeforeMacroExpansion
+): ASTLine {
 	const tokens = tokenizeInstruction(line);
 	const [instruction, ...args] = tokens as [Instruction, ...string[]];
 
 	return {
-		lineNumber,
+		lineNumberBeforeMacroExpansion,
+		lineNumberAfterMacroExpansion,
 		instruction,
 		arguments: args.map(parseArgument),
 	};
@@ -95,10 +101,10 @@ export function compileToAST(
 		.map((line, index) => [index, line] as [number, string])
 		.filter(([, line]) => !isComment(line))
 		.filter(([, line]) => isValidInstruction(line))
-		.map(([lineNumber, line]) => {
-			// Use callSiteLineNumber from metadata if available, otherwise use actual line number
-			const actualLineNumber = lineMetadata?.[lineNumber]?.callSiteLineNumber ?? lineNumber;
-			return parseLine(line, actualLineNumber);
+		.map(([lineNumberAfterMacroExpansion, line]) => {
+			const lineNumberBeforeMacroExpansion =
+				lineMetadata?.[lineNumberAfterMacroExpansion]?.callSiteLineNumber ?? lineNumberAfterMacroExpansion;
+			return parseLine(line, lineNumberBeforeMacroExpansion, lineNumberAfterMacroExpansion);
 		});
 }
 
@@ -151,13 +157,17 @@ export function compileModule(
 	});
 
 	if (!context.namespace.moduleName) {
-		throw getError(ErrorCode.MISSING_MODULE_ID, { lineNumber: 0, instruction: 'module', arguments: [] }, context);
+		throw getError(
+			ErrorCode.MISSING_MODULE_ID,
+			{ lineNumberBeforeMacroExpansion: 0, lineNumberAfterMacroExpansion: 0, instruction: 'module', arguments: [] },
+			context
+		);
 	}
 
 	if (context.stack.length > 0) {
 		throw getError(
 			ErrorCode.STACK_EXPECTED_ZERO_ELEMENTS,
-			{ lineNumber: 0, instruction: 'module', arguments: [] },
+			{ lineNumberBeforeMacroExpansion: 0, lineNumberAfterMacroExpansion: 0, instruction: 'module', arguments: [] },
 			context
 		);
 	}
@@ -212,13 +222,17 @@ export function compileFunction(
 	});
 
 	if (!context.currentFunctionId) {
-		throw getError(ErrorCode.MISSING_FUNCTION_ID, { lineNumber: 0, instruction: 'function', arguments: [] }, context);
+		throw getError(
+			ErrorCode.MISSING_FUNCTION_ID,
+			{ lineNumberBeforeMacroExpansion: 0, lineNumberAfterMacroExpansion: 0, instruction: 'function', arguments: [] },
+			context
+		);
 	}
 
 	if (!context.currentFunctionSignature) {
 		throw getError(
 			ErrorCode.INVALID_FUNCTION_SIGNATURE,
-			{ lineNumber: 0, instruction: 'function', arguments: [] },
+			{ lineNumberBeforeMacroExpansion: 0, lineNumberAfterMacroExpansion: 0, instruction: 'function', arguments: [] },
 			context
 		);
 	}

--- a/packages/compiler/src/compilerError.ts
+++ b/packages/compiler/src/compilerError.ts
@@ -151,7 +151,7 @@ export function getError(
 			return {
 				code,
 				message:
-					line.lineNumber +
+					line.lineNumberBeforeMacroExpansion +
 					': Expected 0 elements on the stack, found ' +
 					context?.stack.length +
 					' [' +

--- a/packages/compiler/src/graphOptimizer.ts
+++ b/packages/compiler/src/graphOptimizer.ts
@@ -178,13 +178,15 @@ if (import.meta.vitest) {
 	const createModuleAst = (moduleId: string, references: string[] = []): AST => {
 		return [
 			{
-				lineNumber: 1,
+				lineNumberBeforeMacroExpansion: 1,
+				lineNumberAfterMacroExpansion: 1,
 				instruction: 'module',
 				arguments: [identifierArgument(moduleId)],
 			},
 			...references.map((reference, index) => {
 				return {
-					lineNumber: index + 2,
+					lineNumberBeforeMacroExpansion: index + 2,
+					lineNumberAfterMacroExpansion: index + 2,
 					instruction: 'int',
 					arguments: [identifierArgument(`value${index}`), identifierArgument(reference)],
 				};
@@ -195,7 +197,8 @@ if (import.meta.vitest) {
 	const createConstantsAst = (): AST => {
 		return [
 			{
-				lineNumber: 1,
+				lineNumberBeforeMacroExpansion: 1,
+				lineNumberAfterMacroExpansion: 1,
 				instruction: 'constants',
 				arguments: [],
 			},

--- a/packages/compiler/src/instructionCompilers/abs.ts
+++ b/packages/compiler/src/instructionCompilers/abs.ts
@@ -21,7 +21,7 @@ const abs: InstructionCompiler = withValidation(
 
 		if (operand.isInteger) {
 			context.stack.push({ isInteger: true, isNonZero: operand.isNonZero });
-			const valueName = '__absify_value' + line.lineNumber;
+			const valueName = '__absify_value' + line.lineNumberAfterMacroExpansion;
 
 			return compileSegment(
 				[
@@ -61,7 +61,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: true });
 
-			abs({ lineNumber: 1, instruction: 'abs', arguments: [] } as AST[number], context);
+			abs(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'abs',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -73,7 +81,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: true });
 
-			abs({ lineNumber: 3, instruction: 'abs', arguments: [] } as AST[number], context);
+			abs(
+				{
+					lineNumberBeforeMacroExpansion: 3,
+					lineNumberAfterMacroExpansion: 3,
+					instruction: 'abs',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -86,7 +102,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isFloat64: true, isNonZero: true });
 
-			abs({ lineNumber: 2, instruction: 'abs', arguments: [] } as AST[number], context);
+			abs(
+				{
+					lineNumberBeforeMacroExpansion: 2,
+					lineNumberAfterMacroExpansion: 2,
+					instruction: 'abs',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/add.ts
+++ b/packages/compiler/src/instructionCompilers/add.ts
@@ -46,7 +46,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: false });
 
-			add({ lineNumber: 1, instruction: 'add', arguments: [] } as AST[number], context);
+			add(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'add',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -58,7 +66,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: false }, { isInteger: false, isNonZero: false });
 
-			add({ lineNumber: 1, instruction: 'add', arguments: [] } as AST[number], context);
+			add(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'add',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -73,7 +89,15 @@ if (import.meta.vitest) {
 				{ isInteger: false, isFloat64: true, isNonZero: false }
 			);
 
-			add({ lineNumber: 1, instruction: 'add', arguments: [] } as AST[number], context);
+			add(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'add',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -89,7 +113,15 @@ if (import.meta.vitest) {
 			);
 
 			expect(() => {
-				add({ lineNumber: 1, instruction: 'add', arguments: [] } as AST[number], context);
+				add(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'add',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/and.ts
+++ b/packages/compiler/src/instructionCompilers/and.ts
@@ -35,7 +35,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: false });
 
-			and({ lineNumber: 1, instruction: 'and', arguments: [] } as AST[number], context);
+			and(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'and',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -48,7 +56,15 @@ if (import.meta.vitest) {
 			context.stack.push({ isInteger: false, isNonZero: false }, { isInteger: false, isNonZero: false });
 
 			expect(() => {
-				and({ lineNumber: 1, instruction: 'and', arguments: [] } as AST[number], context);
+				and(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'and',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/block.ts
+++ b/packages/compiler/src/instructionCompilers/block.ts
@@ -60,7 +60,8 @@ if (import.meta.vitest) {
 
 			block(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'block',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'float' }],
 				} as AST[number],
@@ -78,7 +79,8 @@ if (import.meta.vitest) {
 
 			block(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'block',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'int' }],
 				} as AST[number],
@@ -96,7 +98,8 @@ if (import.meta.vitest) {
 
 			block(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'block',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'void' }],
 				} as AST[number],
@@ -113,7 +116,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 
 			expect(() => {
-				block({ lineNumber: 1, instruction: 'block', arguments: [] } as AST[number], context);
+				block(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'block',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/blockEnd.ts
+++ b/packages/compiler/src/instructionCompilers/blockEnd.ts
@@ -59,7 +59,15 @@ if (import.meta.vitest) {
 			});
 			context.stack.push({ isInteger: true, isNonZero: false });
 
-			blockEnd({ lineNumber: 1, instruction: 'blockEnd', arguments: [] } as AST[number], context);
+			blockEnd(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'blockEnd',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/branch.ts
+++ b/packages/compiler/src/instructionCompilers/branch.ts
@@ -39,7 +39,8 @@ if (import.meta.vitest) {
 
 			branch(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'branch',
 					arguments: [{ type: ArgumentType.LITERAL, value: 0, isInteger: true }],
 				} as AST[number],
@@ -55,7 +56,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 
 			expect(() => {
-				branch({ lineNumber: 1, instruction: 'branch', arguments: [] } as AST[number], context);
+				branch(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'branch',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/branchIfTrue.ts
+++ b/packages/compiler/src/instructionCompilers/branchIfTrue.ts
@@ -45,7 +45,8 @@ if (import.meta.vitest) {
 
 			branchIfTrue(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'branchIfTrue',
 					arguments: [{ type: ArgumentType.LITERAL, value: 2, isInteger: true }],
 				} as AST[number],
@@ -63,7 +64,15 @@ if (import.meta.vitest) {
 			context.stack.push({ isInteger: true, isNonZero: true });
 
 			expect(() => {
-				branchIfTrue({ lineNumber: 1, instruction: 'branchIfTrue', arguments: [] } as AST[number], context);
+				branchIfTrue(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'branchIfTrue',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/branchIfUnchanged.ts
+++ b/packages/compiler/src/instructionCompilers/branchIfUnchanged.ts
@@ -31,8 +31,9 @@ const branchIfUnchanged: InstructionCompiler = withValidation(
 
 		const depth = line.arguments[0].value;
 		const type = operand.isInteger ? 'int' : 'float';
-		const previousValueMemoryName = '__branchIfUnchanged_previousValue' + line.lineNumber;
-		const currentValueMemoryName = '__branchIfUnchanged_currentValue' + line.lineNumber;
+		const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
+		const previousValueMemoryName = '__branchIfUnchanged_previousValue' + lineNumberAfterMacroExpansion;
+		const currentValueMemoryName = '__branchIfUnchanged_currentValue' + lineNumberAfterMacroExpansion;
 
 		return compileSegment(
 			[
@@ -67,7 +68,8 @@ if (import.meta.vitest) {
 
 			branchIfUnchanged(
 				{
-					lineNumber: 4,
+					lineNumberBeforeMacroExpansion: 4,
+					lineNumberAfterMacroExpansion: 4,
 					instruction: 'branchIfUnchanged',
 					arguments: [{ type: ArgumentType.LITERAL, value: 1, isInteger: true }],
 				} as AST[number],
@@ -87,7 +89,15 @@ if (import.meta.vitest) {
 			context.stack.push({ isInteger: false, isNonZero: false });
 
 			expect(() => {
-				branchIfUnchanged({ lineNumber: 1, instruction: 'branchIfUnchanged', arguments: [] } as AST[number], context);
+				branchIfUnchanged(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'branchIfUnchanged',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/buffer.ts
+++ b/packages/compiler/src/instructionCompilers/buffer.ts
@@ -87,7 +87,8 @@ if (import.meta.vitest) {
 
 			buffer(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'int[]',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'values' },
@@ -105,7 +106,8 @@ if (import.meta.vitest) {
 
 			buffer(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'int8[]',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'bytes' },
@@ -128,7 +130,8 @@ if (import.meta.vitest) {
 
 			buffer(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'int8[]',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'bytes' },
@@ -151,7 +154,8 @@ if (import.meta.vitest) {
 
 			buffer(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'int16[]',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'shorts' },
@@ -174,7 +178,8 @@ if (import.meta.vitest) {
 
 			buffer(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'int16[]',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'shorts' },
@@ -197,7 +202,8 @@ if (import.meta.vitest) {
 
 			buffer(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'int32[]',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'ints' },
@@ -219,7 +225,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 
 			expect(() => {
-				buffer({ lineNumber: 1, instruction: 'int[]', arguments: [] } as AST[number], context);
+				buffer(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'int[]',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 
@@ -228,7 +242,8 @@ if (import.meta.vitest) {
 
 			buffer(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'int8u[]',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'unsignedBytes' },
@@ -250,7 +265,8 @@ if (import.meta.vitest) {
 
 			buffer(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'int16u[]',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'unsignedShorts' },
@@ -272,7 +288,8 @@ if (import.meta.vitest) {
 
 			buffer(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'int8[]',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'signedBytes' },
@@ -291,7 +308,8 @@ if (import.meta.vitest) {
 
 			buffer(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'float64[]',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'doubles' },
@@ -315,7 +333,8 @@ if (import.meta.vitest) {
 			// Three int32 variables to force an odd word offset
 			buffer(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'int[]',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'ints' },
@@ -327,7 +346,8 @@ if (import.meta.vitest) {
 
 			buffer(
 				{
-					lineNumber: 2,
+					lineNumberBeforeMacroExpansion: 2,
+					lineNumberAfterMacroExpansion: 2,
 					instruction: 'float64[]',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'doubles' },

--- a/packages/compiler/src/instructionCompilers/call.ts
+++ b/packages/compiler/src/instructionCompilers/call.ts
@@ -87,7 +87,8 @@ if (import.meta.vitest) {
 
 			call(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'call',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'foo' }],
 				} as AST[number],
@@ -115,7 +116,8 @@ if (import.meta.vitest) {
 
 			call(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'call',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'foo64' }],
 				} as AST[number],
@@ -142,7 +144,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				call(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'call',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'foo64' }],
 					} as AST[number],
@@ -157,7 +160,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				call(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'call',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'missing' }],
 					} as AST[number],

--- a/packages/compiler/src/instructionCompilers/castToFloat.ts
+++ b/packages/compiler/src/instructionCompilers/castToFloat.ts
@@ -35,7 +35,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: true });
 
-			castToFloat({ lineNumber: 1, instruction: 'castToFloat', arguments: [] } as AST[number], context);
+			castToFloat(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'castToFloat',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/castToInt.ts
+++ b/packages/compiler/src/instructionCompilers/castToInt.ts
@@ -35,7 +35,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: true });
 
-			castToInt({ lineNumber: 1, instruction: 'castToInt', arguments: [] } as AST[number], context);
+			castToInt(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'castToInt',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/clearStack.ts
+++ b/packages/compiler/src/instructionCompilers/clearStack.ts
@@ -31,7 +31,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: false, isNonZero: true });
 
-			clearStack({ lineNumber: 1, instruction: 'clearStack', arguments: [] } as AST[number], context);
+			clearStack(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'clearStack',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/const.ts
+++ b/packages/compiler/src/instructionCompilers/const.ts
@@ -59,7 +59,8 @@ if (import.meta.vitest) {
 
 			_const(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'const',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'MY_CONST' },
@@ -78,7 +79,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				_const(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'const',
 						arguments: [
 							{ type: ArgumentType.IDENTIFIER, value: 'MY_CONST' },

--- a/packages/compiler/src/instructionCompilers/constants.ts
+++ b/packages/compiler/src/instructionCompilers/constants.ts
@@ -48,7 +48,8 @@ if (import.meta.vitest) {
 
 			constants(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'constants',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'demo' }],
 				} as AST[number],
@@ -65,7 +66,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext({ blockStack: [] });
 
 			expect(() => {
-				constants({ lineNumber: 1, instruction: 'constants', arguments: [] } as AST[number], context);
+				constants(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'constants',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/constantsEnd.ts
+++ b/packages/compiler/src/instructionCompilers/constantsEnd.ts
@@ -41,7 +41,15 @@ if (import.meta.vitest) {
 				],
 			});
 
-			constantsEnd({ lineNumber: 1, instruction: 'constantsEnd', arguments: [] } as AST[number], context);
+			constantsEnd(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'constantsEnd',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({ blockStack: context.blockStack }).toMatchSnapshot();
 		});
@@ -50,7 +58,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext({ blockStack: [] });
 
 			expect(() => {
-				constantsEnd({ lineNumber: 1, instruction: 'constantsEnd', arguments: [] } as AST[number], context);
+				constantsEnd(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'constantsEnd',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/cycle.ts
+++ b/packages/compiler/src/instructionCompilers/cycle.ts
@@ -25,9 +25,10 @@ const cycle: InstructionCompiler = withValidation(
 		context.stack.push({ isInteger: true, isNonZero: false });
 		context.stack.push({ isInteger: true, isNonZero: false });
 
-		const pointerName = '__pointerCycle_pointerToIncrement' + line.lineNumber;
-		const startPositionName = '__pointerCycle_startPosition' + line.lineNumber;
-		const endPositionName = '__pointerCycle_endPosition' + line.lineNumber;
+		const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
+		const pointerName = '__pointerCycle_pointerToIncrement' + lineNumberAfterMacroExpansion;
+		const startPositionName = '__pointerCycle_startPosition' + lineNumberAfterMacroExpansion;
+		const endPositionName = '__pointerCycle_endPosition' + lineNumberAfterMacroExpansion;
 
 		return compileSegment(
 			[
@@ -75,7 +76,15 @@ if (import.meta.vitest) {
 				{ isInteger: true, isNonZero: false }
 			);
 
-			cycle({ lineNumber: 2, instruction: 'cycle', arguments: [] } as AST[number], context);
+			cycle(
+				{
+					lineNumberBeforeMacroExpansion: 2,
+					lineNumberAfterMacroExpansion: 2,
+					instruction: 'cycle',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/default.ts
+++ b/packages/compiler/src/instructionCompilers/default.ts
@@ -70,7 +70,8 @@ if (import.meta.vitest) {
 
 			_default(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'default',
 					arguments: [{ type: ArgumentType.LITERAL, value: 99, isInteger: true }],
 				} as AST[number],
@@ -100,7 +101,15 @@ if (import.meta.vitest) {
 			});
 
 			expect(() => {
-				_default({ lineNumber: 1, instruction: 'default', arguments: [] } as AST[number], context);
+				_default(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'default',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 
@@ -110,7 +119,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				_default(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'default',
 						arguments: [{ type: ArgumentType.LITERAL, value: 0, isInteger: true }],
 					} as AST[number],

--- a/packages/compiler/src/instructionCompilers/div.ts
+++ b/packages/compiler/src/instructionCompilers/div.ts
@@ -50,7 +50,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: true }, { isInteger: true, isNonZero: true });
 
-			div({ lineNumber: 1, instruction: 'div', arguments: [] } as AST[number], context);
+			div(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'div',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -62,7 +70,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: true }, { isInteger: false, isNonZero: true });
 
-			div({ lineNumber: 1, instruction: 'div', arguments: [] } as AST[number], context);
+			div(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'div',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -77,7 +93,15 @@ if (import.meta.vitest) {
 				{ isInteger: false, isFloat64: true, isNonZero: true }
 			);
 
-			div({ lineNumber: 1, instruction: 'div', arguments: [] } as AST[number], context);
+			div(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'div',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -90,7 +114,15 @@ if (import.meta.vitest) {
 			context.stack.push({ isInteger: false, isNonZero: true }, { isInteger: false, isFloat64: true, isNonZero: true });
 
 			expect(() => {
-				div({ lineNumber: 1, instruction: 'div', arguments: [] } as AST[number], context);
+				div(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'div',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 
@@ -99,7 +131,15 @@ if (import.meta.vitest) {
 			context.stack.push({ isInteger: true, isNonZero: true }, { isInteger: true, isNonZero: false });
 
 			expect(() => {
-				div({ lineNumber: 1, instruction: 'div', arguments: [] } as AST[number], context);
+				div(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'div',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/drop.ts
+++ b/packages/compiler/src/instructionCompilers/drop.ts
@@ -31,7 +31,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: false, isNonZero: true });
 
-			drop({ lineNumber: 1, instruction: 'drop', arguments: [] } as AST[number], context);
+			drop(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'drop',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/dup.ts
+++ b/packages/compiler/src/instructionCompilers/dup.ts
@@ -17,7 +17,7 @@ const dup: InstructionCompiler = withValidation(
 		// Non-null assertion is safe: withValidation ensures 1 operand exists
 		const operand = context.stack.pop()!;
 
-		const tempName = '__dupTemp' + line.lineNumber;
+		const tempName = '__dupTemp' + line.lineNumberAfterMacroExpansion;
 
 		context.stack.push(operand);
 		const localType = operand.isInteger ? 'int' : operand.isFloat64 ? 'float64' : 'float';
@@ -39,7 +39,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false });
 
-			dup({ lineNumber: 3, instruction: 'dup', arguments: [] } as AST[number], context);
+			dup(
+				{
+					lineNumberBeforeMacroExpansion: 3,
+					lineNumberAfterMacroExpansion: 3,
+					instruction: 'dup',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -52,7 +60,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isFloat64: true, isNonZero: false });
 
-			dup({ lineNumber: 4, instruction: 'dup', arguments: [] } as AST[number], context);
+			dup(
+				{
+					lineNumberBeforeMacroExpansion: 4,
+					lineNumberAfterMacroExpansion: 4,
+					instruction: 'dup',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/else.ts
+++ b/packages/compiler/src/instructionCompilers/else.ts
@@ -63,7 +63,15 @@ if (import.meta.vitest) {
 			});
 			context.stack.push({ isInteger: true, isNonZero: false });
 
-			_else({ lineNumber: 1, instruction: 'else', arguments: [] } as AST[number], context);
+			_else(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'else',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -76,7 +84,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext({ blockStack: [] });
 
 			expect(() => {
-				_else({ lineNumber: 1, instruction: 'else', arguments: [] } as AST[number], context);
+				_else(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'else',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/ensureNonZero.ts
+++ b/packages/compiler/src/instructionCompilers/ensureNonZero.ts
@@ -36,7 +36,7 @@ const ensureNonZero: InstructionCompiler = withValidation(
 			defaultNonZeroValue = defaultNonZeroValue + 'f64';
 		}
 
-		const tempVariableName = '__ensureNonZero_temp_' + line.lineNumber;
+		const tempVariableName = '__ensureNonZero_temp_' + line.lineNumberAfterMacroExpansion;
 
 		if (operand.isInteger) {
 			const ret = compileSegment(
@@ -89,7 +89,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false });
 
-			ensureNonZero({ lineNumber: 1, instruction: 'ensureNonZero', arguments: [] } as AST[number], context);
+			ensureNonZero(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'ensureNonZero',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -104,7 +112,8 @@ if (import.meta.vitest) {
 
 			ensureNonZero(
 				{
-					lineNumber: 2,
+					lineNumberBeforeMacroExpansion: 2,
+					lineNumberAfterMacroExpansion: 2,
 					instruction: 'ensureNonZero',
 					arguments: [{ type: ArgumentType.LITERAL, value: 2.5, isInteger: false }],
 				} as AST[number],
@@ -124,7 +133,8 @@ if (import.meta.vitest) {
 
 			ensureNonZero(
 				{
-					lineNumber: 3,
+					lineNumberBeforeMacroExpansion: 3,
+					lineNumberAfterMacroExpansion: 3,
 					instruction: 'ensureNonZero',
 					arguments: [{ type: ArgumentType.LITERAL, value: 2.5, isInteger: false, isFloat64: true }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/equal.ts
+++ b/packages/compiler/src/instructionCompilers/equal.ts
@@ -37,7 +37,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: false });
 
-			equal({ lineNumber: 1, instruction: 'equal', arguments: [] } as AST[number], context);
+			equal(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'equal',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -49,7 +57,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: false }, { isInteger: false, isNonZero: false });
 
-			equal({ lineNumber: 1, instruction: 'equal', arguments: [] } as AST[number], context);
+			equal(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'equal',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/equalToZero.ts
+++ b/packages/compiler/src/instructionCompilers/equalToZero.ts
@@ -43,7 +43,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false });
 
-			equalToZero({ lineNumber: 1, instruction: 'equalToZero', arguments: [] } as AST[number], context);
+			equalToZero(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'equalToZero',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -55,7 +63,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: false });
 
-			equalToZero({ lineNumber: 1, instruction: 'equalToZero', arguments: [] } as AST[number], context);
+			equalToZero(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'equalToZero',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -67,7 +83,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isFloat64: true, isNonZero: false });
 
-			equalToZero({ lineNumber: 1, instruction: 'equalToZero', arguments: [] } as AST[number], context);
+			equalToZero(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'equalToZero',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/fallingEdge.ts
+++ b/packages/compiler/src/instructionCompilers/fallingEdge.ts
@@ -17,8 +17,9 @@ const fallingEdge: InstructionCompiler = withValidation(
 		// Non-null assertion is safe: withValidation with minOperands: 1 guarantees at least 1 operand exists on the stack
 		const operand = context.stack.pop()!;
 
-		const currentValueName = '__fallingEdgeDetector_currentValue' + line.lineNumber;
-		const previousValueName = '__fallingEdgeDetector_previousValue' + line.lineNumber;
+		const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
+		const currentValueName = '__fallingEdgeDetector_currentValue' + lineNumberAfterMacroExpansion;
+		const previousValueName = '__fallingEdgeDetector_previousValue' + lineNumberAfterMacroExpansion;
 		const memoryType = operand.isInteger ? 'int' : 'float';
 		const loadInstruction = operand.isInteger ? 'load' : 'loadFloat';
 
@@ -58,7 +59,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false });
 
-			fallingEdge({ lineNumber: 5, instruction: 'fallingEdge', arguments: [] } as AST[number], context);
+			fallingEdge(
+				{
+					lineNumberBeforeMacroExpansion: 5,
+					lineNumberAfterMacroExpansion: 5,
+					instruction: 'fallingEdge',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/float.ts
+++ b/packages/compiler/src/instructionCompilers/float.ts
@@ -19,12 +19,7 @@ const float: InstructionCompiler = withValidation(
 	},
 	(line, context) => {
 		const wordAlignedAddress = calculateWordAlignedSizeOfMemory(context.namespace.memory);
-		const { id, defaultValue } = parseMemoryInstructionArguments(
-			line.arguments,
-			line.lineNumberAfterMacroExpansion,
-			line.instruction,
-			context
-		);
+		const { id, defaultValue } = parseMemoryInstructionArguments(line, context);
 		const pointerDepth = getPointerDepth(line.instruction);
 		const flags = getMemoryFlags('float', pointerDepth);
 

--- a/packages/compiler/src/instructionCompilers/float.ts
+++ b/packages/compiler/src/instructionCompilers/float.ts
@@ -21,7 +21,7 @@ const float: InstructionCompiler = withValidation(
 		const wordAlignedAddress = calculateWordAlignedSizeOfMemory(context.namespace.memory);
 		const { id, defaultValue } = parseMemoryInstructionArguments(
 			line.arguments,
-			line.lineNumber,
+			line.lineNumberAfterMacroExpansion,
 			line.instruction,
 			context
 		);
@@ -55,7 +55,8 @@ if (import.meta.vitest) {
 
 			float(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'float',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'temperature' }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/float64.ts
+++ b/packages/compiler/src/instructionCompilers/float64.ts
@@ -32,7 +32,7 @@ const float64: InstructionCompiler = withValidation(
 		const localWordOffset = calculateWordAlignedSizeOfMemory(context.namespace.memory);
 		const { id, defaultValue } = parseMemoryInstructionArguments(
 			line.arguments,
-			line.lineNumber,
+			line.lineNumberAfterMacroExpansion,
 			line.instruction,
 			context
 		);
@@ -91,7 +91,8 @@ if (import.meta.vitest) {
 
 			float64(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'float64',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'value' }],
 				} as AST[number],
@@ -106,7 +107,8 @@ if (import.meta.vitest) {
 
 			float64(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'float64',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'value' }],
 				} as AST[number],
@@ -121,7 +123,8 @@ if (import.meta.vitest) {
 
 			float64(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'float64',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'value' }],
 				} as AST[number],
@@ -137,7 +140,8 @@ if (import.meta.vitest) {
 			// First float64 (starts at word 0, even)
 			float64(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'float64',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'a' }],
 				} as AST[number],
@@ -147,7 +151,8 @@ if (import.meta.vitest) {
 			// Three int32 variables (odd count) push the offset to an odd word boundary
 			int(
 				{
-					lineNumber: 2,
+					lineNumberBeforeMacroExpansion: 2,
+					lineNumberAfterMacroExpansion: 2,
 					instruction: 'int',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'x' }],
 				} as AST[number],
@@ -155,7 +160,8 @@ if (import.meta.vitest) {
 			);
 			int(
 				{
-					lineNumber: 3,
+					lineNumberBeforeMacroExpansion: 3,
+					lineNumberAfterMacroExpansion: 3,
 					instruction: 'int',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'y' }],
 				} as AST[number],
@@ -163,7 +169,8 @@ if (import.meta.vitest) {
 			);
 			int(
 				{
-					lineNumber: 4,
+					lineNumberBeforeMacroExpansion: 4,
+					lineNumberAfterMacroExpansion: 4,
 					instruction: 'int',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'z' }],
 				} as AST[number],
@@ -173,7 +180,8 @@ if (import.meta.vitest) {
 			// Second float64 must still be 8-byte aligned despite odd preceding offset
 			float64(
 				{
-					lineNumber: 5,
+					lineNumberBeforeMacroExpansion: 5,
+					lineNumberAfterMacroExpansion: 5,
 					instruction: 'float64',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'b' }],
 				} as AST[number],
@@ -190,7 +198,8 @@ if (import.meta.vitest) {
 
 			float64(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'float64*',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'ptr' }],
 				} as AST[number],
@@ -209,7 +218,8 @@ if (import.meta.vitest) {
 
 			float64(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'float64**',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'pptr' }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/float64.ts
+++ b/packages/compiler/src/instructionCompilers/float64.ts
@@ -30,12 +30,7 @@ const float64: InstructionCompiler = withValidation(
 	},
 	(line, context) => {
 		const localWordOffset = calculateWordAlignedSizeOfMemory(context.namespace.memory);
-		const { id, defaultValue } = parseMemoryInstructionArguments(
-			line.arguments,
-			line.lineNumberAfterMacroExpansion,
-			line.instruction,
-			context
-		);
+		const { id, defaultValue } = parseMemoryInstructionArguments(line, context);
 		const pointerDepth = getPointerDepth(line.instruction);
 		const flags = getMemoryFlags('float64', pointerDepth);
 

--- a/packages/compiler/src/instructionCompilers/function.ts
+++ b/packages/compiler/src/instructionCompilers/function.ts
@@ -57,7 +57,8 @@ if (import.meta.vitest) {
 
 			_function(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'function',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'doThing' }],
 				} as AST[number],
@@ -79,7 +80,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				_function(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'function',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'nested' }],
 					} as AST[number],

--- a/packages/compiler/src/instructionCompilers/functionEnd.ts
+++ b/packages/compiler/src/instructionCompilers/functionEnd.ts
@@ -107,7 +107,8 @@ if (import.meta.vitest) {
 
 			functionEnd(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'functionEnd',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'int' }],
 				} as AST[number],
@@ -147,7 +148,8 @@ if (import.meta.vitest) {
 
 			functionEnd(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'functionEnd',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'float64' }],
 				} as AST[number],
@@ -173,7 +175,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				functionEnd(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'functionEnd',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'int' }],
 					} as AST[number],

--- a/packages/compiler/src/instructionCompilers/greaterOrEqual.ts
+++ b/packages/compiler/src/instructionCompilers/greaterOrEqual.ts
@@ -41,7 +41,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: false });
 
-			greaterOrEqual({ lineNumber: 1, instruction: 'greaterOrEqual', arguments: [] } as AST[number], context);
+			greaterOrEqual(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'greaterOrEqual',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -53,7 +61,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: false }, { isInteger: false, isNonZero: false });
 
-			greaterOrEqual({ lineNumber: 1, instruction: 'greaterOrEqual', arguments: [] } as AST[number], context);
+			greaterOrEqual(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'greaterOrEqual',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/greaterOrEqualUnsigned.ts
+++ b/packages/compiler/src/instructionCompilers/greaterOrEqualUnsigned.ts
@@ -42,7 +42,12 @@ if (import.meta.vitest) {
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: false });
 
 			greaterOrEqualUnsigned(
-				{ lineNumber: 1, instruction: 'greaterOrEqualUnsigned', arguments: [] } as AST[number],
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'greaterOrEqualUnsigned',
+					arguments: [],
+				} as AST[number],
 				context
 			);
 
@@ -57,7 +62,12 @@ if (import.meta.vitest) {
 			context.stack.push({ isInteger: false, isNonZero: false }, { isInteger: false, isNonZero: false });
 
 			greaterOrEqualUnsigned(
-				{ lineNumber: 1, instruction: 'greaterOrEqualUnsigned', arguments: [] } as AST[number],
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'greaterOrEqualUnsigned',
+					arguments: [],
+				} as AST[number],
 				context
 			);
 

--- a/packages/compiler/src/instructionCompilers/greaterThan.ts
+++ b/packages/compiler/src/instructionCompilers/greaterThan.ts
@@ -37,7 +37,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: false });
 
-			greaterThan({ lineNumber: 1, instruction: 'greaterThan', arguments: [] } as AST[number], context);
+			greaterThan(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'greaterThan',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -49,7 +57,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: false }, { isInteger: false, isNonZero: false });
 
-			greaterThan({ lineNumber: 1, instruction: 'greaterThan', arguments: [] } as AST[number], context);
+			greaterThan(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'greaterThan',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/hasChanged.ts
+++ b/packages/compiler/src/instructionCompilers/hasChanged.ts
@@ -16,8 +16,9 @@ const hasChanged: InstructionCompiler = withValidation(
 	(line, context) => {
 		const operand = context.stack.pop()!;
 
-		const currentValueName = '__hasChangedDetector_currentValue' + line.lineNumber;
-		const previousValueName = '__hasChangedDetector_previousValue' + line.lineNumber;
+		const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
+		const currentValueName = '__hasChangedDetector_currentValue' + lineNumberAfterMacroExpansion;
+		const previousValueName = '__hasChangedDetector_previousValue' + lineNumberAfterMacroExpansion;
 		const memoryType = operand.isInteger ? 'int' : 'float';
 
 		context.stack.push({ isInteger: operand.isInteger, isNonZero: false });
@@ -51,7 +52,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false });
 
-			hasChanged({ lineNumber: 3, instruction: 'hasChanged', arguments: [] } as AST[number], context);
+			hasChanged(
+				{
+					lineNumberBeforeMacroExpansion: 3,
+					lineNumberAfterMacroExpansion: 3,
+					instruction: 'hasChanged',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/if.ts
+++ b/packages/compiler/src/instructionCompilers/if.ts
@@ -64,7 +64,8 @@ if (import.meta.vitest) {
 
 			_if(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'if',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'void' }],
 				} as AST[number],
@@ -83,7 +84,8 @@ if (import.meta.vitest) {
 
 			_if(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'if',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'float' }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/ifEnd.ts
+++ b/packages/compiler/src/instructionCompilers/ifEnd.ts
@@ -63,7 +63,15 @@ if (import.meta.vitest) {
 			});
 			context.stack.push({ isInteger: true, isNonZero: false });
 
-			ifEnd({ lineNumber: 1, instruction: 'ifEnd', arguments: [] } as AST[number], context);
+			ifEnd(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'ifEnd',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -76,7 +84,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 
 			expect(() => {
-				ifEnd({ lineNumber: 1, instruction: 'ifEnd', arguments: [] } as AST[number], context);
+				ifEnd(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'ifEnd',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/init.ts
+++ b/packages/compiler/src/instructionCompilers/init.ts
@@ -148,7 +148,8 @@ if (import.meta.vitest) {
 
 			init(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'init',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'buffer' },
@@ -165,7 +166,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 
 			expect(() => {
-				init({ lineNumber: 1, instruction: 'init', arguments: [] } as AST[number], context);
+				init(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'init',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/initOnly.ts
+++ b/packages/compiler/src/instructionCompilers/initOnly.ts
@@ -41,7 +41,8 @@ if (import.meta.vitest) {
 
 			initOnly(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: '#initOnly',
 					arguments: [],
 				} as AST[number],
@@ -59,7 +60,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				initOnly(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: '#initOnly',
 						arguments: [],
 					} as AST[number],
@@ -81,7 +83,8 @@ if (import.meta.vitest) {
 
 			initOnly(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: '#initOnly',
 					arguments: [],
 				} as AST[number],
@@ -92,7 +95,8 @@ if (import.meta.vitest) {
 
 			initOnly(
 				{
-					lineNumber: 2,
+					lineNumberBeforeMacroExpansion: 2,
+					lineNumberAfterMacroExpansion: 2,
 					instruction: '#initOnly',
 					arguments: [],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/int.ts
+++ b/packages/compiler/src/instructionCompilers/int.ts
@@ -19,12 +19,7 @@ const int: InstructionCompiler = withValidation(
 	},
 	(line, context) => {
 		const wordAlignedAddress = calculateWordAlignedSizeOfMemory(context.namespace.memory);
-		const { id, defaultValue } = parseMemoryInstructionArguments(
-			line.arguments,
-			line.lineNumberAfterMacroExpansion,
-			line.instruction,
-			context
-		);
+		const { id, defaultValue } = parseMemoryInstructionArguments(line, context);
 		const pointerDepth = getPointerDepth(line.instruction);
 		const flags = getMemoryFlags('int', pointerDepth);
 

--- a/packages/compiler/src/instructionCompilers/int.ts
+++ b/packages/compiler/src/instructionCompilers/int.ts
@@ -21,7 +21,7 @@ const int: InstructionCompiler = withValidation(
 		const wordAlignedAddress = calculateWordAlignedSizeOfMemory(context.namespace.memory);
 		const { id, defaultValue } = parseMemoryInstructionArguments(
 			line.arguments,
-			line.lineNumber,
+			line.lineNumberAfterMacroExpansion,
 			line.instruction,
 			context
 		);
@@ -58,7 +58,8 @@ if (import.meta.vitest) {
 
 			int(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'int',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'counter' }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/lessOrEqual.ts
+++ b/packages/compiler/src/instructionCompilers/lessOrEqual.ts
@@ -37,7 +37,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: false });
 
-			lessOrEqual({ lineNumber: 1, instruction: 'lessOrEqual', arguments: [] } as AST[number], context);
+			lessOrEqual(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'lessOrEqual',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -49,7 +57,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: false }, { isInteger: false, isNonZero: false });
 
-			lessOrEqual({ lineNumber: 1, instruction: 'lessOrEqual', arguments: [] } as AST[number], context);
+			lessOrEqual(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'lessOrEqual',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/lessThan.ts
+++ b/packages/compiler/src/instructionCompilers/lessThan.ts
@@ -37,7 +37,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: false });
 
-			lessThan({ lineNumber: 1, instruction: 'lessThan', arguments: [] } as AST[number], context);
+			lessThan(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'lessThan',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -49,7 +57,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: false }, { isInteger: false, isNonZero: false });
 
-			lessThan({ lineNumber: 1, instruction: 'lessThan', arguments: [] } as AST[number], context);
+			lessThan(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'lessThan',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/load.ts
+++ b/packages/compiler/src/instructionCompilers/load.ts
@@ -42,7 +42,7 @@ const load: InstructionCompiler = withValidation(
 			return saveByteCode(context, instructions);
 		} else {
 			context.stack.push({ isInteger: true, isNonZero: false });
-			const tempVariableName = '__loadAddress_temp_' + line.lineNumber;
+			const tempVariableName = '__loadAddress_temp_' + line.lineNumberAfterMacroExpansion;
 			const instructions = instructionToByteCodeMap[line.instruction];
 			if (!instructions) {
 				throw getError(ErrorCode.UNRECOGNISED_INSTRUCTION, line, context);
@@ -79,7 +79,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false, isSafeMemoryAddress: true });
 
-			load({ lineNumber: 1, instruction: 'load', arguments: [] } as AST[number], context);
+			load(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'load',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -91,7 +99,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext({ memoryByteSize: 32 });
 			context.stack.push({ isInteger: true, isNonZero: false, isSafeMemoryAddress: false });
 
-			load({ lineNumber: 2, instruction: 'load8u', arguments: [] } as AST[number], context);
+			load(
+				{
+					lineNumberBeforeMacroExpansion: 2,
+					lineNumberAfterMacroExpansion: 2,
+					instruction: 'load8u',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/loadFloat.ts
+++ b/packages/compiler/src/instructionCompilers/loadFloat.ts
@@ -24,7 +24,7 @@ const loadFloat: InstructionCompiler = withValidation(
 			return saveByteCode(context, f32load());
 		} else {
 			context.stack.push(operand);
-			const tempVariableName = '__loadAddress_temp_' + line.lineNumber;
+			const tempVariableName = '__loadAddress_temp_' + line.lineNumberAfterMacroExpansion;
 			const ret = compileSegment(
 				[
 					`local int ${tempVariableName}`,
@@ -60,7 +60,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false, isSafeMemoryAddress: true });
 
-			loadFloat({ lineNumber: 1, instruction: 'loadFloat', arguments: [] } as AST[number], context);
+			loadFloat(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'loadFloat',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -72,7 +80,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext({ memoryByteSize: 16 });
 			context.stack.push({ isInteger: true, isNonZero: false, isSafeMemoryAddress: false });
 
-			loadFloat({ lineNumber: 2, instruction: 'loadFloat', arguments: [] } as AST[number], context);
+			loadFloat(
+				{
+					lineNumberBeforeMacroExpansion: 2,
+					lineNumberAfterMacroExpansion: 2,
+					instruction: 'loadFloat',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/local.ts
+++ b/packages/compiler/src/instructionCompilers/local.ts
@@ -44,7 +44,8 @@ if (import.meta.vitest) {
 
 			local(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'local',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'int' },
@@ -61,7 +62,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 
 			expect(() => {
-				local({ lineNumber: 1, instruction: 'local', arguments: [] } as AST[number], context);
+				local(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'local',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/localGet.ts
+++ b/packages/compiler/src/instructionCompilers/localGet.ts
@@ -59,7 +59,8 @@ if (import.meta.vitest) {
 
 			_localGet(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'localGet',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'value' }],
 				} as AST[number],
@@ -78,7 +79,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				_localGet(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'localGet',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'missing' }],
 					} as AST[number],

--- a/packages/compiler/src/instructionCompilers/localSet.ts
+++ b/packages/compiler/src/instructionCompilers/localSet.ts
@@ -64,7 +64,8 @@ if (import.meta.vitest) {
 
 			_localSet(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'localSet',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'value' }],
 				} as AST[number],
@@ -82,7 +83,15 @@ if (import.meta.vitest) {
 			context.stack.push({ isInteger: true, isNonZero: false });
 
 			expect(() => {
-				_localSet({ lineNumber: 1, instruction: 'localSet', arguments: [] } as AST[number], context);
+				_localSet(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'localSet',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/loop.ts
+++ b/packages/compiler/src/instructionCompilers/loop.ts
@@ -22,7 +22,7 @@ const loop: InstructionCompiler = withValidation(
 			blockType: BLOCK_TYPE.LOOP,
 		});
 
-		const infiniteLoopProtectionCounterName = '__infiniteLoopProtectionCounter' + line.lineNumber;
+		const infiniteLoopProtectionCounterName = '__infiniteLoopProtectionCounter' + line.lineNumberAfterMacroExpansion;
 		const loopErrorSignalerName = '__loopErrorSignaler';
 
 		return compileSegment(
@@ -46,7 +46,7 @@ const loop: InstructionCompiler = withValidation(
 				'greaterOrEqual',
 				'if void',
 				` push &${loopErrorSignalerName}`,
-				` push ${line.lineNumber}`,
+				` push ${line.lineNumberBeforeMacroExpansion}`,
 				' store',
 				` branch 2`,
 				'ifEnd',
@@ -69,7 +69,15 @@ if (import.meta.vitest) {
 		it('compiles the loop segment', () => {
 			const context = createInstructionCompilerTestContext();
 
-			loop({ lineNumber: 2, instruction: 'loop', arguments: [] } as AST[number], context);
+			loop(
+				{
+					lineNumberBeforeMacroExpansion: 2,
+					lineNumberAfterMacroExpansion: 2,
+					instruction: 'loop',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				blockStack: context.blockStack,

--- a/packages/compiler/src/instructionCompilers/loopEnd.ts
+++ b/packages/compiler/src/instructionCompilers/loopEnd.ts
@@ -59,7 +59,15 @@ if (import.meta.vitest) {
 				],
 			});
 
-			loopEnd({ lineNumber: 1, instruction: 'loopEnd', arguments: [] } as AST[number], context);
+			loopEnd(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'loopEnd',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				blockStack: context.blockStack,
@@ -71,7 +79,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 
 			expect(() => {
-				loopEnd({ lineNumber: 1, instruction: 'loopEnd', arguments: [] } as AST[number], context);
+				loopEnd(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'loopEnd',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/map.ts
+++ b/packages/compiler/src/instructionCompilers/map.ts
@@ -120,7 +120,8 @@ if (import.meta.vitest) {
 
 			map(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'map',
 					arguments: [
 						{ type: ArgumentType.LITERAL, value: 1, isInteger: true },
@@ -152,7 +153,8 @@ if (import.meta.vitest) {
 
 			map(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'map',
 					arguments: [
 						{ type: ArgumentType.STRING_LITERAL, value: 'A' },
@@ -187,7 +189,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				map(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'map',
 						arguments: [
 							{ type: ArgumentType.STRING_LITERAL, value: 'AB' },
@@ -219,7 +222,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				map(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'map',
 						arguments: [
 							{ type: ArgumentType.LITERAL, value: 1.5, isInteger: false },
@@ -249,7 +253,15 @@ if (import.meta.vitest) {
 			});
 
 			expect(() => {
-				map({ lineNumber: 1, instruction: 'map', arguments: [] } as AST[number], context);
+				map(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'map',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 
@@ -259,7 +271,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				map(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'map',
 						arguments: [
 							{ type: ArgumentType.LITERAL, value: 1, isInteger: true },

--- a/packages/compiler/src/instructionCompilers/mapBegin.ts
+++ b/packages/compiler/src/instructionCompilers/mapBegin.ts
@@ -52,7 +52,8 @@ if (import.meta.vitest) {
 
 			mapBegin(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'mapBegin',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'int' }],
 				} as AST[number],
@@ -69,7 +70,8 @@ if (import.meta.vitest) {
 
 			mapBegin(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'mapBegin',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'float' }],
 				} as AST[number],
@@ -86,7 +88,8 @@ if (import.meta.vitest) {
 
 			mapBegin(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'mapBegin',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'float64' }],
 				} as AST[number],
@@ -102,7 +105,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 
 			expect(() => {
-				mapBegin({ lineNumber: 1, instruction: 'mapBegin', arguments: [] } as AST[number], context);
+				mapBegin(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'mapBegin',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 
@@ -112,7 +123,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				mapBegin(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'mapBegin',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'unknown' }],
 					} as AST[number],

--- a/packages/compiler/src/instructionCompilers/mapEnd.ts
+++ b/packages/compiler/src/instructionCompilers/mapEnd.ts
@@ -267,7 +267,15 @@ if (import.meta.vitest) {
 			context.stack.push({ isInteger: true });
 
 			expect(() => {
-				mapEnd({ lineNumber: 1, instruction: 'mapEnd', arguments: [] } as AST[number], context);
+				mapEnd(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'mapEnd',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 
@@ -278,7 +286,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				mapEnd(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'mapEnd',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'int' }],
 					} as AST[number],
@@ -307,7 +316,8 @@ if (import.meta.vitest) {
 
 			mapEnd(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'mapEnd',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'int' }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/module.ts
+++ b/packages/compiler/src/instructionCompilers/module.ts
@@ -43,7 +43,8 @@ if (import.meta.vitest) {
 
 			_module(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'module',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'demo' }],
 				} as AST[number],
@@ -60,7 +61,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext({ blockStack: [] });
 
 			expect(() => {
-				_module({ lineNumber: 1, instruction: 'module', arguments: [] } as AST[number], context);
+				_module(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'module',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/moduleEnd.ts
+++ b/packages/compiler/src/instructionCompilers/moduleEnd.ts
@@ -45,7 +45,15 @@ if (import.meta.vitest) {
 				],
 			});
 
-			moduleEnd({ lineNumber: 1, instruction: 'moduleEnd', arguments: [] } as AST[number], context);
+			moduleEnd(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'moduleEnd',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({ blockStack: context.blockStack }).toMatchSnapshot();
 		});

--- a/packages/compiler/src/instructionCompilers/mul.ts
+++ b/packages/compiler/src/instructionCompilers/mul.ts
@@ -46,7 +46,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: false });
 
-			mul({ lineNumber: 1, instruction: 'mul', arguments: [] } as AST[number], context);
+			mul(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'mul',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -58,7 +66,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: false }, { isInteger: false, isNonZero: false });
 
-			mul({ lineNumber: 1, instruction: 'mul', arguments: [] } as AST[number], context);
+			mul(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'mul',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -73,7 +89,15 @@ if (import.meta.vitest) {
 				{ isInteger: false, isFloat64: true, isNonZero: false }
 			);
 
-			mul({ lineNumber: 1, instruction: 'mul', arguments: [] } as AST[number], context);
+			mul(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'mul',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -89,7 +113,15 @@ if (import.meta.vitest) {
 			);
 
 			expect(() => {
-				mul({ lineNumber: 1, instruction: 'mul', arguments: [] } as AST[number], context);
+				mul(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'mul',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/or.ts
+++ b/packages/compiler/src/instructionCompilers/or.ts
@@ -36,7 +36,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: true });
 
-			or({ lineNumber: 1, instruction: 'or', arguments: [] } as AST[number], context);
+			or(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'or',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/param.ts
+++ b/packages/compiler/src/instructionCompilers/param.ts
@@ -100,7 +100,8 @@ if (import.meta.vitest) {
 
 			param(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'param',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'int' },
@@ -135,7 +136,8 @@ if (import.meta.vitest) {
 
 			param(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'param',
 					arguments: [
 						{ type: ArgumentType.IDENTIFIER, value: 'float64' },
@@ -171,7 +173,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				param(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'param',
 						arguments: [
 							{ type: ArgumentType.IDENTIFIER, value: 'int' },

--- a/packages/compiler/src/instructionCompilers/pow2.ts
+++ b/packages/compiler/src/instructionCompilers/pow2.ts
@@ -34,7 +34,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: true });
 
-			pow2({ lineNumber: 1, instruction: 'pow2', arguments: [] } as AST[number], context);
+			pow2(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'pow2',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/push.ts
+++ b/packages/compiler/src/instructionCompilers/push.ts
@@ -76,7 +76,8 @@ if (import.meta.vitest) {
 
 			push(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.LITERAL, value: 5, isInteger: true }],
 				} as AST[number],
@@ -101,7 +102,8 @@ if (import.meta.vitest) {
 
 			push(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'ANSWER' }],
 				} as AST[number],
@@ -118,7 +120,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 
 			expect(() => {
-				push({ lineNumber: 1, instruction: 'push', arguments: [] } as AST[number], context);
+				push(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'push',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 
@@ -127,7 +137,8 @@ if (import.meta.vitest) {
 
 			push(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.STRING_LITERAL, value: 'hi' }],
 				} as AST[number],
@@ -145,7 +156,8 @@ if (import.meta.vitest) {
 
 			push(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.LITERAL, value: 3.14, isInteger: false, isFloat64: true }],
 				} as AST[number],
@@ -163,7 +175,8 @@ if (import.meta.vitest) {
 
 			push(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.LITERAL, value: 1.5, isInteger: false, isFloat64: true }],
 				} as AST[number],
@@ -186,7 +199,8 @@ if (import.meta.vitest) {
 
 			push(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'PI64' }],
 				} as AST[number],
@@ -211,7 +225,8 @@ if (import.meta.vitest) {
 
 			push(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'PI64' }],
 				} as AST[number],
@@ -227,7 +242,8 @@ if (import.meta.vitest) {
 
 			push(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.LITERAL, value: 3.14, isInteger: false }],
 				} as AST[number],
@@ -255,7 +271,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: '^myInt' }],
 					} as AST[number],
@@ -283,7 +300,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: '^myInt16' }],
 					} as AST[number],
@@ -311,7 +329,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: '^myInt8' }],
 					} as AST[number],
@@ -339,7 +358,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: '^myFloat' }],
 					} as AST[number],
@@ -368,7 +388,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: '^myF64' }],
 					} as AST[number],
@@ -398,7 +419,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: '!myInt' }],
 					} as AST[number],
@@ -426,7 +448,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: '!myInt16' }],
 					} as AST[number],
@@ -454,7 +477,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: '!myInt8' }],
 					} as AST[number],
@@ -482,7 +506,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: '!myFloat' }],
 					} as AST[number],
@@ -511,7 +536,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: '!myF64' }],
 					} as AST[number],
@@ -543,7 +569,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'myF64' }],
 					} as AST[number],
@@ -573,7 +600,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'myF64' }],
 					} as AST[number],
@@ -601,7 +629,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'myF32' }],
 					} as AST[number],
@@ -629,7 +658,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'myF64' }],
 					} as AST[number],
@@ -656,7 +686,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'myF32' }],
 					} as AST[number],
@@ -684,7 +715,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: '*floatPointer' }],
 					} as AST[number],
@@ -712,7 +744,8 @@ if (import.meta.vitest) {
 
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: '*floatPointerPointer' }],
 					} as AST[number],
@@ -751,7 +784,8 @@ if (import.meta.vitest) {
 				const contextInt = { ...context, stack: [] as typeof context.stack, byteCode: [] as typeof context.byteCode };
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'myInt' }],
 					} as AST[number],
@@ -764,7 +798,8 @@ if (import.meta.vitest) {
 				const contextFloat = { ...context, stack: [] as typeof context.stack, byteCode: [] as typeof context.byteCode };
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'myFloat' }],
 					} as AST[number],
@@ -777,7 +812,8 @@ if (import.meta.vitest) {
 				const contextF64 = { ...context, stack: [] as typeof context.stack, byteCode: [] as typeof context.byteCode };
 				push(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'myF64' }],
 					} as AST[number],

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushConst.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushConst.ts
@@ -32,7 +32,8 @@ if (import.meta.vitest) {
 
 			pushConst(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'ANSWER' }],
 				} as AST[number],
@@ -55,7 +56,8 @@ if (import.meta.vitest) {
 
 			pushConst(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'PI64' }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushElementCount.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushElementCount.ts
@@ -44,7 +44,8 @@ if (import.meta.vitest) {
 
 			pushElementCount(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: '$buffer' }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushElementMax.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushElementMax.ts
@@ -54,7 +54,8 @@ if (import.meta.vitest) {
 
 			pushElementMax(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: '^buffer' }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushElementMin.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushElementMin.ts
@@ -54,7 +54,8 @@ if (import.meta.vitest) {
 
 			pushElementMin(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: '!buffer' }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushElementWordSize.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushElementWordSize.ts
@@ -44,7 +44,8 @@ if (import.meta.vitest) {
 
 			pushElementWordSize(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: '%buffer' }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushLocal.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushLocal.ts
@@ -34,7 +34,8 @@ if (import.meta.vitest) {
 
 			pushLocal(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'temp' }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryIdentifier.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryIdentifier.ts
@@ -54,7 +54,8 @@ if (import.meta.vitest) {
 
 			pushMemoryIdentifier(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'value' }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryPointer.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryPointer.ts
@@ -61,7 +61,8 @@ if (import.meta.vitest) {
 
 			pushMemoryPointer(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: '*ptr' }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryReference.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryReference.ts
@@ -54,7 +54,8 @@ if (import.meta.vitest) {
 
 			pushMemoryReference(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: '&buffer' }],
 				} as AST[number],
@@ -91,7 +92,8 @@ if (import.meta.vitest) {
 
 			pushMemoryReference(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'buffer&' }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/remainder.ts
+++ b/packages/compiler/src/instructionCompilers/remainder.ts
@@ -40,7 +40,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: true }, { isInteger: true, isNonZero: true });
 
-			remainder({ lineNumber: 1, instruction: 'remainder', arguments: [] } as AST[number], context);
+			remainder(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'remainder',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -53,7 +61,15 @@ if (import.meta.vitest) {
 			context.stack.push({ isInteger: true, isNonZero: true }, { isInteger: true, isNonZero: false });
 
 			expect(() => {
-				remainder({ lineNumber: 1, instruction: 'remainder', arguments: [] } as AST[number], context);
+				remainder(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'remainder',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/risingEdge.ts
+++ b/packages/compiler/src/instructionCompilers/risingEdge.ts
@@ -17,8 +17,9 @@ const risingEdge: InstructionCompiler = withValidation(
 		// Non-null assertion is safe: withValidation with minOperands: 1 guarantees at least 1 operand exists on the stack
 		const operand = context.stack.pop()!;
 
-		const currentValueName = '__risingEdgeDetector_currentValue' + line.lineNumber;
-		const previousValueName = '__risingEdgeDetector_previousValue' + line.lineNumber;
+		const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
+		const currentValueName = '__risingEdgeDetector_currentValue' + lineNumberAfterMacroExpansion;
+		const previousValueName = '__risingEdgeDetector_previousValue' + lineNumberAfterMacroExpansion;
 		const memoryType = operand.isInteger ? 'int' : 'float';
 		const loadInstruction = operand.isInteger ? 'load' : 'loadFloat';
 
@@ -58,7 +59,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false });
 
-			risingEdge({ lineNumber: 4, instruction: 'risingEdge', arguments: [] } as AST[number], context);
+			risingEdge(
+				{
+					lineNumberBeforeMacroExpansion: 4,
+					lineNumberAfterMacroExpansion: 4,
+					instruction: 'risingEdge',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -72,7 +81,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: false });
 
-			risingEdge({ lineNumber: 4, instruction: 'risingEdge', arguments: [] } as AST[number], context);
+			risingEdge(
+				{
+					lineNumberBeforeMacroExpansion: 4,
+					lineNumberAfterMacroExpansion: 4,
+					instruction: 'risingEdge',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/round.ts
+++ b/packages/compiler/src/instructionCompilers/round.ts
@@ -35,7 +35,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: true });
 
-			round({ lineNumber: 1, instruction: 'round', arguments: [] } as AST[number], context);
+			round(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'round',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/shiftLeft.ts
+++ b/packages/compiler/src/instructionCompilers/shiftLeft.ts
@@ -35,7 +35,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: false });
 
-			shiftLeft({ lineNumber: 1, instruction: 'shiftLeft', arguments: [] } as AST[number], context);
+			shiftLeft(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'shiftLeft',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/shiftRight.ts
+++ b/packages/compiler/src/instructionCompilers/shiftRight.ts
@@ -35,7 +35,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: false });
 
-			shiftRight({ lineNumber: 1, instruction: 'shiftRight', arguments: [] } as AST[number], context);
+			shiftRight(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'shiftRight',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/shiftRightUnsigned.ts
+++ b/packages/compiler/src/instructionCompilers/shiftRightUnsigned.ts
@@ -35,7 +35,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: false });
 
-			shiftRightUnsigned({ lineNumber: 1, instruction: 'shiftRightUnsigned', arguments: [] } as AST[number], context);
+			shiftRightUnsigned(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'shiftRightUnsigned',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/skip.ts
+++ b/packages/compiler/src/instructionCompilers/skip.ts
@@ -98,7 +98,15 @@ if (import.meta.vitest) {
 		it('returns early without arguments', () => {
 			const context = createInstructionCompilerTestContext();
 
-			skip({ lineNumber: 1, instruction: 'skip', arguments: [] } as AST[number], context);
+			skip(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'skip',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				byteCode: context.byteCode,
@@ -110,7 +118,8 @@ if (import.meta.vitest) {
 
 			skip(
 				{
-					lineNumber: 2,
+					lineNumberBeforeMacroExpansion: 2,
+					lineNumberAfterMacroExpansion: 2,
 					instruction: 'skip',
 					arguments: [{ type: ArgumentType.LITERAL, value: 3, isInteger: true }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/skipExecution.ts
+++ b/packages/compiler/src/instructionCompilers/skipExecution.ts
@@ -42,7 +42,8 @@ if (import.meta.vitest) {
 
 			skipExecution(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: '#skipExecution',
 					arguments: [],
 				} as AST[number],
@@ -60,7 +61,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				skipExecution(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: '#skipExecution',
 						arguments: [],
 					} as AST[number],
@@ -82,7 +84,8 @@ if (import.meta.vitest) {
 
 			skipExecution(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: '#skipExecution',
 					arguments: [],
 				} as AST[number],
@@ -93,7 +96,8 @@ if (import.meta.vitest) {
 
 			skipExecution(
 				{
-					lineNumber: 2,
+					lineNumberBeforeMacroExpansion: 2,
+					lineNumberAfterMacroExpansion: 2,
 					instruction: '#skipExecution',
 					arguments: [],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/sqrt.ts
+++ b/packages/compiler/src/instructionCompilers/sqrt.ts
@@ -34,7 +34,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: true });
 
-			sqrt({ lineNumber: 1, instruction: 'sqrt', arguments: [] } as AST[number], context);
+			sqrt(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'sqrt',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/store.ts
+++ b/packages/compiler/src/instructionCompilers/store.ts
@@ -33,8 +33,9 @@ const store: InstructionCompiler = withValidation(
 			context.stack.push(operand2Address);
 			context.stack.push(operand1Value);
 
-			const tempAddressVariableName = '__storeAddress_temp_' + line.lineNumber;
-			const tempValueVariableName = '__storeValue_temp_' + line.lineNumber;
+			const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
+			const tempAddressVariableName = '__storeAddress_temp_' + lineNumberAfterMacroExpansion;
+			const tempValueVariableName = '__storeValue_temp_' + lineNumberAfterMacroExpansion;
 			const tempValueType = operand1Value.isInteger ? 'int' : operand1Value.isFloat64 ? 'float64' : 'float';
 			const storeOpcodes = operand1Value.isInteger ? i32store() : operand1Value.isFloat64 ? f64store() : f32store();
 			// Memory overflow protection.
@@ -83,7 +84,15 @@ if (import.meta.vitest) {
 				{ isInteger: true, isNonZero: false }
 			);
 
-			store({ lineNumber: 1, instruction: 'store', arguments: [] } as AST[number], context);
+			store(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'store',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -98,7 +107,15 @@ if (import.meta.vitest) {
 				{ isInteger: true, isNonZero: false }
 			);
 
-			store({ lineNumber: 2, instruction: 'store', arguments: [] } as AST[number], context);
+			store(
+				{
+					lineNumberBeforeMacroExpansion: 2,
+					lineNumberAfterMacroExpansion: 2,
+					instruction: 'store',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -113,7 +130,15 @@ if (import.meta.vitest) {
 				{ isInteger: false, isFloat64: true, isNonZero: false }
 			);
 
-			store({ lineNumber: 3, instruction: 'store', arguments: [] } as AST[number], context);
+			store(
+				{
+					lineNumberBeforeMacroExpansion: 3,
+					lineNumberAfterMacroExpansion: 3,
+					instruction: 'store',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect(context.byteCode).toContain(57); // F64_STORE opcode
 			expect(context.byteCode).not.toContain(56); // no F32_STORE
@@ -128,7 +153,15 @@ if (import.meta.vitest) {
 				{ isInteger: false, isNonZero: false }
 			);
 
-			store({ lineNumber: 4, instruction: 'store', arguments: [] } as AST[number], context);
+			store(
+				{
+					lineNumberBeforeMacroExpansion: 4,
+					lineNumberAfterMacroExpansion: 4,
+					instruction: 'store',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect(context.byteCode).toContain(56); // F32_STORE opcode
 			expect(context.byteCode).not.toContain(57); // no F64_STORE
@@ -141,7 +174,15 @@ if (import.meta.vitest) {
 				{ isInteger: false, isFloat64: true, isNonZero: false }
 			);
 
-			store({ lineNumber: 5, instruction: 'store', arguments: [] } as AST[number], context);
+			store(
+				{
+					lineNumberBeforeMacroExpansion: 5,
+					lineNumberAfterMacroExpansion: 5,
+					instruction: 'store',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect(context.byteCode).toContain(57); // F64_STORE opcode
 			expect(context.byteCode).not.toContain(56); // no F32_STORE
@@ -155,7 +196,15 @@ if (import.meta.vitest) {
 				{ isInteger: false, isFloat64: true, isNonZero: false }
 			);
 
-			store({ lineNumber: 6, instruction: 'store', arguments: [] } as AST[number], context);
+			store(
+				{
+					lineNumberBeforeMacroExpansion: 6,
+					lineNumberAfterMacroExpansion: 6,
+					instruction: 'store',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			const valueLocal = Object.entries(context.namespace.locals).find(([name]) =>
 				name.startsWith('__storeValue_temp_')

--- a/packages/compiler/src/instructionCompilers/storeBytes.ts
+++ b/packages/compiler/src/instructionCompilers/storeBytes.ts
@@ -29,8 +29,9 @@ const storeBytes: InstructionCompiler = withValidation(
 	(line, context) => {
 		const count = (line.arguments[0] as Extract<(typeof line.arguments)[number], { type: ArgumentType.LITERAL }>).value;
 
-		const tempAddrVar = `__storeBytesAddr_${line.lineNumber}`;
-		const tempByteVar = `__storeBytesByte_${line.lineNumber}`;
+		const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
+		const tempAddrVar = `__storeBytesAddr_${lineNumberAfterMacroExpansion}`;
+		const tempByteVar = `__storeBytesByte_${lineNumberAfterMacroExpansion}`;
 
 		const lines = [`local int ${tempAddrVar}`, `local int ${tempByteVar}`, `localSet ${tempAddrVar}`];
 		for (let i = 0; i < count; i++) {
@@ -64,7 +65,15 @@ if (import.meta.vitest) {
 			context.stack.push({ isInteger: true, isNonZero: false, isSafeMemoryAddress: true });
 
 			expect(() => {
-				storeBytes({ lineNumber: 1, instruction: 'storeBytes', arguments: [] } as AST[number], context);
+				storeBytes(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'storeBytes',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrow();
 		});
 
@@ -75,7 +84,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				storeBytes(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'storeBytes',
 						arguments: [{ type: ArgumentType.LITERAL, value: 1.5, isInteger: false }],
 					} as AST[number],
@@ -91,7 +101,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				storeBytes(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'storeBytes',
 						arguments: [{ type: ArgumentType.LITERAL, value: -1, isInteger: true }],
 					} as AST[number],
@@ -108,7 +119,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				storeBytes(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'storeBytes',
 						arguments: [{ type: ArgumentType.LITERAL, value: 3, isInteger: true }],
 					} as AST[number],
@@ -129,7 +141,8 @@ if (import.meta.vitest) {
 
 			storeBytes(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'storeBytes',
 					arguments: [{ type: ArgumentType.LITERAL, value: 3, isInteger: true }],
 				} as AST[number],
@@ -150,7 +163,8 @@ if (import.meta.vitest) {
 
 			storeBytes(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'storeBytes',
 					arguments: [{ type: ArgumentType.LITERAL, value: 2, isInteger: true }],
 				} as AST[number],
@@ -166,7 +180,8 @@ if (import.meta.vitest) {
 
 			storeBytes(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'storeBytes',
 					arguments: [{ type: ArgumentType.LITERAL, value: 0, isInteger: true }],
 				} as AST[number],

--- a/packages/compiler/src/instructionCompilers/sub.ts
+++ b/packages/compiler/src/instructionCompilers/sub.ts
@@ -46,7 +46,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: false });
 
-			sub({ lineNumber: 1, instruction: 'sub', arguments: [] } as AST[number], context);
+			sub(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'sub',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -58,7 +66,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: false, isNonZero: false }, { isInteger: false, isNonZero: false });
 
-			sub({ lineNumber: 1, instruction: 'sub', arguments: [] } as AST[number], context);
+			sub(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'sub',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -73,7 +89,15 @@ if (import.meta.vitest) {
 				{ isInteger: false, isFloat64: true, isNonZero: false }
 			);
 
-			sub({ lineNumber: 1, instruction: 'sub', arguments: [] } as AST[number], context);
+			sub(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'sub',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,
@@ -89,7 +113,15 @@ if (import.meta.vitest) {
 			);
 
 			expect(() => {
-				sub({ lineNumber: 1, instruction: 'sub', arguments: [] } as AST[number], context);
+				sub(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'sub',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/swap.ts
+++ b/packages/compiler/src/instructionCompilers/swap.ts
@@ -18,8 +18,9 @@ const swap: InstructionCompiler = withValidation(
 		const operand1 = context.stack.pop()!;
 		const operand2 = context.stack.pop()!;
 
-		const tempAName = '__swapTempA' + line.lineNumber;
-		const tempBName = '__swapTempB' + line.lineNumber;
+		const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
+		const tempAName = '__swapTempA' + lineNumberAfterMacroExpansion;
+		const tempBName = '__swapTempB' + lineNumberAfterMacroExpansion;
 
 		context.stack.push(operand2);
 		context.stack.push(operand1);
@@ -48,7 +49,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: false, isNonZero: true });
 
-			swap({ lineNumber: 3, instruction: 'swap', arguments: [] } as AST[number], context);
+			swap(
+				{
+					lineNumberBeforeMacroExpansion: 3,
+					lineNumberAfterMacroExpansion: 3,
+					instruction: 'swap',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/instructionCompilers/use.ts
+++ b/packages/compiler/src/instructionCompilers/use.ts
@@ -45,7 +45,8 @@ if (import.meta.vitest) {
 
 			use(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'use',
 					arguments: [{ type: ArgumentType.IDENTIFIER, value: 'shared' }],
 				} as AST[number],
@@ -61,7 +62,8 @@ if (import.meta.vitest) {
 			expect(() => {
 				use(
 					{
-						lineNumber: 1,
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
 						instruction: 'use',
 						arguments: [{ type: ArgumentType.IDENTIFIER, value: 'missing' }],
 					} as AST[number],

--- a/packages/compiler/src/instructionCompilers/wasm.ts
+++ b/packages/compiler/src/instructionCompilers/wasm.ts
@@ -32,7 +32,8 @@ if (import.meta.vitest) {
 
 			wasm(
 				{
-					lineNumber: 1,
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
 					instruction: 'wasm',
 					arguments: [{ type: ArgumentType.LITERAL, value: 42, isInteger: true }],
 				} as AST[number],
@@ -48,7 +49,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 
 			expect(() => {
-				wasm({ lineNumber: 1, instruction: 'wasm', arguments: [] } as AST[number], context);
+				wasm(
+					{
+						lineNumberBeforeMacroExpansion: 1,
+						lineNumberAfterMacroExpansion: 1,
+						instruction: 'wasm',
+						arguments: [],
+					} as AST[number],
+					context
+				);
 			}).toThrowError();
 		});
 	});

--- a/packages/compiler/src/instructionCompilers/xor.ts
+++ b/packages/compiler/src/instructionCompilers/xor.ts
@@ -35,7 +35,15 @@ if (import.meta.vitest) {
 			const context = createInstructionCompilerTestContext();
 			context.stack.push({ isInteger: true, isNonZero: false }, { isInteger: true, isNonZero: false });
 
-			xor({ lineNumber: 1, instruction: 'xor', arguments: [] } as AST[number], context);
+			xor(
+				{
+					lineNumberBeforeMacroExpansion: 1,
+					lineNumberAfterMacroExpansion: 1,
+					instruction: 'xor',
+					arguments: [],
+				} as AST[number],
+				context
+			);
 
 			expect({
 				stack: context.stack,

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -96,7 +96,14 @@ export interface Module {
 // Re-export types from syntax subpath for backward compatibility
 export { ArgumentType, type Argument, type ArgumentLiteral, type ArgumentIdentifier, type ArgumentStringLiteral };
 
-export type AST = Array<{ lineNumber: number; instruction: Instruction; arguments: Array<Argument> }>;
+export interface ASTLine {
+	lineNumberBeforeMacroExpansion: number;
+	lineNumberAfterMacroExpansion: number;
+	instruction: Instruction;
+	arguments: Array<Argument>;
+}
+
+export type AST = ASTLine[];
 
 export interface TestModule {
 	memory: MemoryBuffer & {

--- a/packages/compiler/src/utils/macroExpansion.ts
+++ b/packages/compiler/src/utils/macroExpansion.ts
@@ -71,7 +71,8 @@ export function parseMacroDefinitions(macros: Module[]): Map<string, MacroDefini
 			if (instruction === 'defineMacro') {
 				if (insideMacro) {
 					const astLine: AST[number] = {
-						lineNumber: lineIndex,
+						lineNumberBeforeMacroExpansion: lineIndex,
+						lineNumberAfterMacroExpansion: lineIndex,
 						instruction: 'push' as Instruction, // Placeholder instruction for error reporting
 						arguments: [],
 					};
@@ -91,7 +92,8 @@ export function parseMacroDefinitions(macros: Module[]): Map<string, MacroDefini
 
 				if (macroMap.has(macroName)) {
 					const astLine: AST[number] = {
-						lineNumber: lineIndex,
+						lineNumberBeforeMacroExpansion: lineIndex,
+						lineNumberAfterMacroExpansion: lineIndex,
 						instruction: 'push' as Instruction, // Placeholder instruction for error reporting
 						arguments: [],
 					};
@@ -108,7 +110,8 @@ export function parseMacroDefinitions(macros: Module[]): Map<string, MacroDefini
 			} else if (instruction === 'defineMacroEnd') {
 				if (!insideMacro || !currentMacro) {
 					const astLine: AST[number] = {
-						lineNumber: lineIndex,
+						lineNumberBeforeMacroExpansion: lineIndex,
+						lineNumberAfterMacroExpansion: lineIndex,
 						instruction: 'push' as Instruction, // Placeholder instruction for error reporting
 						arguments: [],
 					};
@@ -122,7 +125,8 @@ export function parseMacroDefinitions(macros: Module[]): Map<string, MacroDefini
 				// Check for nested macro calls or definitions inside macro body
 				if (instruction === 'macro') {
 					const astLine: AST[number] = {
-						lineNumber: lineIndex,
+						lineNumberBeforeMacroExpansion: lineIndex,
+						lineNumberAfterMacroExpansion: lineIndex,
 						instruction: 'push' as Instruction, // Placeholder instruction for error reporting
 						arguments: [],
 					};
@@ -138,7 +142,8 @@ export function parseMacroDefinitions(macros: Module[]): Map<string, MacroDefini
 		if (insideMacro) {
 			const macro = currentMacro!;
 			const astLine: AST[number] = {
-				lineNumber: macro.definitionLineNumber,
+				lineNumberBeforeMacroExpansion: macro.definitionLineNumber,
+				lineNumberAfterMacroExpansion: macro.definitionLineNumber,
 				instruction: 'push' as Instruction, // Placeholder instruction for error reporting
 				arguments: [],
 			};
@@ -193,7 +198,8 @@ export function expandMacros(module: Module, macroDefinitions: Map<string, Macro
 			const macroDef = macroDefinitions.get(macroName);
 			if (!macroDef) {
 				const astLine: AST[number] = {
-					lineNumber: lineIndex,
+					lineNumberBeforeMacroExpansion: lineIndex,
+					lineNumberAfterMacroExpansion: lineIndex,
 					instruction: 'push' as Instruction, // Placeholder instruction for error reporting
 					arguments: [],
 				};

--- a/packages/compiler/src/utils/memoryInstructionParser.ts
+++ b/packages/compiler/src/utils/memoryInstructionParser.ts
@@ -8,8 +8,6 @@ import hasMemoryReferencePrefixStart from '../syntax/hasMemoryReferencePrefixSta
 import isConstantName from '../syntax/isConstantName';
 
 import type { AST, CompilationContext, Argument } from '../types';
-import type { Instruction } from '../instructionCompilers';
-
 /**
  * Returns the maximum number of bytes allowed for a split-byte default value.
  * Split-byte is restricted to 4 bytes (32-bit) for all declaration types to avoid
@@ -78,17 +76,11 @@ function resolveSplitByteTokens(
 }
 
 export default function parseMemoryInstructionArguments(
-	args: Array<Argument>,
-	lineNumberAfterMacroExpansion: number,
-	instruction: Instruction,
+	line: AST[number],
 	context: CompilationContext
 ): { id: string; defaultValue: number } {
-	const lineForError: AST[number] = {
-		lineNumberBeforeMacroExpansion: lineNumberAfterMacroExpansion,
-		lineNumberAfterMacroExpansion,
-		instruction,
-		arguments: args,
-	};
+	const { arguments: args, lineNumberAfterMacroExpansion } = line;
+	const lineForError = line;
 
 	// Use syntax parser for syntax-level validation and classification
 	let parsedArgs;
@@ -209,21 +201,45 @@ if (import.meta.vitest) {
 
 		it('parses literal argument as anonymous variable', () => {
 			const args: Argument[] = [{ type: ArgumentType.LITERAL, value: 123, isInteger: true }];
-			const result = parseMemoryInstructionArguments(args, 10, 'int', mockContext);
+			const result = parseMemoryInstructionArguments(
+				{
+					lineNumberBeforeMacroExpansion: 10,
+					lineNumberAfterMacroExpansion: 10,
+					instruction: 'int',
+					arguments: args,
+				},
+				mockContext
+			);
 			expect(result.id).toBe('__anonymous__10');
 			expect(result.defaultValue).toBe(123);
 		});
 
 		it('parses identifier argument', () => {
 			const args: Argument[] = [{ type: ArgumentType.IDENTIFIER, value: 'myId' }];
-			const result = parseMemoryInstructionArguments(args, 20, 'int', mockContext);
+			const result = parseMemoryInstructionArguments(
+				{
+					lineNumberBeforeMacroExpansion: 20,
+					lineNumberAfterMacroExpansion: 20,
+					instruction: 'int',
+					arguments: args,
+				},
+				mockContext
+			);
 			expect(result.id).toBe('myId');
 			expect(result.defaultValue).toBe(0);
 		});
 
 		it('parses constant as anonymous variable', () => {
 			const args: Argument[] = [{ type: ArgumentType.IDENTIFIER, value: 'myConst' }];
-			const result = parseMemoryInstructionArguments(args, 30, 'int', mockContext);
+			const result = parseMemoryInstructionArguments(
+				{
+					lineNumberBeforeMacroExpansion: 30,
+					lineNumberAfterMacroExpansion: 30,
+					instruction: 'int',
+					arguments: args,
+				},
+				mockContext
+			);
 			expect(result.id).toBe('__anonymous__30');
 			expect(result.defaultValue).toBe(42);
 		});
@@ -233,7 +249,15 @@ if (import.meta.vitest) {
 				{ type: ArgumentType.IDENTIFIER, value: 'myVar' },
 				{ type: ArgumentType.LITERAL, value: 99, isInteger: true },
 			];
-			const result = parseMemoryInstructionArguments(args, 40, 'int', mockContext);
+			const result = parseMemoryInstructionArguments(
+				{
+					lineNumberBeforeMacroExpansion: 40,
+					lineNumberAfterMacroExpansion: 40,
+					instruction: 'int',
+					arguments: args,
+				},
+				mockContext
+			);
 			expect(result.id).toBe('myVar');
 			expect(result.defaultValue).toBe(99);
 		});
@@ -243,7 +267,15 @@ if (import.meta.vitest) {
 				{ type: ArgumentType.IDENTIFIER, value: 'myVar' },
 				{ type: ArgumentType.IDENTIFIER, value: 'myConst' },
 			];
-			const result = parseMemoryInstructionArguments(args, 50, 'int', mockContext);
+			const result = parseMemoryInstructionArguments(
+				{
+					lineNumberBeforeMacroExpansion: 50,
+					lineNumberAfterMacroExpansion: 50,
+					instruction: 'int',
+					arguments: args,
+				},
+				mockContext
+			);
 			expect(result.id).toBe('myVar');
 			expect(result.defaultValue).toBe(42);
 		});
@@ -254,7 +286,15 @@ if (import.meta.vitest) {
 				{ type: ArgumentType.LITERAL, value: 0xa8, isInteger: true, isHex: true },
 				{ type: ArgumentType.LITERAL, value: 0xff, isInteger: true, isHex: true },
 			];
-			const result = parseMemoryInstructionArguments(args, 60, 'int', mockContext);
+			const result = parseMemoryInstructionArguments(
+				{
+					lineNumberBeforeMacroExpansion: 60,
+					lineNumberAfterMacroExpansion: 60,
+					instruction: 'int',
+					arguments: args,
+				},
+				mockContext
+			);
 			expect(result.id).toBe('myVar');
 			expect(result.defaultValue).toBe(0xa8ff0000);
 		});
@@ -267,7 +307,15 @@ if (import.meta.vitest) {
 				{ type: ArgumentType.LITERAL, value: 0x00, isInteger: true, isHex: true },
 				{ type: ArgumentType.LITERAL, value: 0x00, isInteger: true, isHex: true },
 			];
-			const result = parseMemoryInstructionArguments(args, 70, 'int', mockContext);
+			const result = parseMemoryInstructionArguments(
+				{
+					lineNumberBeforeMacroExpansion: 70,
+					lineNumberAfterMacroExpansion: 70,
+					instruction: 'int',
+					arguments: args,
+				},
+				mockContext
+			);
 			expect(result.id).toBe('myVar');
 			expect(result.defaultValue).toBe(0xa8ff0000);
 		});
@@ -277,7 +325,15 @@ if (import.meta.vitest) {
 				{ type: ArgumentType.LITERAL, value: 0xa8, isInteger: true, isHex: true },
 				{ type: ArgumentType.LITERAL, value: 0xff, isInteger: true, isHex: true },
 			];
-			const result = parseMemoryInstructionArguments(args, 80, 'int', mockContext);
+			const result = parseMemoryInstructionArguments(
+				{
+					lineNumberBeforeMacroExpansion: 80,
+					lineNumberAfterMacroExpansion: 80,
+					instruction: 'int',
+					arguments: args,
+				},
+				mockContext
+			);
 			expect(result.id).toBe('__anonymous__80');
 			expect(result.defaultValue).toBe(0xa8ff0000);
 		});
@@ -291,7 +347,17 @@ if (import.meta.vitest) {
 				{ type: ArgumentType.LITERAL, value: 0x00, isInteger: true, isHex: true },
 				{ type: ArgumentType.LITERAL, value: 0x01, isInteger: true, isHex: true },
 			];
-			expect(() => parseMemoryInstructionArguments(args, 90, 'int', mockContext)).toThrow();
+			expect(() =>
+				parseMemoryInstructionArguments(
+					{
+						lineNumberBeforeMacroExpansion: 90,
+						lineNumberAfterMacroExpansion: 90,
+						instruction: 'int',
+						arguments: args,
+					},
+					mockContext
+				)
+			).toThrow();
 		});
 
 		it('resolves named constant split-byte sequence (HI LO) into combined default', () => {
@@ -300,7 +366,15 @@ if (import.meta.vitest) {
 				{ type: ArgumentType.IDENTIFIER, value: 'HI' },
 				{ type: ArgumentType.IDENTIFIER, value: 'LO' },
 			];
-			const result = parseMemoryInstructionArguments(args, 100, 'int', mockContext);
+			const result = parseMemoryInstructionArguments(
+				{
+					lineNumberBeforeMacroExpansion: 100,
+					lineNumberAfterMacroExpansion: 100,
+					instruction: 'int',
+					arguments: args,
+				},
+				mockContext
+			);
 			expect(result.id).toBe('myVar');
 			// HI=32=0x20, LO=64=0x40 → [0x20, 0x40, 0x00, 0x00] = 0x20400000
 			expect(result.defaultValue).toBe(0x20400000);
@@ -311,7 +385,15 @@ if (import.meta.vitest) {
 				{ type: ArgumentType.IDENTIFIER, value: 'HI' },
 				{ type: ArgumentType.IDENTIFIER, value: 'LO' },
 			];
-			const result = parseMemoryInstructionArguments(args, 110, 'int', mockContext);
+			const result = parseMemoryInstructionArguments(
+				{
+					lineNumberBeforeMacroExpansion: 110,
+					lineNumberAfterMacroExpansion: 110,
+					instruction: 'int',
+					arguments: args,
+				},
+				mockContext
+			);
 			expect(result.id).toBe('__anonymous__110');
 			expect(result.defaultValue).toBe(0x20400000);
 		});
@@ -322,7 +404,15 @@ if (import.meta.vitest) {
 				{ type: ArgumentType.LITERAL, value: 0xa8, isInteger: true, isHex: true },
 				{ type: ArgumentType.IDENTIFIER, value: 'LO' },
 			];
-			const result = parseMemoryInstructionArguments(args, 120, 'int', mockContext);
+			const result = parseMemoryInstructionArguments(
+				{
+					lineNumberBeforeMacroExpansion: 120,
+					lineNumberAfterMacroExpansion: 120,
+					instruction: 'int',
+					arguments: args,
+				},
+				mockContext
+			);
 			expect(result.id).toBe('myVar');
 			// 0xA8=168, LO=64=0x40 → [168, 64, 0, 0] = 0xA8400000
 			expect(result.defaultValue).toBe(0xa8400000);
@@ -334,7 +424,17 @@ if (import.meta.vitest) {
 				{ type: ArgumentType.IDENTIFIER, value: 'HI' },
 				{ type: ArgumentType.IDENTIFIER, value: 'BIG' },
 			];
-			expect(() => parseMemoryInstructionArguments(args, 130, 'int', mockContext)).toThrow();
+			expect(() =>
+				parseMemoryInstructionArguments(
+					{
+						lineNumberBeforeMacroExpansion: 130,
+						lineNumberAfterMacroExpansion: 130,
+						instruction: 'int',
+						arguments: args,
+					},
+					mockContext
+				)
+			).toThrow();
 		});
 
 		it('throws when constant in split-byte sequence is a non-integer (float)', () => {
@@ -343,12 +443,32 @@ if (import.meta.vitest) {
 				{ type: ArgumentType.IDENTIFIER, value: 'HI' },
 				{ type: ArgumentType.IDENTIFIER, value: 'FRAC' },
 			];
-			expect(() => parseMemoryInstructionArguments(args, 140, 'int', mockContext)).toThrow();
+			expect(() =>
+				parseMemoryInstructionArguments(
+					{
+						lineNumberBeforeMacroExpansion: 140,
+						lineNumberAfterMacroExpansion: 140,
+						instruction: 'int',
+						arguments: args,
+					},
+					mockContext
+				)
+			).toThrow();
 		});
 
 		it('throws when constant-style name is used as memory identifier', () => {
 			const args: Argument[] = [{ type: ArgumentType.IDENTIFIER, value: 'MY_VAR' }];
-			expect(() => parseMemoryInstructionArguments(args, 150, 'int', mockContext)).toThrow();
+			expect(() =>
+				parseMemoryInstructionArguments(
+					{
+						lineNumberBeforeMacroExpansion: 150,
+						lineNumberAfterMacroExpansion: 150,
+						instruction: 'int',
+						arguments: args,
+					},
+					mockContext
+				)
+			).toThrow();
 		});
 	});
 }

--- a/packages/compiler/src/utils/memoryInstructionParser.ts
+++ b/packages/compiler/src/utils/memoryInstructionParser.ts
@@ -7,7 +7,8 @@ import { ErrorCode, getError } from '../compilerError';
 import hasMemoryReferencePrefixStart from '../syntax/hasMemoryReferencePrefixStart';
 import isConstantName from '../syntax/isConstantName';
 
-import type { CompilationContext, Argument } from '../types';
+import type { AST, CompilationContext, Argument } from '../types';
+import type { Instruction } from '../instructionCompilers';
 
 /**
  * Returns the maximum number of bytes allowed for a split-byte default value.
@@ -78,12 +79,16 @@ function resolveSplitByteTokens(
 
 export default function parseMemoryInstructionArguments(
 	args: Array<Argument>,
-	lineNumber: number,
-	instruction: string,
+	lineNumberAfterMacroExpansion: number,
+	instruction: Instruction,
 	context: CompilationContext
 ): { id: string; defaultValue: number } {
-	// eslint-disable-next-line @typescript-eslint/no-explicit-any
-	const lineForError = { lineNumber, instruction, arguments: args } as any;
+	const lineForError: AST[number] = {
+		lineNumberBeforeMacroExpansion: lineNumberAfterMacroExpansion,
+		lineNumberAfterMacroExpansion,
+		instruction,
+		arguments: args,
+	};
 
 	// Use syntax parser for syntax-level validation and classification
 	let parsedArgs;
@@ -107,16 +112,16 @@ export default function parseMemoryInstructionArguments(
 	// Process first argument
 	if (parsedArgs.firstArg.type === 'literal') {
 		defaultValue = parsedArgs.firstArg.value;
-		id = '__anonymous__' + lineNumber;
+		id = '__anonymous__' + lineNumberAfterMacroExpansion;
 	} else if (parsedArgs.firstArg.type === 'split-byte-tokens') {
 		defaultValue = resolveSplitByteTokens(parsedArgs.firstArg.tokens, maxBytes, lineForError, context);
-		id = '__anonymous__' + lineNumber;
+		id = '__anonymous__' + lineNumberAfterMacroExpansion;
 	} else if (parsedArgs.firstArg.type === 'identifier') {
 		const constant = tryResolveConstantValueOrExpression(context.namespace.consts, parsedArgs.firstArg.value);
 
 		if (constant) {
 			defaultValue = constant.value;
-			id = '__anonymous__' + lineNumber;
+			id = '__anonymous__' + lineNumberAfterMacroExpansion;
 		} else {
 			id = parsedArgs.firstArg.value;
 		}

--- a/packages/compiler/src/utils/resolveConstantValue.ts
+++ b/packages/compiler/src/utils/resolveConstantValue.ts
@@ -111,7 +111,8 @@ if (import.meta.vitest) {
 
 	describe('resolveConstantValue', () => {
 		const mockLine = {
-			lineNumber: 1,
+			lineNumberBeforeMacroExpansion: 1,
+			lineNumberAfterMacroExpansion: 1,
 			instruction: 'const',
 			arguments: [{ type: ArgumentType.IDENTIFIER, value: 'A' }],
 		} as unknown as AST[number];

--- a/packages/compiler/src/withValidation/validateArgumentByRule.ts
+++ b/packages/compiler/src/withValidation/validateArgumentByRule.ts
@@ -46,7 +46,8 @@ if (import.meta.vitest) {
 	const { describe, it, expect } = import.meta.vitest;
 
 	const line: Parameters<InstructionCompiler>[0] = {
-		lineNumber: 1,
+		lineNumberBeforeMacroExpansion: 1,
+		lineNumberAfterMacroExpansion: 1,
 		instruction: 'test' as never,
 		arguments: [],
 	};

--- a/packages/compiler/src/withValidation/validateArgumentTypes.ts
+++ b/packages/compiler/src/withValidation/validateArgumentTypes.ts
@@ -30,7 +30,8 @@ if (import.meta.vitest) {
 	const { describe, it, expect } = import.meta.vitest;
 
 	const line: Parameters<InstructionCompiler>[0] = {
-		lineNumber: 1,
+		lineNumberBeforeMacroExpansion: 1,
+		lineNumberAfterMacroExpansion: 1,
 		instruction: 'test' as never,
 		arguments: [],
 	};

--- a/packages/compiler/src/withValidation/validateOperandTypes.ts
+++ b/packages/compiler/src/withValidation/validateOperandTypes.ts
@@ -44,7 +44,8 @@ if (import.meta.vitest) {
 	const { describe, it, expect } = import.meta.vitest;
 
 	const line: Parameters<InstructionCompiler>[0] = {
-		lineNumber: 1,
+		lineNumberBeforeMacroExpansion: 1,
+		lineNumberAfterMacroExpansion: 1,
 		instruction: 'test' as never,
 		arguments: [],
 	};

--- a/packages/compiler/src/withValidation/validateScope.ts
+++ b/packages/compiler/src/withValidation/validateScope.ts
@@ -48,7 +48,8 @@ if (import.meta.vitest) {
 	const { describe, it, expect } = import.meta.vitest;
 
 	const line: Parameters<InstructionCompiler>[0] = {
-		lineNumber: 1,
+		lineNumberBeforeMacroExpansion: 1,
+		lineNumberAfterMacroExpansion: 1,
 		instruction: 'test' as never,
 		arguments: [],
 	};

--- a/packages/compiler/src/withValidation/withValidation.ts
+++ b/packages/compiler/src/withValidation/withValidation.ts
@@ -63,7 +63,8 @@ if (import.meta.vitest) {
 	const { describe, it, expect } = import.meta.vitest;
 
 	const line: Parameters<InstructionCompiler>[0] = {
-		lineNumber: 1,
+		lineNumberBeforeMacroExpansion: 1,
+		lineNumberAfterMacroExpansion: 1,
 		instruction: 'test' as never,
 		arguments: [],
 	};

--- a/packages/compiler/tests/__snapshots__/compileModules.test.ts.snap
+++ b/packages/compiler/tests/__snapshots__/compileModules.test.ts.snap
@@ -12,7 +12,8 @@ exports[`compiler > compileModules 1`] = `
           },
         ],
         "instruction": "module",
-        "lineNumber": 1,
+        "lineNumberAfterMacroExpansion": 1,
+        "lineNumberBeforeMacroExpansion": 1,
       },
       {
         "arguments": [
@@ -27,7 +28,8 @@ exports[`compiler > compileModules 1`] = `
           },
         ],
         "instruction": "int",
-        "lineNumber": 4,
+        "lineNumberAfterMacroExpansion": 4,
+        "lineNumberBeforeMacroExpansion": 4,
       },
       {
         "arguments": [
@@ -41,7 +43,8 @@ exports[`compiler > compileModules 1`] = `
           },
         ],
         "instruction": "int*",
-        "lineNumber": 5,
+        "lineNumberAfterMacroExpansion": 5,
+        "lineNumberBeforeMacroExpansion": 5,
       },
       {
         "arguments": [
@@ -56,7 +59,8 @@ exports[`compiler > compileModules 1`] = `
           },
         ],
         "instruction": "int",
-        "lineNumber": 6,
+        "lineNumberAfterMacroExpansion": 6,
+        "lineNumberBeforeMacroExpansion": 6,
       },
       {
         "arguments": [
@@ -71,7 +75,8 @@ exports[`compiler > compileModules 1`] = `
           },
         ],
         "instruction": "int",
-        "lineNumber": 7,
+        "lineNumberAfterMacroExpansion": 7,
+        "lineNumberBeforeMacroExpansion": 7,
       },
       {
         "arguments": [
@@ -85,7 +90,8 @@ exports[`compiler > compileModules 1`] = `
           },
         ],
         "instruction": "local",
-        "lineNumber": 10,
+        "lineNumberAfterMacroExpansion": 10,
+        "lineNumberBeforeMacroExpansion": 10,
       },
       {
         "arguments": [
@@ -95,7 +101,8 @@ exports[`compiler > compileModules 1`] = `
           },
         ],
         "instruction": "push",
-        "lineNumber": 13,
+        "lineNumberAfterMacroExpansion": 13,
+        "lineNumberBeforeMacroExpansion": 13,
       },
       {
         "arguments": [
@@ -105,7 +112,8 @@ exports[`compiler > compileModules 1`] = `
           },
         ],
         "instruction": "push",
-        "lineNumber": 14,
+        "lineNumberAfterMacroExpansion": 14,
+        "lineNumberBeforeMacroExpansion": 14,
       },
       {
         "arguments": [
@@ -115,7 +123,8 @@ exports[`compiler > compileModules 1`] = `
           },
         ],
         "instruction": "localSet",
-        "lineNumber": 15,
+        "lineNumberAfterMacroExpansion": 15,
+        "lineNumberBeforeMacroExpansion": 15,
       },
       {
         "arguments": [
@@ -125,7 +134,8 @@ exports[`compiler > compileModules 1`] = `
           },
         ],
         "instruction": "push",
-        "lineNumber": 16,
+        "lineNumberAfterMacroExpansion": 16,
+        "lineNumberBeforeMacroExpansion": 16,
       },
       {
         "arguments": [
@@ -136,17 +146,20 @@ exports[`compiler > compileModules 1`] = `
           },
         ],
         "instruction": "push",
-        "lineNumber": 17,
+        "lineNumberAfterMacroExpansion": 17,
+        "lineNumberBeforeMacroExpansion": 17,
       },
       {
         "arguments": [],
         "instruction": "lessThan",
-        "lineNumber": 18,
+        "lineNumberAfterMacroExpansion": 18,
+        "lineNumberBeforeMacroExpansion": 18,
       },
       {
         "arguments": [],
         "instruction": "if",
-        "lineNumber": 19,
+        "lineNumberAfterMacroExpansion": 19,
+        "lineNumberBeforeMacroExpansion": 19,
       },
       {
         "arguments": [
@@ -157,7 +170,8 @@ exports[`compiler > compileModules 1`] = `
           },
         ],
         "instruction": "push",
-        "lineNumber": 20,
+        "lineNumberAfterMacroExpansion": 20,
+        "lineNumberBeforeMacroExpansion": 20,
       },
       {
         "arguments": [
@@ -167,17 +181,20 @@ exports[`compiler > compileModules 1`] = `
           },
         ],
         "instruction": "push",
-        "lineNumber": 21,
+        "lineNumberAfterMacroExpansion": 21,
+        "lineNumberBeforeMacroExpansion": 21,
       },
       {
         "arguments": [],
         "instruction": "sub",
-        "lineNumber": 22,
+        "lineNumberAfterMacroExpansion": 22,
+        "lineNumberBeforeMacroExpansion": 22,
       },
       {
         "arguments": [],
         "instruction": "else",
-        "lineNumber": 23,
+        "lineNumberAfterMacroExpansion": 23,
+        "lineNumberBeforeMacroExpansion": 23,
       },
       {
         "arguments": [
@@ -187,22 +204,26 @@ exports[`compiler > compileModules 1`] = `
           },
         ],
         "instruction": "push",
-        "lineNumber": 24,
+        "lineNumberAfterMacroExpansion": 24,
+        "lineNumberBeforeMacroExpansion": 24,
       },
       {
         "arguments": [],
         "instruction": "ifEnd",
-        "lineNumber": 25,
+        "lineNumberAfterMacroExpansion": 25,
+        "lineNumberBeforeMacroExpansion": 25,
       },
       {
         "arguments": [],
         "instruction": "store",
-        "lineNumber": 26,
+        "lineNumberAfterMacroExpansion": 26,
+        "lineNumberBeforeMacroExpansion": 26,
       },
       {
         "arguments": [],
         "instruction": "moduleEnd",
-        "lineNumber": 27,
+        "lineNumberAfterMacroExpansion": 27,
+        "lineNumberBeforeMacroExpansion": 27,
       },
     ],
     "byteAddress": 0,

--- a/packages/compiler/tests/__snapshots__/moduleCompiler.test.ts.snap
+++ b/packages/compiler/tests/__snapshots__/moduleCompiler.test.ts.snap
@@ -10,7 +10,8 @@ exports[`moduleCompiler > ast 1`] = `
       },
     ],
     "instruction": "module",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -25,7 +26,8 @@ exports[`moduleCompiler > ast 1`] = `
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -39,7 +41,8 @@ exports[`moduleCompiler > ast 1`] = `
       },
     ],
     "instruction": "int*",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -54,7 +57,8 @@ exports[`moduleCompiler > ast 1`] = `
       },
     ],
     "instruction": "int",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -74,7 +78,8 @@ exports[`moduleCompiler > ast 1`] = `
       },
     ],
     "instruction": "int[]",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -88,7 +93,8 @@ exports[`moduleCompiler > ast 1`] = `
       },
     ],
     "instruction": "local",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [
@@ -98,7 +104,8 @@ exports[`moduleCompiler > ast 1`] = `
       },
     ],
     "instruction": "push",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
   {
     "arguments": [
@@ -108,17 +115,20 @@ exports[`moduleCompiler > ast 1`] = `
       },
     ],
     "instruction": "push",
-    "lineNumber": 14,
+    "lineNumberAfterMacroExpansion": 14,
+    "lineNumberBeforeMacroExpansion": 14,
   },
   {
     "arguments": [],
     "instruction": "load",
-    "lineNumber": 15,
+    "lineNumberAfterMacroExpansion": 15,
+    "lineNumberBeforeMacroExpansion": 15,
   },
   {
     "arguments": [],
     "instruction": "load",
-    "lineNumber": 16,
+    "lineNumberAfterMacroExpansion": 16,
+    "lineNumberBeforeMacroExpansion": 16,
   },
   {
     "arguments": [
@@ -128,7 +138,8 @@ exports[`moduleCompiler > ast 1`] = `
       },
     ],
     "instruction": "localSet",
-    "lineNumber": 17,
+    "lineNumberAfterMacroExpansion": 17,
+    "lineNumberBeforeMacroExpansion": 17,
   },
   {
     "arguments": [
@@ -138,7 +149,8 @@ exports[`moduleCompiler > ast 1`] = `
       },
     ],
     "instruction": "localGet",
-    "lineNumber": 18,
+    "lineNumberAfterMacroExpansion": 18,
+    "lineNumberBeforeMacroExpansion": 18,
   },
   {
     "arguments": [
@@ -149,17 +161,20 @@ exports[`moduleCompiler > ast 1`] = `
       },
     ],
     "instruction": "push",
-    "lineNumber": 19,
+    "lineNumberAfterMacroExpansion": 19,
+    "lineNumberBeforeMacroExpansion": 19,
   },
   {
     "arguments": [],
     "instruction": "lessThan",
-    "lineNumber": 20,
+    "lineNumberAfterMacroExpansion": 20,
+    "lineNumberBeforeMacroExpansion": 20,
   },
   {
     "arguments": [],
     "instruction": "if",
-    "lineNumber": 21,
+    "lineNumberAfterMacroExpansion": 21,
+    "lineNumberBeforeMacroExpansion": 21,
   },
   {
     "arguments": [
@@ -170,7 +185,8 @@ exports[`moduleCompiler > ast 1`] = `
       },
     ],
     "instruction": "push",
-    "lineNumber": 22,
+    "lineNumberAfterMacroExpansion": 22,
+    "lineNumberBeforeMacroExpansion": 22,
   },
   {
     "arguments": [
@@ -180,17 +196,20 @@ exports[`moduleCompiler > ast 1`] = `
       },
     ],
     "instruction": "localGet",
-    "lineNumber": 23,
+    "lineNumberAfterMacroExpansion": 23,
+    "lineNumberBeforeMacroExpansion": 23,
   },
   {
     "arguments": [],
     "instruction": "sub",
-    "lineNumber": 24,
+    "lineNumberAfterMacroExpansion": 24,
+    "lineNumberBeforeMacroExpansion": 24,
   },
   {
     "arguments": [],
     "instruction": "else",
-    "lineNumber": 25,
+    "lineNumberAfterMacroExpansion": 25,
+    "lineNumberBeforeMacroExpansion": 25,
   },
   {
     "arguments": [
@@ -200,22 +219,26 @@ exports[`moduleCompiler > ast 1`] = `
       },
     ],
     "instruction": "localGet",
-    "lineNumber": 26,
+    "lineNumberAfterMacroExpansion": 26,
+    "lineNumberBeforeMacroExpansion": 26,
   },
   {
     "arguments": [],
     "instruction": "ifEnd",
-    "lineNumber": 27,
+    "lineNumberAfterMacroExpansion": 27,
+    "lineNumberBeforeMacroExpansion": 27,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 28,
+    "lineNumberAfterMacroExpansion": 28,
+    "lineNumberBeforeMacroExpansion": 28,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 29,
+    "lineNumberAfterMacroExpansion": 29,
+    "lineNumberBeforeMacroExpansion": 29,
   },
 ]
 `;

--- a/packages/compiler/tests/compiler.test.ts
+++ b/packages/compiler/tests/compiler.test.ts
@@ -60,7 +60,8 @@ describe('parseLine', () => {
 					},
 				],
 				instruction: 'int',
-				lineNumber: 1,
+				lineNumberBeforeMacroExpansion: 1,
+				lineNumberAfterMacroExpansion: 1,
 			},
 		],
 		[
@@ -76,7 +77,8 @@ describe('parseLine', () => {
 					},
 				],
 				instruction: 'push',
-				lineNumber: 100,
+				lineNumberBeforeMacroExpansion: 100,
+				lineNumberAfterMacroExpansion: 100,
 			},
 		],
 	];
@@ -119,11 +121,14 @@ describe('compileToAST', () => {
 
 		const ast = compileToAST(code, lineMetadata);
 
-		// All AST entries should have lineNumber 5 (the call site)
+		// Call-site line numbers are preserved for diagnostics.
 		expect(ast).toHaveLength(3);
-		expect(ast[0].lineNumber).toBe(5);
-		expect(ast[1].lineNumber).toBe(5);
-		expect(ast[2].lineNumber).toBe(5);
+		expect(ast[0].lineNumberBeforeMacroExpansion).toBe(5);
+		expect(ast[1].lineNumberBeforeMacroExpansion).toBe(5);
+		expect(ast[2].lineNumberBeforeMacroExpansion).toBe(5);
+		expect(ast[0].lineNumberAfterMacroExpansion).toBe(0);
+		expect(ast[1].lineNumberAfterMacroExpansion).toBe(1);
+		expect(ast[2].lineNumberAfterMacroExpansion).toBe(2);
 	});
 
 	test('should use actual line numbers when lineMetadata is not provided', () => {
@@ -131,11 +136,14 @@ describe('compileToAST', () => {
 
 		const ast = compileToAST(code);
 
-		// Should use 0-indexed line numbers
+		// Both line number fields match when no macro expansion happened.
 		expect(ast).toHaveLength(3);
-		expect(ast[0].lineNumber).toBe(0);
-		expect(ast[1].lineNumber).toBe(1);
-		expect(ast[2].lineNumber).toBe(2);
+		expect(ast[0].lineNumberBeforeMacroExpansion).toBe(0);
+		expect(ast[1].lineNumberBeforeMacroExpansion).toBe(1);
+		expect(ast[2].lineNumberBeforeMacroExpansion).toBe(2);
+		expect(ast[0].lineNumberAfterMacroExpansion).toBe(0);
+		expect(ast[1].lineNumberAfterMacroExpansion).toBe(1);
+		expect(ast[2].lineNumberAfterMacroExpansion).toBe(2);
 	});
 });
 

--- a/packages/compiler/tests/compilerError.test.ts
+++ b/packages/compiler/tests/compilerError.test.ts
@@ -6,7 +6,8 @@ import { ArgumentType, type AST } from '../src/types';
 describe('getError', () => {
 	it('includes the undeclared identifier when provided', () => {
 		const line = {
-			lineNumber: 1,
+			lineNumberBeforeMacroExpansion: 1,
+			lineNumberAfterMacroExpansion: 1,
 			instruction: 'localGet',
 			arguments: [{ type: ArgumentType.IDENTIFIER, value: 'missingLocal' }],
 		} as AST[number];
@@ -18,7 +19,8 @@ describe('getError', () => {
 
 	it('keeps the generic undeclared identifier message when no identifier is available', () => {
 		const line = {
-			lineNumber: 1,
+			lineNumberBeforeMacroExpansion: 1,
+			lineNumberAfterMacroExpansion: 1,
 			instruction: 'use',
 			arguments: [],
 		} as AST[number];

--- a/packages/compiler/tests/instructions/__snapshots__/abs.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/abs.test.ts.snap
@@ -10,7 +10,8 @@ exports[`abs (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`abs (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`abs (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "float",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`abs (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -50,22 +54,26 @@ exports[`abs (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "abs",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
 ]
 `;
@@ -129,7 +137,8 @@ exports[`abs (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -139,7 +148,8 @@ exports[`abs (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -149,7 +159,8 @@ exports[`abs (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -159,7 +170,8 @@ exports[`abs (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -169,22 +181,26 @@ exports[`abs (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "abs",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/add.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/add.test.ts.snap
@@ -10,7 +10,8 @@ exports[`add (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`add (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`add (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`add (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`add (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`add (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -70,22 +76,26 @@ exports[`add (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "add",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/and.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/and.test.ts.snap
@@ -10,7 +10,8 @@ exports[`and > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`and > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`and > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`and > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`and > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`and > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -70,22 +76,26 @@ exports[`and > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "and",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/block.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/block.test.ts.snap
@@ -10,7 +10,8 @@ exports[`block (float) > if the generated AST, WAT and memory map match the snap
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`block (float) > if the generated AST, WAT and memory map match the snap
       },
     ],
     "instruction": "float",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`block (float) > if the generated AST, WAT and memory map match the snap
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`block (float) > if the generated AST, WAT and memory map match the snap
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`block (float) > if the generated AST, WAT and memory map match the snap
       },
     ],
     "instruction": "block",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,22 +65,26 @@ exports[`block (float) > if the generated AST, WAT and memory map match the snap
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "blockEnd",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
 ]
 `;
@@ -140,7 +149,8 @@ exports[`block (int) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -150,7 +160,8 @@ exports[`block (int) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -160,7 +171,8 @@ exports[`block (int) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -170,7 +182,8 @@ exports[`block (int) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -180,7 +193,8 @@ exports[`block (int) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "block",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -190,22 +204,26 @@ exports[`block (int) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "blockEnd",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/branch.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/branch.test.ts.snap
@@ -10,7 +10,8 @@ exports[`branch (int) > if the generated AST, WAT and memory map match the snaps
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`branch (int) > if the generated AST, WAT and memory map match the snaps
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`branch (int) > if the generated AST, WAT and memory map match the snaps
       },
     ],
     "instruction": "block",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -41,7 +44,8 @@ exports[`branch (int) > if the generated AST, WAT and memory map match the snaps
       },
     ],
     "instruction": "branch",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -51,7 +55,8 @@ exports[`branch (int) > if the generated AST, WAT and memory map match the snaps
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -62,22 +67,26 @@ exports[`branch (int) > if the generated AST, WAT and memory map match the snaps
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "blockEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/branchIfUnchanged.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/branchIfUnchanged.test.ts.snap
@@ -10,7 +10,8 @@ exports[`branchIfUnchanged > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`branchIfUnchanged > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`branchIfUnchanged > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`branchIfUnchanged > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -51,12 +55,14 @@ exports[`branchIfUnchanged > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -66,7 +72,8 @@ exports[`branchIfUnchanged > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "block",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [
@@ -76,7 +83,8 @@ exports[`branchIfUnchanged > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "push",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [
@@ -87,7 +95,8 @@ exports[`branchIfUnchanged > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "branchIfUnchanged",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [
@@ -97,7 +106,8 @@ exports[`branchIfUnchanged > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "push",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
   {
     "arguments": [
@@ -108,22 +118,26 @@ exports[`branchIfUnchanged > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "push",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 14,
+    "lineNumberAfterMacroExpansion": 14,
+    "lineNumberBeforeMacroExpansion": 14,
   },
   {
     "arguments": [],
     "instruction": "blockEnd",
-    "lineNumber": 15,
+    "lineNumberAfterMacroExpansion": 15,
+    "lineNumberBeforeMacroExpansion": 15,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 17,
+    "lineNumberAfterMacroExpansion": 17,
+    "lineNumberBeforeMacroExpansion": 17,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/call.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/call.test.ts.snap
@@ -10,7 +10,8 @@ exports[`call constant function > if the generated AST, WAT and memory map match
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,12 +21,14 @@ exports[`call constant function > if the generated AST, WAT and memory map match
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [],
     "instruction": "loop",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -35,7 +38,8 @@ exports[`call constant function > if the generated AST, WAT and memory map match
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -45,22 +49,26 @@ exports[`call constant function > if the generated AST, WAT and memory map match
       },
     ],
     "instruction": "call",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "loopEnd",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
 ]
 `;
@@ -173,7 +181,8 @@ exports[`call float64-returning function > if the generated AST, WAT and memory 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -183,12 +192,14 @@ exports[`call float64-returning function > if the generated AST, WAT and memory 
       },
     ],
     "instruction": "float64",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [],
     "instruction": "loop",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -198,7 +209,8 @@ exports[`call float64-returning function > if the generated AST, WAT and memory 
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -208,22 +220,26 @@ exports[`call float64-returning function > if the generated AST, WAT and memory 
       },
     ],
     "instruction": "call",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "loopEnd",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
 ]
 `;
@@ -339,7 +355,8 @@ exports[`call function multiple times > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -349,12 +366,14 @@ exports[`call function multiple times > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [],
     "instruction": "loop",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -364,7 +383,8 @@ exports[`call function multiple times > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -374,7 +394,8 @@ exports[`call function multiple times > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "call",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -384,27 +405,32 @@ exports[`call function multiple times > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "call",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "add",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "loopEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
 ]
 `;
@@ -521,7 +547,8 @@ exports[`call function with parameter > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -531,7 +558,8 @@ exports[`call function with parameter > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -541,12 +569,14 @@ exports[`call function with parameter > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [],
     "instruction": "loop",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -556,7 +586,8 @@ exports[`call function with parameter > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -566,7 +597,8 @@ exports[`call function with parameter > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -576,22 +608,26 @@ exports[`call function with parameter > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "call",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "loopEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/castToFloat.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/castToFloat.test.ts.snap
@@ -10,7 +10,8 @@ exports[`castToFloat > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`castToFloat > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`castToFloat > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "float",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`castToFloat > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -50,22 +54,26 @@ exports[`castToFloat > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "castToFloat",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/castToInt.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/castToInt.test.ts.snap
@@ -10,7 +10,8 @@ exports[`castToInt > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`castToInt > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`castToInt > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`castToInt > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -50,22 +54,26 @@ exports[`castToInt > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "castToInt",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/clearStack.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/clearStack.test.ts.snap
@@ -10,7 +10,8 @@ exports[`clearStack > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -21,7 +22,8 @@ exports[`clearStack > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -32,17 +34,20 @@ exports[`clearStack > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [],
     "instruction": "clearStack",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/const.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/const.test.ts.snap
@@ -10,7 +10,8 @@ exports[`const instruction > const with valid constant names > if the generated 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -25,7 +26,8 @@ exports[`const instruction > const with valid constant names > if the generated 
       },
     ],
     "instruction": "const",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -40,7 +42,8 @@ exports[`const instruction > const with valid constant names > if the generated 
       },
     ],
     "instruction": "const",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -55,7 +58,8 @@ exports[`const instruction > const with valid constant names > if the generated 
       },
     ],
     "instruction": "const",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -65,7 +69,8 @@ exports[`const instruction > const with valid constant names > if the generated 
       },
     ],
     "instruction": "int",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -75,7 +80,8 @@ exports[`const instruction > const with valid constant names > if the generated 
       },
     ],
     "instruction": "float",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -89,7 +95,8 @@ exports[`const instruction > const with valid constant names > if the generated 
       },
     ],
     "instruction": "int",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -99,7 +106,8 @@ exports[`const instruction > const with valid constant names > if the generated 
       },
     ],
     "instruction": "push",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [
@@ -109,12 +117,14 @@ exports[`const instruction > const with valid constant names > if the generated 
       },
     ],
     "instruction": "push",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
   {
     "arguments": [
@@ -124,7 +134,8 @@ exports[`const instruction > const with valid constant names > if the generated 
       },
     ],
     "instruction": "push",
-    "lineNumber": 14,
+    "lineNumberAfterMacroExpansion": 14,
+    "lineNumberBeforeMacroExpansion": 14,
   },
   {
     "arguments": [
@@ -134,17 +145,20 @@ exports[`const instruction > const with valid constant names > if the generated 
       },
     ],
     "instruction": "push",
-    "lineNumber": 15,
+    "lineNumberAfterMacroExpansion": 15,
+    "lineNumberBeforeMacroExpansion": 15,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 16,
+    "lineNumberAfterMacroExpansion": 16,
+    "lineNumberBeforeMacroExpansion": 16,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 18,
+    "lineNumberAfterMacroExpansion": 18,
+    "lineNumberBeforeMacroExpansion": 18,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/constantExpressions.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/constantExpressions.test.ts.snap
@@ -10,7 +10,8 @@ exports[`const: expression from another constant > if the generated AST, WAT and
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -25,7 +26,8 @@ exports[`const: expression from another constant > if the generated AST, WAT and
       },
     ],
     "instruction": "const",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -39,7 +41,8 @@ exports[`const: expression from another constant > if the generated AST, WAT and
       },
     ],
     "instruction": "const",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -49,7 +52,8 @@ exports[`const: expression from another constant > if the generated AST, WAT and
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -59,7 +63,8 @@ exports[`const: expression from another constant > if the generated AST, WAT and
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -69,17 +74,20 @@ exports[`const: expression from another constant > if the generated AST, WAT and
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
 ]
 `;
@@ -126,7 +134,8 @@ exports[`init: constant expression > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -141,7 +150,8 @@ exports[`init: constant expression > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "const",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -151,7 +161,8 @@ exports[`init: constant expression > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -165,7 +176,8 @@ exports[`init: constant expression > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "init",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -175,7 +187,8 @@ exports[`init: constant expression > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -185,7 +198,8 @@ exports[`init: constant expression > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -195,17 +209,20 @@ exports[`init: constant expression > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
 ]
 `;
@@ -268,7 +285,8 @@ exports[`int[]: buffer size from constant division expression > if the generated
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -283,7 +301,8 @@ exports[`int[]: buffer size from constant division expression > if the generated
       },
     ],
     "instruction": "const",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -297,7 +316,8 @@ exports[`int[]: buffer size from constant division expression > if the generated
       },
     ],
     "instruction": "int[]",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -307,7 +327,8 @@ exports[`int[]: buffer size from constant division expression > if the generated
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -317,7 +338,8 @@ exports[`int[]: buffer size from constant division expression > if the generated
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -327,17 +349,20 @@ exports[`int[]: buffer size from constant division expression > if the generated
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
 ]
 `;
@@ -399,7 +424,8 @@ exports[`int[]: buffer size from constant multiplication expression > if the gen
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -414,7 +440,8 @@ exports[`int[]: buffer size from constant multiplication expression > if the gen
       },
     ],
     "instruction": "const",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -428,7 +455,8 @@ exports[`int[]: buffer size from constant multiplication expression > if the gen
       },
     ],
     "instruction": "int[]",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -438,7 +466,8 @@ exports[`int[]: buffer size from constant multiplication expression > if the gen
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -448,7 +477,8 @@ exports[`int[]: buffer size from constant multiplication expression > if the gen
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -458,17 +488,20 @@ exports[`int[]: buffer size from constant multiplication expression > if the gen
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
 ]
 `;
@@ -530,7 +563,8 @@ exports[`push: constant expression > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -545,7 +579,8 @@ exports[`push: constant expression > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "const",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -555,7 +590,8 @@ exports[`push: constant expression > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -565,7 +601,8 @@ exports[`push: constant expression > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -575,17 +612,20 @@ exports[`push: constant expression > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/div.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/div.test.ts.snap
@@ -10,7 +10,8 @@ exports[`div (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`div (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`div (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "float",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`div (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "float",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`div (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`div (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -70,27 +76,32 @@ exports[`div (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "ensureNonZero",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "div",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
 ]
 `;
@@ -181,7 +192,8 @@ exports[`div (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -191,7 +203,8 @@ exports[`div (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -201,7 +214,8 @@ exports[`div (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -211,7 +225,8 @@ exports[`div (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -221,7 +236,8 @@ exports[`div (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -231,7 +247,8 @@ exports[`div (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -241,27 +258,32 @@ exports[`div (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "ensureNonZero",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "div",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/drop.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/drop.test.ts.snap
@@ -10,7 +10,8 @@ exports[`drop > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -21,17 +22,20 @@ exports[`drop > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "push",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [],
     "instruction": "drop",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/dup.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/dup.test.ts.snap
@@ -10,7 +10,8 @@ exports[`dup > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`dup > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`dup > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`dup > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`dup > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`dup > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -70,27 +76,32 @@ exports[`dup > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "dup",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/ensureNonZero.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/ensureNonZero.test.ts.snap
@@ -10,7 +10,8 @@ exports[`ensureNonZero (float) > if the generated AST, WAT and memory map match 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`ensureNonZero (float) > if the generated AST, WAT and memory map match 
       },
     ],
     "instruction": "float",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`ensureNonZero (float) > if the generated AST, WAT and memory map match 
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`ensureNonZero (float) > if the generated AST, WAT and memory map match 
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,22 +54,26 @@ exports[`ensureNonZero (float) > if the generated AST, WAT and memory map match 
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "ensureNonZero",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
 ]
 `;
@@ -138,7 +146,8 @@ exports[`ensureNonZero (int) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -148,7 +157,8 @@ exports[`ensureNonZero (int) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -158,7 +168,8 @@ exports[`ensureNonZero (int) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -168,7 +179,8 @@ exports[`ensureNonZero (int) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -178,22 +190,26 @@ exports[`ensureNonZero (int) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "ensureNonZero",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/equal.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/equal.test.ts.snap
@@ -10,7 +10,8 @@ exports[`equal > if the generated AST, WAT and memory map match the snapshot 1`]
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`equal > if the generated AST, WAT and memory map match the snapshot 1`]
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`equal > if the generated AST, WAT and memory map match the snapshot 1`]
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`equal > if the generated AST, WAT and memory map match the snapshot 1`]
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`equal > if the generated AST, WAT and memory map match the snapshot 1`]
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`equal > if the generated AST, WAT and memory map match the snapshot 1`]
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -70,22 +76,26 @@ exports[`equal > if the generated AST, WAT and memory map match the snapshot 1`]
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "equal",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/equalToZero.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/equalToZero.test.ts.snap
@@ -10,7 +10,8 @@ exports[`equalToZero > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`equalToZero > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`equalToZero > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`equalToZero > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -50,22 +54,26 @@ exports[`equalToZero > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "equalToZero",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/fallingEdge.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/fallingEdge.test.ts.snap
@@ -10,7 +10,8 @@ exports[`fallingEdge (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`fallingEdge (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`fallingEdge (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`fallingEdge (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -50,12 +54,14 @@ exports[`fallingEdge (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "fallingEdge",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -65,7 +71,8 @@ exports[`fallingEdge (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "if",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -76,12 +83,14 @@ exports[`fallingEdge (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "push",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "else",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [
@@ -92,22 +101,26 @@ exports[`fallingEdge (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "push",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "ifEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 15,
+    "lineNumberAfterMacroExpansion": 15,
+    "lineNumberBeforeMacroExpansion": 15,
   },
 ]
 `;
@@ -204,7 +217,8 @@ exports[`fallingEdge > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -214,7 +228,8 @@ exports[`fallingEdge > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -224,7 +239,8 @@ exports[`fallingEdge > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -234,7 +250,8 @@ exports[`fallingEdge > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -244,12 +261,14 @@ exports[`fallingEdge > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "fallingEdge",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -259,7 +278,8 @@ exports[`fallingEdge > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "if",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -270,12 +290,14 @@ exports[`fallingEdge > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "else",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [
@@ -286,22 +308,26 @@ exports[`fallingEdge > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "ifEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 15,
+    "lineNumberAfterMacroExpansion": 15,
+    "lineNumberBeforeMacroExpansion": 15,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/float.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/float.test.ts.snap
@@ -10,7 +10,8 @@ exports[`float: anonymous float with negative literal > if the generated AST, WA
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -21,7 +22,8 @@ exports[`float: anonymous float with negative literal > if the generated AST, WA
       },
     ],
     "instruction": "float",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -31,7 +33,8 @@ exports[`float: anonymous float with negative literal > if the generated AST, WA
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -41,7 +44,8 @@ exports[`float: anonymous float with negative literal > if the generated AST, WA
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -51,17 +55,20 @@ exports[`float: anonymous float with negative literal > if the generated AST, WA
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -124,7 +131,8 @@ exports[`float: with constant identifier (anonymous allocation) > if the generat
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -139,7 +147,8 @@ exports[`float: with constant identifier (anonymous allocation) > if the generat
       },
     ],
     "instruction": "const",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -149,7 +158,8 @@ exports[`float: with constant identifier (anonymous allocation) > if the generat
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -159,7 +169,8 @@ exports[`float: with constant identifier (anonymous allocation) > if the generat
       },
     ],
     "instruction": "float",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -169,7 +180,8 @@ exports[`float: with constant identifier (anonymous allocation) > if the generat
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -179,17 +191,20 @@ exports[`float: with constant identifier (anonymous allocation) > if the generat
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
 ]
 `;
@@ -252,7 +267,8 @@ exports[`float: with literal (anonymous allocation) > if the generated AST, WAT 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -263,7 +279,8 @@ exports[`float: with literal (anonymous allocation) > if the generated AST, WAT 
       },
     ],
     "instruction": "float",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -273,7 +290,8 @@ exports[`float: with literal (anonymous allocation) > if the generated AST, WAT 
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -283,7 +301,8 @@ exports[`float: with literal (anonymous allocation) > if the generated AST, WAT 
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -293,17 +312,20 @@ exports[`float: with literal (anonymous allocation) > if the generated AST, WAT 
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/fractionLiterals.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/fractionLiterals.test.ts.snap
@@ -10,7 +10,8 @@ exports[`const: with fraction literal (1/8) > if the generated AST, WAT and memo
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -25,7 +26,8 @@ exports[`const: with fraction literal (1/8) > if the generated AST, WAT and memo
       },
     ],
     "instruction": "const",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -35,7 +37,8 @@ exports[`const: with fraction literal (1/8) > if the generated AST, WAT and memo
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -45,7 +48,8 @@ exports[`const: with fraction literal (1/8) > if the generated AST, WAT and memo
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -55,17 +59,20 @@ exports[`const: with fraction literal (1/8) > if the generated AST, WAT and memo
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -112,7 +119,8 @@ exports[`float: with fraction literal (1/16) > if the generated AST, WAT and mem
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -127,7 +135,8 @@ exports[`float: with fraction literal (1/16) > if the generated AST, WAT and mem
       },
     ],
     "instruction": "float",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -137,7 +146,8 @@ exports[`float: with fraction literal (1/16) > if the generated AST, WAT and mem
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -147,7 +157,8 @@ exports[`float: with fraction literal (1/16) > if the generated AST, WAT and mem
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -157,17 +168,20 @@ exports[`float: with fraction literal (1/16) > if the generated AST, WAT and mem
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -230,7 +244,8 @@ exports[`float: with negative fraction literal (-1/2) > if the generated AST, WA
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -245,7 +260,8 @@ exports[`float: with negative fraction literal (-1/2) > if the generated AST, WA
       },
     ],
     "instruction": "float",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -255,7 +271,8 @@ exports[`float: with negative fraction literal (-1/2) > if the generated AST, WA
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -265,7 +282,8 @@ exports[`float: with negative fraction literal (-1/2) > if the generated AST, WA
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -275,17 +293,20 @@ exports[`float: with negative fraction literal (-1/2) > if the generated AST, WA
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -348,7 +369,8 @@ exports[`int: with fraction literal (1/16) truncates to 0 > if the generated AST
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -363,7 +385,8 @@ exports[`int: with fraction literal (1/16) truncates to 0 > if the generated AST
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -373,7 +396,8 @@ exports[`int: with fraction literal (1/16) truncates to 0 > if the generated AST
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -383,7 +407,8 @@ exports[`int: with fraction literal (1/16) truncates to 0 > if the generated AST
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -393,17 +418,20 @@ exports[`int: with fraction literal (1/16) truncates to 0 > if the generated AST
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -466,7 +494,8 @@ exports[`int: with fraction literal (8/2) equals 4 > if the generated AST, WAT a
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -481,7 +510,8 @@ exports[`int: with fraction literal (8/2) equals 4 > if the generated AST, WAT a
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -491,7 +521,8 @@ exports[`int: with fraction literal (8/2) equals 4 > if the generated AST, WAT a
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -501,7 +532,8 @@ exports[`int: with fraction literal (8/2) equals 4 > if the generated AST, WAT a
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -511,17 +543,20 @@ exports[`int: with fraction literal (8/2) equals 4 > if the generated AST, WAT a
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -584,7 +619,8 @@ exports[`push: with fraction literal (1/16) > if the generated AST, WAT and memo
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -599,7 +635,8 @@ exports[`push: with fraction literal (1/16) > if the generated AST, WAT and memo
       },
     ],
     "instruction": "float",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -609,7 +646,8 @@ exports[`push: with fraction literal (1/16) > if the generated AST, WAT and memo
       },
     ],
     "instruction": "push",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -620,17 +658,20 @@ exports[`push: with fraction literal (1/16) > if the generated AST, WAT and memo
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/function.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/function.test.ts.snap
@@ -10,7 +10,8 @@ exports[`function returns constant > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,12 +21,14 @@ exports[`function returns constant > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [],
     "instruction": "loop",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -35,7 +38,8 @@ exports[`function returns constant > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -45,22 +49,26 @@ exports[`function returns constant > if the generated AST, WAT and memory map ma
       },
     ],
     "instruction": "call",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "loopEnd",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
 ]
 `;
@@ -173,7 +181,8 @@ exports[`function with parameter > if the generated AST, WAT and memory map matc
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -183,7 +192,8 @@ exports[`function with parameter > if the generated AST, WAT and memory map matc
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -193,12 +203,14 @@ exports[`function with parameter > if the generated AST, WAT and memory map matc
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [],
     "instruction": "loop",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -208,7 +220,8 @@ exports[`function with parameter > if the generated AST, WAT and memory map matc
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -218,7 +231,8 @@ exports[`function with parameter > if the generated AST, WAT and memory map matc
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -228,22 +242,26 @@ exports[`function with parameter > if the generated AST, WAT and memory map matc
       },
     ],
     "instruction": "call",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "loopEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
 ]
 `;
@@ -375,7 +393,8 @@ exports[`function with two parameters > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -385,7 +404,8 @@ exports[`function with two parameters > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -395,7 +415,8 @@ exports[`function with two parameters > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -405,12 +426,14 @@ exports[`function with two parameters > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [],
     "instruction": "loop",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -420,7 +443,8 @@ exports[`function with two parameters > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -430,7 +454,8 @@ exports[`function with two parameters > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -440,7 +465,8 @@ exports[`function with two parameters > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -450,22 +476,26 @@ exports[`function with two parameters > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "call",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "loopEnd",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/functionEnd.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/functionEnd.test.ts.snap
@@ -10,7 +10,8 @@ exports[`functionEnd validates stack > if the generated AST, WAT and memory map 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,12 +21,14 @@ exports[`functionEnd validates stack > if the generated AST, WAT and memory map 
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [],
     "instruction": "loop",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -35,7 +38,8 @@ exports[`functionEnd validates stack > if the generated AST, WAT and memory map 
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -45,22 +49,26 @@ exports[`functionEnd validates stack > if the generated AST, WAT and memory map 
       },
     ],
     "instruction": "call",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "loopEnd",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
 ]
 `;
@@ -175,7 +183,8 @@ exports[`functionEnd with float return > if the generated AST, WAT and memory ma
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -185,12 +194,14 @@ exports[`functionEnd with float return > if the generated AST, WAT and memory ma
       },
     ],
     "instruction": "float",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [],
     "instruction": "loop",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -200,7 +211,8 @@ exports[`functionEnd with float return > if the generated AST, WAT and memory ma
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -210,22 +222,26 @@ exports[`functionEnd with float return > if the generated AST, WAT and memory ma
       },
     ],
     "instruction": "call",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "loopEnd",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
 ]
 `;
@@ -338,7 +354,8 @@ exports[`functionEnd with int return > if the generated AST, WAT and memory map 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -348,12 +365,14 @@ exports[`functionEnd with int return > if the generated AST, WAT and memory map 
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [],
     "instruction": "loop",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -363,7 +382,8 @@ exports[`functionEnd with int return > if the generated AST, WAT and memory map 
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -373,22 +393,26 @@ exports[`functionEnd with int return > if the generated AST, WAT and memory map 
       },
     ],
     "instruction": "call",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "loopEnd",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/greaterOrEqual.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/greaterOrEqual.test.ts.snap
@@ -10,7 +10,8 @@ exports[`greaterOrEqual (float) > if the generated AST, WAT and memory map match
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`greaterOrEqual (float) > if the generated AST, WAT and memory map match
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`greaterOrEqual (float) > if the generated AST, WAT and memory map match
       },
     ],
     "instruction": "float",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`greaterOrEqual (float) > if the generated AST, WAT and memory map match
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`greaterOrEqual (float) > if the generated AST, WAT and memory map match
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`greaterOrEqual (float) > if the generated AST, WAT and memory map match
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -70,22 +76,26 @@ exports[`greaterOrEqual (float) > if the generated AST, WAT and memory map match
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "greaterOrEqual",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;
@@ -166,7 +176,8 @@ exports[`greaterOrEqual (int) > if the generated AST, WAT and memory map match t
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -176,7 +187,8 @@ exports[`greaterOrEqual (int) > if the generated AST, WAT and memory map match t
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -186,7 +198,8 @@ exports[`greaterOrEqual (int) > if the generated AST, WAT and memory map match t
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -196,7 +209,8 @@ exports[`greaterOrEqual (int) > if the generated AST, WAT and memory map match t
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -206,7 +220,8 @@ exports[`greaterOrEqual (int) > if the generated AST, WAT and memory map match t
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -216,7 +231,8 @@ exports[`greaterOrEqual (int) > if the generated AST, WAT and memory map match t
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -226,22 +242,26 @@ exports[`greaterOrEqual (int) > if the generated AST, WAT and memory map match t
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "greaterOrEqual",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/greaterThan.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/greaterThan.test.ts.snap
@@ -10,7 +10,8 @@ exports[`greaterThan (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`greaterThan (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`greaterThan (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "float",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`greaterThan (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`greaterThan (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`greaterThan (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -70,22 +76,26 @@ exports[`greaterThan (float) > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "greaterThan",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;
@@ -166,7 +176,8 @@ exports[`greaterThan (int) > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -176,7 +187,8 @@ exports[`greaterThan (int) > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -186,7 +198,8 @@ exports[`greaterThan (int) > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -196,7 +209,8 @@ exports[`greaterThan (int) > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -206,7 +220,8 @@ exports[`greaterThan (int) > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -216,7 +231,8 @@ exports[`greaterThan (int) > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -226,22 +242,26 @@ exports[`greaterThan (int) > if the generated AST, WAT and memory map match the 
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "greaterThan",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/hasChanged.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/hasChanged.test.ts.snap
@@ -10,7 +10,8 @@ exports[`hasChanged with float > if the generated AST, WAT and memory map match 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`hasChanged with float > if the generated AST, WAT and memory map match 
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`hasChanged with float > if the generated AST, WAT and memory map match 
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`hasChanged with float > if the generated AST, WAT and memory map match 
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -50,12 +54,14 @@ exports[`hasChanged with float > if the generated AST, WAT and memory map match 
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "hasChanged",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -65,7 +71,8 @@ exports[`hasChanged with float > if the generated AST, WAT and memory map match 
       },
     ],
     "instruction": "if",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -76,12 +83,14 @@ exports[`hasChanged with float > if the generated AST, WAT and memory map match 
       },
     ],
     "instruction": "push",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "else",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [
@@ -92,22 +101,26 @@ exports[`hasChanged with float > if the generated AST, WAT and memory map match 
       },
     ],
     "instruction": "push",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "ifEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 15,
+    "lineNumberAfterMacroExpansion": 15,
+    "lineNumberBeforeMacroExpansion": 15,
   },
 ]
 `;
@@ -200,7 +213,8 @@ exports[`hasChanged with int > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -210,7 +224,8 @@ exports[`hasChanged with int > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -220,7 +235,8 @@ exports[`hasChanged with int > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -230,7 +246,8 @@ exports[`hasChanged with int > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -240,12 +257,14 @@ exports[`hasChanged with int > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "hasChanged",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -255,7 +274,8 @@ exports[`hasChanged with int > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "if",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -266,12 +286,14 @@ exports[`hasChanged with int > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "push",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "else",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [
@@ -282,22 +304,26 @@ exports[`hasChanged with int > if the generated AST, WAT and memory map match th
       },
     ],
     "instruction": "push",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "ifEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 15,
+    "lineNumberAfterMacroExpansion": 15,
+    "lineNumberBeforeMacroExpansion": 15,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/if.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/if.test.ts.snap
@@ -10,7 +10,8 @@ exports[`if (float) > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`if (float) > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`if (float) > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`if (float) > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`if (float) > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`if (float) > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "if",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -71,12 +77,14 @@ exports[`if (float) > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "else",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -87,22 +95,26 @@ exports[`if (float) > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "ifEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
 ]
 `;
@@ -170,7 +182,8 @@ exports[`if (int) > if the generated AST, WAT and memory map match the snapshot 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -180,7 +193,8 @@ exports[`if (int) > if the generated AST, WAT and memory map match the snapshot 
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -190,7 +204,8 @@ exports[`if (int) > if the generated AST, WAT and memory map match the snapshot 
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -200,7 +215,8 @@ exports[`if (int) > if the generated AST, WAT and memory map match the snapshot 
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -210,7 +226,8 @@ exports[`if (int) > if the generated AST, WAT and memory map match the snapshot 
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -220,7 +237,8 @@ exports[`if (int) > if the generated AST, WAT and memory map match the snapshot 
       },
     ],
     "instruction": "if",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -231,12 +249,14 @@ exports[`if (int) > if the generated AST, WAT and memory map match the snapshot 
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "else",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -247,22 +267,26 @@ exports[`if (int) > if the generated AST, WAT and memory map match the snapshot 
       },
     ],
     "instruction": "push",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "ifEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
 ]
 `;
@@ -330,7 +354,8 @@ exports[`if (void) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -340,7 +365,8 @@ exports[`if (void) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -350,7 +376,8 @@ exports[`if (void) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -360,7 +387,8 @@ exports[`if (void) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -370,7 +398,8 @@ exports[`if (void) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "if",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -380,7 +409,8 @@ exports[`if (void) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -391,17 +421,20 @@ exports[`if (void) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "else",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [
@@ -411,7 +444,8 @@ exports[`if (void) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [
@@ -422,22 +456,26 @@ exports[`if (void) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
   {
     "arguments": [],
     "instruction": "ifEnd",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 15,
+    "lineNumberAfterMacroExpansion": 15,
+    "lineNumberBeforeMacroExpansion": 15,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/int.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/int.test.ts.snap
@@ -10,7 +10,8 @@ exports[`int: anonymous allocation with negative literal > if the generated AST,
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -21,7 +22,8 @@ exports[`int: anonymous allocation with negative literal > if the generated AST,
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -31,7 +33,8 @@ exports[`int: anonymous allocation with negative literal > if the generated AST,
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -41,7 +44,8 @@ exports[`int: anonymous allocation with negative literal > if the generated AST,
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -51,17 +55,20 @@ exports[`int: anonymous allocation with negative literal > if the generated AST,
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -124,7 +131,8 @@ exports[`int: anonymous byte literal and constant split-byte > if the generated 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -139,7 +147,8 @@ exports[`int: anonymous byte literal and constant split-byte > if the generated 
       },
     ],
     "instruction": "const",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -155,7 +164,8 @@ exports[`int: anonymous byte literal and constant split-byte > if the generated 
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -165,7 +175,8 @@ exports[`int: anonymous byte literal and constant split-byte > if the generated 
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -175,7 +186,8 @@ exports[`int: anonymous byte literal and constant split-byte > if the generated 
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -185,17 +197,20 @@ exports[`int: anonymous byte literal and constant split-byte > if the generated 
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
 ]
 `;
@@ -258,7 +273,8 @@ exports[`int: anonymous constant split-byte default (2 constants) > if the gener
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -273,7 +289,8 @@ exports[`int: anonymous constant split-byte default (2 constants) > if the gener
       },
     ],
     "instruction": "const",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -288,7 +305,8 @@ exports[`int: anonymous constant split-byte default (2 constants) > if the gener
       },
     ],
     "instruction": "const",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -302,7 +320,8 @@ exports[`int: anonymous constant split-byte default (2 constants) > if the gener
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -312,7 +331,8 @@ exports[`int: anonymous constant split-byte default (2 constants) > if the gener
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -322,7 +342,8 @@ exports[`int: anonymous constant split-byte default (2 constants) > if the gener
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -332,17 +353,20 @@ exports[`int: anonymous constant split-byte default (2 constants) > if the gener
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
 ]
 `;
@@ -405,7 +429,8 @@ exports[`int: anonymous split decimal default (2 bytes, right-padded) > if the g
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -421,7 +446,8 @@ exports[`int: anonymous split decimal default (2 bytes, right-padded) > if the g
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -431,7 +457,8 @@ exports[`int: anonymous split decimal default (2 bytes, right-padded) > if the g
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -441,7 +468,8 @@ exports[`int: anonymous split decimal default (2 bytes, right-padded) > if the g
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -451,17 +479,20 @@ exports[`int: anonymous split decimal default (2 bytes, right-padded) > if the g
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -524,7 +555,8 @@ exports[`int: anonymous split hex default (2 bytes, right-padded) > if the gener
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -542,7 +574,8 @@ exports[`int: anonymous split hex default (2 bytes, right-padded) > if the gener
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -552,7 +585,8 @@ exports[`int: anonymous split hex default (2 bytes, right-padded) > if the gener
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -562,7 +596,8 @@ exports[`int: anonymous split hex default (2 bytes, right-padded) > if the gener
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -572,17 +607,20 @@ exports[`int: anonymous split hex default (2 bytes, right-padded) > if the gener
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -645,7 +683,8 @@ exports[`int: mix of anonymous and named allocations > if the generated AST, WAT
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -656,7 +695,8 @@ exports[`int: mix of anonymous and named allocations > if the generated AST, WAT
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -671,7 +711,8 @@ exports[`int: mix of anonymous and named allocations > if the generated AST, WAT
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -682,7 +723,8 @@ exports[`int: mix of anonymous and named allocations > if the generated AST, WAT
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -692,7 +734,8 @@ exports[`int: mix of anonymous and named allocations > if the generated AST, WAT
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -702,7 +745,8 @@ exports[`int: mix of anonymous and named allocations > if the generated AST, WAT
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -712,7 +756,8 @@ exports[`int: mix of anonymous and named allocations > if the generated AST, WAT
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -722,12 +767,14 @@ exports[`int: mix of anonymous and named allocations > if the generated AST, WAT
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "add",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -737,22 +784,26 @@ exports[`int: mix of anonymous and named allocations > if the generated AST, WAT
       },
     ],
     "instruction": "push",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "add",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;
@@ -851,7 +902,8 @@ exports[`int: mixed hex and decimal bytes in split-byte default > if the generat
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -872,7 +924,8 @@ exports[`int: mixed hex and decimal bytes in split-byte default > if the generat
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -882,7 +935,8 @@ exports[`int: mixed hex and decimal bytes in split-byte default > if the generat
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -892,7 +946,8 @@ exports[`int: mixed hex and decimal bytes in split-byte default > if the generat
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -902,17 +957,20 @@ exports[`int: mixed hex and decimal bytes in split-byte default > if the generat
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -975,7 +1033,8 @@ exports[`int: multiple anonymous allocations > if the generated AST, WAT and mem
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -986,7 +1045,8 @@ exports[`int: multiple anonymous allocations > if the generated AST, WAT and mem
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -997,7 +1057,8 @@ exports[`int: multiple anonymous allocations > if the generated AST, WAT and mem
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -1008,7 +1069,8 @@ exports[`int: multiple anonymous allocations > if the generated AST, WAT and mem
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -1018,7 +1080,8 @@ exports[`int: multiple anonymous allocations > if the generated AST, WAT and mem
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -1028,7 +1091,8 @@ exports[`int: multiple anonymous allocations > if the generated AST, WAT and mem
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -1038,7 +1102,8 @@ exports[`int: multiple anonymous allocations > if the generated AST, WAT and mem
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -1048,12 +1113,14 @@ exports[`int: multiple anonymous allocations > if the generated AST, WAT and mem
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "add",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -1063,22 +1130,26 @@ exports[`int: multiple anonymous allocations > if the generated AST, WAT and mem
       },
     ],
     "instruction": "push",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "add",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;
@@ -1177,7 +1248,8 @@ exports[`int: named constant split-byte default (2 constants) > if the generated
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -1192,7 +1264,8 @@ exports[`int: named constant split-byte default (2 constants) > if the generated
       },
     ],
     "instruction": "const",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -1207,7 +1280,8 @@ exports[`int: named constant split-byte default (2 constants) > if the generated
       },
     ],
     "instruction": "const",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -1225,7 +1299,8 @@ exports[`int: named constant split-byte default (2 constants) > if the generated
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -1235,7 +1310,8 @@ exports[`int: named constant split-byte default (2 constants) > if the generated
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -1245,7 +1321,8 @@ exports[`int: named constant split-byte default (2 constants) > if the generated
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -1255,17 +1332,20 @@ exports[`int: named constant split-byte default (2 constants) > if the generated
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
 ]
 `;
@@ -1328,7 +1408,8 @@ exports[`int: named mixed byte literal and constant split-byte > if the generate
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -1343,7 +1424,8 @@ exports[`int: named mixed byte literal and constant split-byte > if the generate
       },
     ],
     "instruction": "const",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -1363,7 +1445,8 @@ exports[`int: named mixed byte literal and constant split-byte > if the generate
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -1373,7 +1456,8 @@ exports[`int: named mixed byte literal and constant split-byte > if the generate
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -1383,7 +1467,8 @@ exports[`int: named mixed byte literal and constant split-byte > if the generate
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -1393,17 +1478,20 @@ exports[`int: named mixed byte literal and constant split-byte > if the generate
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
 ]
 `;
@@ -1466,7 +1554,8 @@ exports[`int: named split decimal default (2 bytes, right-padded) > if the gener
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -1486,7 +1575,8 @@ exports[`int: named split decimal default (2 bytes, right-padded) > if the gener
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -1496,7 +1586,8 @@ exports[`int: named split decimal default (2 bytes, right-padded) > if the gener
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -1506,7 +1597,8 @@ exports[`int: named split decimal default (2 bytes, right-padded) > if the gener
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -1516,17 +1608,20 @@ exports[`int: named split decimal default (2 bytes, right-padded) > if the gener
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -1589,7 +1684,8 @@ exports[`int: named split decimal default (4 bytes) > if the generated AST, WAT 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -1619,7 +1715,8 @@ exports[`int: named split decimal default (4 bytes) > if the generated AST, WAT 
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -1629,7 +1726,8 @@ exports[`int: named split decimal default (4 bytes) > if the generated AST, WAT 
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -1639,7 +1737,8 @@ exports[`int: named split decimal default (4 bytes) > if the generated AST, WAT 
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -1649,17 +1748,20 @@ exports[`int: named split decimal default (4 bytes) > if the generated AST, WAT 
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -1722,7 +1824,8 @@ exports[`int: named split hex default (2 bytes, right-padded) > if the generated
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -1744,7 +1847,8 @@ exports[`int: named split hex default (2 bytes, right-padded) > if the generated
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -1754,7 +1858,8 @@ exports[`int: named split hex default (2 bytes, right-padded) > if the generated
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -1764,7 +1869,8 @@ exports[`int: named split hex default (2 bytes, right-padded) > if the generated
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -1774,17 +1880,20 @@ exports[`int: named split hex default (2 bytes, right-padded) > if the generated
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -1847,7 +1956,8 @@ exports[`int: named split hex default (4 bytes) > if the generated AST, WAT and 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -1881,7 +1991,8 @@ exports[`int: named split hex default (4 bytes) > if the generated AST, WAT and 
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -1891,7 +2002,8 @@ exports[`int: named split hex default (4 bytes) > if the generated AST, WAT and 
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -1901,7 +2013,8 @@ exports[`int: named split hex default (4 bytes) > if the generated AST, WAT and 
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -1911,17 +2024,20 @@ exports[`int: named split hex default (4 bytes) > if the generated AST, WAT and 
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -1984,7 +2100,8 @@ exports[`int: single decimal literal remains anonymous int with that value > if 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -1995,7 +2112,8 @@ exports[`int: single decimal literal remains anonymous int with that value > if 
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -2005,7 +2123,8 @@ exports[`int: single decimal literal remains anonymous int with that value > if 
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -2015,7 +2134,8 @@ exports[`int: single decimal literal remains anonymous int with that value > if 
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -2025,17 +2145,20 @@ exports[`int: single decimal literal remains anonymous int with that value > if 
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -2098,7 +2221,8 @@ exports[`int: with constant identifier (anonymous allocation) > if the generated
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -2113,7 +2237,8 @@ exports[`int: with constant identifier (anonymous allocation) > if the generated
       },
     ],
     "instruction": "const",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -2123,7 +2248,8 @@ exports[`int: with constant identifier (anonymous allocation) > if the generated
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -2133,7 +2259,8 @@ exports[`int: with constant identifier (anonymous allocation) > if the generated
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -2143,7 +2270,8 @@ exports[`int: with constant identifier (anonymous allocation) > if the generated
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -2153,17 +2281,20 @@ exports[`int: with constant identifier (anonymous allocation) > if the generated
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
 ]
 `;
@@ -2226,7 +2357,8 @@ exports[`int: with literal (anonymous allocation) > if the generated AST, WAT an
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -2237,7 +2369,8 @@ exports[`int: with literal (anonymous allocation) > if the generated AST, WAT an
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -2247,7 +2380,8 @@ exports[`int: with literal (anonymous allocation) > if the generated AST, WAT an
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -2257,7 +2391,8 @@ exports[`int: with literal (anonymous allocation) > if the generated AST, WAT an
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -2267,17 +2402,20 @@ exports[`int: with literal (anonymous allocation) > if the generated AST, WAT an
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;
@@ -2340,7 +2478,8 @@ exports[`int: with named identifier > if the generated AST, WAT and memory map m
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -2355,7 +2494,8 @@ exports[`int: with named identifier > if the generated AST, WAT and memory map m
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -2365,7 +2505,8 @@ exports[`int: with named identifier > if the generated AST, WAT and memory map m
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -2375,7 +2516,8 @@ exports[`int: with named identifier > if the generated AST, WAT and memory map m
       },
     ],
     "instruction": "push",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -2385,17 +2527,20 @@ exports[`int: with named identifier > if the generated AST, WAT and memory map m
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/loadFloat.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/loadFloat.test.ts.snap
@@ -10,7 +10,8 @@ exports[`loadFloat > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`loadFloat > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "float",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`loadFloat > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`loadFloat > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,22 +54,26 @@ exports[`loadFloat > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "loadFloat",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/loop.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/loop.test.ts.snap
@@ -10,7 +10,8 @@ exports[`infinite loop protection > if the generated AST, WAT and memory map mat
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,12 +21,14 @@ exports[`infinite loop protection > if the generated AST, WAT and memory map mat
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [],
     "instruction": "loop",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -35,7 +38,8 @@ exports[`infinite loop protection > if the generated AST, WAT and memory map mat
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -45,7 +49,8 @@ exports[`infinite loop protection > if the generated AST, WAT and memory map mat
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -56,27 +61,32 @@ exports[`infinite loop protection > if the generated AST, WAT and memory map mat
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "add",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "loopEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
 ]
 `;
@@ -162,7 +172,8 @@ exports[`loop > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -172,12 +183,14 @@ exports[`loop > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "int",
-    "lineNumber": 1,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
   },
   {
     "arguments": [],
     "instruction": "loop",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -187,7 +200,8 @@ exports[`loop > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "push",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -198,12 +212,14 @@ exports[`loop > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [],
     "instruction": "equal",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -214,7 +230,8 @@ exports[`loop > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "branchIfTrue",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -224,7 +241,8 @@ exports[`loop > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "push",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [
@@ -234,7 +252,8 @@ exports[`loop > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "push",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [
@@ -245,27 +264,32 @@ exports[`loop > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "push",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "add",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
   {
     "arguments": [],
     "instruction": "loopEnd",
-    "lineNumber": 14,
+    "lineNumberAfterMacroExpansion": 14,
+    "lineNumberBeforeMacroExpansion": 14,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 16,
+    "lineNumberAfterMacroExpansion": 16,
+    "lineNumberBeforeMacroExpansion": 16,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/map.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/map.test.ts.snap
@@ -10,7 +10,8 @@ exports[`map: first-match-wins with duplicate keys > if the generated AST, WAT a
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`map: first-match-wins with duplicate keys > if the generated AST, WAT a
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`map: first-match-wins with duplicate keys > if the generated AST, WAT a
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`map: first-match-wins with duplicate keys > if the generated AST, WAT a
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`map: first-match-wins with duplicate keys > if the generated AST, WAT a
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`map: first-match-wins with duplicate keys > if the generated AST, WAT a
       },
     ],
     "instruction": "mapBegin",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -76,7 +82,8 @@ exports[`map: first-match-wins with duplicate keys > if the generated AST, WAT a
       },
     ],
     "instruction": "map",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -92,7 +99,8 @@ exports[`map: first-match-wins with duplicate keys > if the generated AST, WAT a
       },
     ],
     "instruction": "map",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [
@@ -102,17 +110,20 @@ exports[`map: first-match-wins with duplicate keys > if the generated AST, WAT a
       },
     ],
     "instruction": "mapEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
 ]
 `;
@@ -214,7 +225,8 @@ exports[`map: float→float mapping > if the generated AST, WAT and memory map m
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -224,7 +236,8 @@ exports[`map: float→float mapping > if the generated AST, WAT and memory map m
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -234,7 +247,8 @@ exports[`map: float→float mapping > if the generated AST, WAT and memory map m
       },
     ],
     "instruction": "float",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -244,7 +258,8 @@ exports[`map: float→float mapping > if the generated AST, WAT and memory map m
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -254,7 +269,8 @@ exports[`map: float→float mapping > if the generated AST, WAT and memory map m
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -264,7 +280,8 @@ exports[`map: float→float mapping > if the generated AST, WAT and memory map m
       },
     ],
     "instruction": "mapBegin",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -280,7 +297,8 @@ exports[`map: float→float mapping > if the generated AST, WAT and memory map m
       },
     ],
     "instruction": "map",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -296,7 +314,8 @@ exports[`map: float→float mapping > if the generated AST, WAT and memory map m
       },
     ],
     "instruction": "map",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [
@@ -306,17 +325,20 @@ exports[`map: float→float mapping > if the generated AST, WAT and memory map m
       },
     ],
     "instruction": "mapEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
 ]
 `;
@@ -418,7 +440,8 @@ exports[`map: implicit default zero for int output > if the generated AST, WAT a
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -428,7 +451,8 @@ exports[`map: implicit default zero for int output > if the generated AST, WAT a
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -438,7 +462,8 @@ exports[`map: implicit default zero for int output > if the generated AST, WAT a
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -448,7 +473,8 @@ exports[`map: implicit default zero for int output > if the generated AST, WAT a
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -458,7 +484,8 @@ exports[`map: implicit default zero for int output > if the generated AST, WAT a
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -468,7 +495,8 @@ exports[`map: implicit default zero for int output > if the generated AST, WAT a
       },
     ],
     "instruction": "mapBegin",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -484,7 +512,8 @@ exports[`map: implicit default zero for int output > if the generated AST, WAT a
       },
     ],
     "instruction": "map",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -494,17 +523,20 @@ exports[`map: implicit default zero for int output > if the generated AST, WAT a
       },
     ],
     "instruction": "mapEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;
@@ -590,7 +622,8 @@ exports[`map: int→float mapping > if the generated AST, WAT and memory map mat
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -600,7 +633,8 @@ exports[`map: int→float mapping > if the generated AST, WAT and memory map mat
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -610,7 +644,8 @@ exports[`map: int→float mapping > if the generated AST, WAT and memory map mat
       },
     ],
     "instruction": "float",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -620,7 +655,8 @@ exports[`map: int→float mapping > if the generated AST, WAT and memory map mat
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -630,7 +666,8 @@ exports[`map: int→float mapping > if the generated AST, WAT and memory map mat
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -640,7 +677,8 @@ exports[`map: int→float mapping > if the generated AST, WAT and memory map mat
       },
     ],
     "instruction": "mapBegin",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -656,7 +694,8 @@ exports[`map: int→float mapping > if the generated AST, WAT and memory map mat
       },
     ],
     "instruction": "map",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -672,7 +711,8 @@ exports[`map: int→float mapping > if the generated AST, WAT and memory map mat
       },
     ],
     "instruction": "map",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [
@@ -682,17 +722,20 @@ exports[`map: int→float mapping > if the generated AST, WAT and memory map mat
       },
     ],
     "instruction": "mapEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
 ]
 `;
@@ -794,7 +837,8 @@ exports[`map: int→int basic mapping > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -804,7 +848,8 @@ exports[`map: int→int basic mapping > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -814,7 +859,8 @@ exports[`map: int→int basic mapping > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -824,7 +870,8 @@ exports[`map: int→int basic mapping > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -834,7 +881,8 @@ exports[`map: int→int basic mapping > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -844,7 +892,8 @@ exports[`map: int→int basic mapping > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "mapBegin",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -860,7 +909,8 @@ exports[`map: int→int basic mapping > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "map",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -876,7 +926,8 @@ exports[`map: int→int basic mapping > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "map",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [
@@ -892,7 +943,8 @@ exports[`map: int→int basic mapping > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "map",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [
@@ -902,17 +954,20 @@ exports[`map: int→int basic mapping > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "mapEnd",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 14,
+    "lineNumberAfterMacroExpansion": 14,
+    "lineNumberBeforeMacroExpansion": 14,
   },
 ]
 `;
@@ -1030,7 +1085,8 @@ exports[`map: int→int with explicit default > if the generated AST, WAT and me
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -1040,7 +1096,8 @@ exports[`map: int→int with explicit default > if the generated AST, WAT and me
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -1050,7 +1107,8 @@ exports[`map: int→int with explicit default > if the generated AST, WAT and me
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -1060,7 +1118,8 @@ exports[`map: int→int with explicit default > if the generated AST, WAT and me
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -1070,7 +1129,8 @@ exports[`map: int→int with explicit default > if the generated AST, WAT and me
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -1080,7 +1140,8 @@ exports[`map: int→int with explicit default > if the generated AST, WAT and me
       },
     ],
     "instruction": "mapBegin",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -1096,7 +1157,8 @@ exports[`map: int→int with explicit default > if the generated AST, WAT and me
       },
     ],
     "instruction": "map",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -1107,7 +1169,8 @@ exports[`map: int→int with explicit default > if the generated AST, WAT and me
       },
     ],
     "instruction": "default",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [
@@ -1117,17 +1180,20 @@ exports[`map: int→int with explicit default > if the generated AST, WAT and me
       },
     ],
     "instruction": "mapEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
 ]
 `;
@@ -1213,7 +1279,8 @@ exports[`map: int→int with single-character literals as ASCII > if the generat
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -1223,7 +1290,8 @@ exports[`map: int→int with single-character literals as ASCII > if the generat
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -1233,7 +1301,8 @@ exports[`map: int→int with single-character literals as ASCII > if the generat
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -1243,7 +1312,8 @@ exports[`map: int→int with single-character literals as ASCII > if the generat
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -1253,7 +1323,8 @@ exports[`map: int→int with single-character literals as ASCII > if the generat
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -1263,7 +1334,8 @@ exports[`map: int→int with single-character literals as ASCII > if the generat
       },
     ],
     "instruction": "mapBegin",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -1277,7 +1349,8 @@ exports[`map: int→int with single-character literals as ASCII > if the generat
       },
     ],
     "instruction": "map",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -1287,17 +1360,20 @@ exports[`map: int→int with single-character literals as ASCII > if the generat
       },
     ],
     "instruction": "mapEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;
@@ -1383,7 +1459,8 @@ exports[`map: zero-row map returns default > if the generated AST, WAT and memor
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -1393,7 +1470,8 @@ exports[`map: zero-row map returns default > if the generated AST, WAT and memor
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -1403,7 +1481,8 @@ exports[`map: zero-row map returns default > if the generated AST, WAT and memor
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -1413,7 +1492,8 @@ exports[`map: zero-row map returns default > if the generated AST, WAT and memor
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -1423,7 +1503,8 @@ exports[`map: zero-row map returns default > if the generated AST, WAT and memor
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -1433,7 +1514,8 @@ exports[`map: zero-row map returns default > if the generated AST, WAT and memor
       },
     ],
     "instruction": "mapBegin",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -1443,17 +1525,20 @@ exports[`map: zero-row map returns default > if the generated AST, WAT and memor
       },
     ],
     "instruction": "mapEnd",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
 ]
 `;
@@ -1518,7 +1603,8 @@ exports[`map: zero-row map with explicit default > if the generated AST, WAT and
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -1528,7 +1614,8 @@ exports[`map: zero-row map with explicit default > if the generated AST, WAT and
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -1538,7 +1625,8 @@ exports[`map: zero-row map with explicit default > if the generated AST, WAT and
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -1548,7 +1636,8 @@ exports[`map: zero-row map with explicit default > if the generated AST, WAT and
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -1558,7 +1647,8 @@ exports[`map: zero-row map with explicit default > if the generated AST, WAT and
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -1568,7 +1658,8 @@ exports[`map: zero-row map with explicit default > if the generated AST, WAT and
       },
     ],
     "instruction": "mapBegin",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -1579,7 +1670,8 @@ exports[`map: zero-row map with explicit default > if the generated AST, WAT and
       },
     ],
     "instruction": "default",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -1589,17 +1681,20 @@ exports[`map: zero-row map with explicit default > if the generated AST, WAT and
       },
     ],
     "instruction": "mapEnd",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/mul.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/mul.test.ts.snap
@@ -10,7 +10,8 @@ exports[`mul (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`mul (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`mul (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "float",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`mul (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "float",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`mul (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`mul (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -70,22 +76,26 @@ exports[`mul (float) > if the generated AST, WAT and memory map match the snapsh
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "mul",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;
@@ -166,7 +176,8 @@ exports[`mul (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -176,7 +187,8 @@ exports[`mul (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -186,7 +198,8 @@ exports[`mul (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -196,7 +209,8 @@ exports[`mul (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -206,7 +220,8 @@ exports[`mul (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -216,7 +231,8 @@ exports[`mul (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -226,22 +242,26 @@ exports[`mul (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "mul",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/or.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/or.test.ts.snap
@@ -10,7 +10,8 @@ exports[`or > if the generated AST, WAT and memory map match the snapshot 1`] = 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`or > if the generated AST, WAT and memory map match the snapshot 1`] = 
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`or > if the generated AST, WAT and memory map match the snapshot 1`] = 
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`or > if the generated AST, WAT and memory map match the snapshot 1`] = 
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`or > if the generated AST, WAT and memory map match the snapshot 1`] = 
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`or > if the generated AST, WAT and memory map match the snapshot 1`] = 
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -70,22 +76,26 @@ exports[`or > if the generated AST, WAT and memory map match the snapshot 1`] = 
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "or",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/pow2.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/pow2.test.ts.snap
@@ -10,7 +10,8 @@ exports[`pow2 > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`pow2 > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`pow2 > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`pow2 > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -50,22 +54,26 @@ exports[`pow2 > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "pow2",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/remainder.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/remainder.test.ts.snap
@@ -10,7 +10,8 @@ exports[`remainder with ensureNonZero > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`remainder with ensureNonZero > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`remainder with ensureNonZero > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`remainder with ensureNonZero > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`remainder with ensureNonZero > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`remainder with ensureNonZero > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -70,27 +76,32 @@ exports[`remainder with ensureNonZero > if the generated AST, WAT and memory map
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "ensureNonZero",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "remainder",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/risingEdge.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/risingEdge.test.ts.snap
@@ -10,7 +10,8 @@ exports[`risingEdge (float) > if the generated AST, WAT and memory map match the
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`risingEdge (float) > if the generated AST, WAT and memory map match the
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`risingEdge (float) > if the generated AST, WAT and memory map match the
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`risingEdge (float) > if the generated AST, WAT and memory map match the
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -50,12 +54,14 @@ exports[`risingEdge (float) > if the generated AST, WAT and memory map match the
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "risingEdge",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -65,7 +71,8 @@ exports[`risingEdge (float) > if the generated AST, WAT and memory map match the
       },
     ],
     "instruction": "if",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -76,12 +83,14 @@ exports[`risingEdge (float) > if the generated AST, WAT and memory map match the
       },
     ],
     "instruction": "push",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "else",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [
@@ -92,22 +101,26 @@ exports[`risingEdge (float) > if the generated AST, WAT and memory map match the
       },
     ],
     "instruction": "push",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "ifEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 15,
+    "lineNumberAfterMacroExpansion": 15,
+    "lineNumberBeforeMacroExpansion": 15,
   },
 ]
 `;
@@ -204,7 +217,8 @@ exports[`risingEdge > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -214,7 +228,8 @@ exports[`risingEdge > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -224,7 +239,8 @@ exports[`risingEdge > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -234,7 +250,8 @@ exports[`risingEdge > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -244,12 +261,14 @@ exports[`risingEdge > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "risingEdge",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -259,7 +278,8 @@ exports[`risingEdge > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "if",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [
@@ -270,12 +290,14 @@ exports[`risingEdge > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "else",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [
@@ -286,22 +308,26 @@ exports[`risingEdge > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 11,
+    "lineNumberAfterMacroExpansion": 11,
+    "lineNumberBeforeMacroExpansion": 11,
   },
   {
     "arguments": [],
     "instruction": "ifEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 13,
+    "lineNumberAfterMacroExpansion": 13,
+    "lineNumberBeforeMacroExpansion": 13,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 15,
+    "lineNumberAfterMacroExpansion": 15,
+    "lineNumberBeforeMacroExpansion": 15,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/round.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/round.test.ts.snap
@@ -10,7 +10,8 @@ exports[`round > if the generated AST, WAT and memory map match the snapshot 1`]
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`round > if the generated AST, WAT and memory map match the snapshot 1`]
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`round > if the generated AST, WAT and memory map match the snapshot 1`]
       },
     ],
     "instruction": "float",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`round > if the generated AST, WAT and memory map match the snapshot 1`]
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -50,22 +54,26 @@ exports[`round > if the generated AST, WAT and memory map match the snapshot 1`]
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "round",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/shiftLeft.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/shiftLeft.test.ts.snap
@@ -10,7 +10,8 @@ exports[`shiftLeft > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`shiftLeft > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`shiftLeft > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`shiftLeft > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`shiftLeft > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`shiftLeft > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -70,22 +76,26 @@ exports[`shiftLeft > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "shiftLeft",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/shiftRight.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/shiftRight.test.ts.snap
@@ -10,7 +10,8 @@ exports[`shiftRight > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`shiftRight > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`shiftRight > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`shiftRight > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`shiftRight > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`shiftRight > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -70,22 +76,26 @@ exports[`shiftRight > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "shiftRight",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/sqrt.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/sqrt.test.ts.snap
@@ -10,7 +10,8 @@ exports[`sqrt > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`sqrt > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "float",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`sqrt > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "float",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`sqrt > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -50,22 +54,26 @@ exports[`sqrt > if the generated AST, WAT and memory map match the snapshot 1`] 
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "sqrt",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/sub.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/sub.test.ts.snap
@@ -10,7 +10,8 @@ exports[`sub (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`sub (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`sub (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`sub (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`sub (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`sub (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -70,22 +76,26 @@ exports[`sub (int) > if the generated AST, WAT and memory map match the snapshot
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "sub",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/swap.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/swap.test.ts.snap
@@ -10,7 +10,8 @@ exports[`swap (int) > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`swap (int) > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`swap (int) > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`swap (int) > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 5,
+    "lineNumberAfterMacroExpansion": 5,
+    "lineNumberBeforeMacroExpansion": 5,
   },
   {
     "arguments": [
@@ -50,22 +54,26 @@ exports[`swap (int) > if the generated AST, WAT and memory map match the snapsho
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [],
     "instruction": "swap",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
 ]
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/xor.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/xor.test.ts.snap
@@ -10,7 +10,8 @@ exports[`xor > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "module",
-    "lineNumber": 0,
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
   },
   {
     "arguments": [
@@ -20,7 +21,8 @@ exports[`xor > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "int",
-    "lineNumber": 2,
+    "lineNumberAfterMacroExpansion": 2,
+    "lineNumberBeforeMacroExpansion": 2,
   },
   {
     "arguments": [
@@ -30,7 +32,8 @@ exports[`xor > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "int",
-    "lineNumber": 3,
+    "lineNumberAfterMacroExpansion": 3,
+    "lineNumberBeforeMacroExpansion": 3,
   },
   {
     "arguments": [
@@ -40,7 +43,8 @@ exports[`xor > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "int",
-    "lineNumber": 4,
+    "lineNumberAfterMacroExpansion": 4,
+    "lineNumberBeforeMacroExpansion": 4,
   },
   {
     "arguments": [
@@ -50,7 +54,8 @@ exports[`xor > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "push",
-    "lineNumber": 6,
+    "lineNumberAfterMacroExpansion": 6,
+    "lineNumberBeforeMacroExpansion": 6,
   },
   {
     "arguments": [
@@ -60,7 +65,8 @@ exports[`xor > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "push",
-    "lineNumber": 7,
+    "lineNumberAfterMacroExpansion": 7,
+    "lineNumberBeforeMacroExpansion": 7,
   },
   {
     "arguments": [
@@ -70,22 +76,26 @@ exports[`xor > if the generated AST, WAT and memory map match the snapshot 1`] =
       },
     ],
     "instruction": "push",
-    "lineNumber": 8,
+    "lineNumberAfterMacroExpansion": 8,
+    "lineNumberBeforeMacroExpansion": 8,
   },
   {
     "arguments": [],
     "instruction": "xor",
-    "lineNumber": 9,
+    "lineNumberAfterMacroExpansion": 9,
+    "lineNumberBeforeMacroExpansion": 9,
   },
   {
     "arguments": [],
     "instruction": "store",
-    "lineNumber": 10,
+    "lineNumberAfterMacroExpansion": 10,
+    "lineNumberBeforeMacroExpansion": 10,
   },
   {
     "arguments": [],
     "instruction": "moduleEnd",
-    "lineNumber": 12,
+    "lineNumberAfterMacroExpansion": 12,
+    "lineNumberBeforeMacroExpansion": 12,
   },
 ]
 `;

--- a/packages/compiler/tests/macroIntegration.test.ts
+++ b/packages/compiler/tests/macroIntegration.test.ts
@@ -5,6 +5,20 @@ import compile from '../src/index';
 import type { Module } from '../src/types';
 
 describe('Macro expansion integration', () => {
+	const options = {
+		startingMemoryWordAddress: 0,
+		memorySizeBytes: 1024,
+		disableSharedMemory: true,
+	};
+
+	async function instantiate(codeBuffer: Uint8Array) {
+		return WebAssembly.instantiate(codeBuffer, {
+			js: {
+				memory: new WebAssembly.Memory({ initial: 1, maximum: 1 }),
+			},
+		});
+	}
+
 	test('should compile functions with macro expansion', () => {
 		const macros: Module[] = [
 			{
@@ -35,11 +49,6 @@ describe('Macro expansion integration', () => {
 			},
 		];
 
-		const options = {
-			startingMemoryWordAddress: 0,
-			memorySizeBytes: 1024,
-		};
-
 		// Should not throw
 		const result = compile(modules, options, functions, macros);
 
@@ -61,11 +70,6 @@ describe('Macro expansion integration', () => {
 			},
 		];
 
-		const options = {
-			startingMemoryWordAddress: 0,
-			memorySizeBytes: 1024,
-		};
-
 		expect(() => compile(modules, options, functions, [])).toThrow(/Undefined macro/);
 	});
 
@@ -82,11 +86,6 @@ describe('Macro expansion integration', () => {
 			},
 		];
 
-		const options = {
-			startingMemoryWordAddress: 0,
-			memorySizeBytes: 1024,
-		};
-
 		// Should not throw
 		const result = compile(modules, options, undefined, macros);
 
@@ -101,11 +100,6 @@ describe('Macro expansion integration', () => {
 				code: ['module test', 'int counter 0', 'push counter', 'macro undefined', 'drop', 'moduleEnd'],
 			},
 		];
-
-		const options = {
-			startingMemoryWordAddress: 0,
-			memorySizeBytes: 1024,
-		};
 
 		expect(() => compile(modules, options, undefined, [])).toThrow(/Undefined macro/);
 	});
@@ -134,11 +128,6 @@ describe('Macro expansion integration', () => {
 			},
 		];
 
-		const options = {
-			startingMemoryWordAddress: 0,
-			memorySizeBytes: 1024,
-		};
-
 		// Should not throw when no macros provided
 		const result = compile(modules, options, functions);
 
@@ -147,5 +136,66 @@ describe('Macro expansion integration', () => {
 		expect(result.compiledModules.test).toBeDefined();
 		expect(result.compiledFunctions).toBeDefined();
 		expect(result.compiledFunctions.doubleValue).toBeDefined();
+	});
+
+	test('should instantiate macro-expanded temp-local instructions the same as manual inline', async () => {
+		const macros: Module[] = [
+			{
+				code: ['defineMacro duplicateTwice', 'dup', 'dup', 'defineMacroEnd'],
+			},
+		];
+
+		const macroModules: Module[] = [
+			{
+				code: [
+					'module test',
+					'int input 7',
+					'int output1',
+					'int output2',
+					'int output3',
+					'loop',
+					'push &output1',
+					'push &output2',
+					'push &output3',
+					'push input',
+					'macro duplicateTwice',
+					'store',
+					'store',
+					'store',
+					'loopEnd',
+					'moduleEnd',
+				],
+			},
+		];
+
+		const inlineModules: Module[] = [
+			{
+				code: [
+					'module test',
+					'int input 7',
+					'int output1',
+					'int output2',
+					'int output3',
+					'loop',
+					'push &output1',
+					'push &output2',
+					'push &output3',
+					'push input',
+					'dup',
+					'dup',
+					'store',
+					'store',
+					'store',
+					'loopEnd',
+					'moduleEnd',
+				],
+			},
+		];
+
+		const inlineResult = compile(inlineModules, options);
+		await expect(instantiate(inlineResult.codeBuffer)).resolves.toBeDefined();
+
+		const macroResult = compile(macroModules, options, undefined, macros);
+		await expect(instantiate(macroResult.codeBuffer)).resolves.toBeDefined();
 	});
 });

--- a/packages/compiler/tests/utils/parseMemoryInstructionArguments.test.ts
+++ b/packages/compiler/tests/utils/parseMemoryInstructionArguments.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 
 import parseMemoryInstructionArguments from '../../src/utils/memoryInstructionParser';
-import { ArgumentType, type CompilationContext } from '../../src/types';
+import { ArgumentType, type AST, type CompilationContext } from '../../src/types';
 
 describe('parseMemoryInstructionArguments', () => {
 	const createMockContext = (memory = {}, consts = {}): CompilationContext => ({
@@ -21,23 +21,30 @@ describe('parseMemoryInstructionArguments', () => {
 		mode: 'module',
 	});
 
+	const createLine = (lineNumber: number, instruction: AST[number]['instruction'], args: AST[number]['arguments']) => ({
+		lineNumberBeforeMacroExpansion: lineNumber,
+		lineNumberAfterMacroExpansion: lineNumber,
+		instruction,
+		arguments: args,
+	});
+
 	describe('first argument handling', () => {
 		it('should handle literal as first argument', () => {
 			const args = [{ type: ArgumentType.LITERAL, value: 42 }];
-			const result = parseMemoryInstructionArguments(args, 1, 'float', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(1, 'float', args), createMockContext());
 			expect(result).toEqual({ id: '__anonymous__1', defaultValue: 42 });
 		});
 
 		it('should handle identifier that is a constant as first argument', () => {
 			const context = createMockContext({}, { MY_CONST: { value: 100, isInteger: true } });
 			const args = [{ type: ArgumentType.IDENTIFIER, value: 'MY_CONST' }];
-			const result = parseMemoryInstructionArguments(args, 2, 'int', context);
+			const result = parseMemoryInstructionArguments(createLine(2, 'int', args), context);
 			expect(result).toEqual({ id: '__anonymous__2', defaultValue: 100 });
 		});
 
 		it('should use identifier as id when not a constant', () => {
 			const args = [{ type: ArgumentType.IDENTIFIER, value: 'myVar' }];
-			const result = parseMemoryInstructionArguments(args, 3, 'float', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(3, 'float', args), createMockContext());
 			expect(result).toEqual({ id: 'myVar', defaultValue: 0 });
 		});
 	});
@@ -48,7 +55,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'myVar' },
 				{ type: ArgumentType.LITERAL, value: 50 },
 			];
-			const result = parseMemoryInstructionArguments(args, 4, 'int', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(4, 'int', args), createMockContext());
 			expect(result).toEqual({ id: 'myVar', defaultValue: 50 });
 		});
 	});
@@ -59,7 +66,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'bufferIn' },
 				{ type: ArgumentType.IDENTIFIER, value: '&notesMux2:out' },
 			];
-			const result = parseMemoryInstructionArguments(args, 5, 'float*', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(5, 'float*', args), createMockContext());
 			// Intermodular references are resolved later, so defaultValue stays 0
 			expect(result).toEqual({ id: 'bufferIn', defaultValue: 0 });
 		});
@@ -69,7 +76,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'myPtr' },
 				{ type: ArgumentType.IDENTIFIER, value: '&module:identifier' },
 			];
-			const result = parseMemoryInstructionArguments(args, 6, 'int*', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(6, 'int*', args), createMockContext());
 			expect(result).toEqual({ id: 'myPtr', defaultValue: 0 });
 		});
 
@@ -78,7 +85,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'myPtr' },
 				{ type: ArgumentType.IDENTIFIER, value: '&module:' },
 			];
-			const result = parseMemoryInstructionArguments(args, 6, 'int*', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(6, 'int*', args), createMockContext());
 			expect(result).toEqual({ id: 'myPtr', defaultValue: 0 });
 		});
 
@@ -87,7 +94,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'myPtr' },
 				{ type: ArgumentType.IDENTIFIER, value: 'module:&' },
 			];
-			const result = parseMemoryInstructionArguments(args, 6, 'int*', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(6, 'int*', args), createMockContext());
 			expect(result).toEqual({ id: 'myPtr', defaultValue: 0 });
 		});
 	});
@@ -101,7 +108,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'myPtr' },
 				{ type: ArgumentType.IDENTIFIER, value: '&out1' },
 			];
-			const result = parseMemoryInstructionArguments(args, 7, 'float*', createMockContext(memory));
+			const result = parseMemoryInstructionArguments(createLine(7, 'float*', args), createMockContext(memory));
 			expect(result).toEqual({ id: 'myPtr', defaultValue: 100 });
 		});
 
@@ -113,7 +120,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'myPtr' },
 				{ type: ArgumentType.IDENTIFIER, value: 'buffer&' },
 			];
-			const result = parseMemoryInstructionArguments(args, 7, 'int*', createMockContext(memory));
+			const result = parseMemoryInstructionArguments(createLine(7, 'int*', args), createMockContext(memory));
 			// End address should be: byteAddress + (wordAlignedSize - 1) * GLOBAL_ALIGNMENT_BOUNDARY
 			// = 100 + (5 - 1) * 4 = 100 + 16 = 116
 			expect(result).toEqual({ id: 'myPtr', defaultValue: 116 });
@@ -125,7 +132,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: '&nonExistent' },
 			];
 			expect(() => {
-				parseMemoryInstructionArguments(args, 8, 'float*', createMockContext());
+				parseMemoryInstructionArguments(createLine(8, 'float*', args), createMockContext());
 			}).toThrow();
 		});
 	});
@@ -139,7 +146,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'count' },
 				{ type: ArgumentType.IDENTIFIER, value: '$buffer' },
 			];
-			const result = parseMemoryInstructionArguments(args, 9, 'int', createMockContext(memory));
+			const result = parseMemoryInstructionArguments(createLine(9, 'int', args), createMockContext(memory));
 			expect(result).toEqual({ id: 'count', defaultValue: 10 });
 		});
 
@@ -149,7 +156,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: '$nonExistent' },
 			];
 			expect(() => {
-				parseMemoryInstructionArguments(args, 10, 'int', createMockContext());
+				parseMemoryInstructionArguments(createLine(10, 'int', args), createMockContext());
 			}).toThrow();
 		});
 	});
@@ -161,7 +168,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'myVar' },
 				{ type: ArgumentType.IDENTIFIER, value: 'INIT_VALUE' },
 			];
-			const result = parseMemoryInstructionArguments(args, 11, 'int', context);
+			const result = parseMemoryInstructionArguments(createLine(11, 'int', args), context);
 			expect(result).toEqual({ id: 'myVar', defaultValue: 999 });
 		});
 
@@ -171,7 +178,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'UNKNOWN_CONST' },
 			];
 			expect(() => {
-				parseMemoryInstructionArguments(args, 12, 'int', createMockContext());
+				parseMemoryInstructionArguments(createLine(12, 'int', args), createMockContext());
 			}).toThrow();
 		});
 	});
@@ -179,7 +186,7 @@ describe('parseMemoryInstructionArguments', () => {
 	describe('error handling', () => {
 		it('should throw error when first argument is missing', () => {
 			expect(() => {
-				parseMemoryInstructionArguments([], 13, 'float', createMockContext());
+				parseMemoryInstructionArguments(createLine(13, 'float', []), createMockContext());
 			}).toThrow();
 		});
 	});
@@ -191,7 +198,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 0xa8, isInteger: true, isHex: true },
 				{ type: ArgumentType.LITERAL, value: 0xff, isInteger: true, isHex: true },
 			];
-			const result = parseMemoryInstructionArguments(args, 20, 'int', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(20, 'int', args), createMockContext());
 			expect(result).toEqual({ id: 'myVar', defaultValue: 0xa8ff0000 });
 		});
 
@@ -203,7 +210,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 0x00, isInteger: true, isHex: true },
 				{ type: ArgumentType.LITERAL, value: 0x00, isInteger: true, isHex: true },
 			];
-			const result = parseMemoryInstructionArguments(args, 21, 'int', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(21, 'int', args), createMockContext());
 			expect(result).toEqual({ id: 'myVar', defaultValue: 0xa8ff0000 });
 		});
 
@@ -212,7 +219,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 0xa8, isInteger: true, isHex: true },
 				{ type: ArgumentType.LITERAL, value: 0xff, isInteger: true, isHex: true },
 			];
-			const result = parseMemoryInstructionArguments(args, 22, 'int', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(22, 'int', args), createMockContext());
 			expect(result).toEqual({ id: '__anonymous__22', defaultValue: 0xa8ff0000 });
 		});
 
@@ -221,7 +228,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'myVar' },
 				{ type: ArgumentType.LITERAL, value: 0xa8, isInteger: true, isHex: true },
 			];
-			const result = parseMemoryInstructionArguments(args, 23, 'int', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(23, 'int', args), createMockContext());
 			expect(result).toEqual({ id: 'myVar', defaultValue: 0xa8 });
 		});
 
@@ -231,7 +238,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 32, isInteger: true },
 				{ type: ArgumentType.LITERAL, value: 64, isInteger: true },
 			];
-			const result = parseMemoryInstructionArguments(args, 28, 'int', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(28, 'int', args), createMockContext());
 			// 32 = 0x20, 64 = 0x40 → [0x20, 0x40, 0x00, 0x00] = 0x20400000
 			expect(result).toEqual({ id: 'myVar', defaultValue: 0x20400000 });
 		});
@@ -244,7 +251,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 0, isInteger: true },
 				{ type: ArgumentType.LITERAL, value: 0, isInteger: true },
 			];
-			const result = parseMemoryInstructionArguments(args, 29, 'int', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(29, 'int', args), createMockContext());
 			expect(result).toEqual({ id: 'myVar', defaultValue: 0x20400000 });
 		});
 
@@ -253,13 +260,13 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 32, isInteger: true },
 				{ type: ArgumentType.LITERAL, value: 64, isInteger: true },
 			];
-			const result = parseMemoryInstructionArguments(args, 30, 'int', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(30, 'int', args), createMockContext());
 			expect(result).toEqual({ id: '__anonymous__30', defaultValue: 0x20400000 });
 		});
 
 		it('should treat single decimal byte literal as a regular literal (no split)', () => {
 			const args = [{ type: ArgumentType.LITERAL, value: 32, isInteger: true }];
-			const result = parseMemoryInstructionArguments(args, 31, 'int', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(31, 'int', args), createMockContext());
 			expect(result).toEqual({ id: '__anonymous__31', defaultValue: 32 });
 		});
 
@@ -269,7 +276,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 0xa8, isInteger: true, isHex: true },
 				{ type: ArgumentType.LITERAL, value: 255, isInteger: true },
 			];
-			const result = parseMemoryInstructionArguments(args, 32, 'int', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(32, 'int', args), createMockContext());
 			// 0xA8=168, 255=0xFF → [168, 255, 0, 0] = 0xA8FF0000
 			expect(result).toEqual({ id: 'myVar', defaultValue: 0xa8ff0000 });
 		});
@@ -279,7 +286,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 255, isInteger: true },
 				{ type: ArgumentType.LITERAL, value: 0xa8, isInteger: true, isHex: true },
 			];
-			const result = parseMemoryInstructionArguments(args, 33, 'int', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(33, 'int', args), createMockContext());
 			// 255=0xFF, 0xA8=168 → [255, 168, 0, 0] = 0xFFA80000
 			expect(result).toEqual({ id: '__anonymous__33', defaultValue: 0xffa80000 });
 		});
@@ -293,7 +300,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 0x00, isInteger: true, isHex: true },
 				{ type: ArgumentType.LITERAL, value: 0x01, isInteger: true, isHex: true },
 			];
-			expect(() => parseMemoryInstructionArguments(args, 24, 'int', createMockContext())).toThrow();
+			expect(() => parseMemoryInstructionArguments(createLine(24, 'int', args), createMockContext())).toThrow();
 		});
 
 		it('should throw when a constant identifier in split-byte mode is not in scope', () => {
@@ -303,7 +310,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 0xa8, isInteger: true, isHex: true },
 				{ type: ArgumentType.IDENTIFIER, value: 'CONST' },
 			];
-			expect(() => parseMemoryInstructionArguments(args, 25, 'int', createMockContext())).toThrow();
+			expect(() => parseMemoryInstructionArguments(createLine(25, 'int', args), createMockContext())).toThrow();
 		});
 
 		it('should throw when a byte literal is followed by a value greater than 255', () => {
@@ -312,7 +319,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 32, isInteger: true },
 				{ type: ArgumentType.LITERAL, value: 256, isInteger: true },
 			];
-			expect(() => parseMemoryInstructionArguments(args, 26, 'int', createMockContext())).toThrow();
+			expect(() => parseMemoryInstructionArguments(createLine(26, 'int', args), createMockContext())).toThrow();
 		});
 
 		it('should throw when a byte literal is followed by a negative integer', () => {
@@ -321,7 +328,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 32, isInteger: true },
 				{ type: ArgumentType.LITERAL, value: -5, isInteger: true },
 			];
-			expect(() => parseMemoryInstructionArguments(args, 27, 'int', createMockContext())).toThrow();
+			expect(() => parseMemoryInstructionArguments(createLine(27, 'int', args), createMockContext())).toThrow();
 		});
 
 		it('should throw when anonymous byte literal is followed by a non-byte', () => {
@@ -329,7 +336,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 32, isInteger: true },
 				{ type: ArgumentType.LITERAL, value: 256, isInteger: true },
 			];
-			expect(() => parseMemoryInstructionArguments(args, 34, 'int', createMockContext())).toThrow();
+			expect(() => parseMemoryInstructionArguments(createLine(34, 'int', args), createMockContext())).toThrow();
 		});
 
 		it('should throw when named non-byte second arg is followed by extra tokens', () => {
@@ -339,7 +346,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 256, isInteger: true },
 				{ type: ArgumentType.LITERAL, value: 1, isInteger: true },
 			];
-			expect(() => parseMemoryInstructionArguments(args, 35, 'int', createMockContext())).toThrow();
+			expect(() => parseMemoryInstructionArguments(createLine(35, 'int', args), createMockContext())).toThrow();
 		});
 
 		it('should throw when anonymous out-of-range first literal is followed by another literal', () => {
@@ -348,7 +355,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 256, isInteger: true },
 				{ type: ArgumentType.LITERAL, value: 1, isInteger: true },
 			];
-			expect(() => parseMemoryInstructionArguments(args, 36, 'int', createMockContext())).toThrow();
+			expect(() => parseMemoryInstructionArguments(createLine(36, 'int', args), createMockContext())).toThrow();
 		});
 	});
 
@@ -360,7 +367,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'HI' },
 				{ type: ArgumentType.IDENTIFIER, value: 'LO' },
 			];
-			const result = parseMemoryInstructionArguments(args, 40, 'int', context);
+			const result = parseMemoryInstructionArguments(createLine(40, 'int', args), context);
 			// HI=32=0x20, LO=64=0x40 → [0x20, 0x40, 0x00, 0x00] = 0x20400000
 			expect(result).toEqual({ id: 'myVar', defaultValue: 0x20400000 });
 		});
@@ -371,7 +378,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'HI' },
 				{ type: ArgumentType.IDENTIFIER, value: 'LO' },
 			];
-			const result = parseMemoryInstructionArguments(args, 41, 'int', context);
+			const result = parseMemoryInstructionArguments(createLine(41, 'int', args), context);
 			expect(result).toEqual({ id: '__anonymous__41', defaultValue: 0x20400000 });
 		});
 
@@ -382,7 +389,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 0xa8, isInteger: true, isHex: true },
 				{ type: ArgumentType.IDENTIFIER, value: 'LO' },
 			];
-			const result = parseMemoryInstructionArguments(args, 42, 'int', context);
+			const result = parseMemoryInstructionArguments(createLine(42, 'int', args), context);
 			// 0xA8=168, LO=64=0x40 → [168, 64, 0, 0] = 0xA8400000
 			expect(result).toEqual({ id: 'myVar', defaultValue: 0xa8400000 });
 		});
@@ -393,7 +400,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.LITERAL, value: 0xa8, isInteger: true, isHex: true },
 				{ type: ArgumentType.IDENTIFIER, value: 'LO' },
 			];
-			const result = parseMemoryInstructionArguments(args, 43, 'int', context);
+			const result = parseMemoryInstructionArguments(createLine(43, 'int', args), context);
 			// 0xA8=168, LO=64=0x40 → [168, 64, 0, 0] = 0xA8400000
 			expect(result).toEqual({ id: '__anonymous__43', defaultValue: 0xa8400000 });
 		});
@@ -408,7 +415,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'HI' },
 				{ type: ArgumentType.IDENTIFIER, value: 'BIG' },
 			];
-			expect(() => parseMemoryInstructionArguments(args, 44, 'int', context)).toThrow();
+			expect(() => parseMemoryInstructionArguments(createLine(44, 'int', args), context)).toThrow();
 		});
 
 		it('should throw when a constant in split-byte resolves to a negative value', () => {
@@ -421,7 +428,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'HI' },
 				{ type: ArgumentType.IDENTIFIER, value: 'NEG' },
 			];
-			expect(() => parseMemoryInstructionArguments(args, 45, 'int', context)).toThrow();
+			expect(() => parseMemoryInstructionArguments(createLine(45, 'int', args), context)).toThrow();
 		});
 
 		it('should throw when a constant in split-byte is a non-integer (float)', () => {
@@ -434,13 +441,13 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'HI' },
 				{ type: ArgumentType.IDENTIFIER, value: 'FRAC' },
 			];
-			expect(() => parseMemoryInstructionArguments(args, 46, 'int', context)).toThrow();
+			expect(() => parseMemoryInstructionArguments(createLine(46, 'int', args), context)).toThrow();
 		});
 
 		it('should throw when constant-style name is used as memory identifier', () => {
 			// MY_VAR matches isConstantName — constant-style names are reserved for constants only
 			const args = [{ type: ArgumentType.IDENTIFIER, value: 'MY_VAR' }];
-			expect(() => parseMemoryInstructionArguments(args, 47, 'int', createMockContext())).toThrow();
+			expect(() => parseMemoryInstructionArguments(createLine(47, 'int', args), createMockContext())).toThrow();
 		});
 
 		it('should throw when constant-style name as memory identifier has a default value', () => {
@@ -449,7 +456,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'COUNTER' },
 				{ type: ArgumentType.LITERAL, value: 0, isInteger: true },
 			];
-			expect(() => parseMemoryInstructionArguments(args, 48, 'int', createMockContext())).toThrow();
+			expect(() => parseMemoryInstructionArguments(createLine(48, 'int', args), createMockContext())).toThrow();
 		});
 
 		it('should resolve 4-constant split-byte sequence (4 tokens)', () => {
@@ -469,7 +476,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'C' },
 				{ type: ArgumentType.IDENTIFIER, value: 'D' },
 			];
-			const result = parseMemoryInstructionArguments(args, 49, 'int', context);
+			const result = parseMemoryInstructionArguments(createLine(49, 'int', args), context);
 			expect(result).toEqual({ id: 'myVar', defaultValue: 0xa8ff0000 });
 		});
 	});
@@ -477,7 +484,7 @@ describe('parseMemoryInstructionArguments', () => {
 	describe('edge cases', () => {
 		it('should handle only first argument provided', () => {
 			const args = [{ type: ArgumentType.IDENTIFIER, value: 'solo' }];
-			const result = parseMemoryInstructionArguments(args, 14, 'float', createMockContext());
+			const result = parseMemoryInstructionArguments(createLine(14, 'float', args), createMockContext());
 			expect(result).toEqual({ id: 'solo', defaultValue: 0 });
 		});
 
@@ -491,7 +498,7 @@ describe('parseMemoryInstructionArguments', () => {
 				{ type: ArgumentType.IDENTIFIER, value: 'test' },
 				{ type: ArgumentType.IDENTIFIER, value: '&module:identifier' },
 			];
-			const result = parseMemoryInstructionArguments(args, 15, 'float*', createMockContext(memory));
+			const result = parseMemoryInstructionArguments(createLine(15, 'float*', args), createMockContext(memory));
 			// Should be treated as intermodular, not memory reference
 			expect(result).toEqual({ id: 'test', defaultValue: 0 });
 		});

--- a/packages/compiler/tests/utils/withValidation.test.ts
+++ b/packages/compiler/tests/utils/withValidation.test.ts
@@ -33,7 +33,8 @@ function createMockASTLeaf(instruction: string): AST[number] {
 	return {
 		instruction: instruction as never,
 		arguments: [],
-		lineNumber: 0,
+		lineNumberBeforeMacroExpansion: 0,
+		lineNumberAfterMacroExpansion: 0,
 	};
 }
 

--- a/packages/editor/packages/editor-state/src/features/program-compiler/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/effect.ts
@@ -77,14 +77,14 @@ export default async function compiler(store: StateManager<State>, events: Event
 
 			store.set('compiler.isCompiling', false);
 			const errorObject = error as Error & {
-				line?: { lineNumber: number };
+				line?: { lineNumberBeforeMacroExpansion: number };
 				context?: { namespace?: { moduleName: string } };
 				errorCode?: number;
 			};
 
 			store.set('codeErrors.compilationErrors', [
 				{
-					lineNumber: errorObject?.line?.lineNumber || 1,
+					lineNumber: errorObject?.line?.lineNumberBeforeMacroExpansion || 1,
 					codeBlockId: errorObject?.context?.namespace?.moduleName || '',
 					message: errorObject?.message || error?.toString() || 'Compilation failed',
 				},

--- a/packages/editor/packages/editor-state/src/features/program-compiler/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/effect.ts
@@ -84,7 +84,7 @@ export default async function compiler(store: StateManager<State>, events: Event
 
 			store.set('codeErrors.compilationErrors', [
 				{
-					lineNumber: errorObject?.line?.lineNumberBeforeMacroExpansion || 1,
+					lineNumber: errorObject?.line?.lineNumberBeforeMacroExpansion ?? 0,
 					codeBlockId: errorObject?.context?.namespace?.moduleName || '',
 					message: errorObject?.message || error?.toString() || 'Compilation failed',
 				},


### PR DESCRIPTION

This PR updates the compiler’s AST line metadata to distinguish source line numbers before vs after macro expansion, and threads that through compiler diagnostics, CLI tracing, and editor error display.

Changes:

Replace single lineNumber on AST lines with lineNumberBeforeMacroExpansion and lineNumberAfterMacroExpansion.
Update compiler, instruction compilers, utilities, and CLI trace output to use the new fields (including for temp symbol naming vs diagnostics).
Update/extend tests and snapshots, including a new macro expansion instantiation integration test.