### PR TITLE
feat(compiler-wasm-utils): support multi-memory memargs

### DIFF
--- a/packages/compiler/packages/wasm-utils/src/load/f32load.test.ts
+++ b/packages/compiler/packages/wasm-utils/src/load/f32load.test.ts
@@ -5,4 +5,5 @@ import f32load from './f32load';
 test('f32load generates correct bytecode', () => {
 	expect(f32load()).toStrictEqual([42, 2, 0]);
 	expect(f32load(0, 16)).toStrictEqual([42, 0, 16]);
+	expect(f32load(2, 0, 1)).toStrictEqual([42, 0x42, 1, 0]);
 });

--- a/packages/compiler/packages/wasm-utils/src/load/f32load.ts
+++ b/packages/compiler/packages/wasm-utils/src/load/f32load.ts
@@ -1,13 +1,14 @@
 import { WASM_F32_LOAD } from '../wasmInstruction';
-import unsignedLEB128 from '../encoding/unsignedLEB128';
+import memarg from '../memory/memarg';
 
 /**
  * Creates a WebAssembly f32.load instruction to load a 32-bit float from memory.
  *
  * @param alignment - Memory alignment (power of 2), defaults to 2 (4-byte aligned)
  * @param offset - Static offset from the address, defaults to 0
+ * @param memoryIndex - Memory index to load from, defaults to 0
  * @returns Byte array representing the f32.load instruction
  */
-export default function f32load(alignment = 2, offset = 0): number[] {
-	return [WASM_F32_LOAD, ...unsignedLEB128(alignment), ...unsignedLEB128(offset)];
+export default function f32load(alignment = 2, offset = 0, memoryIndex = 0): number[] {
+	return [WASM_F32_LOAD, ...memarg(alignment, offset, memoryIndex)];
 }

--- a/packages/compiler/packages/wasm-utils/src/load/f64load.test.ts
+++ b/packages/compiler/packages/wasm-utils/src/load/f64load.test.ts
@@ -5,4 +5,5 @@ import f64load from './f64load';
 test('f64load generates correct bytecode', () => {
 	expect(f64load()).toStrictEqual([43, 3, 0]);
 	expect(f64load(0, 8)).toStrictEqual([43, 0, 8]);
+	expect(f64load(3, 0, 1)).toStrictEqual([43, 0x43, 1, 0]);
 });

--- a/packages/compiler/packages/wasm-utils/src/load/f64load.ts
+++ b/packages/compiler/packages/wasm-utils/src/load/f64load.ts
@@ -1,13 +1,14 @@
 import { WASM_F64_LOAD } from '../wasmInstruction';
-import unsignedLEB128 from '../encoding/unsignedLEB128';
+import memarg from '../memory/memarg';
 
 /**
  * Creates a WebAssembly f64.load instruction to load a 64-bit float from memory.
  *
  * @param alignment - Memory alignment (power of 2), defaults to 3 (8-byte aligned)
  * @param offset - Static offset from the address, defaults to 0
+ * @param memoryIndex - Memory index to load from, defaults to 0
  * @returns Byte array representing the f64.load instruction
  */
-export default function f64load(alignment = 3, offset = 0): number[] {
-	return [WASM_F64_LOAD, ...unsignedLEB128(alignment), ...unsignedLEB128(offset)];
+export default function f64load(alignment = 3, offset = 0, memoryIndex = 0): number[] {
+	return [WASM_F64_LOAD, ...memarg(alignment, offset, memoryIndex)];
 }

--- a/packages/compiler/packages/wasm-utils/src/load/i32load.test.ts
+++ b/packages/compiler/packages/wasm-utils/src/load/i32load.test.ts
@@ -5,4 +5,5 @@ import i32load from './i32load';
 test('i32load generates correct bytecode', () => {
 	expect(i32load()).toStrictEqual([40, 2, 0]);
 	expect(i32load(3, 8)).toStrictEqual([40, 3, 8]);
+	expect(i32load(2, 0, 1)).toStrictEqual([40, 0x42, 1, 0]);
 });

--- a/packages/compiler/packages/wasm-utils/src/load/i32load.ts
+++ b/packages/compiler/packages/wasm-utils/src/load/i32load.ts
@@ -1,13 +1,14 @@
 import { WASM_I32_LOAD } from '../wasmInstruction';
-import unsignedLEB128 from '../encoding/unsignedLEB128';
+import memarg from '../memory/memarg';
 
 /**
  * Creates a WebAssembly i32.load instruction to load a 32-bit integer from memory.
  *
  * @param alignment - Memory alignment (power of 2), defaults to 2 (4-byte aligned)
  * @param offset - Static offset from the address, defaults to 0
+ * @param memoryIndex - Memory index to load from, defaults to 0
  * @returns Byte array representing the i32.load instruction
  */
-export default function i32load(alignment = 2, offset = 0): number[] {
-	return [WASM_I32_LOAD, ...unsignedLEB128(alignment), ...unsignedLEB128(offset)];
+export default function i32load(alignment = 2, offset = 0, memoryIndex = 0): number[] {
+	return [WASM_I32_LOAD, ...memarg(alignment, offset, memoryIndex)];
 }

--- a/packages/compiler/packages/wasm-utils/src/load/i32load16s.test.ts
+++ b/packages/compiler/packages/wasm-utils/src/load/i32load16s.test.ts
@@ -4,4 +4,5 @@ import i32load16s from './i32load16s';
 
 test('i32load16s generates correct bytecode', () => {
 	expect(i32load16s()).toStrictEqual([46, 1, 0]);
+	expect(i32load16s(1, 0, 1)).toStrictEqual([46, 0x41, 1, 0]);
 });

--- a/packages/compiler/packages/wasm-utils/src/load/i32load16s.ts
+++ b/packages/compiler/packages/wasm-utils/src/load/i32load16s.ts
@@ -1,13 +1,14 @@
 import { WASM_I32_LOAD_16_S } from '../wasmInstruction';
-import unsignedLEB128 from '../encoding/unsignedLEB128';
+import memarg from '../memory/memarg';
 
 /**
  * Creates a WebAssembly i32.load16_s instruction to load a signed 16-bit integer from memory.
  *
  * @param alignment - Memory alignment (power of 2), defaults to 1 (2-byte aligned)
  * @param offset - Static offset from the address, defaults to 0
+ * @param memoryIndex - Memory index to load from, defaults to 0
  * @returns Byte array representing the i32.load16_s instruction
  */
-export default function i32load16s(alignment = 1, offset = 0): number[] {
-	return [WASM_I32_LOAD_16_S, ...unsignedLEB128(alignment), ...unsignedLEB128(offset)];
+export default function i32load16s(alignment = 1, offset = 0, memoryIndex = 0): number[] {
+	return [WASM_I32_LOAD_16_S, ...memarg(alignment, offset, memoryIndex)];
 }

--- a/packages/compiler/packages/wasm-utils/src/load/i32load16u.test.ts
+++ b/packages/compiler/packages/wasm-utils/src/load/i32load16u.test.ts
@@ -4,4 +4,5 @@ import i32load16u from './i32load16u';
 
 test('i32load16u generates correct bytecode', () => {
 	expect(i32load16u()).toStrictEqual([47, 1, 0]);
+	expect(i32load16u(1, 0, 1)).toStrictEqual([47, 0x41, 1, 0]);
 });

--- a/packages/compiler/packages/wasm-utils/src/load/i32load16u.ts
+++ b/packages/compiler/packages/wasm-utils/src/load/i32load16u.ts
@@ -1,13 +1,14 @@
 import { WASM_I32_LOAD_16_U } from '../wasmInstruction';
-import unsignedLEB128 from '../encoding/unsignedLEB128';
+import memarg from '../memory/memarg';
 
 /**
  * Creates a WebAssembly i32.load16_u instruction to load an unsigned 16-bit integer from memory.
  *
  * @param alignment - Memory alignment (power of 2), defaults to 1 (2-byte aligned)
  * @param offset - Static offset from the address, defaults to 0
+ * @param memoryIndex - Memory index to load from, defaults to 0
  * @returns Byte array representing the i32.load16_u instruction
  */
-export default function i32load16u(alignment = 1, offset = 0): number[] {
-	return [WASM_I32_LOAD_16_U, ...unsignedLEB128(alignment), ...unsignedLEB128(offset)];
+export default function i32load16u(alignment = 1, offset = 0, memoryIndex = 0): number[] {
+	return [WASM_I32_LOAD_16_U, ...memarg(alignment, offset, memoryIndex)];
 }

--- a/packages/compiler/packages/wasm-utils/src/load/i32load8s.test.ts
+++ b/packages/compiler/packages/wasm-utils/src/load/i32load8s.test.ts
@@ -4,4 +4,5 @@ import i32load8s from './i32load8s';
 
 test('i32load8s generates correct bytecode', () => {
 	expect(i32load8s()).toStrictEqual([44, 0, 0]);
+	expect(i32load8s(0, 0, 1)).toStrictEqual([44, 0x40, 1, 0]);
 });

--- a/packages/compiler/packages/wasm-utils/src/load/i32load8s.ts
+++ b/packages/compiler/packages/wasm-utils/src/load/i32load8s.ts
@@ -1,13 +1,14 @@
 import { WASM_I32_LOAD_8_S } from '../wasmInstruction';
-import unsignedLEB128 from '../encoding/unsignedLEB128';
+import memarg from '../memory/memarg';
 
 /**
  * Creates a WebAssembly i32.load8_s instruction to load a signed 8-bit integer from memory.
  *
  * @param alignment - Memory alignment (power of 2), defaults to 0 (1-byte aligned)
  * @param offset - Static offset from the address, defaults to 0
+ * @param memoryIndex - Memory index to load from, defaults to 0
  * @returns Byte array representing the i32.load8_s instruction
  */
-export default function i32load8s(alignment = 0, offset = 0): number[] {
-	return [WASM_I32_LOAD_8_S, ...unsignedLEB128(alignment), ...unsignedLEB128(offset)];
+export default function i32load8s(alignment = 0, offset = 0, memoryIndex = 0): number[] {
+	return [WASM_I32_LOAD_8_S, ...memarg(alignment, offset, memoryIndex)];
 }

--- a/packages/compiler/packages/wasm-utils/src/load/i32load8u.test.ts
+++ b/packages/compiler/packages/wasm-utils/src/load/i32load8u.test.ts
@@ -4,4 +4,5 @@ import i32load8u from './i32load8u';
 
 test('i32load8u generates correct bytecode', () => {
 	expect(i32load8u()).toStrictEqual([45, 0, 0]);
+	expect(i32load8u(0, 0, 1)).toStrictEqual([45, 0x40, 1, 0]);
 });

--- a/packages/compiler/packages/wasm-utils/src/load/i32load8u.ts
+++ b/packages/compiler/packages/wasm-utils/src/load/i32load8u.ts
@@ -1,13 +1,14 @@
 import { WASM_I32_LOAD_8_U } from '../wasmInstruction';
-import unsignedLEB128 from '../encoding/unsignedLEB128';
+import memarg from '../memory/memarg';
 
 /**
  * Creates a WebAssembly i32.load8_u instruction to load an unsigned 8-bit integer from memory.
  *
  * @param alignment - Memory alignment (power of 2), defaults to 0 (1-byte aligned)
  * @param offset - Static offset from the address, defaults to 0
+ * @param memoryIndex - Memory index to load from, defaults to 0
  * @returns Byte array representing the i32.load8_u instruction
  */
-export default function i32load8u(alignment = 0, offset = 0): number[] {
-	return [WASM_I32_LOAD_8_U, ...unsignedLEB128(alignment), ...unsignedLEB128(offset)];
+export default function i32load8u(alignment = 0, offset = 0, memoryIndex = 0): number[] {
+	return [WASM_I32_LOAD_8_U, ...memarg(alignment, offset, memoryIndex)];
 }

--- a/packages/compiler/packages/wasm-utils/src/memory/memarg.test.ts
+++ b/packages/compiler/packages/wasm-utils/src/memory/memarg.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest';
+
+import memarg from './memarg';
+
+test('memarg keeps the default memory encoding unchanged', () => {
+	expect(memarg(2, 0)).toStrictEqual([2, 0]);
+	expect(memarg(0, 16)).toStrictEqual([0, 16]);
+});
+
+test('memarg encodes multi-memory immediates for non-default memories', () => {
+	expect(memarg(2, 0, 1)).toStrictEqual([0x42, 1, 0]);
+	expect(memarg(0, 16, 2)).toStrictEqual([0x40, 2, 16]);
+});

--- a/packages/compiler/packages/wasm-utils/src/memory/memarg.ts
+++ b/packages/compiler/packages/wasm-utils/src/memory/memarg.ts
@@ -1,0 +1,15 @@
+import unsignedLEB128 from '../encoding/unsignedLEB128';
+
+const MULTI_MEMORY_MEMARG_FLAG = 0x40;
+
+export default function memarg(alignment: number, offset: number, memoryIndex = 0): number[] {
+	if (memoryIndex === 0) {
+		return [...unsignedLEB128(alignment), ...unsignedLEB128(offset)];
+	}
+
+	return [
+		...unsignedLEB128(alignment | MULTI_MEMORY_MEMARG_FLAG),
+		...unsignedLEB128(memoryIndex),
+		...unsignedLEB128(offset),
+	];
+}

--- a/packages/compiler/packages/wasm-utils/src/store/f32store.test.ts
+++ b/packages/compiler/packages/wasm-utils/src/store/f32store.test.ts
@@ -5,6 +5,7 @@ import f32store from './f32store';
 test('f32store with no setup generates only store instruction', () => {
 	const result = f32store();
 	expect(result.slice(-3)).toStrictEqual([56, 2, 0]);
+	expect(f32store(undefined, undefined, 2, 0, 1)).toStrictEqual([56, 0x42, 1, 0]);
 });
 
 test('f32store with address and value generates full instruction sequence', () => {

--- a/packages/compiler/packages/wasm-utils/src/store/f32store.ts
+++ b/packages/compiler/packages/wasm-utils/src/store/f32store.ts
@@ -1,5 +1,5 @@
 import { WASM_F32_STORE } from '../wasmInstruction';
-import unsignedLEB128 from '../encoding/unsignedLEB128';
+import memarg from '../memory/memarg';
 import i32const from '../const/i32const';
 import f32const from '../const/f32const';
 
@@ -10,14 +10,20 @@ import f32const from '../const/f32const';
  * @param value - Optional value to store (generates f32.const if provided)
  * @param alignment - Memory alignment (power of 2), defaults to 2 (4-byte aligned)
  * @param offset - Static offset from the address, defaults to 0
+ * @param memoryIndex - Memory index to store to, defaults to 0
  * @returns Byte array representing the f32.store instruction and optional setup
  */
-export default function f32store(address?: number, value?: number, alignment = 2, offset = 0): number[] {
+export default function f32store(
+	address?: number,
+	value?: number,
+	alignment = 2,
+	offset = 0,
+	memoryIndex = 0
+): number[] {
 	return [
 		...(typeof address === 'undefined' ? [] : i32const(address)),
 		...(typeof value === 'undefined' ? [] : f32const(value)),
 		WASM_F32_STORE,
-		...unsignedLEB128(alignment),
-		...unsignedLEB128(offset),
+		...memarg(alignment, offset, memoryIndex),
 	];
 }

--- a/packages/compiler/packages/wasm-utils/src/store/f64store.test.ts
+++ b/packages/compiler/packages/wasm-utils/src/store/f64store.test.ts
@@ -5,6 +5,7 @@ import f64store from './f64store';
 test('f64store with no setup generates only store instruction', () => {
 	const result = f64store();
 	expect(result.slice(-3)).toStrictEqual([57, 3, 0]);
+	expect(f64store(undefined, undefined, 3, 0, 1)).toStrictEqual([57, 0x43, 1, 0]);
 });
 
 test('f64store with address and value generates full instruction sequence', () => {

--- a/packages/compiler/packages/wasm-utils/src/store/f64store.ts
+++ b/packages/compiler/packages/wasm-utils/src/store/f64store.ts
@@ -1,5 +1,5 @@
 import { WASM_F64_STORE } from '../wasmInstruction';
-import unsignedLEB128 from '../encoding/unsignedLEB128';
+import memarg from '../memory/memarg';
 import i32const from '../const/i32const';
 import f64const from '../const/f64const';
 
@@ -10,14 +10,20 @@ import f64const from '../const/f64const';
  * @param value - Optional value to store (generates f64.const if provided)
  * @param alignment - Memory alignment (power of 2), defaults to 3 (8-byte aligned)
  * @param offset - Static offset from the address, defaults to 0
+ * @param memoryIndex - Memory index to store to, defaults to 0
  * @returns Byte array representing the f64.store instruction and optional setup
  */
-export default function f64store(address?: number, value?: number, alignment = 3, offset = 0): number[] {
+export default function f64store(
+	address?: number,
+	value?: number,
+	alignment = 3,
+	offset = 0,
+	memoryIndex = 0
+): number[] {
 	return [
 		...(typeof address === 'undefined' ? [] : i32const(address)),
 		...(typeof value === 'undefined' ? [] : f64const(value)),
 		WASM_F64_STORE,
-		...unsignedLEB128(alignment),
-		...unsignedLEB128(offset),
+		...memarg(alignment, offset, memoryIndex),
 	];
 }

--- a/packages/compiler/packages/wasm-utils/src/store/i32store.test.ts
+++ b/packages/compiler/packages/wasm-utils/src/store/i32store.test.ts
@@ -5,6 +5,7 @@ import i32store from './i32store';
 test('i32store with no setup generates only store instruction', () => {
 	const result = i32store();
 	expect(result.slice(-3)).toStrictEqual([54, 2, 0]);
+	expect(i32store(undefined, undefined, 2, 0, 1)).toStrictEqual([54, 0x42, 1, 0]);
 });
 
 test('i32store with address and value generates full instruction sequence', () => {

--- a/packages/compiler/packages/wasm-utils/src/store/i32store.ts
+++ b/packages/compiler/packages/wasm-utils/src/store/i32store.ts
@@ -1,5 +1,5 @@
 import { WASM_I32_STORE } from '../wasmInstruction';
-import unsignedLEB128 from '../encoding/unsignedLEB128';
+import memarg from '../memory/memarg';
 import i32const from '../const/i32const';
 
 /**
@@ -9,14 +9,20 @@ import i32const from '../const/i32const';
  * @param value - Optional value to store (generates i32.const if provided)
  * @param alignment - Memory alignment (power of 2), defaults to 2 (4-byte aligned)
  * @param offset - Static offset from the address, defaults to 0
+ * @param memoryIndex - Memory index to store to, defaults to 0
  * @returns Byte array representing the i32.store instruction and optional setup
  */
-export default function i32store(address?: number, value?: number, alignment = 2, offset = 0): number[] {
+export default function i32store(
+	address?: number,
+	value?: number,
+	alignment = 2,
+	offset = 0,
+	memoryIndex = 0
+): number[] {
 	return [
 		...(typeof address === 'undefined' ? [] : i32const(address)),
 		...(typeof value === 'undefined' ? [] : i32const(value)),
 		WASM_I32_STORE,
-		...unsignedLEB128(alignment),
-		...unsignedLEB128(offset),
+		...memarg(alignment, offset, memoryIndex),
 	];
 }

--- a/packages/compiler/packages/wasm-utils/src/store/i32store16.test.ts
+++ b/packages/compiler/packages/wasm-utils/src/store/i32store16.test.ts
@@ -5,6 +5,7 @@ import i32store16 from './i32store16';
 test('i32store16 with no setup generates only store16 instruction', () => {
 	const result = i32store16();
 	expect(result).toStrictEqual([0x3b, 1, 0]); // opcode 0x3b, alignment 1, offset 0
+	expect(i32store16(undefined, undefined, 1, 0, 1)).toStrictEqual([0x3b, 0x41, 1, 0]);
 });
 
 test('i32store16 with offset generates correct encoding', () => {

--- a/packages/compiler/packages/wasm-utils/src/store/i32store16.ts
+++ b/packages/compiler/packages/wasm-utils/src/store/i32store16.ts
@@ -1,5 +1,5 @@
 import { WASM_I32_STORE16 } from '../wasmInstruction';
-import unsignedLEB128 from '../encoding/unsignedLEB128';
+import memarg from '../memory/memarg';
 import i32const from '../const/i32const';
 
 /**
@@ -9,14 +9,20 @@ import i32const from '../const/i32const';
  * @param value - Optional value to store (generates i32.const if provided)
  * @param alignment - Log2 of the memory alignment in bytes (defaults to 1, meaning 2^1 = 2-byte alignment)
  * @param offset - Static offset from the address, defaults to 0
+ * @param memoryIndex - Memory index to store to, defaults to 0
  * @returns Byte array representing the i32.store16 instruction and optional setup
  */
-export default function i32store16(address?: number, value?: number, alignment = 1, offset = 0): number[] {
+export default function i32store16(
+	address?: number,
+	value?: number,
+	alignment = 1,
+	offset = 0,
+	memoryIndex = 0
+): number[] {
 	return [
 		...(typeof address === 'undefined' ? [] : i32const(address)),
 		...(typeof value === 'undefined' ? [] : i32const(value)),
 		WASM_I32_STORE16,
-		...unsignedLEB128(alignment),
-		...unsignedLEB128(offset),
+		...memarg(alignment, offset, memoryIndex),
 	];
 }

--- a/packages/compiler/packages/wasm-utils/src/store/i32store8.test.ts
+++ b/packages/compiler/packages/wasm-utils/src/store/i32store8.test.ts
@@ -5,6 +5,7 @@ import i32store8 from './i32store8';
 test('i32store8 with no setup generates only store8 instruction', () => {
 	const result = i32store8();
 	expect(result).toStrictEqual([0x3a, 0, 0]); // opcode 0x3a, alignment 0, offset 0
+	expect(i32store8(undefined, undefined, 0, 0, 1)).toStrictEqual([0x3a, 0x40, 1, 0]);
 });
 
 test('i32store8 with offset generates correct encoding', () => {

--- a/packages/compiler/packages/wasm-utils/src/store/i32store8.ts
+++ b/packages/compiler/packages/wasm-utils/src/store/i32store8.ts
@@ -1,5 +1,5 @@
 import { WASM_I32_STORE8 } from '../wasmInstruction';
-import unsignedLEB128 from '../encoding/unsignedLEB128';
+import memarg from '../memory/memarg';
 import i32const from '../const/i32const';
 
 /**
@@ -9,14 +9,20 @@ import i32const from '../const/i32const';
  * @param value - Optional value to store (generates i32.const if provided)
  * @param alignment - Memory alignment (power of 2), defaults to 0 (byte-aligned)
  * @param offset - Static offset from the address, defaults to 0
+ * @param memoryIndex - Memory index to store to, defaults to 0
  * @returns Byte array representing the i32.store8 instruction and optional setup
  */
-export default function i32store8(address?: number, value?: number, alignment = 0, offset = 0): number[] {
+export default function i32store8(
+	address?: number,
+	value?: number,
+	alignment = 0,
+	offset = 0,
+	memoryIndex = 0
+): number[] {
 	return [
 		...(typeof address === 'undefined' ? [] : i32const(address)),
 		...(typeof value === 'undefined' ? [] : i32const(value)),
 		WASM_I32_STORE8,
-		...unsignedLEB128(alignment),
-		...unsignedLEB128(offset),
+		...memarg(alignment, offset, memoryIndex),
 	];
 }


### PR DESCRIPTION
## Summary
- add a shared memarg encoder for default and multi-memory load/store immediates
- extend load/store builders with a backward-compatible memoryIndex parameter
- cover default-memory bytecode preservation and non-default multi-memory encoding in wasm-utils tests

## Test notes
- npx nx run @8f4e/compiler-wasm-utils:test
- npx nx run @8f4e/compiler-wasm-utils:typecheck
- pre-commit: npx nx run-many --target=typecheck --all