### PR TITLE
fix(compiler): expose stack analysis results

### DIFF
--- a/docs/todos/412-expose-compiler-stack-analysis-results.md
+++ b/docs/todos/412-expose-compiler-stack-analysis-results.md
@@ -4,8 +4,8 @@ priority: Medium
 effort: 4-8h
 created: 2026-05-21
 issue: null
-status: Open
-completed: null
+status: Completed
+completed: 2026-05-21
 ---
 
 # TODO: Expose compiler stack analysis results
@@ -100,11 +100,20 @@ interface CompiledFunction {
 
 ## Success Criteria
 
-- [ ] `compile(...)` can return per-module stack analysis when requested.
-- [ ] `compile(...)` can return per-function stack analysis when requested.
-- [ ] Default compile output remains unchanged.
-- [ ] Stack analysis output is independent from AST output.
-- [ ] The payload contains enough line and stack metadata for editor selected-line tooltips.
+- [x] `compile(...)` can return per-module stack analysis when requested.
+- [x] `compile(...)` can return per-function stack analysis when requested.
+- [x] Default compile output remains unchanged.
+- [x] Stack analysis output is independent from AST output.
+- [x] The payload contains enough line and stack metadata for editor selected-line tooltips.
+
+## Completion Notes
+
+Completed on 2026-05-21.
+
+- Added `includeStackAnalysis?: boolean` to compiler options.
+- Added `CompiledStackAnalysisLine` and optional `stackAnalysis` payloads for compiled modules and functions.
+- Kept stack analysis opt-in and independent from `includeAST`.
+- Added public compiler tests for omitted output, module output, function output, and combined AST plus stack analysis output.
 
 ## Affected Components
 

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -65,7 +65,6 @@ Active todo files are listed below.
 | 409 | Track block context flags during stack analysis | 🟡 | 2-4h | 2026-05-19 | Stack validation repeatedly scans block stack to detect constants/map scope; maintained context flags or counters would avoid per-instruction scans. |
 | 410 | Consolidate release action commits | 🟡 | 2-4h | 2026-05-19 | The release workflow currently creates separate version, bundle-size, bytecode-size, and compiler-coverage commits; collapse these into one release commit or one version commit plus one metrics commit. |
 | 411 | Move compiler analysis metadata into instruction specs | 🟡 | 1-2d | 2026-05-20 | Move generic fixed stack effects, block close behavior, and memory operation metadata into `instructionSpecs.ts` while keeping dynamic function and map algorithms explicit. |
-| 412 | Expose compiler stack analysis results | 🟡 | 4-8h | 2026-05-21 | Add an opt-in compiler result payload for per-module and per-function stack analysis so editor tooltips can show selected-line stack state. |
 
 ### 🟢 Low Priority
 
@@ -83,6 +82,7 @@ Active todo files are listed below.
 
 | ID | Title | Completed | Notes |
 | ---- | ----- | --------- | ----- |
+| 412 | Expose compiler stack analysis results | 2026-05-21 | `includeStackAnalysis` now returns compact per-line stack analysis for compiled modules and functions, independently from AST output. |
 | 399 | Consolidate instruction compiler utilities | 2026-05-12 | Instruction-compiler-only helpers moved under `packages/compiler/src/instructionCompilers/utils/`; `saveByteCode` split out, unused word-alignment helper removed, and numeric binary instruction codegen centralized. |
 | 055 | Implement strength reduction optimization techniques in compiler | 2026-05-12 | Archived original TODO; remaining bytecode peephole optimization work is tracked in `398`. |
 | 392 | Move shared compiler constants to compiler-spec | 2026-05-11 | Shared memory layout, integer range, logic level, memory access-width, and Wasm page constants now resolve from `@8f4e/compiler-spec`; compiler-only bytecode header/export-count constants remain private. |

--- a/packages/compiler-spec/src/compiled.ts
+++ b/packages/compiler-spec/src/compiled.ts
@@ -2,6 +2,14 @@ import type { AST } from './ast';
 import type { ASTCache } from './cache';
 import type { FunctionTypeIdentifier } from './functionTypes';
 import type { InternalResourceMap, MemoryMap } from './memory';
+import type { StackAnalysisResult } from './semantic';
+
+export type CompiledStackAnalysisLine = {
+	lineNumberBeforeMacroExpansion: number;
+	lineNumberAfterMacroExpansion: number;
+	instruction: string;
+	stackAnalysis: StackAnalysisResult;
+};
 
 export interface CompiledModule {
 	index: number;
@@ -16,6 +24,7 @@ export interface CompiledModule {
 	internalResources?: InternalResourceMap;
 	wordAlignedSize: number;
 	ast?: AST;
+	stackAnalysis?: CompiledStackAnalysisLine[];
 	skipExecutionInCycle?: boolean;
 	initOnlyExecution?: boolean;
 }
@@ -44,6 +53,7 @@ export interface CompiledFunction {
 	wasmIndex?: number;
 	typeIndex?: number;
 	ast?: AST;
+	stackAnalysis?: CompiledStackAnalysisLine[];
 }
 
 export type CompiledFunctionLookup = Record<string, CompiledFunction>;

--- a/packages/compiler-spec/src/options.ts
+++ b/packages/compiler-spec/src/options.ts
@@ -11,6 +11,8 @@ export interface CompileOptions {
 	memoryRegions?: string[];
 	/** Whether to include AST in compiled modules. Default is false to reduce payload size. */
 	includeAST?: boolean;
+	/** Whether to include per-instruction stack analysis in compiled modules and functions. Default is false. */
+	includeStackAnalysis?: boolean;
 	/** Disable shared memory for tests (wabt doesn't support shared memory). Default is false (shared enabled). */
 	disableSharedMemory?: boolean;
 	/** Buffer size for the buffer function. Default is 128. */

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -24,6 +24,8 @@ import type {
 	CompiledModule,
 	CompiledFunction,
 	CompiledFunctionLookup,
+	CompiledStackAnalysisLine,
+	CompileOptions,
 	FunctionTypeRegistry,
 	InstructionCompiler,
 	Namespaces,
@@ -40,7 +42,16 @@ export function compileCodegenLine(line: AnalyzedLine, context: CompilationConte
 	compileInstruction(line, context);
 }
 
-export function compileLine(line: AST[number], context: CompilationContext) {
+function toCompiledStackAnalysisLine(line: AnalyzedLine): CompiledStackAnalysisLine {
+	return {
+		lineNumberBeforeMacroExpansion: line.lineNumberBeforeMacroExpansion,
+		lineNumberAfterMacroExpansion: line.lineNumberAfterMacroExpansion,
+		instruction: line.instruction,
+		stackAnalysis: line.stackAnalysis,
+	};
+}
+
+export function compileLine(line: AST[number], context: CompilationContext): AnalyzedLine | undefined {
 	if (line.isMemoryDeclaration && context.mode === 'function') {
 		throw getError(ErrorCode.MEMORY_ACCESS_IN_PURE_FUNCTION, line, context);
 	}
@@ -50,7 +61,9 @@ export function compileLine(line: AST[number], context: CompilationContext) {
 		return;
 	}
 
-	compileCodegenLine(analyzeInstruction(line, context), context);
+	const analyzedLine = analyzeInstruction(line, context);
+	compileCodegenLine(analyzedLine, context);
+	return analyzedLine;
 }
 
 export function compileModule(
@@ -60,7 +73,7 @@ export function compileModule(
 	index: number,
 	functions?: CompiledFunctionLookup,
 	internalAllocator = { nextByteAddress: 0 },
-	options: { memoryRegions?: string[] } = {}
+	options: Pick<CompileOptions, 'includeStackAnalysis' | 'memoryRegions'> = {}
 ): CompiledModule {
 	// Prepass establishes the memory layout (byte addresses, sizes) for this module.
 	// Semantic instructions (const, use, module/moduleEnd) are applied during
@@ -93,12 +106,17 @@ export function compileModule(
 		mode: 'module',
 	});
 
+	const stackAnalysis: CompiledStackAnalysisLine[] = [];
 	const normalizedAst = ast.map(originalLine => {
 		const line = normalizeCompileTimeArguments(originalLine, context);
 		if (line.isSemanticOnly) {
 			applySemanticLine(line, context);
 		} else if (!line.isMemoryDeclaration) {
-			compileCodegenLine(analyzeInstruction(line, context), context);
+			const analyzedLine = analyzeInstruction(line, context);
+			compileCodegenLine(analyzedLine, context);
+			if (options.includeStackAnalysis) {
+				stackAnalysis.push(toCompiledStackAnalysisLine(analyzedLine));
+			}
 		}
 		return line;
 	});
@@ -140,6 +158,7 @@ export function compileModule(
 		...(internalResources ? { internalResources } : {}),
 		wordAlignedSize: context.currentModuleWordAlignedSize ?? 0,
 		ast: normalizedAst,
+		...(options.includeStackAnalysis ? { stackAnalysis } : {}),
 		index,
 		skipExecutionInCycle: context.skipExecutionInCycle,
 		initOnlyExecution: context.initOnlyExecution,
@@ -151,7 +170,8 @@ export function compileFunction(
 	namespaces: Namespaces,
 	wasmIndex: number,
 	typeRegistry: FunctionTypeRegistry,
-	functions?: CompiledFunctionLookup
+	functions?: CompiledFunctionLookup,
+	options: Pick<CompileOptions, 'includeStackAnalysis'> = {}
 ): CompiledFunction {
 	const context = createCompilationContext({
 		namespace: {
@@ -179,9 +199,13 @@ export function compileFunction(
 		functionTypeRegistry: typeRegistry,
 	});
 
+	const stackAnalysis: CompiledStackAnalysisLine[] = [];
 	const normalizedAst = ast.map(originalLine => {
 		const line = normalizeCompileTimeArguments(originalLine, context);
-		compileLine(line, context);
+		const analyzedLine = compileLine(line, context);
+		if (options.includeStackAnalysis && analyzedLine) {
+			stackAnalysis.push(toCompiledStackAnalysisLine(analyzedLine));
+		}
 		return line;
 	});
 
@@ -236,5 +260,6 @@ export function compileFunction(
 		wasmIndex,
 		typeIndex,
 		ast: normalizedAst,
+		...(options.includeStackAnalysis ? { stackAnalysis } : {}),
 	};
 }

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -223,7 +223,7 @@ export default function compile(
 	};
 
 	const compiledFunctions = astFunctions.map((ast, index) =>
-		compileFunction(ast, namespaces, EXPORTED_FUNCTION_COUNT + index, functionTypeRegistry, functionMetadata)
+		compileFunction(ast, namespaces, EXPORTED_FUNCTION_COUNT + index, functionTypeRegistry, functionMetadata, options)
 	);
 	const compiledFunctionsMap = Object.fromEntries(compiledFunctions.map(func => [func.id, func]));
 	assertUniqueFunctionExportNames(compiledFunctionsMap);

--- a/packages/compiler/tests/compileModules.test.ts
+++ b/packages/compiler/tests/compileModules.test.ts
@@ -29,6 +29,19 @@ describe('compiler', () => {
 		}
 	});
 
+	test('compile function excludes stack analysis by default', () => {
+		const result = compile(
+			[{ code: ['module test', 'push 1', 'drop', 'moduleEnd'] }],
+			{
+				startingMemoryWordAddress: 0,
+			},
+			[{ code: ['function noop', 'functionEnd'] }]
+		);
+
+		expect(result.compiledModules.test.stackAnalysis).toBeUndefined();
+		expect(result.compiledFunctions!.noop.stackAnalysis).toBeUndefined();
+	});
+
 	test('compile function includes AST when includeAST is true', () => {
 		const result = compile(modules, {
 			startingMemoryWordAddress: 0,
@@ -40,6 +53,71 @@ describe('compiler', () => {
 			expect(module.ast).toBeDefined();
 			expect(Array.isArray(module.ast)).toBe(true);
 		}
+	});
+
+	test('compile function includes module stack analysis when includeStackAnalysis is true', () => {
+		const result = compile([{ code: ['module test', 'int output', 'push &output', 'push 1', 'store', 'moduleEnd'] }], {
+			startingMemoryWordAddress: 0,
+			includeStackAnalysis: true,
+		});
+
+		expect(result.compiledModules.test.ast).toBeUndefined();
+		expect(result.compiledModules.test.stackAnalysis?.map(line => line.instruction)).toEqual(['push', 'push', 'store']);
+		expect(result.compiledModules.test.stackAnalysis?.[1]).toMatchObject({
+			lineNumberBeforeMacroExpansion: 3,
+			lineNumberAfterMacroExpansion: 3,
+			instruction: 'push',
+			stackAnalysis: {
+				stackBefore: [{ isInteger: true, isNonZero: true }],
+				consumedOperands: [],
+				producedStackItems: [{ isInteger: true, isNonZero: true, knownIntegerValue: 1 }],
+				stackAfter: [
+					{ isInteger: true, isNonZero: true },
+					{ isInteger: true, isNonZero: true, knownIntegerValue: 1 },
+				],
+			},
+		});
+	});
+
+	test('compile function includes function stack analysis when includeStackAnalysis is true', () => {
+		const result = compile(
+			[{ code: ['module test', 'moduleEnd'] }],
+			{
+				startingMemoryWordAddress: 0,
+				includeStackAnalysis: true,
+			},
+			[{ code: ['function double', 'param int value', 'push value', 'push value', 'add', 'functionEnd int'] }]
+		);
+
+		expect(result.compiledFunctions!.double.stackAnalysis?.map(line => line.instruction)).toEqual([
+			'function',
+			'param',
+			'push',
+			'push',
+			'add',
+			'functionEnd',
+		]);
+		expect(result.compiledFunctions!.double.stackAnalysis?.[4]).toMatchObject({
+			instruction: 'add',
+			stackAnalysis: {
+				consumedOperands: [
+					{ isInteger: true, isNonZero: false },
+					{ isInteger: true, isNonZero: false },
+				],
+				producedStackItems: [{ isInteger: true, isNonZero: false }],
+			},
+		});
+	});
+
+	test('includeAST and includeStackAnalysis can be enabled together', () => {
+		const result = compile([{ code: ['module test', 'push 1', 'drop', 'moduleEnd'] }], {
+			startingMemoryWordAddress: 0,
+			includeAST: true,
+			includeStackAnalysis: true,
+		});
+
+		expect(result.compiledModules.test.ast).toBeDefined();
+		expect(result.compiledModules.test.stackAnalysis?.map(line => line.instruction)).toEqual(['push', 'drop']);
 	});
 
 	test('rejects duplicate module ids', () => {


### PR DESCRIPTION
## Summary
- add `includeStackAnalysis` compiler option
- expose compact per-line stack analysis on compiled modules and functions when opted in
- mark TODO 412 complete

## Validation
- `npx nx run compiler:test -- --run tests/compileModules.test.ts`
- `npx nx run compiler:typecheck`
- `npx nx run compiler-spec:typecheck`
- pre-commit: `npx nx run-many --target=typecheck --all`