### PR TITLE
fix(tokenizer): avoid AST cache hashing on initial miss

### DIFF
--- a/packages/compiler-spec/src/cache.ts
+++ b/packages/compiler-spec/src/cache.ts
@@ -1,11 +1,21 @@
-import type { AST } from './ast';
+import type { AST, ParsedLineMetadata } from './ast';
 
 export interface ASTCacheStats {
 	hits: number;
 	misses: number;
 }
 
+export interface ASTCacheEntry {
+	ast: AST;
+	hash?: number;
+	hashInput?: {
+		code: string[];
+		lineMetadata?: ParsedLineMetadata;
+	};
+	lineCount: number;
+}
+
 export interface ASTCache {
-	entries: Map<string, { hash: number; ast: AST }>;
+	entries: Map<string, ASTCacheEntry>;
 	stats: ASTCacheStats;
 }

--- a/packages/compiler/packages/tokenizer/src/cache/compileToASTCache.test.ts
+++ b/packages/compiler/packages/tokenizer/src/cache/compileToASTCache.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import createASTCache from './createASTCache';
+import hashSource from './hashSource';
 
 import { compileToAST } from '../parser';
 
@@ -17,8 +18,30 @@ describe('compileToAST cache', () => {
 		const second = compileToAST(code, lineMetadata, cache, 'module:0');
 
 		expect(second).toBe(first);
-		expect(cache.entries.get('module:0')?.ast).toBe(first);
+		expect(cache.entries.get('module:0')).toMatchObject({
+			ast: first,
+			hash: hashSource(code, lineMetadata),
+		});
+		expect(cache.entries.get('module:0')?.hashInput).toBeUndefined();
 		expect(cache.stats).toEqual({ hits: 1, misses: 1 });
+	});
+
+	it('stores obvious cache misses without hashing the source', () => {
+		const cache = createASTCache();
+		const code = ['push 10'];
+		const lineMetadata = [{ callSiteLineNumber: 4, macroId: 'value' }];
+		const ast = compileToAST(code, lineMetadata, cache, 'module:0');
+		const entry = cache.entries.get('module:0');
+
+		expect(entry).toMatchObject({
+			ast,
+			hashInput: {
+				code,
+				lineMetadata,
+			},
+			lineCount: code.length,
+		});
+		expect(entry?.hash).toBeUndefined();
 	});
 
 	it('reparses when source changes for the same cache key', () => {
@@ -28,6 +51,19 @@ describe('compileToAST cache', () => {
 
 		expect(second).not.toBe(first);
 		expect(second[0].arguments[0]).toMatchObject({ value: 20 });
+		expect(cache.stats).toEqual({ hits: 0, misses: 2 });
+	});
+
+	it('reparses when source line count changes for the same cache key', () => {
+		const cache = createASTCache();
+		const first = compileToAST(['push 10'], undefined, cache, 'module:0');
+		const second = compileToAST(['push 10', 'push 20'], undefined, cache, 'module:0');
+
+		expect(second).not.toBe(first);
+		expect(cache.entries.get('module:0')).toMatchObject({
+			ast: second,
+			lineCount: 2,
+		});
 		expect(cache.stats).toEqual({ hits: 0, misses: 2 });
 	});
 

--- a/packages/compiler/packages/tokenizer/src/parser.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.ts
@@ -14,6 +14,7 @@ import { hashSource } from './cache';
 import type {
 	AST,
 	ASTCache,
+	ASTCacheEntry,
 	ASTLine,
 	BlockEndInstruction,
 	BlockStartInstruction,
@@ -32,6 +33,11 @@ type SourceBlockPrologue = {
 	instruction: 'module' | 'function';
 	blockDepth: number;
 	isOpen: boolean;
+};
+
+type ASTCacheLookupResult = {
+	ast?: AST;
+	hash?: number;
 };
 
 const blockStartInstructionSet = new Set<BlockStartInstruction>(blockStartInstructions);
@@ -81,6 +87,32 @@ function hasExplicitMemoryDefault(instruction: string, args: ASTLine['arguments'
 		return true;
 	}
 	return args.length > 1;
+}
+
+function getASTCacheLookupResult(
+	cached: ASTCacheEntry | undefined,
+	code: string[],
+	lineMetadata: ParsedLineMetadata | undefined
+): ASTCacheLookupResult {
+	// Optimize first compilation and obvious cache misses: only hash when an existing same-line-count entry needs validation.
+	if (!cached || cached.lineCount !== code.length) {
+		return {};
+	}
+
+	const hash = hashSource(code, lineMetadata);
+	const cachedHash =
+		cached.hash ?? (cached.hashInput ? hashSource(cached.hashInput.code, cached.hashInput.lineMetadata) : undefined);
+
+	if (cachedHash === undefined) {
+		return { hash };
+	}
+
+	cached.hash = cachedHash;
+	cached.hashInput = undefined;
+	return {
+		ast: cachedHash === hash ? cached.ast : undefined,
+		hash,
+	};
 }
 
 /**
@@ -176,11 +208,11 @@ export function compileToAST(
 	cache?: ASTCache,
 	cacheKey?: string
 ): AST {
-	const hash = cache && cacheKey !== undefined ? hashSource(code, lineMetadata) : undefined;
 	const cached = cacheKey !== undefined ? cache?.entries.get(cacheKey) : undefined;
-	if (cached && hash !== undefined && cached.hash === hash) {
+	const cachedLookup = getASTCacheLookupResult(cached, code, lineMetadata);
+	if (cachedLookup.ast) {
 		cache!.stats.hits++;
-		return cached.ast;
+		return cachedLookup.ast;
 	}
 	if (cache && cacheKey !== undefined) {
 		cache.stats.misses++;
@@ -343,8 +375,20 @@ export function compileToAST(
 		});
 	}
 
-	if (cache && cacheKey !== undefined && hash !== undefined) {
-		cache.entries.set(cacheKey, { hash, ast });
+	if (cache && cacheKey !== undefined) {
+		const entry: ASTCacheEntry = {
+			ast,
+			hashInput: {
+				code,
+				lineMetadata,
+			},
+			lineCount: code.length,
+		};
+		if (cachedLookup.hash !== undefined) {
+			entry.hash = cachedLookup.hash;
+			entry.hashInput = undefined;
+		}
+		cache.entries.set(cacheKey, entry);
 	}
 
 	return ast;


### PR DESCRIPTION
## Summary
- Store hashless source snapshots for new AST cache entries so first parses do not call `hashSource`
- Compare cached source snapshots on later calls to preserve hits and stale-entry misses
- Keep hash-backed cache entry validation for compatibility

Closes #658

## Verification
- `npx nx run @8f4e/tokenizer:test`
- `npx nx run @8f4e/tokenizer:lint`
- `npx nx run @8f4e/compiler-spec:typecheck`
- `npx nx run @8f4e/tokenizer:typecheck`
- `npx nx run @8f4e/tokenizer:build`
- pre-commit: `npx nx run-many --target=typecheck --all`