### PR TITLE
feat(editor): add serial input plugin

### DIFF
--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -56,7 +56,6 @@ Active todo files are listed below.
 | 390 | Add compiler passive data inputs for array initialization | 🟡 | 1-2d | 2026-05-04 | The compiler now uses passive data segments to restore declared initial memory, but every segment is still derived from source-level memory declarations and compiler-owned inter... |
 | 397 | Finish compiler stack analysis/codegen separation | 🟡 | 2-4d | 2026-05-11 | TODO 394 centralized compiler instruction stack validation: `withValidation` is gone, compiler-owned instruction contracts live in `packages/compiler/src/instructionSpecs.ts`, a... |
 | 398 | Add compiler peephole arithmetic strength reduction | 🟡 | 1-2 days | 2026-05-12 | The compiler now has compile-time folding and stack-level integer metadata, but runtime arithmetic codegen still emits direct WebAssembly arithmetic operations even when the top... |
-| 400 | Add serial input editor environment plugin | 🟡 | 1-2d | 2026-05-13 | Add a Web Serial editor environment plugin with `@info serial`, fixed-size `@serialIn` framing, and `@serialInCallback` fanout to exported 8f4e functions. |
 
 ### 🟢 Low Priority
 
@@ -75,6 +74,7 @@ Active todo files are listed below.
 | ID | Title | Completed | Notes |
 | ---- | ----- | --------- | ----- |
 | 399 | Consolidate instruction compiler utilities | 2026-05-12 | Instruction-compiler-only helpers moved under `packages/compiler/src/instructionCompilers/utils/`; `saveByteCode` split out, unused word-alignment helper removed, and numeric binary instruction codegen centralized. |
+| 400 | Add serial input editor environment plugin | 2026-05-13 | Added a Web Serial editor plugin with `@info serial`, fixed-size `@serialIn` framing, and `@serialInCallback` fanout to exported 8f4e callbacks. |
 | 055 | Implement strength reduction optimization techniques in compiler | 2026-05-12 | Archived original TODO; remaining bytecode peephole optimization work is tracked in `398`. |
 | 392 | Move shared compiler constants to compiler-spec | 2026-05-11 | Shared memory layout, integer range, logic level, memory access-width, and Wasm page constants now resolve from `@8f4e/compiler-spec`; compiler-only bytecode header/export-count constants remain private. |
 | 394 | Extract compiler stack analysis into a separate pass | 2026-05-08 | `withValidation` was removed, stack validation helpers moved under `packages/compiler/src/stackAnalysis/`, and compiler instruction contracts were centralized in `instructionSpecs.ts`; remaining codegen separation is tracked in `397`. |

--- a/docs/todos/archived/400-add-serial-input-editor-environment-plugin.md
+++ b/docs/todos/archived/400-add-serial-input-editor-environment-plugin.md
@@ -3,8 +3,8 @@ title: 'TODO: Add serial input editor environment plugin'
 priority: Medium
 effort: 1-2d
 created: 2026-05-13
-status: Open
-completed: null
+status: Completed
+completed: 2026-05-13
 ---
 
 # TODO: Add serial input editor environment plugin
@@ -56,6 +56,17 @@ onSerialFrame(ptr, frameBytes);
 ```
 
 Incomplete trailing bytes remain buffered until more serial data arrives. Queues are cleared when the Wasm exports or memory are rebound.
+
+Completed changes:
+
+- Added the `serial` editor environment plugin and lazy registry entry.
+- Added Web Serial device discovery backed by `state.info.serial`.
+- Added `@serialIn` pipeline parsing and `@serialInCallback` fanout parsing.
+- Added fixed-size serial input framing over arbitrary `ReadableStream` chunks.
+- Added raw byte copying into Wasm memory and exported callback invocation as `(ptr, length)`.
+- Added cleanup/resync behavior for directive, compile, memory, and port-list changes.
+- Documented the serial directives in the editor directive guide.
+- Added focused tests for device discovery, directive parsing, framing, callback fanout, diagnostics, and cleanup.
 
 ## Initial Decisions
 
@@ -168,16 +179,16 @@ Responsibilities:
 
 ## Success Criteria
 
-- [ ] `@info serial` lists already-granted serial ports while the plugin is active.
-- [ ] `@serialIn <port> <baudRate> <bufferMemoryId> <frameBytes>` configures one fixed-frame serial input pipeline.
-- [ ] `@serialInCallback <port> <callbackExportName>` binds one or more exported callbacks to completed frames.
-- [ ] Serial `ReadableStream` chunks are buffered and reframed deterministically by `frameBytes`.
-- [ ] Completed frames are copied into the configured Wasm memory buffer as raw bytes.
-- [ ] Callbacks receive `(ptr, length)`.
-- [ ] Partial queues are cleared on compile/memory/export rebinding.
-- [ ] Disconnects cancel readers, clear queues, refresh `info.serial`, and surface unavailable-port errors.
-- [ ] Malformed directives, duplicate pipelines, missing ports, missing buffers, and missing exports produce plugin-owned editor directive errors.
-- [ ] Device discovery, directive parsing, framing, callback fanout, and lifecycle cleanup have focused tests.
+- [x] `@info serial` lists already-granted serial ports while the plugin is active.
+- [x] `@serialIn <port> <baudRate> <bufferMemoryId> <frameBytes>` configures one fixed-frame serial input pipeline.
+- [x] `@serialInCallback <port> <callbackExportName>` binds one or more exported callbacks to completed frames.
+- [x] Serial `ReadableStream` chunks are buffered and reframed deterministically by `frameBytes`.
+- [x] Completed frames are copied into the configured Wasm memory buffer as raw bytes.
+- [x] Callbacks receive `(ptr, length)`.
+- [x] Partial queues are cleared on compile/memory/export rebinding.
+- [x] Disconnects cancel readers, clear queues, refresh `info.serial`, and surface unavailable-port errors.
+- [x] Malformed directives, duplicate pipelines, missing ports, missing buffers, and missing exports produce plugin-owned editor directive errors.
+- [x] Device discovery, directive parsing, framing, callback fanout, and lifecycle cleanup have focused tests.
 
 ## Affected Components
 
@@ -200,4 +211,8 @@ Responsibilities:
 
 - **Related**: `docs/todos/archived/396-add-midi-input-editor-environment-plugin.md`
 - **Related**: `docs/todos/archived/395-add-exported-8f4e-functions.md`
-- **Related**: `docs/todos/387-add-lazy-editor-environment-plugins.md`
+- **Related**: `docs/todos/archived/387-add-lazy-editor-environment-plugins.md`
+
+## Notes
+
+- Completed on 2026-05-13 by adding the serial editor environment plugin, directive docs, and focused editor tests.

--- a/packages/editor/docs/editor-directives.md
+++ b/packages/editor/docs/editor-directives.md
@@ -255,6 +255,46 @@ Example:
 ; @midiIn 0 onPitchBend
 ```
 
+### `@serialIn`
+
+Define a fixed-size browser serial input frame pipeline.
+
+```txt
+; @serialIn <port> <baudRate> <bufferMemoryId> <frameBytes>
+```
+
+### `@serialInCallback`
+
+Bind a serial input pipeline to an exported 8f4e function.
+
+```txt
+; @serialInCallback <port> <callbackExportName>
+```
+
+Notes:
+
+- The serial plugin is activated by `@serialIn` or `@serialInCallback`; `; @info serial` can display available already-granted ports while serial is active.
+- `<port>` is the numeric serial port index shown by `; @info serial`.
+- The plugin uses already-granted Web Serial ports. Granting a new browser serial port still needs a user gesture outside this directive.
+- `<baudRate>` is passed to `port.open({ baudRate })`.
+- `<bufferMemoryId>` is the memory item that receives each completed frame. It may be local to the declaring module or use `module:memory` syntax.
+- `<frameBytes>` must be a positive integer. The plugin buffers arbitrary browser serial chunks until exactly this many bytes are available.
+- Browser serial chunks are not message boundaries; fixed-size framing is the directive-defined boundary.
+- Completed frames are copied as raw bytes into `<bufferMemoryId>`.
+- `<callbackExportName>` must be a callable WebAssembly export created with `#export`.
+- The callback receives two integer arguments: `ptr` and `length`.
+- Multiple `@serialInCallback` directives can bind the same serial input pipeline to different callbacks.
+- Partial frames are cleared when the serial pipeline is rebound after compile, memory, or export changes.
+
+Example:
+
+```txt
+; @info serial
+; @serialIn 0 115200 serialBuffer 32
+; @serialInCallback 0 onSerialFrame
+; @serialInCallback 0 onSerialDebug
+```
+
 ### `@offset`
 
 Apply code-block visual position offset from an integer memory value.

--- a/packages/editor/src/editorEnvironmentPlugins/registry.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/registry.ts
@@ -16,4 +16,9 @@ export const editorEnvironmentPluginRegistry: EditorEnvironmentPluginRegistryEnt
 		editorDirectives: ['midiIn'],
 		load: () => import('./midi/plugin'),
 	},
+	{
+		id: 'serial',
+		editorDirectives: ['serialIn', 'serialInCallback'],
+		load: () => import('./serial/plugin'),
+	},
 ];

--- a/packages/editor/src/editorEnvironmentPlugins/serial/devices.test.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/serial/devices.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+import createStateManager from '@8f4e/state-manager';
+
+import createSerialDeviceManager from './devices';
+
+import type { State } from '@8f4e/editor-state-types';
+import type { SerialNavigatorLike, SerialPortLike } from './types';
+
+function createStore() {
+	return createStateManager({
+		info: {},
+	} as unknown as State);
+}
+
+async function flushPromises(): Promise<void> {
+	await Promise.resolve();
+	await Promise.resolve();
+}
+
+describe('createSerialDeviceManager', () => {
+	it('commits an empty serial device list when Web Serial is unavailable', () => {
+		const store = createStore();
+		const manager = createSerialDeviceManager({ store, navigator: {} as Navigator });
+
+		expect(store.getState().info.serial).toEqual({});
+
+		manager.dispose();
+
+		expect(store.getState().info.serial).toBeUndefined();
+	});
+
+	it('commits already-granted serial ports into state.info.serial', async () => {
+		const store = createStore();
+		const portA: SerialPortLike = {
+			open: vi.fn(),
+			getInfo: () => ({ usbVendorId: 0x2341, usbProductId: 0x0043 }),
+		};
+		const portB: SerialPortLike = {
+			open: vi.fn(),
+		};
+		let ports = [portA];
+		let connectHandler: ((event: Event) => void) | undefined;
+		const serial: SerialNavigatorLike = {
+			getPorts: vi.fn(async () => ports),
+			addEventListener: vi.fn((type, handler) => {
+				if (type === 'connect') {
+					connectHandler = handler;
+				}
+			}),
+			removeEventListener: vi.fn(),
+		};
+		const manager = createSerialDeviceManager({
+			store,
+			navigator: { serial } as unknown as Navigator,
+		});
+
+		expect(store.getState().info.serial).toEqual({});
+
+		await flushPromises();
+
+		expect(store.getState().info.serial).toEqual({
+			'0': 'USB 0x2341:0x0043',
+		});
+		expect(manager.getPort('0')).toBe(portA);
+
+		ports = [portA, portB];
+		connectHandler?.({} as Event);
+		await flushPromises();
+
+		expect(store.getState().info.serial).toEqual({
+			'0': 'USB 0x2341:0x0043',
+			'1': 'Serial port 1',
+		});
+		expect(manager.getPort('1')).toBe(portB);
+
+		manager.dispose();
+
+		expect(store.getState().info.serial).toBeUndefined();
+		expect(serial.removeEventListener).toHaveBeenCalledWith('connect', expect.any(Function));
+		expect(serial.removeEventListener).toHaveBeenCalledWith('disconnect', expect.any(Function));
+	});
+});

--- a/packages/editor/src/editorEnvironmentPlugins/serial/devices.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/serial/devices.ts
@@ -1,0 +1,145 @@
+import type { InfoRecord, State } from '@8f4e/editor-state-types';
+import type { StateManager } from '@8f4e/state-manager';
+import type { SerialNavigatorLike, SerialPortLike } from './types';
+
+interface SerialDevicesOptions {
+	store: StateManager<State>;
+	navigator: Navigator;
+	onPortsChanged?: () => void;
+}
+
+interface SerialPortRegistry {
+	portsByIndex: Map<string, SerialPortLike>;
+	indexesByPort: WeakMap<SerialPortLike, number>;
+	nextIndex: number;
+}
+
+export interface SerialDeviceManager {
+	getPort: (port: string) => SerialPortLike | undefined;
+	dispose: () => void;
+}
+
+function getSerialNavigator(navigator: Navigator): SerialNavigatorLike | undefined {
+	return (navigator as unknown as { serial?: SerialNavigatorLike }).serial;
+}
+
+function formatHexId(value: number | undefined, fallback: string): string {
+	if (value === undefined) {
+		return fallback;
+	}
+
+	return `0x${value.toString(16).padStart(4, '0')}`;
+}
+
+function formatPortName(port: SerialPortLike, fallback: string): string {
+	const info = port.getInfo?.();
+	if (!info) {
+		return `Serial port ${fallback}`;
+	}
+
+	const vendor = formatHexId(info.usbVendorId, 'unknown');
+	const product = formatHexId(info.usbProductId, 'unknown');
+
+	return `USB ${vendor}:${product}`;
+}
+
+function getPortIndex(port: SerialPortLike, registry: SerialPortRegistry): string {
+	let index = registry.indexesByPort.get(port);
+	if (index === undefined) {
+		index = registry.nextIndex++;
+		registry.indexesByPort.set(port, index);
+	}
+
+	return String(index);
+}
+
+function createSerialInfo(ports: SerialPortLike[], registry: SerialPortRegistry): InfoRecord {
+	registry.portsByIndex.clear();
+
+	const info: InfoRecord = {};
+	for (const port of ports) {
+		const index = getPortIndex(port, registry);
+		info[index] = formatPortName(port, index);
+		registry.portsByIndex.set(index, port);
+	}
+
+	return info;
+}
+
+export default function createSerialDeviceManager({
+	store,
+	navigator,
+	onPortsChanged,
+}: SerialDevicesOptions): SerialDeviceManager {
+	const serial = getSerialNavigator(navigator);
+	const registry: SerialPortRegistry = {
+		portsByIndex: new Map(),
+		indexesByPort: new WeakMap(),
+		nextIndex: 0,
+	};
+	let disposed = false;
+	let refreshGeneration = 0;
+
+	function setSerialInfo(info: InfoRecord | undefined): void {
+		store.set('info.serial', info);
+	}
+
+	function refreshPorts(): void {
+		if (disposed || typeof serial?.getPorts !== 'function') {
+			return;
+		}
+
+		const generation = ++refreshGeneration;
+		void serial
+			.getPorts()
+			.then(ports => {
+				if (disposed || generation !== refreshGeneration) {
+					return;
+				}
+
+				setSerialInfo(createSerialInfo(ports, registry));
+				onPortsChanged?.();
+			})
+			.catch(() => {
+				if (disposed || generation !== refreshGeneration) {
+					return;
+				}
+
+				registry.portsByIndex.clear();
+				setSerialInfo({});
+				onPortsChanged?.();
+			});
+	}
+
+	if (typeof serial?.getPorts !== 'function') {
+		setSerialInfo({});
+		return {
+			getPort: () => undefined,
+			dispose: () => {
+				disposed = true;
+				setSerialInfo(undefined);
+				onPortsChanged?.();
+			},
+		};
+	}
+
+	const handlePortChange = () => refreshPorts();
+	serial.addEventListener?.('connect', handlePortChange);
+	serial.addEventListener?.('disconnect', handlePortChange);
+
+	setSerialInfo({});
+	refreshPorts();
+
+	return {
+		getPort: port => registry.portsByIndex.get(port),
+		dispose: () => {
+			disposed = true;
+			refreshGeneration++;
+			serial.removeEventListener?.('connect', handlePortChange);
+			serial.removeEventListener?.('disconnect', handlePortChange);
+			registry.portsByIndex.clear();
+			setSerialInfo(undefined);
+			onPortsChanged?.();
+		},
+	};
+}

--- a/packages/editor/src/editorEnvironmentPlugins/serial/directives.test.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/serial/directives.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest';
+
+import parseSerialDirectives from './directives';
+
+import type { CodeBlockGraphicData, ParsedDirectiveRecord, State } from '@8f4e/editor-state-types';
+
+function directive(name: string, args: string[], rawRow = 0): ParsedDirectiveRecord {
+	return {
+		prefix: '@',
+		name,
+		args,
+		rawRow,
+		sourceLine: `; @${name} ${args.join(' ')}`,
+		isTrailing: false,
+	};
+}
+
+function codeBlock(id: string, directives: ParsedDirectiveRecord[]): CodeBlockGraphicData {
+	return {
+		id,
+		moduleId: id,
+		blockType: 'module',
+		parsedDirectives: directives,
+	} as unknown as CodeBlockGraphicData;
+}
+
+function stateWithBlocks(blocks: CodeBlockGraphicData[]): State {
+	return {
+		graphicHelper: {
+			codeBlocks: blocks,
+		},
+	} as unknown as State;
+}
+
+describe('parseSerialDirectives', () => {
+	it('parses one serial pipeline with multiple callbacks', () => {
+		const result = parseSerialDirectives(
+			stateWithBlocks([
+				codeBlock('foo', [
+					directive('serialIn', ['0', '115200', 'serialBuffer', '32'], 1),
+					directive('serialInCallback', ['0', 'onSerialFrame'], 2),
+					directive('serialInCallback', ['0', 'onSerialDebug'], 3),
+				]),
+			])
+		);
+
+		expect(result.errors).toEqual([]);
+		expect(result.pipelines).toEqual([
+			{
+				port: '0',
+				baudRate: 115200,
+				bufferMemoryId: 'serialBuffer',
+				frameBytes: 32,
+				lineNumber: 2,
+				codeBlockId: 'foo',
+				codeBlockType: 'module',
+				moduleId: 'foo',
+			},
+		]);
+		expect(result.callbacks).toEqual([
+			{
+				port: '0',
+				exportName: 'onSerialFrame',
+				lineNumber: 3,
+				codeBlockId: 'foo',
+				codeBlockType: 'module',
+			},
+			{
+				port: '0',
+				exportName: 'onSerialDebug',
+				lineNumber: 4,
+				codeBlockId: 'foo',
+				codeBlockType: 'module',
+			},
+		]);
+	});
+
+	it('reports malformed directives, duplicate pipelines, and duplicate callbacks', () => {
+		const result = parseSerialDirectives(
+			stateWithBlocks([
+				codeBlock('foo', [
+					directive('serialIn', ['0', '115200', 'serialBuffer'], 0),
+					directive('serialIn', ['0', '115200', 'serialBuffer', '32'], 1),
+					directive('serialIn', ['0', '9600', 'otherBuffer', '16'], 2),
+					directive('serialInCallback', ['0', 'onSerialFrame'], 3),
+					directive('serialInCallback', ['0', 'onSerialFrame'], 4),
+					directive('serialInCallback', ['0'], 5),
+				]),
+			])
+		);
+
+		expect(result.pipelines).toEqual([
+			expect.objectContaining({
+				port: '0',
+				baudRate: 115200,
+				bufferMemoryId: 'serialBuffer',
+				frameBytes: 32,
+			}),
+		]);
+		expect(result.callbacks).toEqual([
+			expect.objectContaining({
+				port: '0',
+				exportName: 'onSerialFrame',
+			}),
+		]);
+		expect(result.errors.map(error => error.message)).toEqual([
+			'@serialIn requires <port> <baudRate> <bufferMemoryId> <frameBytes>.',
+			'Duplicate @serialIn binding for port "0".',
+			'Duplicate @serialInCallback binding for port "0" and callback "onSerialFrame".',
+			'@serialInCallback requires <port> <callbackExportName>.',
+		]);
+	});
+
+	it('reports callbacks that do not have a matching input pipeline', () => {
+		const result = parseSerialDirectives(
+			stateWithBlocks([codeBlock('foo', [directive('serialInCallback', ['1', 'onSerialFrame'], 0)])])
+		);
+
+		expect(result.pipelines).toEqual([]);
+		expect(result.callbacks).toEqual([
+			expect.objectContaining({
+				port: '1',
+				exportName: 'onSerialFrame',
+			}),
+		]);
+		expect(result.errors.map(error => error.message)).toEqual([
+			'@serialInCallback references port "1" without a matching @serialIn directive.',
+		]);
+	});
+});

--- a/packages/editor/src/editorEnvironmentPlugins/serial/directives.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/serial/directives.ts
@@ -1,0 +1,144 @@
+import { compilerSourceBlockTypes } from '@8f4e/compiler-spec';
+
+import { getActiveCodeBlocksForEnvironmentPlugins } from '../codeBlocks';
+
+import type { CodeBlockGraphicData, CodeError, State } from '@8f4e/editor-state-types';
+import type { CompilerSourceBlockType } from '@8f4e/compiler-spec';
+import type { SerialInCallbackBinding, SerialInPipeline } from './types';
+
+const diagnosticBlockTypes = new Set<string>(compilerSourceBlockTypes);
+
+function isDiagnosticBlockType(blockType: string): blockType is CompilerSourceBlockType {
+	return diagnosticBlockTypes.has(blockType);
+}
+
+export interface SerialDirectiveParseResult {
+	pipelines: SerialInPipeline[];
+	callbacks: SerialInCallbackBinding[];
+	errors: CodeError[];
+}
+
+function getCodeBlockType(block: CodeBlockGraphicData): CodeError['codeBlockType'] | undefined {
+	if (isDiagnosticBlockType(block.blockType)) {
+		return block.blockType;
+	}
+
+	return undefined;
+}
+
+function createDirectiveError(block: CodeBlockGraphicData, rawRow: number, message: string): CodeError {
+	return {
+		codeBlockId: block.id,
+		codeBlockType: getCodeBlockType(block),
+		lineNumber: rawRow + 1,
+		message,
+	};
+}
+
+function parsePositiveInteger(value: string | undefined): number | undefined {
+	if (!value || !/^\d+$/.test(value)) {
+		return undefined;
+	}
+
+	const parsed = Number(value);
+	if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+		return undefined;
+	}
+
+	return parsed;
+}
+
+export default function parseSerialDirectives(state: State): SerialDirectiveParseResult {
+	const pipelines: SerialInPipeline[] = [];
+	const callbacks: SerialInCallbackBinding[] = [];
+	const errors: CodeError[] = [];
+	const pipelinePorts = new Set<string>();
+	const callbackKeys = new Set<string>();
+
+	for (const block of getActiveCodeBlocksForEnvironmentPlugins(state)) {
+		for (const directive of block.parsedDirectives ?? []) {
+			if (directive.prefix !== '@') {
+				continue;
+			}
+
+			if (directive.name === 'serialIn') {
+				const [port, baudRateArg, bufferMemoryId, frameBytesArg, extraArg] = directive.args;
+				const baudRate = parsePositiveInteger(baudRateArg);
+				const frameBytes = parsePositiveInteger(frameBytesArg);
+				if (!port || !baudRate || !bufferMemoryId || !frameBytes || extraArg) {
+					errors.push(
+						createDirectiveError(
+							block,
+							directive.rawRow,
+							'@serialIn requires <port> <baudRate> <bufferMemoryId> <frameBytes>.'
+						)
+					);
+					continue;
+				}
+
+				if (pipelinePorts.has(port)) {
+					errors.push(createDirectiveError(block, directive.rawRow, `Duplicate @serialIn binding for port "${port}".`));
+					continue;
+				}
+
+				pipelinePorts.add(port);
+				pipelines.push({
+					port,
+					baudRate,
+					bufferMemoryId,
+					frameBytes,
+					lineNumber: directive.rawRow + 1,
+					codeBlockId: block.id,
+					codeBlockType: getCodeBlockType(block),
+					moduleId: block.moduleId,
+				});
+				continue;
+			}
+
+			if (directive.name === 'serialInCallback') {
+				const [port, exportName, extraArg] = directive.args;
+				if (!port || !exportName || extraArg) {
+					errors.push(
+						createDirectiveError(block, directive.rawRow, '@serialInCallback requires <port> <callbackExportName>.')
+					);
+					continue;
+				}
+
+				const callbackKey = `${port}\u0000${exportName}`;
+				if (callbackKeys.has(callbackKey)) {
+					errors.push(
+						createDirectiveError(
+							block,
+							directive.rawRow,
+							`Duplicate @serialInCallback binding for port "${port}" and callback "${exportName}".`
+						)
+					);
+					continue;
+				}
+
+				callbackKeys.add(callbackKey);
+				callbacks.push({
+					port,
+					exportName,
+					lineNumber: directive.rawRow + 1,
+					codeBlockId: block.id,
+					codeBlockType: getCodeBlockType(block),
+				});
+			}
+		}
+	}
+
+	const validPorts = new Set(pipelines.map(pipeline => pipeline.port));
+	for (const callback of callbacks) {
+		if (!validPorts.has(callback.port)) {
+			errors.push({
+				codeBlockId: callback.codeBlockId,
+				codeBlockType: callback.codeBlockType,
+				lineNumber: callback.lineNumber,
+				message: `@serialInCallback references port "${callback.port}" without a matching @serialIn directive.`,
+			});
+		}
+	}
+
+	return { pipelines, callbacks, errors };
+}

--- a/packages/editor/src/editorEnvironmentPlugins/serial/plugin.test.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/serial/plugin.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import createStateManager from '@8f4e/state-manager';
+
+import serialPlugin from './plugin';
+
+import type { State } from '@8f4e/editor-state-types';
+import type { MemoryViews } from '@8f4e/web-ui';
+import type { EditorEnvironmentPluginContext } from '../types';
+
+function createContext(): EditorEnvironmentPluginContext {
+	return {
+		store: createStateManager({
+			info: {},
+			graphicHelper: {
+				codeBlocks: [],
+			},
+			compiler: {
+				isCompiling: false,
+				compiledModules: {},
+			},
+		} as unknown as State),
+		events: {} as never,
+		window: {} as Window,
+		navigator: {} as Navigator,
+		memoryViews: { uint8: new Uint8Array(16) } as MemoryViews,
+		services: {
+			getWasmExports: vi.fn(),
+		},
+		setErrors: vi.fn(),
+	};
+}
+
+describe('serialPlugin', () => {
+	it('cleans up serial info and plugin-owned errors', () => {
+		const context = createContext();
+		const cleanup = serialPlugin(context);
+
+		expect(context.store.getState().info.serial).toEqual({});
+
+		cleanup();
+
+		expect(context.store.getState().info.serial).toBeUndefined();
+		expect(context.setErrors).toHaveBeenLastCalledWith([]);
+	});
+});

--- a/packages/editor/src/editorEnvironmentPlugins/serial/plugin.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/serial/plugin.ts
@@ -1,0 +1,34 @@
+import createSerialDeviceManager from './devices';
+import createSerialIn from './serialIn';
+
+import type { EditorEnvironmentPluginContext } from '../types';
+
+export default function serialPlugin({
+	store,
+	navigator,
+	memoryViews,
+	setErrors,
+	services,
+}: EditorEnvironmentPluginContext): () => void {
+	let syncSerialIn = () => {};
+	const devices = createSerialDeviceManager({
+		store,
+		navigator,
+		onPortsChanged: () => syncSerialIn(),
+	});
+	const serialIn = createSerialIn({
+		store,
+		memoryViews,
+		setErrors,
+		getPort: devices.getPort,
+		getWasmExports: services.getWasmExports,
+	});
+
+	syncSerialIn = serialIn.sync;
+
+	return () => {
+		serialIn.dispose();
+		devices.dispose();
+		setErrors([]);
+	};
+}

--- a/packages/editor/src/editorEnvironmentPlugins/serial/serialIn.test.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/serial/serialIn.test.ts
@@ -1,0 +1,301 @@
+import { describe, expect, it, vi } from 'vitest';
+import createStateManager from '@8f4e/state-manager';
+
+import createSerialIn from './serialIn';
+
+import type { CodeBlockGraphicData, ParsedDirectiveRecord, State } from '@8f4e/editor-state-types';
+import type { MemoryViews } from '@8f4e/web-ui';
+import type { DataStructure } from '@8f4e/compiler-spec';
+import type { EditorEnvironmentPluginContext } from '../types';
+import type { SerialPortLike } from './types';
+
+interface SerialPortMock extends SerialPortLike {
+	close: ReturnType<typeof vi.fn>;
+	enqueue: (data: number[]) => void;
+}
+
+function directive(name: string, args: string[], rawRow = 0): ParsedDirectiveRecord {
+	return {
+		prefix: '@',
+		name,
+		args,
+		rawRow,
+		sourceLine: `; @${name} ${args.join(' ')}`,
+		isTrailing: false,
+	};
+}
+
+function codeBlock(id: string, directives: ParsedDirectiveRecord[]): CodeBlockGraphicData {
+	return {
+		id,
+		moduleId: id,
+		blockType: 'module',
+		parsedDirectives: directives,
+	} as unknown as CodeBlockGraphicData;
+}
+
+function createMemory(byteAddress = 8): DataStructure {
+	return {
+		id: 'serialBuffer',
+		type: 'int8*',
+		numberOfElements: 16,
+		elementWordSize: 1,
+		byteAddress,
+		wordAlignedAddress: byteAddress / 4,
+		wordAlignedSize: 4,
+		default: 0,
+		isInteger: true,
+		isPointingToPointer: false,
+		isUnsigned: false,
+	} as DataStructure;
+}
+
+function createStore(blocks: CodeBlockGraphicData[]) {
+	return createStateManager({
+		graphicHelper: {
+			codeBlocks: blocks,
+		},
+		compiler: {
+			isCompiling: false,
+			compiledModules: {
+				foo: {
+					memoryMap: {
+						serialBuffer: createMemory(),
+					},
+				},
+			},
+		},
+	} as unknown as State);
+}
+
+function createMemoryViews(): MemoryViews {
+	return {
+		uint8: new Uint8Array(64),
+		int8: new Int8Array(64),
+		int16: new Int16Array(32),
+		uint16: new Uint16Array(32),
+		int32: new Int32Array(16),
+		float32: new Float32Array(16),
+		float64: new Float64Array(8),
+	};
+}
+
+function createSerialPortMock(): SerialPortMock {
+	let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+	const stream = new ReadableStream<Uint8Array>({
+		start: activeController => {
+			controller = activeController;
+		},
+		cancel: () => {},
+	});
+
+	return {
+		readable: stream,
+		open: vi.fn(async () => {}),
+		close: vi.fn(async () => {}),
+		enqueue: (data: number[]) => {
+			controller?.enqueue(new Uint8Array(data));
+		},
+	};
+}
+
+async function flushPromises(): Promise<void> {
+	for (let index = 0; index < 8; index++) {
+		await Promise.resolve();
+	}
+}
+
+function createGetWasmExports(
+	exports: Record<string, (ptr: number, length: number) => unknown>
+): EditorEnvironmentPluginContext['services']['getWasmExports'] {
+	return vi.fn(async () => ({
+		getExports: vi.fn(async () => exports as WebAssembly.Exports),
+		invalidate: vi.fn(),
+	}));
+}
+
+describe('createSerialIn', () => {
+	it('frames arbitrary serial chunks and fans completed frames out to callbacks', async () => {
+		const onSerialFrame = vi.fn();
+		const onSerialDebug = vi.fn();
+		const port = createSerialPortMock();
+		const memoryViews = createMemoryViews();
+		const setErrors = vi.fn();
+		const store = createStore([
+			codeBlock('foo', [
+				directive('serialIn', ['0', '115200', 'serialBuffer', '4']),
+				directive('serialInCallback', ['0', 'onSerialFrame']),
+				directive('serialInCallback', ['0', 'onSerialDebug']),
+			]),
+		]);
+
+		const manager = createSerialIn({
+			store,
+			memoryViews,
+			setErrors,
+			getPort: portIndex => (portIndex === '0' ? port : undefined),
+			getWasmExports: createGetWasmExports({
+				onSerialFrame,
+				onSerialDebug,
+			}),
+		});
+
+		await flushPromises();
+		port.enqueue([1, 2]);
+		await flushPromises();
+		expect(onSerialFrame).not.toHaveBeenCalled();
+
+		port.enqueue([3, 4, 5, 6, 7]);
+		await flushPromises();
+
+		expect(port.open).toHaveBeenCalledWith({ baudRate: 115200 });
+		expect(memoryViews.uint8.slice(8, 12)).toEqual(new Uint8Array([1, 2, 3, 4]));
+		expect(onSerialFrame).toHaveBeenCalledWith(8, 4);
+		expect(onSerialDebug).toHaveBeenCalledWith(8, 4);
+		expect(setErrors).toHaveBeenLastCalledWith([]);
+
+		port.enqueue([8]);
+		await flushPromises();
+
+		expect(memoryViews.uint8.slice(8, 12)).toEqual(new Uint8Array([5, 6, 7, 8]));
+		expect(onSerialFrame).toHaveBeenCalledTimes(2);
+
+		manager.dispose();
+	});
+
+	it('reports missing ports, missing buffers, and missing callback exports', async () => {
+		const setErrors = vi.fn();
+		const port = createSerialPortMock();
+		const store = createStore([
+			codeBlock('foo', [
+				directive('serialIn', ['0', '115200', 'missingBuffer', '4']),
+				directive('serialInCallback', ['0', 'missingExport']),
+				directive('serialIn', ['1', '115200', 'serialBuffer', '4']),
+				directive('serialInCallback', ['1', 'onSerialFrame']),
+			]),
+		]);
+
+		const manager = createSerialIn({
+			store,
+			memoryViews: createMemoryViews(),
+			setErrors,
+			getPort: portIndex => (portIndex === '0' ? port : undefined),
+			getWasmExports: createGetWasmExports({
+				onSerialFrame: vi.fn(),
+			}),
+		});
+
+		await flushPromises();
+
+		expect(setErrors).toHaveBeenLastCalledWith(
+			expect.arrayContaining([
+				expect.objectContaining({
+					message: 'Missing callable WebAssembly export for @serialInCallback "missingExport".',
+				}),
+				expect.objectContaining({
+					message: 'Serial input buffer "missingBuffer" is not available.',
+				}),
+				expect.objectContaining({
+					message: 'Serial input port "1" is not available.',
+				}),
+			])
+		);
+
+		manager.dispose();
+	});
+
+	it('clears queued partial frames when serial input resyncs', async () => {
+		const onSerialFrame = vi.fn();
+		const firstPort = createSerialPortMock();
+		const secondPort = createSerialPortMock();
+		let activePort = firstPort;
+		const memoryViews = createMemoryViews();
+		const store = createStore([
+			codeBlock('foo', [
+				directive('serialIn', ['0', '115200', 'serialBuffer', '4']),
+				directive('serialInCallback', ['0', 'onSerialFrame']),
+			]),
+		]);
+
+		const manager = createSerialIn({
+			store,
+			memoryViews,
+			setErrors: vi.fn(),
+			getPort: () => activePort,
+			getWasmExports: createGetWasmExports({
+				onSerialFrame,
+			}),
+		});
+
+		await flushPromises();
+		firstPort.enqueue([1, 2]);
+		await flushPromises();
+		expect(onSerialFrame).not.toHaveBeenCalled();
+
+		activePort = secondPort;
+		store.set('compiler.compiledModules', {
+			foo: {
+				memoryMap: {
+					serialBuffer: createMemory(),
+				},
+			},
+		});
+		await flushPromises();
+
+		secondPort.enqueue([3, 4]);
+		await flushPromises();
+		expect(onSerialFrame).not.toHaveBeenCalled();
+
+		secondPort.enqueue([5, 6]);
+		await flushPromises();
+
+		expect(firstPort.close).toHaveBeenCalled();
+		expect(memoryViews.uint8.slice(8, 12)).toEqual(new Uint8Array([3, 4, 5, 6]));
+		expect(onSerialFrame).toHaveBeenCalledTimes(1);
+
+		manager.dispose();
+	});
+
+	it('continues calling later callbacks when one callback throws', async () => {
+		const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+		const broken = vi.fn(() => {
+			throw new Error('nope');
+		});
+		const later = vi.fn();
+		const setErrors = vi.fn();
+		const port = createSerialPortMock();
+		const store = createStore([
+			codeBlock('foo', [
+				directive('serialIn', ['0', '115200', 'serialBuffer', '2']),
+				directive('serialInCallback', ['0', 'broken']),
+				directive('serialInCallback', ['0', 'later']),
+			]),
+		]);
+
+		const manager = createSerialIn({
+			store,
+			memoryViews: createMemoryViews(),
+			setErrors,
+			getPort: () => port,
+			getWasmExports: createGetWasmExports({
+				broken,
+				later,
+			}),
+		});
+
+		await flushPromises();
+		port.enqueue([1, 2]);
+		await flushPromises();
+
+		expect(broken).toHaveBeenCalledWith(8, 2);
+		expect(later).toHaveBeenCalledWith(8, 2);
+		expect(setErrors).toHaveBeenLastCalledWith([
+			expect.objectContaining({
+				message: 'Serial input callback "broken" failed.',
+			}),
+		]);
+
+		manager.dispose();
+		consoleError.mockRestore();
+	});
+});

--- a/packages/editor/src/editorEnvironmentPlugins/serial/serialIn.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/serial/serialIn.ts
@@ -1,0 +1,386 @@
+import parseSerialDirectives from './directives';
+
+import type { CodeError, State } from '@8f4e/editor-state-types';
+import type { StateManager } from '@8f4e/state-manager';
+import type { MemoryViews } from '@8f4e/web-ui';
+import type { EditorEnvironmentPluginContext } from '../types';
+import type { SerialInCallbackBinding, SerialInPipeline, SerialPortLike, SerialPortLookup } from './types';
+
+type SerialCallback = (ptr: number, length: number) => unknown;
+
+interface SerialBufferTarget {
+	byteAddress: number;
+}
+
+interface ResolvedSerialPipeline {
+	pipeline: SerialInPipeline;
+	port: SerialPortLike;
+	buffer: SerialBufferTarget;
+	callbacks: Array<{
+		binding: SerialInCallbackBinding;
+		callback: SerialCallback;
+	}>;
+}
+
+interface ActiveSerialReader {
+	port: SerialPortLike;
+	reader?: ReadableStreamDefaultReader<Uint8Array>;
+	active: boolean;
+}
+
+interface SerialInOptions {
+	store: StateManager<State>;
+	memoryViews: MemoryViews;
+	setErrors: EditorEnvironmentPluginContext['setErrors'];
+	getPort: SerialPortLookup;
+	getWasmExports: EditorEnvironmentPluginContext['services']['getWasmExports'];
+}
+
+export interface SerialInManager {
+	sync: () => void;
+	dispose: () => void;
+}
+
+function createPipelineError(pipeline: SerialInPipeline, message: string): CodeError {
+	return {
+		codeBlockId: pipeline.codeBlockId,
+		codeBlockType: pipeline.codeBlockType,
+		lineNumber: pipeline.lineNumber,
+		message,
+	};
+}
+
+function createCallbackError(binding: SerialInCallbackBinding, message: string): CodeError {
+	return {
+		codeBlockId: binding.codeBlockId,
+		codeBlockType: binding.codeBlockType,
+		lineNumber: binding.lineNumber,
+		message,
+	};
+}
+
+function resolveBufferMemoryId(pipeline: SerialInPipeline): string | undefined {
+	if (pipeline.bufferMemoryId.includes(':')) {
+		return pipeline.bufferMemoryId;
+	}
+
+	if (!pipeline.moduleId) {
+		return undefined;
+	}
+
+	return `${pipeline.moduleId}:${pipeline.bufferMemoryId}`;
+}
+
+function resolveBufferTarget(state: State, pipeline: SerialInPipeline): SerialBufferTarget | undefined {
+	const memoryId = resolveBufferMemoryId(pipeline);
+	if (!memoryId) {
+		return undefined;
+	}
+
+	const [moduleId, memoryName] = memoryId.split(':');
+	if (!moduleId || !memoryName) {
+		return undefined;
+	}
+
+	const memory = state.compiler.compiledModules[moduleId]?.memoryMap[memoryName];
+	if (!memory) {
+		return undefined;
+	}
+
+	return { byteAddress: memory.byteAddress };
+}
+
+function stopSerialReaders(activeReaders: ActiveSerialReader[]): Promise<void> {
+	const readers = activeReaders.splice(0, activeReaders.length);
+	return Promise.all(
+		readers.map(async activeReader => {
+			activeReader.active = false;
+			try {
+				await activeReader.reader?.cancel();
+			} catch {
+				// The reader may already be closed after a disconnect.
+			}
+
+			try {
+				activeReader.reader?.releaseLock();
+			} catch {
+				// The lock may already be released by the browser.
+			}
+
+			try {
+				await activeReader.port.close?.();
+			} catch {
+				// Closing an already-closed serial port is harmless for cleanup.
+			}
+		})
+	).then(() => undefined);
+}
+
+function groupCallbacksByPort(
+	callbacks: SerialInCallbackBinding[],
+	exports: WebAssembly.Exports
+): {
+	callbacksByPort: Map<string, Array<{ binding: SerialInCallbackBinding; callback: SerialCallback }>>;
+	errors: CodeError[];
+} {
+	const callbacksByPort = new Map<string, Array<{ binding: SerialInCallbackBinding; callback: SerialCallback }>>();
+	const errors: CodeError[] = [];
+
+	for (const binding of callbacks) {
+		const callback = exports[binding.exportName];
+		if (typeof callback !== 'function') {
+			errors.push(
+				createCallbackError(
+					binding,
+					`Missing callable WebAssembly export for @serialInCallback "${binding.exportName}".`
+				)
+			);
+			continue;
+		}
+
+		const portCallbacks = callbacksByPort.get(binding.port) ?? [];
+		portCallbacks.push({ binding, callback: callback as SerialCallback });
+		callbacksByPort.set(binding.port, portCallbacks);
+	}
+
+	return { callbacksByPort, errors };
+}
+
+function resolvePipelines({
+	state,
+	pipelines,
+	callbacksByPort,
+	getPort,
+}: {
+	state: State;
+	pipelines: SerialInPipeline[];
+	callbacksByPort: Map<string, Array<{ binding: SerialInCallbackBinding; callback: SerialCallback }>>;
+	getPort: SerialPortLookup;
+}): { resolvedPipelines: ResolvedSerialPipeline[]; errors: CodeError[] } {
+	const resolvedPipelines: ResolvedSerialPipeline[] = [];
+	const errors: CodeError[] = [];
+
+	for (const pipeline of pipelines) {
+		const callbacks = callbacksByPort.get(pipeline.port) ?? [];
+		const port = getPort(pipeline.port);
+		if (!port) {
+			errors.push(createPipelineError(pipeline, `Serial input port "${pipeline.port}" is not available.`));
+			continue;
+		}
+
+		const buffer = resolveBufferTarget(state, pipeline);
+		if (!buffer) {
+			errors.push(createPipelineError(pipeline, `Serial input buffer "${pipeline.bufferMemoryId}" is not available.`));
+			continue;
+		}
+
+		if (callbacks.length > 0) {
+			resolvedPipelines.push({ pipeline, port, buffer, callbacks });
+		}
+	}
+
+	return { resolvedPipelines, errors };
+}
+
+function processSerialChunk({
+	chunk,
+	queue,
+	resolvedPipeline,
+	memoryViews,
+	baseErrors,
+	setErrors,
+}: {
+	chunk: Uint8Array;
+	queue: number[];
+	resolvedPipeline: ResolvedSerialPipeline;
+	memoryViews: MemoryViews;
+	baseErrors: CodeError[];
+	setErrors: EditorEnvironmentPluginContext['setErrors'];
+}): void {
+	queue.push(...chunk);
+
+	while (queue.length >= resolvedPipeline.pipeline.frameBytes) {
+		const frame = queue.splice(0, resolvedPipeline.pipeline.frameBytes);
+		memoryViews.uint8.set(frame, resolvedPipeline.buffer.byteAddress);
+		const callbackErrors: CodeError[] = [];
+
+		for (const { binding, callback } of resolvedPipeline.callbacks) {
+			try {
+				callback(resolvedPipeline.buffer.byteAddress, resolvedPipeline.pipeline.frameBytes);
+			} catch (error) {
+				console.error('Serial input callback failed:', error);
+				callbackErrors.push(createCallbackError(binding, `Serial input callback "${binding.exportName}" failed.`));
+			}
+		}
+
+		if (callbackErrors.length > 0) {
+			setErrors([...baseErrors, ...callbackErrors]);
+		}
+	}
+}
+
+function startSerialReader({
+	resolvedPipeline,
+	memoryViews,
+	activeReaders,
+	baseErrors,
+	setErrors,
+	onReadFailure,
+}: {
+	resolvedPipeline: ResolvedSerialPipeline;
+	memoryViews: MemoryViews;
+	activeReaders: ActiveSerialReader[];
+	baseErrors: CodeError[];
+	setErrors: EditorEnvironmentPluginContext['setErrors'];
+	onReadFailure: (pipeline: SerialInPipeline) => void;
+}): void {
+	const activeReader: ActiveSerialReader = { port: resolvedPipeline.port, active: true };
+	activeReaders.push(activeReader);
+	const queue: number[] = [];
+
+	void (async () => {
+		try {
+			await resolvedPipeline.port.open({ baudRate: resolvedPipeline.pipeline.baudRate });
+			const reader = resolvedPipeline.port.readable?.getReader();
+			if (!reader) {
+				throw new Error('Serial port did not expose a readable stream.');
+			}
+
+			activeReader.reader = reader;
+
+			while (activeReader.active) {
+				const { value, done } = await reader.read();
+				if (done) {
+					break;
+				}
+
+				if (value && value.length > 0) {
+					processSerialChunk({
+						chunk: value,
+						queue,
+						resolvedPipeline,
+						memoryViews,
+						baseErrors,
+						setErrors,
+					});
+				}
+			}
+		} catch (error) {
+			if (!activeReader.active) {
+				return;
+			}
+
+			console.error('Serial input reader failed:', error);
+			queue.length = 0;
+			onReadFailure(resolvedPipeline.pipeline);
+		}
+	})();
+}
+
+export default function createSerialIn({
+	store,
+	memoryViews,
+	setErrors,
+	getPort,
+	getWasmExports,
+}: SerialInOptions): SerialInManager {
+	const activeReaders: ActiveSerialReader[] = [];
+	let disposed = false;
+	let syncGeneration = 0;
+
+	function sync(): void {
+		if (disposed) {
+			return;
+		}
+
+		const generation = ++syncGeneration;
+		const cleanupPromise = stopSerialReaders(activeReaders);
+
+		const state = store.getState();
+		if (state.compiler.isCompiling) {
+			setErrors([]);
+			return;
+		}
+
+		const parsed = parseSerialDirectives(state);
+		const errors: CodeError[] = [...parsed.errors];
+
+		if (parsed.pipelines.length === 0 || parsed.callbacks.length === 0) {
+			setErrors(errors);
+			return;
+		}
+
+		void getWasmExports()
+			.then(wasmExports => wasmExports.getExports())
+			.then(async exports => {
+				await cleanupPromise;
+				if (disposed || generation !== syncGeneration) {
+					return;
+				}
+
+				if (!exports) {
+					setErrors(errors);
+					return;
+				}
+
+				const groupedCallbacks = groupCallbacksByPort(parsed.callbacks, exports);
+				errors.push(...groupedCallbacks.errors);
+				const resolved = resolvePipelines({
+					state: store.getState(),
+					pipelines: parsed.pipelines,
+					callbacksByPort: groupedCallbacks.callbacksByPort,
+					getPort,
+				});
+				errors.push(...resolved.errors);
+
+				for (const resolvedPipeline of resolved.resolvedPipelines) {
+					startSerialReader({
+						resolvedPipeline,
+						memoryViews,
+						activeReaders,
+						baseErrors: errors,
+						setErrors,
+						onReadFailure: pipeline => {
+							if (disposed || generation !== syncGeneration) {
+								return;
+							}
+
+							setErrors([
+								...errors,
+								createPipelineError(pipeline, `Serial input port "${pipeline.port}" is not available.`),
+							]);
+						},
+					});
+				}
+
+				setErrors(errors);
+			})
+			.catch(error => {
+				if (disposed || generation !== syncGeneration) {
+					return;
+				}
+
+				console.error('Failed to instantiate serial input WebAssembly module:', error);
+				setErrors(errors);
+			});
+	}
+
+	store.subscribe('graphicHelper.codeBlocks', sync);
+	store.subscribe('graphicHelper.selectedCodeBlock.code', sync);
+	store.subscribe('compiler.isCompiling', sync);
+	store.subscribe('compiler.compiledModules', sync);
+	sync();
+
+	return {
+		sync,
+		dispose: () => {
+			disposed = true;
+			syncGeneration++;
+			void stopSerialReaders(activeReaders);
+			store.unsubscribe('graphicHelper.codeBlocks', sync);
+			store.unsubscribe('graphicHelper.selectedCodeBlock.code', sync);
+			store.unsubscribe('compiler.isCompiling', sync);
+			store.unsubscribe('compiler.compiledModules', sync);
+		},
+	};
+}

--- a/packages/editor/src/editorEnvironmentPlugins/serial/types.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/serial/types.ts
@@ -1,0 +1,38 @@
+import type { CodeError } from '@8f4e/editor-state-types';
+
+export interface SerialPortLike {
+	readable?: ReadableStream<Uint8Array> | null;
+	open: (options: { baudRate: number }) => Promise<void>;
+	close?: () => Promise<void>;
+	getInfo?: () => {
+		usbVendorId?: number;
+		usbProductId?: number;
+	};
+}
+
+export interface SerialNavigatorLike {
+	getPorts: () => Promise<SerialPortLike[]>;
+	addEventListener?: (type: 'connect' | 'disconnect', listener: (event: Event) => void) => void;
+	removeEventListener?: (type: 'connect' | 'disconnect', listener: (event: Event) => void) => void;
+}
+
+export interface SerialInPipeline {
+	port: string;
+	baudRate: number;
+	bufferMemoryId: string;
+	frameBytes: number;
+	lineNumber: number;
+	codeBlockId: string | number;
+	codeBlockType?: CodeError['codeBlockType'];
+	moduleId?: string;
+}
+
+export interface SerialInCallbackBinding {
+	port: string;
+	exportName: string;
+	lineNumber: number;
+	codeBlockId: string | number;
+	codeBlockType?: CodeError['codeBlockType'];
+}
+
+export type SerialPortLookup = (port: string) => SerialPortLike | undefined;


### PR DESCRIPTION
## Summary
- add a lazy-loaded serial editor environment plugin with `@serialIn` and `@serialInCallback`
- list already-granted Web Serial ports through `@info serial`
- frame arbitrary serial stream chunks by fixed byte count, copy frames into Wasm memory, and fan out callbacks as `(ptr, length)`
- document the directives and archive the implementation TODO

## Validation
- `npx nx run editor:test`
- `npx nx run editor:typecheck`
- `npx nx run app:build`
- pre-commit: `npx nx run-many --target=typecheck --all`