### PR TITLE
[codex] Store observed AudioWorklet buffer size

### DIFF
--- a/packages/editor/packages/editor-state-testing/src/index.ts
+++ b/packages/editor/packages/editor-state-testing/src/index.ts
@@ -285,6 +285,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 				timerDriftMs: 0,
 				timerExpectedIntervalTimeMs: 0,
 			},
+			values: {},
 		},
 		globalEditorDirectives: {},
 		dialog: {

--- a/packages/editor/packages/editor-state-types/src/features/runtime/types.ts
+++ b/packages/editor/packages/editor-state-types/src/features/runtime/types.ts
@@ -36,6 +36,9 @@ export type RuntimeDirectiveResolver = (
 	errors: CodeError[];
 };
 
+export type RuntimeValueMap = Record<string, unknown>;
+export type RuntimeValuesByRuntimeId = Record<string, RuntimeValueMap>;
+
 /**
  * Runtime registry entry describing a runtime configuration.
  * Each entry defines a runtime's id, default configuration, schema, and factory function.

--- a/packages/editor/packages/editor-state-types/src/index.ts
+++ b/packages/editor/packages/editor-state-types/src/index.ts
@@ -49,6 +49,7 @@ import type {
 	AudioWorkletRuntime,
 	Runtimes,
 	RuntimeStats,
+	RuntimeValuesByRuntimeId,
 	RuntimeDirectiveResolver,
 	RuntimeEnvConstantsContributor,
 	JSONSchemaLike,
@@ -123,6 +124,7 @@ export type {
 	AudioWorkletRuntime,
 	Runtimes,
 	RuntimeStats,
+	RuntimeValuesByRuntimeId,
 	RuntimeDirectiveResolver,
 	RuntimeEnvConstantsContributor,
 };
@@ -283,6 +285,7 @@ export interface State {
 	console: ConsoleState;
 	runtime: {
 		stats: RuntimeStats;
+		values: RuntimeValuesByRuntimeId;
 	};
 	/** Runtime registry for configurable runtime schemas */
 	runtimeRegistry: RuntimeRegistry;

--- a/packages/editor/packages/editor-state/src/pureHelpers/state/createDefaultState.ts
+++ b/packages/editor/packages/editor-state/src/pureHelpers/state/createDefaultState.ts
@@ -58,6 +58,7 @@ export default function createDefaultState() {
 				timerDriftMs: 0,
 				timerExpectedIntervalTimeMs: 0,
 			},
+			values: {},
 		},
 		dialog: {
 			show: false,

--- a/packages/editor/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
+++ b/packages/editor/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
@@ -320,6 +320,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 				timerDriftMs: 0,
 				timerExpectedIntervalTimeMs: 0,
 			},
+			values: {},
 		},
 		globalEditorDirectives: {},
 		dialog: {

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -26,6 +26,7 @@ export type {
 	RuntimeFactory,
 	RuntimeRegistry,
 	RuntimeRegistryEntry,
+	RuntimeValuesByRuntimeId,
 	WebWorkerRuntime,
 	MainThreadRuntime,
 	AudioWorkletRuntime,

--- a/packages/runtime-audio-worklet/src/index.ts
+++ b/packages/runtime-audio-worklet/src/index.ts
@@ -44,12 +44,31 @@ class Main extends AudioWorkletProcessor {
 	memoryBuffer: Float32Array = new Float32Array(128).fill(0);
 	audioOutputBuffers = [] as { channel: number; output: number; audioBufferWordAddress: number }[];
 	audioInputBuffers = [] as { channel: number; input: number; audioBufferWordAddress: number }[];
+	audioBufferSize: number | undefined;
 
 	static get parameterDescriptors() {
 		return [{ name: 'amplitude', defaultValue: 0.25, minValue: 0, maxValue: 1 }];
 	}
 
+	private reportAudioBufferSize(inputs: Float32Array[][], outputs: Float32Array[][]) {
+		const audioBufferSize = outputs[0]?.[0]?.length ?? inputs[0]?.[0]?.length;
+
+		if (!audioBufferSize || audioBufferSize === this.audioBufferSize) {
+			return;
+		}
+
+		this.audioBufferSize = audioBufferSize;
+		this.port.postMessage({
+			type: 'runtimeValues',
+			payload: {
+				audioBufferSize,
+			},
+		});
+	}
+
 	process(inputs: Float32Array[][], outputs: Float32Array[][]) {
+		this.reportAudioBufferSize(inputs, outputs);
+
 		for (let i = 0; i < this.audioInputBuffers.length; i++) {
 			const input = inputs[this.audioInputBuffers[i].input];
 			if (!input) {

--- a/packages/runtime-audio-worklet/src/runtimeDef.test.ts
+++ b/packages/runtime-audio-worklet/src/runtimeDef.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import createStateManager from '@8f4e/state-manager';
+
+import { storeAudioWorkletRuntimeValues } from './runtimeValues';
+
+import type { State } from '@8f4e/editor';
+
+describe('storeAudioWorkletRuntimeValues', () => {
+	it('merges AudioWorklet runtime values into editor state', () => {
+		const state = {
+			runtime: {
+				values: {},
+			},
+		} as State;
+		const store = createStateManager(state);
+
+		storeAudioWorkletRuntimeValues(store, state, { audioBufferSize: 128 });
+		storeAudioWorkletRuntimeValues(store, state, { sampleRate: 48000 });
+
+		expect(state.runtime.values.AudioWorkletRuntime).toEqual({
+			audioBufferSize: 128,
+			sampleRate: 48000,
+		});
+	});
+});

--- a/packages/runtime-audio-worklet/src/runtimeDef.ts
+++ b/packages/runtime-audio-worklet/src/runtimeDef.ts
@@ -8,6 +8,7 @@ import {
 	resolveAudioWorkletRuntimeDirectives,
 	resolveAudioWorkletRuntimeDirectivesFromBlocks,
 } from './runtimeDirectives';
+import { AUDIO_WORKLET_RUNTIME_ID, storeAudioWorkletRuntimeValues } from './runtimeValues';
 
 import type { State, EventDispatcher, RuntimeRegistryEntry, JSONSchemaLike } from '@8f4e/editor';
 
@@ -119,6 +120,9 @@ export function audioWorkletRuntimeFactory(
 				case 'initialized':
 					events.dispatch('runtimeInitialized', typedData.payload);
 					break;
+				case 'runtimeValues':
+					storeAudioWorkletRuntimeValues(store, state, typedData.payload);
+					break;
 			}
 		};
 
@@ -219,7 +223,7 @@ export function createAudioWorkletRuntimeDef(
 	audioWorkletUrl: string
 ): RuntimeRegistryEntry {
 	return {
-		id: 'AudioWorkletRuntime',
+		id: AUDIO_WORKLET_RUNTIME_ID,
 		defaults: {
 			sampleRate: 48000,
 		},

--- a/packages/runtime-audio-worklet/src/runtimeValues.ts
+++ b/packages/runtime-audio-worklet/src/runtimeValues.ts
@@ -1,0 +1,19 @@
+import { StateManager } from '@8f4e/state-manager';
+
+import type { State } from '@8f4e/editor';
+
+export const AUDIO_WORKLET_RUNTIME_ID = 'AudioWorkletRuntime';
+
+export function storeAudioWorkletRuntimeValues(
+	store: StateManager<State>,
+	state: State,
+	values: Record<string, unknown>
+) {
+	store.set('runtime.values', {
+		...state.runtime.values,
+		[AUDIO_WORKLET_RUNTIME_ID]: {
+			...(state.runtime.values[AUDIO_WORKLET_RUNTIME_ID] ?? {}),
+			...values,
+		},
+	});
+}


### PR DESCRIPTION
## Summary

- Add `state.runtime.values` as a generic per-runtime value store.
- Have the AudioWorklet processor report its observed audio buffer size from `process()`.
- Store the reported value directly from `audioWorkletRuntimeFactory` under `state.runtime.values.AudioWorkletRuntime.audioBufferSize`.

## Rationale

The AudioWorklet render quantum is only observable inside the worklet. This change captures that runtime-observed value without changing the existing compile-time `AUDIO_BUFFER_SIZE` contract yet.

## Validation

- `npx eslint --fix ...`
- `npx nx run runtime-audio-worklet:test`
- `npx nx run runtime-audio-worklet:typecheck`
- `npx nx run editor:typecheck`
- pre-commit `npx nx run-many --target=typecheck --all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Editor state now includes runtime value storage and reporting capabilities.
  * Audio worklet now tracks and reports real-time audio buffer size metrics.
  * Enhanced runtime metrics collection and persistence across audio processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->