### PR TITLE
fix: restore typed code block error mapping

### DIFF
--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -150,6 +150,7 @@ export function compileModule(
 		startingByteAddress,
 		memoryByteSize: memorySizeBytes,
 		mode: 'module',
+		codeBlockType: ast[0]?.instruction === 'constants' ? 'constants' : 'module',
 	};
 
 	ast.forEach(line => {
@@ -214,6 +215,7 @@ export function compileFunction(
 		startingByteAddress: 0,
 		memoryByteSize: 0,
 		mode: 'function',
+		codeBlockType: 'function',
 		functionTypeRegistry: typeRegistry,
 	};
 

--- a/packages/compiler/src/instructionCompilers/constants.ts
+++ b/packages/compiler/src/instructionCompilers/constants.ts
@@ -32,6 +32,8 @@ const constants: InstructionCompiler = withValidation(
 		});
 
 		context.namespace.moduleName = line.arguments[0].value;
+		context.codeBlockId = line.arguments[0].value;
+		context.codeBlockType = 'constants';
 
 		return context;
 	}

--- a/packages/compiler/src/instructionCompilers/function.ts
+++ b/packages/compiler/src/instructionCompilers/function.ts
@@ -28,6 +28,8 @@ const _function: InstructionCompiler = function (line, context) {
 	const functionId = nameArg.value;
 
 	context.currentFunctionId = functionId;
+	context.codeBlockId = functionId;
+	context.codeBlockType = 'function';
 	context.currentFunctionSignature = {
 		parameters: [],
 		returns: [],

--- a/packages/compiler/src/instructionCompilers/module.ts
+++ b/packages/compiler/src/instructionCompilers/module.ts
@@ -28,6 +28,8 @@ const _module: InstructionCompiler = function (line, context) {
 	});
 
 	context.namespace.moduleName = line.arguments[0].value;
+	context.codeBlockId = line.arguments[0].value;
+	context.codeBlockType = 'module';
 
 	return context;
 };

--- a/packages/compiler/src/types.ts
+++ b/packages/compiler/src/types.ts
@@ -144,6 +144,8 @@ export interface CompilationContext {
 	memoryByteSize: number;
 	byteCode: Array<WASMInstruction | Type | number>;
 	mode?: CompilationMode;
+	codeBlockId?: string;
+	codeBlockType?: 'module' | 'function' | 'constants';
 	currentFunctionId?: string;
 	currentFunctionSignature?: FunctionSignature;
 	functionTypeRegistry?: FunctionTypeRegistry;

--- a/packages/compiler/src/utils/testUtils.ts
+++ b/packages/compiler/src/utils/testUtils.ts
@@ -24,6 +24,8 @@ export default function createInstructionCompilerTestContext(
 		startingByteAddress: 0,
 		memoryByteSize: 0,
 		byteCode: [],
+		codeBlockId: 'test',
+		codeBlockType: 'module',
 	};
 
 	return {

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/graphicHelper/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/graphicHelper/effect.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import createStateManager from '@8f4e/state-manager';
+
+import graphicHelperEffect from './effect';
+
+import { createMockState, createMockCodeBlock } from '~/pureHelpers/testingUtils/testUtils';
+import { createMockEventDispatcherWithVitest } from '~/pureHelpers/testingUtils/vitestTestUtils';
+
+describe('graphic helper error mapping', () => {
+	it('maps typed compiler errors to function blocks', () => {
+		const functionBlock = createMockCodeBlock({
+			id: 'function_helper',
+			code: ['function helper', 'push 1', 'functionEnd'],
+			blockType: 'function',
+		});
+		const state = createMockState({
+			graphicHelper: {
+				codeBlocks: [functionBlock],
+			},
+			codeErrors: {
+				compilationErrors: [
+					{
+						lineNumber: 2,
+						codeBlockId: 'helper',
+						codeBlockType: 'function',
+						message: 'Memory access is not allowed in pure functions. (19)',
+					},
+				],
+			},
+		});
+		const store = createStateManager(state);
+		const events = createMockEventDispatcherWithVitest();
+
+		graphicHelperEffect(store, events);
+
+		expect(functionBlock.widgets.errorMessages).toHaveLength(1);
+		expect(functionBlock.widgets.errorMessages[0].lineNumber).toBe(2);
+		expect(functionBlock.widgets.errorMessages[0].message).toContain('Error:');
+	});
+});

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/graphicHelper/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/graphicHelper/effect.ts
@@ -315,16 +315,12 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 		state.graphicHelper.codeBlocks.forEach(codeBlock => {
 			codeBlock.widgets.errorMessages = [];
 			codeErrors.forEach(codeError => {
-				const prefixedCodeBlockId =
+				const matchesCodeBlock =
 					typeof codeError.codeBlockId === 'string' && codeError.codeBlockType
-						? `${codeError.codeBlockType}_${codeError.codeBlockId}`
-						: undefined;
+						? codeBlock.id === `${codeError.codeBlockType}_${codeError.codeBlockId}`
+						: codeBlock.creationIndex === codeError.codeBlockId || codeBlock.id === codeError.codeBlockId;
 
-				if (
-					codeBlock.creationIndex === codeError.codeBlockId ||
-					codeBlock.id === codeError.codeBlockId ||
-					(prefixedCodeBlockId !== undefined && codeBlock.id === prefixedCodeBlockId)
-				) {
+				if (matchesCodeBlock) {
 					const message = wrapText(codeError.message, codeBlock.width / state.viewport.vGrid - 1);
 
 					codeBlock.widgets.errorMessages.push({

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/graphicHelper/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/graphicHelper/effect.ts
@@ -315,7 +315,16 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 		state.graphicHelper.codeBlocks.forEach(codeBlock => {
 			codeBlock.widgets.errorMessages = [];
 			codeErrors.forEach(codeError => {
-				if (codeBlock.creationIndex === codeError.codeBlockId || codeBlock.id === codeError.codeBlockId) {
+				const prefixedCodeBlockId =
+					typeof codeError.codeBlockId === 'string' && codeError.codeBlockType
+						? `${codeError.codeBlockType}_${codeError.codeBlockId}`
+						: undefined;
+
+				if (
+					codeBlock.creationIndex === codeError.codeBlockId ||
+					codeBlock.id === codeError.codeBlockId ||
+					(prefixedCodeBlockId !== undefined && codeBlock.id === prefixedCodeBlockId)
+				) {
 					const message = wrapText(codeError.message, codeBlock.width / state.viewport.vGrid - 1);
 
 					codeBlock.widgets.errorMessages.push({

--- a/packages/editor/packages/editor-state/src/features/program-compiler/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/effect.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, vi, type MockInstance } from 'vitest';
+import createStateManager from '@8f4e/state-manager';
+
+import compilerEffect from './effect';
+
+import type { State } from '~/types';
+
+import { createMockState, createMockCodeBlock } from '~/pureHelpers/testingUtils/testUtils';
+import { createMockEventDispatcherWithVitest } from '~/pureHelpers/testingUtils/vitestTestUtils';
+
+describe('program compiler effect', () => {
+	let mockState: State;
+	let store: ReturnType<typeof createStateManager<State>>;
+	let mockEvents: ReturnType<typeof createMockEventDispatcherWithVitest>;
+	let mockCompileCode: MockInstance;
+
+	beforeEach(() => {
+		mockCompileCode = vi.fn().mockRejectedValue({
+			message: 'Memory access is not allowed in pure functions. (19)',
+			line: { lineNumberBeforeMacroExpansion: 2 },
+			context: {
+				codeBlockId: 'helper',
+				codeBlockType: 'function',
+				currentFunctionId: 'helper',
+				mode: 'function',
+			},
+		});
+
+		mockState = createMockState({
+			callbacks: {
+				compileCode: mockCompileCode,
+			},
+		});
+
+		mockState.graphicHelper.codeBlocks.push(
+			createMockCodeBlock({
+				id: 'function_helper',
+				code: ['function helper', 'push 1', 'functionEnd'],
+				creationIndex: 0,
+				blockType: 'function',
+			})
+		);
+
+		mockEvents = createMockEventDispatcherWithVitest();
+		store = createStateManager(mockState);
+	});
+
+	it('stores code block type for compiler errors', async () => {
+		vi.useFakeTimers();
+
+		compilerEffect(store, mockEvents);
+
+		store.set('compiledProjectConfig', { ...mockState.compiledProjectConfig });
+		await vi.runAllTimersAsync();
+		vi.useRealTimers();
+
+		expect(mockState.codeErrors.compilationErrors).toEqual([
+			{
+				lineNumber: 2,
+				codeBlockId: 'helper',
+				codeBlockType: 'function',
+				message: 'Memory access is not allowed in pure functions. (19)',
+			},
+		]);
+	});
+});

--- a/packages/editor/packages/editor-state/src/features/program-compiler/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/effect.test.ts
@@ -21,8 +21,6 @@ describe('program compiler effect', () => {
 			context: {
 				codeBlockId: 'helper',
 				codeBlockType: 'function',
-				currentFunctionId: 'helper',
-				mode: 'function',
 			},
 		});
 

--- a/packages/editor/packages/editor-state/src/features/program-compiler/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/effect.ts
@@ -77,15 +77,19 @@ export default async function compiler(store: StateManager<State>, events: Event
 
 			store.set('compiler.isCompiling', false);
 			const errorObject = error as Error & {
-				line?: { lineNumberBeforeMacroExpansion: number };
-				context?: { namespace?: { moduleName: string } };
+				line?: { lineNumberBeforeMacroExpansion?: number; lineNumberAfterMacroExpansion?: number };
+				context?: {
+					codeBlockId?: string;
+					codeBlockType?: 'module' | 'function' | 'constants';
+				};
 				errorCode?: number;
 			};
 
 			store.set('codeErrors.compilationErrors', [
 				{
 					lineNumber: errorObject?.line?.lineNumberBeforeMacroExpansion ?? 0,
-					codeBlockId: errorObject?.context?.namespace?.moduleName || '',
+					codeBlockId: errorObject?.context?.codeBlockId || '',
+					codeBlockType: errorObject?.context?.codeBlockType,
 					message: errorObject?.message || error?.toString() || 'Compilation failed',
 				},
 			]);

--- a/packages/editor/packages/editor-state/src/types.ts
+++ b/packages/editor/packages/editor-state/src/types.ts
@@ -251,6 +251,7 @@ export interface CodeError {
 	lineNumber: number;
 	message: string;
 	codeBlockId: string | number;
+	codeBlockType?: 'module' | 'function' | 'constants';
 }
 
 // State interface - complete editor state tree (top-level public API)


### PR DESCRIPTION
Restores accurate mapping of compiler errors back to the originating typed code blocks (module/function/constants) by propagating codeBlockId + codeBlockType through the compiler error context and using that to resolve the editor’s prefixed code block IDs.

Changes:

Extend editor CodeError to optionally carry codeBlockType, and record it when compilation fails.
Emit codeBlockId / codeBlockType from the compiler’s CompilationContext (module/function/constants compilers + initial contexts).
Update graphic-helper error-to-block matching to support typed IDs, and add targeted tests for both effects.
