### PR TITLE
Optimize sprite generator bundle size

### DIFF
--- a/packages/editor/packages/sprite-generator/src/atlasLayout.ts
+++ b/packages/editor/packages/sprite-generator/src/atlasLayout.ts
@@ -1,58 +1,10 @@
+import defaultColorScheme from './defaultColorScheme';
+
 import type { SpriteCoordinates } from 'glugglug';
+import type { ColorScheme } from './types';
 
-export const TEXT_COLOR_NAMES = [
-	'lineNumber',
-	'debugInfo',
-	'arrow',
-	'instruction',
-	'codeComment',
-	'code',
-	'errorMessage',
-	'disabledCode',
-	'numbers',
-	'menuItemText',
-	'menuItemTextHighlighted',
-	'dialogText',
-	'dialogTitle',
-	'binaryZero',
-	'binaryOne',
-	'basePrefix',
-	'pianoKeyWhitePressedOverlay',
-	'pianoKeyBlackPressedOverlay',
-] as const;
-
-export const FILL_COLOR_NAMES = [
-	'menuItemBackground',
-	'menuItemBackgroundHighlighted',
-	'background',
-	'backgroundDots',
-	'debugInfoBackground',
-	'moduleBackground',
-	'moduleBackgroundDragged',
-	'moduleBackgroundDisabled',
-	'wire',
-	'wireHighlighted',
-	'errorMessageBackground',
-	'dialogBackground',
-	'dialogDimmer',
-	'highlightedCodeLine',
-	'trace',
-	'plotterBackground',
-	'bars',
-	'waveform',
-	'meterGreen',
-	'meterYellow',
-	'meterRed',
-	'scanLine',
-	'track',
-	'fill',
-	'handle',
-	'codeBlockHighlightLevel1',
-	'codeBlockHighlightLevel2',
-	'codeBlockHighlightLevel3',
-	'pianoKeyWhite',
-	'pianoKeyBlack',
-] as const;
+export const TEXT_COLOR_NAMES = Object.keys(defaultColorScheme.text) as Array<keyof ColorScheme['text']>;
+export const FILL_COLOR_NAMES = Object.keys(defaultColorScheme.fill) as Array<keyof ColorScheme['fill']>;
 
 const FONT_COLUMNS = 128;
 const BACKGROUND_COLUMNS = 64;

--- a/packages/editor/packages/sprite-generator/src/index.ts
+++ b/packages/editor/packages/sprite-generator/src/index.ts
@@ -8,8 +8,6 @@ import generateIcons, { Icon, generateLookup as generateLookupForIcons } from '.
 import { createAtlasLayout } from './atlasLayout';
 import { Command, FONT_NAMES, type Config, type ColorScheme, type ColorSchemeOverrides, type Font } from './types';
 import decodeFontBase64 from './fonts/font-decoder';
-import { fontMetadata as ascii8x16Metadata } from './fonts/ibmvga8x16/generated/ascii';
-import { fontMetadata as glyphs8x16Metadata } from './fonts/ibmvga8x16/generated/glyphs';
 import defaultColorScheme from './defaultColorScheme';
 
 import type { FontMetadata } from './fonts/ibmvga8x16/generated/ascii';
@@ -66,10 +64,14 @@ const FONT_DEFINITIONS: Record<Font, FontDefinition> = {
 	ibmvga8x16: {
 		characterWidth: 8,
 		characterHeight: 16,
-		loadMetadata: async () => ({
-			asciiMetadata: ascii8x16Metadata,
-			glyphsMetadata: glyphs8x16Metadata,
-		}),
+		loadMetadata: async () => {
+			const [{ fontMetadata: asciiMetadata }, { fontMetadata: glyphsMetadata }] = await Promise.all([
+				import('./fonts/ibmvga8x16/generated/ascii'),
+				import('./fonts/ibmvga8x16/generated/glyphs'),
+			]);
+
+			return { asciiMetadata, glyphsMetadata };
+		},
 	},
 	nix8810m168x16: {
 		characterWidth: 8,
@@ -262,16 +264,8 @@ function decodeFontData({ asciiMetadata, glyphsMetadata }: FontMetadataSet, defi
 	};
 }
 
-// ibmvga8x16 is the default font: eagerly decoded at module initialization for a fast startup path.
-const fontCache: Partial<Record<Font, FontData>> = {
-	ibmvga8x16: decodeFontData(
-		{
-			asciiMetadata: ascii8x16Metadata,
-			glyphsMetadata: glyphs8x16Metadata,
-		},
-		FONT_DEFINITIONS.ibmvga8x16
-	),
-};
+// Fonts are loaded on first use and cached so each bitmap is decoded at most once.
+const fontCache: Partial<Record<Font, FontData>> = {};
 
 export const DEFAULT_FONT: Font = 'ibmvga8x16';
 
@@ -279,7 +273,6 @@ function resolveFont(font: Config['font']): Font {
 	return FONT_NAMES.includes(font as Font) ? (font as Font) : DEFAULT_FONT;
 }
 
-// Lazily load and decode an alternate font, caching the result so it is decoded at most once.
 async function loadFont(font: Font): Promise<FontData> {
 	if (fontCache[font]) {
 		return fontCache[font]!;


### PR DESCRIPTION
## Summary
- Lazy-load default sprite-generator font metadata instead of eagerly bundling/decoding it
- Derive atlas text/fill color name lists from `defaultColorScheme` to avoid duplicated color key arrays
- Includes `backgroundDots2` in fill color atlas keys because it exists in the default fill scheme

## Verification
- `npx nx run @8f4e/sprite-generator:typecheck`
- `npx nx run @8f4e/sprite-generator:test`
- `npx nx run @8f4e/sprite-generator:build --skip-nx-cache`
- `npx nx run app:build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Color scheme configuration now dynamically derives from default values at runtime instead of static arrays, enabling more flexible configuration management
  * Font metadata loading changed from eager initialization during startup to lazy loading on first use
  * Color name definitions consolidated from multiple static lists into unified runtime-derived values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->