### PR TITLE
fix(compiler): restrict directives to block prologue

### DIFF
--- a/docs/todos/402-restrict-compiler-directives-to-block-prologue.md
+++ b/docs/todos/402-restrict-compiler-directives-to-block-prologue.md
@@ -3,8 +3,8 @@ title: 'TODO: Restrict compiler directives to block prologue'
 priority: Medium
 effort: 2-4h
 created: 2026-05-19
-status: Open
-completed: null
+status: Completed
+completed: 2026-05-19
 ---
 
 # TODO: Restrict compiler directives to block prologue
@@ -79,4 +79,3 @@ Add compiler validation that treats compiler directives as source-block prologue
 - **Blocks**: `403-add-logical-memory-regions-for-multi-memory`
 - **Related**: `381-add-follow-module-layout-directive.md`
 - **Related**: `docs/brainstorming_notes/041-logical-memory-regions-for-multi-memory-runtimes.md`
-

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -58,7 +58,6 @@ Active todo files are listed below.
 | 398 | Add compiler peephole arithmetic strength reduction | 🟡 | 1-2 days | 2026-05-12 | The compiler now has compile-time folding and stack-level integer metadata, but runtime arithmetic codegen still emits direct WebAssembly arithmetic operations even when the top... |
 | 400 | Add serial input editor environment plugin | 🟡 | 1-2d | 2026-05-13 | Add a Web Serial editor environment plugin with `@info serial`, fixed-size `@serialIn` framing, and `@serialInCallback` fanout to exported 8f4e functions. |
 | 401 | Tighten runtime browser API typing | 🟡 | 2-4h | 2026-05-18 | Browser runtime packages cross platform-specific API boundaries and currently rely on broad `any` casts and `@ts-expect-error` comments in production runtime code. |
-| 402 | Restrict compiler directives to block prologue | 🟡 | 2-4h | 2026-05-19 | Compiler directives should be block prologue metadata, appearing directly after `module` or `function` before declarations or executable instructions. |
 | 403 | Add logical memory regions for multi-memory | 🟡 | 3-5d | 2026-05-19 | Add module-level logical memory regions that map declarations, address provenance, pointer dereference, and Wasm memory operations to the correct linear memory. |
 | 404 | Refactor address metadata into first-class shape | 🟡 | 1-2d | 2026-05-19 | Replace scattered stack address fields with `StackItem.address` so future memory-region tracking has one internal metadata shape to extend. |
 | 405 | Centralize memory access target selection | 🟡 | 4-8h | 2026-05-19 | Add a shared internal helper for memory operation target selection so future region support has one place to resolve memory indices. |
@@ -94,6 +93,7 @@ Active todo files are listed below.
 | 268 | Add float64 support for sqrt instruction | 2026-05-10 | `sqrt` now emits `F64_SQRT`, preserves float64 metadata, and no longer marks the result as always non-zero. |
 | 395 | Add exported 8f4e functions | 2026-05-10 | `#export <exportedName>` now exports user functions through the generated WebAssembly ABI with positional JS numeric arguments and duplicate-name validation. |
 | 396 | Add MIDI input editor environment plugin | 2026-05-11 | The editor MIDI plugin now lazy-loads from `@midiIn`, lists devices via `@info midi`, and forwards MIDI input bytes to exported 8f4e callbacks through a shared-memory Wasm instance. |
+| 402 | Restrict compiler directives to block prologue | 2026-05-19 | Compiler directives are now validated as module/function prologue metadata, with late directives rejected by a dedicated compiler diagnostic. |
 | 391 | Add compiler AST cache for incremental compiles | 2026-05-04 | `compile()` now returns and accepts an opaque AST cache for unchanged expanded module and function inputs. |
 | 329 | Replace literal-only const collection with semantic namespace prepass | 2026-03-27 | Replaced `collectConstants(ast)` bootstrap with semantic namespace prepass. |
 | 330 | Centralize compile-time folding as an AST normalization pass | 2026-03-27 | Compile-time folding now runs as a semantic normalization pass before codegen. |

--- a/packages/compiler-spec/src/errors.ts
+++ b/packages/compiler-spec/src/errors.ts
@@ -52,6 +52,7 @@ export const ErrorCode = {
 	ADDRESS_RANGE_TOO_SMALL: 50,
 	EXPORT_DIRECTIVE_INVALID_CONTEXT: 51,
 	DUPLICATE_EXPORT_NAME: 52,
+	COMPILER_DIRECTIVE_MUST_BE_PROLOGUE: 53,
 } as const;
 
 export type ErrorCodeValue = (typeof ErrorCode)[keyof typeof ErrorCode];

--- a/packages/compiler/docs/directives.md
+++ b/packages/compiler/docs/directives.md
@@ -2,6 +2,8 @@
 
 Compiler directives are special instructions prefixed with `#` that control compilation behavior without affecting runtime execution. They are processed during compilation and filtered out before code generation.
 
+Compiler directives are block prologue metadata. In a `module`, module-scoped directives must appear immediately after the `module` line and before declarations or executable instructions. In a `function`, function-scoped directives must appear immediately after the `function` line and before `param`, `local`, or executable instructions. Blank lines and comments are ignored by parsing, so they can still appear around prologue directives.
+
 ## Module-Scoped Directives
 
 ### `#skipExecution`
@@ -23,7 +25,7 @@ moduleEnd
 - The module is compiled normally (AST, memory map, inter-module references preserved)
 - Module memory defaults and initialization still run during the init/memory-init phase
 - The module's cycle function is not called from the global cycle dispatcher
-- Multiple `#skipExecution` directives in the same module are idempotent (same effect)
+- Multiple prologue `#skipExecution` directives in the same module are idempotent (same effect)
 
 **Use Cases:**
 - Temporarily disable a module during development without removing it
@@ -32,6 +34,7 @@ moduleEnd
 
 **Errors:**
 - Using `#skipExecution` outside of a module block (e.g., in `constants` or `function` blocks) will result in a `COMPILER_DIRECTIVE_INVALID_CONTEXT` error
+- Placing `#skipExecution` after a declaration or executable instruction will result in a `COMPILER_DIRECTIVE_MUST_BE_PROLOGUE` error
 
 **Example:**
 
@@ -87,7 +90,7 @@ moduleEnd
 - The module code does not run during the cycle loop
 - Memory declared in the module is initialized with default values before the module code runs
 - Incremental recompiles that patch default memory values rerun all init-only modules via the `initOnly` export; full `init` still runs on first compile or memory recreation
-- Multiple `#initOnly` directives in the same module have the same effect as one
+- Multiple prologue `#initOnly` directives in the same module have the same effect as one
 - If both `#skipExecution` and `#initOnly` are present, `#skipExecution` takes precedence (the module does not execute at all)
 
 **Use Cases:**
@@ -97,6 +100,7 @@ moduleEnd
 
 **Errors:**
 - Using `#initOnly` outside of a module block (e.g., in `constants` or `function` blocks) will result in a `COMPILER_DIRECTIVE_INVALID_CONTEXT` error
+- Placing `#initOnly` after a declaration or executable instruction will result in a `COMPILER_DIRECTIVE_MUST_BE_PROLOGUE` error
 
 **Example:**
 
@@ -180,10 +184,11 @@ functionEnd
 **Errors:**
 - Using `#impure` outside a function block results in an `IMPURE_DIRECTIVE_INVALID_CONTEXT` error
 - Using memory IO in a function without `#impure` results in an `IMPURE_DIRECTIVE_REQUIRED_FOR_MEMORY_IO` error
+- Placing `#impure` after params, locals, or executable instructions results in a `COMPILER_DIRECTIVE_MUST_BE_PROLOGUE` error
 
 ### `#loopCap`
 
-Sets the default loop cap for subsequent `loop` blocks in the current module or function block. The loop cap limits the maximum number of iterations to prevent infinite loops at runtime.
+Sets the default loop cap for `loop` blocks in the current module or function block. The loop cap limits the maximum number of iterations to prevent infinite loops at runtime.
 
 **Scope:** Module and function blocks
 
@@ -198,12 +203,11 @@ moduleEnd
 ```
 
 **Behavior:**
-- Sets the ambient loop cap for all `loop` instructions that follow in the same module or function body
-- Only affects `loop` instructions that appear after the directive (single-pass compilation)
+- Sets the ambient loop cap for `loop` instructions in the same module or function body
 - A per-loop explicit argument (`loop <int>`) takes precedence over the ambient `#loopCap`
 - When no `#loopCap` is present and no per-loop argument is given, the built-in default of `1000` applies
 - The cap value `0` is valid and causes the loop guard to exit immediately on the first guard check
-- Multiple `#loopCap` directives in the same block update the ambient default each time they appear
+- Multiple prologue `#loopCap` directives in the same block are allowed; the last prologue value becomes the ambient default
 
 **Precedence order (highest to lowest):**
 1. Explicit `loop <int>` argument
@@ -244,6 +248,7 @@ functionEnd
 
 **Errors:**
 - Using `#loopCap` outside of a module or function block (e.g., in `constants` blocks or at the top level before any `module`) will result in a `COMPILER_DIRECTIVE_INVALID_CONTEXT` error
+- Placing `#loopCap` after params, declarations, locals, or executable instructions will result in a `COMPILER_DIRECTIVE_MUST_BE_PROLOGUE` error
 - Providing a non-integer, float, or negative integer argument is a syntax error detected by the tokenizer
 
 ## Error Handling
@@ -253,3 +258,5 @@ If an unknown compiler directive is encountered, the compiler will throw an `UNR
 If a module-scoped directive like `#skipExecution` or `#initOnly` is used outside of a module block, the compiler will throw a `COMPILER_DIRECTIVE_INVALID_CONTEXT` error.
 
 If `#loopCap` is used outside of a module or function block, the compiler will throw a `COMPILER_DIRECTIVE_INVALID_CONTEXT` error.
+
+If a compiler directive appears after the block prologue has ended, the compiler will throw a `COMPILER_DIRECTIVE_MUST_BE_PROLOGUE` error.

--- a/packages/compiler/docs/instructions/blocks/function.md
+++ b/packages/compiler/docs/instructions/blocks/function.md
@@ -76,6 +76,8 @@ Argument mapping:
 Export names must be unique and must not reuse built-in exports such as `init`, `cycle`, `initOnly`, or `buffer`.
 Functions that read from or write to memory still need `#impure`.
 
+Function compiler directives are prologue metadata: place `#impure`, `#export`, and `#loopCap` directly after the `function` line and before params, locals, or executable instructions.
+
 ### Example Function
 
 ```

--- a/packages/compiler/docs/instructions/control-flow.md
+++ b/packages/compiler/docs/instructions/control-flow.md
@@ -131,7 +131,7 @@ ifEnd int
 
 The loop instruction begins a loop block. The loop body repeats until a branch exits the loop.
 
-An optional non-negative integer argument sets the cap for this loop's infinite-loop guard. When omitted, the effective cap is determined by the ambient `#loopCap` directive in the current block, or the built-in default of `1000` if no directive is active.
+An optional non-negative integer argument sets the cap for this loop's infinite-loop guard. When omitted, the effective cap is determined by the ambient prologue `#loopCap` directive in the current block, or the built-in default of `1000` if no directive is active.
 
 **Precedence:** explicit `loop <int>` > ambient `#loopCap` > built-in default `1000`
 
@@ -165,7 +165,7 @@ loop 32
 loopEnd
 ```
 
-Loop cap set for all subsequent loops via the `#loopCap` directive:
+Loop cap set for loops in the block via the `#loopCap` prologue directive:
 
 ```
 #loopCap 5000

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -12,6 +12,7 @@ import instructions from './instructionCompilers';
 import { getError } from './compilerError';
 import normalizeCompileTimeArguments from './semantic/normalizeCompileTimeArguments';
 import { applySemanticLine, prepassNamespace } from './semantic/buildNamespace';
+import { validateCompilerDirectivePrologue } from './semantic/compilerDirectives';
 import { validateInstruction } from './stackAnalysis/validateInstruction';
 import { functionValueTypeToWasmType } from './utils/functionValueType';
 
@@ -67,6 +68,8 @@ export function compileModule(
 	functions?: CompiledFunctionLookup,
 	internalAllocator = { nextByteAddress: 0 }
 ): CompiledModule {
+	validateCompilerDirectivePrologue(ast);
+
 	// Prepass establishes the memory layout (byte addresses, sizes) for this module.
 	// Semantic instructions (const, use, module/moduleEnd) are applied during
 	// the compilation loop below, so consts are not copied from the prepass context.
@@ -151,6 +154,8 @@ export function compileFunction(
 	typeRegistry: FunctionTypeRegistry,
 	functions?: CompiledFunctionLookup
 ): CompiledFunction {
+	validateCompilerDirectivePrologue(ast, 'function');
+
 	const context: CompilationContext = {
 		namespace: {
 			namespaces,

--- a/packages/compiler/src/compilerError.ts
+++ b/packages/compiler/src/compilerError.ts
@@ -305,6 +305,14 @@ export function getError(
 				line,
 				context,
 			};
+		case ErrorCode.COMPILER_DIRECTIVE_MUST_BE_PROLOGUE:
+			return {
+				code,
+				message:
+					'Compiler directives must appear in the block prologue, immediately after module or function. (' + code + ')',
+				line,
+				context,
+			};
 		case ErrorCode.MIXED_FLOAT_WIDTH:
 			return {
 				code,

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -29,6 +29,7 @@ import {
 	collectNamespacesFromASTs,
 	collectFunctionMetadataFromAsts,
 } from './semantic/buildNamespace';
+import { validateCompilerDirectivePrologue } from './semantic/compilerDirectives';
 import { EXPORTED_FUNCTION_COUNT, HEADER, VERSION } from './consts';
 import sortModules from './graphOptimizer';
 import { createInitialMemoryDataSegments } from './initialMemoryDataSegments';
@@ -162,6 +163,7 @@ export default function compile(
 	const astModules = expandedModules.map(({ code, lineMetadata }, index) =>
 		compileToAST(code, lineMetadata, cache.ast, `module:${index}`)
 	);
+	astModules.forEach(ast => validateCompilerDirectivePrologue(ast));
 	assertUniqueModuleIds(astModules);
 	const dependencyOrderedModules = sortModules(astModules);
 
@@ -171,6 +173,7 @@ export default function compile(
 	const astFunctions = expandedFunctions.map(({ code, lineMetadata }, index) =>
 		compileToAST(code, lineMetadata, cache.ast, `function:${index}`)
 	);
+	astFunctions.forEach(ast => validateCompilerDirectivePrologue(ast));
 
 	// Collect pre-codegen function metadata so `call` target validation and
 	// function-body codegen can rely on the same registry before compilation finishes.

--- a/packages/compiler/src/semantic/compilerDirectives.ts
+++ b/packages/compiler/src/semantic/compilerDirectives.ts
@@ -1,0 +1,49 @@
+import { compilerSourceBlockInstructionByType, ErrorCode } from '@8f4e/compiler-spec';
+
+import { getError } from '../compilerError';
+
+import type { AST, CompilerSourceBlockType } from '@8f4e/compiler-spec';
+
+const moduleBlock = compilerSourceBlockInstructionByType.module;
+const functionBlock = compilerSourceBlockInstructionByType.function;
+
+export const moduleCompilerDirectives = ['#skipExecution', '#initOnly', '#loopCap'] as const;
+export const functionCompilerDirectives = ['#impure', '#export', '#loopCap'] as const;
+
+const compilerDirectivesByBlockType = {
+	[moduleBlock.type]: new Set<string>(moduleCompilerDirectives),
+	[functionBlock.type]: new Set<string>(functionCompilerDirectives),
+} as const;
+
+function getAstBlockType(ast: AST): CompilerSourceBlockType | undefined {
+	const firstInstruction = ast[0]?.instruction;
+
+	if (firstInstruction === moduleBlock.start) {
+		return moduleBlock.type;
+	}
+	if (firstInstruction === functionBlock.start) {
+		return functionBlock.type;
+	}
+
+	return undefined;
+}
+
+export function validateCompilerDirectivePrologue(ast: AST, blockType = getAstBlockType(ast)): void {
+	if (blockType !== moduleBlock.type && blockType !== functionBlock.type) {
+		return;
+	}
+
+	const blockDirectives = compilerDirectivesByBlockType[blockType];
+	let prologueOpen = true;
+
+	for (const line of ast.slice(1)) {
+		if (blockDirectives.has(line.instruction)) {
+			if (!prologueOpen) {
+				throw getError(ErrorCode.COMPILER_DIRECTIVE_MUST_BE_PROLOGUE, line);
+			}
+			continue;
+		}
+
+		prologueOpen = false;
+	}
+}

--- a/packages/compiler/tests/__snapshots__/loopCap.test.ts.snap
+++ b/packages/compiler/tests/__snapshots__/loopCap.test.ts.snap
@@ -20,6 +20,20 @@ exports[`#loopCap changes the default cap for subsequent loops > if the generate
   {
     "arguments": [
       {
+        "isInteger": true,
+        "type": "literal",
+        "value": 500,
+      },
+    ],
+    "instruction": "#loopCap",
+    "isMemoryDeclaration": false,
+    "isSemanticOnly": false,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
+  },
+  {
+    "arguments": [
+      {
         "referenceKind": "plain",
         "scope": "local",
         "type": "identifier",
@@ -29,20 +43,6 @@ exports[`#loopCap changes the default cap for subsequent loops > if the generate
     "hasExplicitMemoryDefault": false,
     "instruction": "int",
     "isMemoryDeclaration": true,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 1,
-    "lineNumberBeforeMacroExpansion": 1,
-  },
-  {
-    "arguments": [
-      {
-        "isInteger": true,
-        "type": "literal",
-        "value": 500,
-      },
-    ],
-    "instruction": "#loopCap",
-    "isMemoryDeclaration": false,
     "isSemanticOnly": false,
     "lineNumberAfterMacroExpansion": 2,
     "lineNumberBeforeMacroExpansion": 2,
@@ -186,331 +186,6 @@ exports[`#loopCap changes the default cap for subsequent loops > if the generate
     "numberOfElements": 1,
     "type": "int",
     "wordAlignedAddress": 0,
-    "wordAlignedSize": 1,
-  },
-}
-`;
-
-exports[`#loopCap does not affect loops declared before it > if the generated AST, WAT and memory map match the snapshot 1`] = `
-[
-  {
-    "arguments": [
-      {
-        "referenceKind": "plain",
-        "scope": "local",
-        "type": "identifier",
-        "value": "loop",
-      },
-    ],
-    "instruction": "module",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": true,
-    "lineNumberAfterMacroExpansion": 0,
-    "lineNumberBeforeMacroExpansion": 0,
-  },
-  {
-    "arguments": [
-      {
-        "referenceKind": "plain",
-        "scope": "local",
-        "type": "identifier",
-        "value": "counter",
-      },
-    ],
-    "hasExplicitMemoryDefault": false,
-    "instruction": "int",
-    "isMemoryDeclaration": true,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 1,
-    "lineNumberBeforeMacroExpansion": 1,
-  },
-  {
-    "arguments": [
-      {
-        "referenceKind": "plain",
-        "scope": "local",
-        "type": "identifier",
-        "value": "counter2",
-      },
-    ],
-    "hasExplicitMemoryDefault": false,
-    "instruction": "int",
-    "isMemoryDeclaration": true,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
-  },
-  {
-    "arguments": [],
-    "instruction": "loop",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 4,
-    "lineNumberBeforeMacroExpansion": 4,
-  },
-  {
-    "arguments": [
-      {
-        "isInteger": true,
-        "safeAddressRange": {
-          "byteAddress": 0,
-          "memoryId": "counter",
-          "safeByteLength": 4,
-          "source": "memory-start",
-        },
-        "type": "literal",
-        "value": 0,
-      },
-    ],
-    "instruction": "push",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 5,
-    "lineNumberBeforeMacroExpansion": 5,
-  },
-  {
-    "arguments": [
-      {
-        "referenceKind": "plain",
-        "scope": "local",
-        "type": "identifier",
-        "value": "counter",
-      },
-    ],
-    "instruction": "push",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 6,
-    "lineNumberBeforeMacroExpansion": 6,
-  },
-  {
-    "arguments": [
-      {
-        "isInteger": true,
-        "type": "literal",
-        "value": 1,
-      },
-    ],
-    "instruction": "push",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 7,
-    "lineNumberBeforeMacroExpansion": 7,
-  },
-  {
-    "arguments": [],
-    "instruction": "add",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 8,
-    "lineNumberBeforeMacroExpansion": 8,
-  },
-  {
-    "arguments": [],
-    "instruction": "store",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 9,
-    "lineNumberBeforeMacroExpansion": 9,
-  },
-  {
-    "arguments": [],
-    "instruction": "loopEnd",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 10,
-    "lineNumberBeforeMacroExpansion": 10,
-  },
-  {
-    "arguments": [
-      {
-        "isInteger": true,
-        "type": "literal",
-        "value": 500,
-      },
-    ],
-    "instruction": "#loopCap",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 12,
-    "lineNumberBeforeMacroExpansion": 12,
-  },
-  {
-    "arguments": [],
-    "instruction": "loop",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 14,
-    "lineNumberBeforeMacroExpansion": 14,
-  },
-  {
-    "arguments": [
-      {
-        "isInteger": true,
-        "safeAddressRange": {
-          "byteAddress": 4,
-          "memoryId": "counter2",
-          "safeByteLength": 4,
-          "source": "memory-start",
-        },
-        "type": "literal",
-        "value": 4,
-      },
-    ],
-    "instruction": "push",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 15,
-    "lineNumberBeforeMacroExpansion": 15,
-  },
-  {
-    "arguments": [
-      {
-        "referenceKind": "plain",
-        "scope": "local",
-        "type": "identifier",
-        "value": "counter2",
-      },
-    ],
-    "instruction": "push",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 16,
-    "lineNumberBeforeMacroExpansion": 16,
-  },
-  {
-    "arguments": [
-      {
-        "isInteger": true,
-        "type": "literal",
-        "value": 1,
-      },
-    ],
-    "instruction": "push",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 17,
-    "lineNumberBeforeMacroExpansion": 17,
-  },
-  {
-    "arguments": [],
-    "instruction": "add",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 18,
-    "lineNumberBeforeMacroExpansion": 18,
-  },
-  {
-    "arguments": [],
-    "instruction": "store",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 19,
-    "lineNumberBeforeMacroExpansion": 19,
-  },
-  {
-    "arguments": [],
-    "instruction": "loopEnd",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 20,
-    "lineNumberBeforeMacroExpansion": 20,
-  },
-  {
-    "arguments": [],
-    "instruction": "moduleEnd",
-    "isMemoryDeclaration": false,
-    "isSemanticOnly": true,
-    "lineNumberAfterMacroExpansion": 22,
-    "lineNumberBeforeMacroExpansion": 22,
-  },
-]
-`;
-
-exports[`#loopCap does not affect loops declared before it > if the generated AST, WAT and memory map match the snapshot 2`] = `
-"(module
-  (type (;0;) (func))
-  (import "js" "memory" (memory (;0;) 1))
-  (func (;0;) (type 0)
-    (local i32 i32)
-    i32.const 0
-    local.set 0
-    block  ;; label = @1
-      loop  ;; label = @2
-        local.get 0
-        i32.const 1000
-        i32.ge_s
-        if  ;; label = @3
-          br 2 (;@1;)
-        end
-        local.get 0
-        i32.const 1
-        i32.add
-        local.set 0
-        i32.const 0
-        i32.const 0
-        i32.load
-        i32.const 1
-        i32.add
-        i32.store
-        br 0 (;@2;)
-      end
-    end
-    i32.const 0
-    local.set 1
-    block  ;; label = @1
-      loop  ;; label = @2
-        local.get 1
-        i32.const 500
-        i32.ge_s
-        if  ;; label = @3
-          br 2 (;@1;)
-        end
-        local.get 1
-        i32.const 1
-        i32.add
-        local.set 1
-        i32.const 4
-        i32.const 4
-        i32.load
-        i32.const 1
-        i32.add
-        i32.store
-        br 0 (;@2;)
-      end
-    end)
-  (export "test" (func 0)))
-"
-`;
-
-exports[`#loopCap does not affect loops declared before it > if the generated AST, WAT and memory map match the snapshot 3`] = `
-{
-  "counter": {
-    "byteAddress": 0,
-    "default": 0,
-    "elementWordSize": 4,
-    "hasExplicitDefault": false,
-    "id": "counter",
-    "isInteger": true,
-    "isPointingToPointer": false,
-    "isUnsigned": false,
-    "numberOfElements": 1,
-    "type": "int",
-    "wordAlignedAddress": 0,
-    "wordAlignedSize": 1,
-  },
-  "counter2": {
-    "byteAddress": 4,
-    "default": 0,
-    "elementWordSize": 4,
-    "hasExplicitDefault": false,
-    "id": "counter2",
-    "isInteger": true,
-    "isPointingToPointer": false,
-    "isUnsigned": false,
-    "numberOfElements": 1,
-    "type": "int",
-    "wordAlignedAddress": 1,
     "wordAlignedSize": 1,
   },
 }
@@ -719,6 +394,20 @@ exports[`loop with explicit cap argument overrides #loopCap > if the generated A
   {
     "arguments": [
       {
+        "isInteger": true,
+        "type": "literal",
+        "value": 500,
+      },
+    ],
+    "instruction": "#loopCap",
+    "isMemoryDeclaration": false,
+    "isSemanticOnly": false,
+    "lineNumberAfterMacroExpansion": 1,
+    "lineNumberBeforeMacroExpansion": 1,
+  },
+  {
+    "arguments": [
+      {
         "referenceKind": "plain",
         "scope": "local",
         "type": "identifier",
@@ -728,20 +417,6 @@ exports[`loop with explicit cap argument overrides #loopCap > if the generated A
     "hasExplicitMemoryDefault": false,
     "instruction": "int",
     "isMemoryDeclaration": true,
-    "isSemanticOnly": false,
-    "lineNumberAfterMacroExpansion": 1,
-    "lineNumberBeforeMacroExpansion": 1,
-  },
-  {
-    "arguments": [
-      {
-        "isInteger": true,
-        "type": "literal",
-        "value": 500,
-      },
-    ],
-    "instruction": "#loopCap",
-    "isMemoryDeclaration": false,
     "isSemanticOnly": false,
     "lineNumberAfterMacroExpansion": 2,
     "lineNumberBeforeMacroExpansion": 2,

--- a/packages/compiler/tests/compilerDirectivePrologue.test.ts
+++ b/packages/compiler/tests/compilerDirectivePrologue.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from 'vitest';
+import { ErrorCode } from '@8f4e/compiler-spec';
+
+import compile from '../src/index';
+
+const defaultOptions = {
+	startingMemoryWordAddress: 1,
+	environmentExtensions: {
+		constants: {},
+	},
+	disableSharedMemory: true,
+	includeAST: true,
+};
+
+describe('compiler directive prologue validation', () => {
+	test('accepts module directives immediately after module', () => {
+		expect(() =>
+			compile(
+				[
+					{
+						code: ['module metadataOnly', '#skipExecution', '#initOnly', '#loopCap 64', 'int counter 0', 'moduleEnd'],
+					},
+				],
+				defaultOptions
+			)
+		).not.toThrow();
+	});
+
+	test('rejects module directives after declarations', () => {
+		expect(() =>
+			compile(
+				[
+					{
+						code: ['module lateDirective', 'int counter 0', '#skipExecution', 'moduleEnd'],
+					},
+				],
+				defaultOptions
+			)
+		).toThrow(expect.objectContaining({ code: ErrorCode.COMPILER_DIRECTIVE_MUST_BE_PROLOGUE }));
+	});
+
+	test('rejects module loop caps after executable instructions', () => {
+		expect(() =>
+			compile(
+				[
+					{
+						code: ['module lateLoopCap', 'loop', 'loopEnd', '#loopCap 64', 'moduleEnd'],
+					},
+				],
+				defaultOptions
+			)
+		).toThrow(expect.objectContaining({ code: ErrorCode.COMPILER_DIRECTIVE_MUST_BE_PROLOGUE }));
+	});
+
+	test('accepts function directives immediately after function', () => {
+		expect(() =>
+			compile([{ code: ['module test', 'moduleEnd'] }], defaultOptions, [
+				{
+					code: [
+						'function writeValue',
+						'#export writeValue',
+						'#impure',
+						'#loopCap 64',
+						'param int address',
+						'param int value',
+						'push address',
+						'push value',
+						'store',
+						'functionEnd',
+					],
+				},
+			])
+		).not.toThrow();
+	});
+
+	test('rejects function directives after params', () => {
+		expect(() =>
+			compile([{ code: ['module test', 'moduleEnd'] }], defaultOptions, [
+				{
+					code: ['function lateImpure', 'param int address', '#impure', 'push address', 'load', 'functionEnd int'],
+				},
+			])
+		).toThrow(expect.objectContaining({ code: ErrorCode.COMPILER_DIRECTIVE_MUST_BE_PROLOGUE }));
+	});
+
+	test('rejects function exports after executable instructions', () => {
+		expect(() =>
+			compile([{ code: ['module test', 'moduleEnd'] }], defaultOptions, [
+				{
+					code: ['function lateExport', 'push 1', '#export lateExport', 'functionEnd int'],
+				},
+			])
+		).toThrow(expect.objectContaining({ code: ErrorCode.COMPILER_DIRECTIVE_MUST_BE_PROLOGUE }));
+	});
+});

--- a/packages/compiler/tests/initOnly.test.ts
+++ b/packages/compiler/tests/initOnly.test.ts
@@ -83,8 +83,8 @@ moduleEnd
 				code: `
 module testModule
 #initOnly
-int counter 0
 #initOnly
+int counter 0
 push counter
 push counter
 load

--- a/packages/compiler/tests/loopCap.test.ts
+++ b/packages/compiler/tests/loopCap.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expect } from 'vitest';
+import { ErrorCode } from '@8f4e/compiler-spec';
 
 import { moduleTester } from './instructions/testUtils';
 
@@ -91,7 +92,7 @@ moduleEnd
 		}).toThrow();
 	});
 
-	test('#loopCap only affects loops declared after it', () => {
+	test('rejects #loopCap after declarations', () => {
 		const modules = [
 			{
 				code: `
@@ -111,9 +112,9 @@ moduleEnd
 			},
 		];
 
-		// Should compile without error — #loopCap affects the loop after it
-		const result = compile(modules, { startingMemoryWordAddress: 1 });
-		expect(result.compiledModules.test).toBeDefined();
+		expect(() => compile(modules, { startingMemoryWordAddress: 1 })).toThrow(
+			expect.objectContaining({ code: ErrorCode.COMPILER_DIRECTIVE_MUST_BE_PROLOGUE })
+		);
 	});
 });
 
@@ -139,8 +140,8 @@ moduleEnd
 moduleTester(
 	'#loopCap changes the default cap for subsequent loops',
 	`module loop
-int counter
 #loopCap 500
+int counter
 
 loop
  push &counter
@@ -176,8 +177,8 @@ moduleEnd
 moduleTester(
 	'loop with explicit cap argument overrides #loopCap',
 	`module loop
-int counter
 #loopCap 500
+int counter
 
 loop 12
  push &counter
@@ -190,35 +191,6 @@ loopEnd
 moduleEnd
 `,
 	[[{}, { counter: 12 }]]
-);
-
-moduleTester(
-	'#loopCap does not affect loops declared before it',
-	`module loop
-int counter
-int counter2
-
-loop
- push &counter
- push counter
- push 1
- add
- store
-loopEnd
-
-#loopCap 500
-
-loop
- push &counter2
- push counter2
- push 1
- add
- store
-loopEnd
-
-moduleEnd
-`,
-	[[{}, { counter: 1000, counter2: 500 }]]
 );
 
 moduleTester(

--- a/packages/compiler/tests/skipExecution.test.ts
+++ b/packages/compiler/tests/skipExecution.test.ts
@@ -64,8 +64,8 @@ moduleEnd
 				code: `
 module testModule
 #skipExecution
-int counter 0
 #skipExecution
+int counter 0
 push counter
 push counter
 load


### PR DESCRIPTION
## Summary
- validate module and function compiler directives as block prologue metadata
- add a dedicated compiler diagnostic for late directives
- update loop cap tests/snapshots and compiler directive docs

## Tests
- `npx nx run compiler:test -- compilerDirective loopCap skipExecution initOnly exportedFunctions pureFunction`
- `npx nx run compiler:typecheck`
- pre-commit: `npx nx run-many --target=typecheck --all`