### PR TITLE
feat(compiler): add exported function directive

### DIFF
--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -84,6 +84,7 @@ Active todo files are listed below.
 | 266 | Add float64 support for greaterOrEqual instruction | 2026-05-10 | `greaterOrEqual` now emits `F64_GE` for float64 operands and has unit/public regression coverage. |
 | 267 | Add float64 support for greaterOrEqualUnsigned instruction | 2026-05-10 | `greaterOrEqualUnsigned` now emits `F64_GE` for float64 operands and has unit/public regression coverage. |
 | 268 | Add float64 support for sqrt instruction | 2026-05-10 | `sqrt` now emits `F64_SQRT`, preserves float64 metadata, and no longer marks the result as always non-zero. |
+| 395 | Add exported 8f4e functions | 2026-05-10 | `#export <exportedName>` now exports user functions through the generated WebAssembly ABI with positional JS numeric arguments and duplicate-name validation. |
 | 391 | Add compiler AST cache for incremental compiles | 2026-05-04 | `compile()` now returns and accepts an opaque AST cache for unchanged expanded module and function inputs. |
 | 329 | Replace literal-only const collection with semantic namespace prepass | 2026-03-27 | Replaced `collectConstants(ast)` bootstrap with semantic namespace prepass. |
 | 330 | Centralize compile-time folding as an AST normalization pass | 2026-03-27 | Compile-time folding now runs as a semantic normalization pass before codegen. |

--- a/docs/todos/archived/395-add-exported-8f4e-functions.md
+++ b/docs/todos/archived/395-add-exported-8f4e-functions.md
@@ -1,0 +1,125 @@
+---
+title: 'TODO: Add exported 8f4e functions'
+priority: Medium
+effort: 4-8h
+created: 2026-05-10
+status: Completed
+completed: 2026-05-10
+---
+
+# TODO: Add exported 8f4e functions
+
+## Problem Description
+
+8f4e functions can currently be called from other 8f4e code, but user-defined functions are not exported from the generated WebAssembly module. This prevents runtimes and host integrations from calling small 8f4e-authored updater functions directly from JavaScript.
+
+This blocks a simpler control-event architecture where external event sources, such as MIDI, UI controls, keyboard input, OSC, or WebSocket messages, can call a compiled 8f4e function that writes into shared WebAssembly memory. The audio runtime can then keep running `buffer()` normally and read the updated memory values without receiving event messages or dispatching handlers inside the AudioWorklet.
+
+## Proposed Solution
+
+Add a compiler directive for exporting user functions:
+
+```8f4e
+function onMidiCC
+#export onMidiCC
+param int channel
+param int controller
+param int value
+functionEnd
+```
+
+The directive should export the enclosing 8f4e function under the provided WebAssembly export name. JavaScript can then call the export with positional numeric arguments:
+
+```ts
+(instance.exports.onMidiCC as CallableFunction)(channel, controller, value);
+```
+
+Initial ABI rules:
+
+- `int` maps to Wasm `i32` and JS `number`.
+- `float` maps to Wasm `f32` and JS `number`.
+- `float64` maps to Wasm `f64` and JS `number`.
+- Do not introduce object, array, or dynamic event payload arguments.
+- Richer data should be passed through shared memory addresses in later work.
+- Event/updater functions should usually return no values and communicate by writing shared memory.
+
+## Anti-Patterns
+
+- Do not make this MIDI-specific. MIDI should become one possible host integration that calls exported functions.
+- Do not route main-thread events through the AudioWorklet just to call handlers there if shared-memory updater functions are enough.
+- Do not introduce dynamic event objects or stringly typed payloads into the Wasm ABI.
+- Do not export every function automatically; exported functions should be explicit source-level ABI.
+
+## Implementation Plan
+
+### Step 1: Add syntax support
+
+- Add `#export` as a recognized compiler directive with one required argument.
+- Allow `#export <exportedName>` only inside function blocks.
+- Decide whether duplicate `#export` directives in one function are rejected or last-wins; prefer rejecting duplicates.
+
+### Step 2: Carry export metadata through function compilation
+
+- Extend compiled function metadata with an optional `exportName`.
+- Collect the directive during function compilation without changing ordinary `call` behavior.
+- Keep function-local stack, parameter, and return validation unchanged.
+
+### Step 3: Emit additional Wasm exports
+
+- Add `createFunctionExport(exportName, wasmIndex)` entries for exported user functions.
+- Preserve the existing built-in exports: `init`, `cycle`, `initOnly`, and `buffer`.
+- Ensure exported function indices continue to match the compiled function section ordering.
+
+### Step 4: Add compiler tests
+
+- Verify that `#export onMidiCC` exposes `instance.exports.onMidiCC`.
+- Verify multiple positional arguments work by exporting a small function such as `add`.
+- Verify float and float64 signatures still instantiate correctly.
+- Verify `#export` outside a function reports a compiler error.
+- Verify duplicate export names across functions are rejected.
+
+### Step 5: Update docs
+
+- Document `#export <exportedName>` in the function block docs.
+- Add a short JS calling example.
+- Note that functions with memory IO still need `#impure`.
+
+## Validation Checkpoints
+
+- `npx nx run compiler:test`
+- `npx nx run compiler:typecheck`
+- A focused WebAssembly instantiation test confirms exported user functions are callable from JS.
+
+## Success Criteria
+
+- [x] Users can mark a function with `#export <exportedName>`.
+- [x] Generated Wasm exports the marked function under the requested name.
+- [x] JS can call exported functions with multiple positional numeric arguments.
+- [x] Existing module execution exports and internal function calls keep working.
+- [x] Invalid export usage has targeted test coverage.
+
+## Affected Components
+
+- `packages/compiler/packages/tokenizer` - Recognize and validate `#export` directive shape.
+- `packages/compiler/src` - Carry export metadata and emit Wasm export entries.
+- `packages/compiler-types/src/index.ts` - Add exported-function metadata fields as needed.
+- `packages/compiler/docs/instructions/blocks/function.md` - Document function export syntax and ABI.
+- `packages/compiler/tests` - Add integration coverage for exported functions.
+
+## Risks & Considerations
+
+- **Duplicate export names**: Must be rejected so the generated Wasm export section is unambiguous.
+- **Runtime instance reuse**: Any future Wasm instance reuse must treat exported function layout changes as incompatible.
+- **Shared-memory updates**: Exported updater functions that write memory should use `#impure`; synchronization for multi-word updates is a separate design concern.
+- **Host ABI stability**: `#export <exportedName>` creates a public ABI. Renaming exports should be treated as a source-level breaking change for host integrations.
+
+## Related Items
+
+- **Related**: `docs/todos/305-reuse-wasm-instance-across-incremental-compiles.md`
+- **Related**: `docs/todos/380-remove-hardcoded-audio-worklet-buffer-size-from-runtime-contract.md`
+
+## Notes
+
+- This TODO intentionally covers the compiler/export syntax first.
+- A later runtime TODO can define a separate control/updater Wasm instantiation strategy that imports the same shared memory as the audio program and exposes host-callable event updater functions.
+- Completed on 2026-05-10 by adding tokenizer validation, compiler metadata, Wasm export emission, docs, and compiler integration tests for `#export <exportedName>`.

--- a/packages/compiler-types/src/index.ts
+++ b/packages/compiler-types/src/index.ts
@@ -49,6 +49,7 @@ import {
 	type LoopIndexLine,
 	type LoopCapLine,
 	type ImpureLine,
+	type ExportLine,
 } from '@8f4e/tokenizer';
 
 import type { Type, WASMInstruction } from '@8f4e/compiler-wasm-utils';
@@ -145,6 +146,7 @@ export interface CompiledFunction {
 	signature: FunctionSignature;
 	body: number[];
 	locals: Array<{ isInteger: boolean; count: number }>;
+	exportName?: string;
 	wasmIndex?: number;
 	typeIndex?: number;
 	ast?: AST;
@@ -269,6 +271,7 @@ export {
 	type LoopIndexLine,
 	type LoopCapLine,
 	type ImpureLine,
+	type ExportLine,
 };
 
 export interface TestModule {
@@ -360,6 +363,7 @@ export interface CompilationContext {
 	currentFunctionId?: string;
 	currentFunctionSignature?: FunctionSignature;
 	currentFunctionIsImpure?: boolean;
+	currentFunctionExportName?: string;
 	functionTypeRegistry?: FunctionTypeRegistry;
 	currentMacroId?: string;
 	skipExecutionInCycle?: boolean;
@@ -624,6 +628,7 @@ export type Instruction =
 	| '#skipExecution'
 	| '#initOnly'
 	| '#impure'
+	| '#export'
 	| '#loopCap'
 	| 'mapBegin'
 	| 'map'

--- a/packages/compiler/docs/instructions/blocks/function.md
+++ b/packages/compiler/docs/instructions/blocks/function.md
@@ -24,6 +24,7 @@ Functions are reusable code blocks that:
 - Can be called from modules using the `call` instruction
 - Are pure by default
 - Can opt into explicit address-driven memory IO with `#impure`
+- Can be exported to the host WebAssembly ABI with `#export <exportedName>`
 - Do not have direct access to module memory identifiers by name
 - Cannot declare their own memory
 
@@ -46,6 +47,34 @@ mul
 store
 functionEnd
 ```
+
+### `#export`
+
+Use `#export <exportedName>` inside a function to export it from the generated WebAssembly module under the provided name.
+
+```
+function onMidiCC
+#export onMidiCC
+param int channel
+param int controller
+param int value
+functionEnd
+```
+
+Host code calls exported functions with positional numeric arguments:
+
+```ts
+(instance.exports.onMidiCC as CallableFunction)(channel, controller, value);
+```
+
+Argument mapping:
+
+- `int` maps to Wasm `i32` and a JavaScript `number`
+- `float` maps to Wasm `f32` and a JavaScript `number`
+- `float64` maps to Wasm `f64` and a JavaScript `number`
+
+Export names must be unique and must not reuse built-in exports such as `init`, `cycle`, `initOnly`, or `buffer`.
+Functions that read from or write to memory still need `#impure`.
 
 ### Example Function
 

--- a/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.test.ts
+++ b/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.test.ts
@@ -64,6 +64,17 @@ describe('validateInstructionArguments', () => {
 		expect(() => validateInstructionArguments('#impure', [classifyIdentifier('x')])).toThrowError(SyntaxRulesError);
 	});
 
+	it('requires one identifier argument for #export', () => {
+		expect(() => validateInstructionArguments('#export', [classifyIdentifier('onMidiCC')])).not.toThrow();
+		expect(() => validateInstructionArguments('#export', [])).toThrowError(SyntaxRulesError);
+		expect(() =>
+			validateInstructionArguments('#export', [classifyIdentifier('onMidiCC'), classifyIdentifier('extra')])
+		).toThrowError(SyntaxRulesError);
+		expect(() =>
+			validateInstructionArguments('#export', [{ type: ArgumentType.LITERAL, value: 1, isInteger: true }])
+		).toThrowError(SyntaxRulesError);
+	});
+
 	it('accepts bare exitIfTrue and rejects any arguments', () => {
 		expect(() => validateInstructionArguments('exitIfTrue', [])).not.toThrow();
 		expect(() => validateInstructionArguments('exitIfTrue', [classifyIdentifier('x')])).toThrowError(SyntaxRulesError);

--- a/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.ts
+++ b/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.ts
@@ -53,6 +53,7 @@ const instructionArgumentSpecs: Partial<Record<string, InstructionArgumentSpec>>
 	loopIndex: { maxArguments: 0 },
 	'#loopCap': { minArguments: 1, argumentTypes: ['nonNegativeIntegerLiteral'] },
 	'#impure': { maxArguments: 0 },
+	'#export': { minArguments: 1, maxArguments: 1, argumentTypes: ['identifier'] },
 	module: { minArguments: 1, argumentTypes: ['identifier'] },
 	constants: { minArguments: 1, argumentTypes: ['identifier'] },
 	use: { minArguments: 1, argumentTypes: ['identifier'] },

--- a/packages/compiler/packages/tokenizer/src/types.ts
+++ b/packages/compiler/packages/tokenizer/src/types.ts
@@ -119,3 +119,4 @@ export type LoopLine = ASTLineBase<'loop', [] | [ArgumentLiteral]>;
 export type LoopIndexLine = ASTLineBase<'loopIndex', []>;
 export type LoopCapLine = ASTLineBase<'#loopCap', [ArgumentLiteral]>;
 export type ImpureLine = ASTLineBase<'#impure', []>;
+export type ExportLine = ASTLineBase<'#export', [ArgumentIdentifier]>;

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -215,6 +215,7 @@ export function compileFunction(
 			context.byteCode
 		),
 		locals: localDeclarations,
+		...(context.currentFunctionExportName ? { exportName: context.currentFunctionExportName } : {}),
 		wasmIndex,
 		typeIndex,
 		ast: normalizedAst,

--- a/packages/compiler/src/compilerError.ts
+++ b/packages/compiler/src/compilerError.ts
@@ -73,6 +73,8 @@ export enum ErrorCode {
 	ADDRESS_RANGE_REQUIRED,
 	INVALID_ACCESS_WIDTH,
 	ADDRESS_RANGE_TOO_SMALL,
+	EXPORT_DIRECTIVE_INVALID_CONTEXT,
+	DUPLICATE_EXPORT_NAME,
 }
 
 interface ErrorDetails {
@@ -350,6 +352,13 @@ export function getError(
 				line,
 				context,
 			};
+		case ErrorCode.EXPORT_DIRECTIVE_INVALID_CONTEXT:
+			return {
+				code,
+				message: '#export can only be used within a function block. (' + code + ')',
+				line,
+				context,
+			};
 		case ErrorCode.MIXED_FLOAT_WIDTH:
 			return {
 				code,
@@ -470,6 +479,18 @@ export function getError(
 					'Duplicate identifier' +
 					(details?.identifier ? `: ${details.identifier}` : '') +
 					'. Module and function IDs must be unique. (' +
+					code +
+					')',
+				line,
+				context,
+			};
+		case ErrorCode.DUPLICATE_EXPORT_NAME:
+			return {
+				code,
+				message:
+					'Duplicate function export name' +
+					(details?.identifier ? `: ${details.identifier}` : '') +
+					'. Exported function names must be unique and must not reuse built-in export names. (' +
 					code +
 					')',
 				line,

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -31,6 +31,7 @@ import {
 import { EXPORTED_FUNCTION_COUNT, GLOBAL_ALIGNMENT_BOUNDARY, HEADER, VERSION } from './consts';
 import sortModules from './graphOptimizer';
 import { createInitialMemoryDataSegments } from './initialMemoryDataSegments';
+import { ErrorCode, getError } from './compilerError';
 
 import type {
 	AST,
@@ -119,6 +120,26 @@ function createCompilerCache(): CompilerCache {
 	};
 }
 
+const BUILT_IN_EXPORT_NAMES = new Set(['init', 'cycle', 'initOnly', 'buffer']);
+
+function assertUniqueFunctionExportNames(functions: CompiledFunctionLookup): void {
+	const seen = new Set<string>();
+
+	for (const compiledFunction of Object.values(functions)) {
+		const exportName = compiledFunction.exportName;
+		if (!exportName) {
+			continue;
+		}
+
+		const exportLine = compiledFunction.ast?.find(line => line.instruction === '#export') ?? compiledFunction.ast![0];
+		if (BUILT_IN_EXPORT_NAMES.has(exportName) || seen.has(exportName)) {
+			throw getError(ErrorCode.DUPLICATE_EXPORT_NAME, exportLine, undefined, { identifier: exportName });
+		}
+
+		seen.add(exportName);
+	}
+}
+
 export default function compile(
 	modules: Module[],
 	options: CompileOptions,
@@ -176,6 +197,7 @@ export default function compile(
 		compileFunction(ast, namespaces, EXPORTED_FUNCTION_COUNT + index, functionTypeRegistry, functionMetadata)
 	);
 	const compiledFunctionsMap = Object.fromEntries(compiledFunctions.map(func => [func.id, func]));
+	assertUniqueFunctionExportNames(compiledFunctionsMap);
 	const totalModuleBytes = Object.values(namespaces).reduce((max, namespace) => {
 		const byteAddress = namespace.byteAddress ?? 0;
 		const wordAlignedSize = namespace.wordAlignedSize ?? 0;
@@ -279,6 +301,9 @@ export default function compile(
 				createFunctionExport('cycle', 0x01),
 				createFunctionExport('initOnly', 0x02),
 				createFunctionExport('buffer', 0x03),
+				...compiledFunctions
+					.filter(func => func.exportName && func.wasmIndex !== undefined)
+					.map(func => createFunctionExport(func.exportName!, func.wasmIndex!)),
 			]),
 			...(initialMemoryDataSegments.length > 0 ? createDataCountSection(initialMemoryDataSegments.length) : []),
 			...createCodeSection([

--- a/packages/compiler/src/instructionCompilers/exportFunction.ts
+++ b/packages/compiler/src/instructionCompilers/exportFunction.ts
@@ -1,0 +1,29 @@
+import { BLOCK_TYPE } from '@8f4e/compiler-types';
+
+import { ErrorCode, getError } from '../compilerError';
+
+import type { ExportLine, InstructionCompiler } from '@8f4e/compiler-types';
+
+/**
+ * Instruction compiler for `#export`.
+ * Marks the current function as a WebAssembly export under the provided name.
+ */
+const exportFunction: InstructionCompiler<ExportLine> = function (line, context) {
+	const isInFunctionBlock = context.blockStack.some(block => block.blockType === BLOCK_TYPE.FUNCTION);
+
+	if (!isInFunctionBlock) {
+		throw getError(ErrorCode.EXPORT_DIRECTIVE_INVALID_CONTEXT, line, context);
+	}
+
+	if (context.currentFunctionExportName !== undefined) {
+		throw getError(ErrorCode.DUPLICATE_EXPORT_NAME, line, context, {
+			identifier: line.arguments[0].value,
+		});
+	}
+
+	context.currentFunctionExportName = line.arguments[0].value;
+
+	return context;
+};
+
+export default exportFunction;

--- a/packages/compiler/src/instructionCompilers/function.ts
+++ b/packages/compiler/src/instructionCompilers/function.ts
@@ -29,6 +29,7 @@ const _function = function (line: FunctionLine, context: CompilationContext) {
 		returns: [],
 	};
 	context.currentFunctionIsImpure = false;
+	context.currentFunctionExportName = undefined;
 	context.mode = 'function';
 
 	// Initialize empty locals - parameters will be added by param instructions

--- a/packages/compiler/src/instructionCompilers/index.ts
+++ b/packages/compiler/src/instructionCompilers/index.ts
@@ -58,6 +58,7 @@ import call from './call';
 import skipExecution from './skipExecution';
 import initOnly from './initOnly';
 import impure from './impure';
+import exportFunction from './exportFunction';
 import loopCap from './loopCap';
 import mapBegin from './mapBegin';
 import map from './map';
@@ -135,6 +136,7 @@ const instructions = {
 	'#skipExecution': skipExecution,
 	'#initOnly': initOnly,
 	'#impure': impure,
+	'#export': exportFunction,
 	'#loopCap': loopCap,
 	mapBegin,
 	map,

--- a/packages/compiler/src/instructionSpecs.ts
+++ b/packages/compiler/src/instructionSpecs.ts
@@ -222,6 +222,11 @@ export const instructionSpecs = {
 		scope: 'moduleOrFunction',
 		onInvalidScope: ErrorCode.COMPILER_DIRECTIVE_INVALID_CONTEXT,
 	},
+	// #export <exportName> ( -- )
+	'#export': {
+		scope: 'function',
+		onInvalidScope: ErrorCode.EXPORT_DIRECTIVE_INVALID_CONTEXT,
+	},
 	// loopEnd ( -- ), loopEnd (T -- T)
 	loopEnd: {
 		scope: 'moduleOrFunction',

--- a/packages/compiler/tests/exportedFunctions.test.ts
+++ b/packages/compiler/tests/exportedFunctions.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, test } from 'vitest';
+
+import { ErrorCode } from '../src/compilerError';
+import compile from '../src/index';
+
+import type { Module } from '@8f4e/compiler-types';
+
+const defaultOptions = {
+	startingMemoryWordAddress: 1,
+	environmentExtensions: {
+		constants: {},
+	},
+	disableSharedMemory: true,
+	includeAST: true,
+};
+
+async function instantiate(functions: Module[]) {
+	const result = compile([{ code: ['module test', 'moduleEnd'] }], defaultOptions, functions);
+	const { instance } = await WebAssembly.instantiate(result.codeBuffer, {
+		js: { memory: new WebAssembly.Memory({ initial: 1, maximum: 1 }) },
+	});
+	return { result, exports: instance.exports };
+}
+
+describe('exported 8f4e functions', () => {
+	test('exports a function under the requested name', async () => {
+		const { result, exports } = await instantiate([
+			{
+				code: [
+					'function add',
+					'#export addFromJs',
+					'param int a',
+					'param int b',
+					'push a',
+					'push b',
+					'add',
+					'functionEnd int',
+				],
+			},
+		]);
+
+		expect(result.compiledFunctions.add.exportName).toBe('addFromJs');
+		expect(exports.addFromJs).toBeTypeOf('function');
+		expect((exports.addFromJs as CallableFunction)(2, 3)).toBe(5);
+	});
+
+	test('passes float and float64 arguments as positional JS numbers', async () => {
+		const { exports } = await instantiate([
+			{
+				code: [
+					'function addFloat',
+					'#export addFloat',
+					'param float a',
+					'param float b',
+					'push a',
+					'push b',
+					'add',
+					'functionEnd float',
+				],
+			},
+			{
+				code: [
+					'function addFloat64',
+					'#export addFloat64',
+					'param float64 a',
+					'param float64 b',
+					'push a',
+					'push b',
+					'add',
+					'functionEnd float64',
+				],
+			},
+		]);
+
+		expect((exports.addFloat as CallableFunction)(0.25, 0.5)).toBeCloseTo(0.75);
+		expect((exports.addFloat64 as CallableFunction)(0.1, 0.2)).toBeCloseTo(0.3);
+	});
+
+	test('rejects duplicate export directives in one function', () => {
+		expect(() =>
+			compile([{ code: ['module test', 'moduleEnd'] }], defaultOptions, [
+				{ code: ['function bad', '#export first', '#export second', 'functionEnd'] },
+			])
+		).toThrow(expect.objectContaining({ code: ErrorCode.DUPLICATE_EXPORT_NAME }));
+	});
+
+	test('rejects duplicate export names across functions', () => {
+		expect(() =>
+			compile([{ code: ['module test', 'moduleEnd'] }], defaultOptions, [
+				{ code: ['function a', '#export same', 'functionEnd'] },
+				{ code: ['function b', '#export same', 'functionEnd'] },
+			])
+		).toThrow(expect.objectContaining({ code: ErrorCode.DUPLICATE_EXPORT_NAME }));
+	});
+
+	test('rejects built-in export names', () => {
+		expect(() =>
+			compile([{ code: ['module test', 'moduleEnd'] }], defaultOptions, [
+				{ code: ['function bad', '#export buffer', 'functionEnd'] },
+			])
+		).toThrow(expect.objectContaining({ code: ErrorCode.DUPLICATE_EXPORT_NAME }));
+	});
+
+	test('rejects #export outside a function block', () => {
+		expect(() => compile([{ code: ['module test', '#export outside', 'moduleEnd'] }], defaultOptions)).toThrow(
+			expect.objectContaining({ code: ErrorCode.EXPORT_DIRECTIVE_INVALID_CONTEXT })
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- add `#export <exportName>` support for 8f4e function exports
- emit exported WebAssembly functions alongside the built-in runtime exports
- document the directive and archive the implementation TODO

## Validation
- `npx nx run compiler:test -- exportedFunctions.test.ts`
- `npx nx run @8f4e/tokenizer:test -- validateInstructionArguments.test.ts`
- `npx nx run compiler:typecheck`
- `npx nx run @8f4e/tokenizer:typecheck`
- `npx nx run @8f4e/compiler-types:typecheck`
- pre-commit: `npx nx run-many --target=typecheck --all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `#export <exportedName>` directive to export user-defined functions from WebAssembly modules, callable from JavaScript with positional numeric arguments.

* **Documentation**
  * Updated function block documentation with `#export` usage examples, type mappings (int/float/float64), and constraints on export names.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/andorthehood/8f4e/pull/626)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->