### PR TITLE
fix(compiler): move analysis metadata into instruction specs

### DIFF
--- a/docs/todos/411-move-compiler-analysis-metadata-into-instruction-specs.md
+++ b/docs/todos/411-move-compiler-analysis-metadata-into-instruction-specs.md
@@ -4,8 +4,8 @@ priority: Medium
 effort: 1-2d
 created: 2026-05-20
 issue: null
-status: Open
-completed: null
+status: Done
+completed: 2026-05-25
 ---
 
 # TODO: Move compiler analysis metadata into instruction specs
@@ -38,32 +38,32 @@ The stack analyzer and code generator should read this metadata for generic case
 
 ### Step 1: Design the Spec Metadata
 
-- Add narrowly scoped analysis metadata types to `packages/compiler-spec`.
-- Keep the metadata declarative and instruction-agnostic.
-- Avoid strategy callbacks or instruction-specific config names that just move code into data.
+- [x] Add narrowly scoped analysis metadata types to `packages/compiler-spec`.
+- [x] Keep the metadata declarative and instruction-agnostic.
+- [x] Avoid strategy callbacks or instruction-specific config names that just move code into data.
 
 ### Step 2: Move Fixed Stack Effects
 
-- Convert simple fixed-effect instructions to read stack behavior from the spec.
-- Cover arithmetic, comparisons, casts, stack manipulation, and other instructions that only consume and produce fixed stack shapes.
-- Update analyzer tests alongside the refactor.
+- [x] Convert simple fixed-effect instructions to read stack behavior from the spec.
+- [x] Cover comparisons, casts, stack manipulation, loads/stores, and other instructions that only consume and produce fixed stack shapes.
+- [x] Preserve custom arithmetic analysis where integer/address metadata derivation remains algorithmic.
 
 ### Step 3: Move Block Close Metadata
 
-- Move generic block-close shape into the specs for instructions such as `else`, `blockEnd`, `loopEnd`, and `ifEnd`.
-- Keep custom function and map result validation logic explicit unless a genuinely reusable abstraction emerges.
+- [x] Move generic block-close shape into the specs for instructions such as `else`, `blockEnd`, `loopEnd`, and `ifEnd`.
+- [x] Keep custom function and map result validation logic explicit unless a genuinely reusable abstraction emerges.
 
 ### Step 4: Move Memory Operation Metadata
 
-- Move memory access width, operation kind, address operand role, and produced value type into the instruction specs.
-- Use the same spec metadata from stack analysis and code generation where possible.
-- Remove duplicated memory maps once the spec becomes the source of truth.
+- [x] Move memory access width, operation kind, address operand role, and produced value type into the instruction specs.
+- [x] Use the same spec metadata from stack analysis and code generation where possible.
+- [x] Remove duplicated memory maps once the spec becomes the source of truth.
 
 ### Step 5: Leave Dynamic Algorithms Explicit
 
-- Keep `call`, `return`, and function-end signature logic in compiler code.
-- Keep map-specific row/default/selection analysis in compiler code.
-- Reconsider these only after a more generic abstraction becomes obvious from repeated behavior.
+- [x] Keep `call`, `return`, and function-end signature logic in compiler code.
+- [x] Keep map-specific row/default/selection analysis in compiler code.
+- [x] Reconsider these only after a more generic abstraction becomes obvious from repeated behavior.
 
 ## Validation Checkpoints
 
@@ -75,18 +75,18 @@ The stack analyzer and code generator should read this metadata for generic case
 
 ## Success Criteria
 
-- [ ] Generic fixed stack effects are read from instruction specs.
-- [ ] Generic block close behavior is read from instruction specs.
-- [ ] Generic memory operation metadata is read from instruction specs.
-- [ ] `analyzeInstruction.ts` only keeps custom algorithmic cases where configuration would be too specific.
-- [ ] Code generation no longer maintains duplicate memory metadata that can live in the spec.
-- [ ] Tests are updated to match the new spec-first structure.
+- [x] Generic fixed stack effects are read from instruction specs.
+- [x] Generic block close behavior is read from instruction specs.
+- [x] Generic memory operation metadata is read from instruction specs.
+- [x] `analyzeInstruction.ts` only keeps custom algorithmic cases where configuration would be too specific.
+- [x] Code generation no longer maintains duplicate memory metadata that can live in the spec.
+- [x] Tests are updated to match the new spec-first structure.
 
 ## Affected Components
 
 - `packages/compiler-spec/src/instructionSpecs.ts`
 - `packages/compiler/src/stackAnalysis/analyzeInstruction.ts`
-- `packages/compiler/src/codegen/`
+- `packages/compiler/src/instructionCompilers/`
 - compiler stack analysis tests
 - compiler architecture boundary tests
 - editor tooltip stack signature rendering
@@ -101,3 +101,10 @@ The stack analyzer and code generator should read this metadata for generic case
 ## Related Items
 
 - **Follows**: `397-finish-compiler-stack-analysis-codegen-separation.md`
+
+## Completion Notes
+
+- Completed on 2026-05-25 by adding declarative `InstructionSpec.analysis` metadata for generic stack effects, block-close behavior, and memory operations.
+- Stack analysis now resolves configured generic effects from instruction specs before falling back to custom algorithmic cases.
+- Memory load/store/copy codegen now reads operation metadata from instruction specs; opcode builders and truly dynamic value-width choices remain in instruction compilers.
+- Verified with `npx nx run compiler-spec:typecheck`, `npx nx run compiler:typecheck`, and `npx nx run compiler:test`.

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -64,7 +64,6 @@ Active todo files are listed below.
 | 408 | Reduce tokenizer identifier classification work | 🟡 | 1-2d | 2026-05-19 | `classifyIdentifier` runs many ordered reference-shape checks for every identifier; cheap prefix/suffix dispatch could avoid most checks for plain identifiers. |
 | 409 | Track block context flags during stack analysis | 🟡 | 2-4h | 2026-05-19 | Stack validation repeatedly scans block stack to detect constants/map scope; maintained context flags or counters would avoid per-instruction scans. |
 | 410 | Consolidate release action commits | 🟡 | 2-4h | 2026-05-19 | The release workflow currently creates separate version, bundle-size, bytecode-size, and compiler-coverage commits; collapse these into one release commit or one version commit plus one metrics commit. |
-| 411 | Move compiler analysis metadata into instruction specs | 🟡 | 1-2d | 2026-05-20 | Move generic fixed stack effects, block close behavior, and memory operation metadata into `instructionSpecs.ts` while keeping dynamic function and map algorithms explicit. |
 
 ### 🟢 Low Priority
 
@@ -82,6 +81,7 @@ Active todo files are listed below.
 
 | ID | Title | Completed | Notes |
 | ---- | ----- | --------- | ----- |
+| 411 | Move compiler analysis metadata into instruction specs | 2026-05-25 | Generic fixed stack effects, block-close behavior, and memory operation metadata now live in `instructionSpecs.ts`; stack analysis and memory codegen consume the metadata while dynamic function, map, and arithmetic metadata algorithms stay explicit. |
 | 412 | Expose compiler stack analysis results | 2026-05-21 | `includeStackAnalysis` now returns compact per-line stack analysis for compiled modules and functions, independently from AST output. |
 | 399 | Consolidate instruction compiler utilities | 2026-05-12 | Instruction-compiler-only helpers moved under `packages/compiler/src/instructionCompilers/utils/`; `saveByteCode` split out, unused word-alignment helper removed, and numeric binary instruction codegen centralized. |
 | 055 | Implement strength reduction optimization techniques in compiler | 2026-05-12 | Archived original TODO; remaining bytecode peephole optimization work is tracked in `398`. |

--- a/packages/compiler-spec/src/instructionSpecs.ts
+++ b/packages/compiler-spec/src/instructionSpecs.ts
@@ -57,10 +57,6 @@ export interface ResolvedStackEffect {
 	outputs: readonly StackValueLabel[];
 }
 
-export interface StackEffectSpec<TLine extends AST[number] = AST[number]> extends ResolvedStackEffect {
-	resolve?: (line: TLine) => ResolvedStackEffect;
-}
-
 export type AnalysisStackConsumeSpec =
 	| number
 	| 'all'
@@ -97,6 +93,11 @@ export interface AnalysisStackEffectSpec {
 	dropped?: 'consumed';
 }
 
+export interface StackEffectSpec<TLine extends AST[number] = AST[number]> extends ResolvedStackEffect {
+	resolve?: (line: TLine) => ResolvedStackEffect;
+	analysis?: AnalysisStackEffectSpec;
+}
+
 export interface AnalysisBlockCloseSpec {
 	blockType: BlockTypeValue;
 	restoreResult?: boolean;
@@ -116,7 +117,6 @@ export interface AnalysisMemoryOperationSpec {
 }
 
 export interface InstructionAnalysisSpec {
-	stack?: AnalysisStackEffectSpec;
 	blockClose?: AnalysisBlockCloseSpec;
 	memory?: AnalysisMemoryOperationSpec;
 }
@@ -131,24 +131,29 @@ function withDocsAndStack<TSpec extends ValidationSpec>(
 	spec: TSpec,
 	shortDescription: string,
 	inputs: readonly StackValueLabel[],
-	outputs: readonly StackValueLabel[]
+	outputs: readonly StackValueLabel[],
+	analysis?: AnalysisStackEffectSpec
 ): TSpec & { docs: InstructionDocumentation; stack: StackEffectSpec } {
 	return {
 		...spec,
 		docs: { shortDescription },
-		stack: { inputs, outputs },
+		stack: { inputs, outputs, ...(analysis ? { analysis } : {}) },
 	};
 }
 
-function stack(inputs: readonly StackValueLabel[], outputs: readonly StackValueLabel[]): StackEffectSpec {
-	return { inputs, outputs };
+function stack(
+	inputs: readonly StackValueLabel[],
+	outputs: readonly StackValueLabel[],
+	analysis?: AnalysisStackEffectSpec
+): StackEffectSpec {
+	return { inputs, outputs, ...(analysis ? { analysis } : {}) };
 }
 
 function fixedStack(
 	consumes: AnalysisStackConsumeSpec,
 	produces: readonly AnalysisProducedStackItemSpec[] = []
-): InstructionAnalysisSpec {
-	return { stack: { consumes, produces } };
+): AnalysisStackEffectSpec {
+	return { consumes, produces };
 }
 
 function memoryLoad(
@@ -157,10 +162,6 @@ function memoryLoad(
 	resultType: 'int' | 'float'
 ): InstructionAnalysisSpec {
 	return {
-		stack: {
-			consumes: 1,
-			produces: [{ kind: resultType, isNonZero: false }],
-		},
 		memory: {
 			kind: 'load',
 			accessByteWidth,
@@ -257,16 +258,14 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Branches out of enclosing blocks when the condition is non-zero.' },
-		stack: stack(['int'], []),
-		analysis: fixedStack(1),
+		stack: stack(['int'], [], fixedStack(1)),
 	},
 	// branchIfUnchanged (T -- )
 	branchIfUnchanged: {
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Branches when the consumed value matches the previous value seen by this instruction.' },
-		stack: stack(['T'], []),
-		analysis: fixedStack(1),
+		stack: stack(['T'], [], fixedStack(1)),
 	},
 	// call (args... -- returns...)
 	call: {
@@ -281,15 +280,15 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Converts an integer stack value to a float.' },
-		stack: stack(['int'], ['float']),
-		analysis: fixedStack(1, [{ kind: 'float', isNonZero: 'fromInput' }]),
+		stack: stack(['int'], ['float'], fixedStack(1, [{ kind: 'float', isNonZero: 'fromInput' }])),
 	},
 	// castToFloat64 (int -- float64), castToFloat64 (float -- float64), castToFloat64 (float64 -- float64)
 	castToFloat64: withDocsAndStack(
-		{ ...unaryModuleOrFunctionSpec, analysis: fixedStack(1, [{ kind: 'float64', isNonZero: 'fromInput' }]) },
+		unaryModuleOrFunctionSpec,
 		'Converts a numeric stack value to float64.',
 		['T'],
-		['float64']
+		['float64'],
+		fixedStack(1, [{ kind: 'float64', isNonZero: 'fromInput' }])
 	),
 	// castToInt (float -- int), castToInt (float64 -- int)
 	castToInt: {
@@ -297,8 +296,7 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'float',
 		docs: { shortDescription: 'Converts a floating-point stack value to an integer.' },
-		stack: stack(['float'], ['int']),
-		analysis: fixedStack(1, [{ kind: 'int', isNonZero: 'fromInput' }]),
+		stack: stack(['float'], ['int'], fixedStack(1, [{ kind: 'int', isNonZero: 'fromInput' }])),
 	},
 	// clampAddress (ptr -- ptr)
 	clampAddress: {
@@ -328,8 +326,7 @@ export const instructionSpecs = {
 	clearStack: {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Removes every value from the stack.' },
-		stack: stack(['...'], []),
-		analysis: { stack: { consumes: 'all', produces: [], dropped: 'consumed' } },
+		stack: stack(['...'], [], { consumes: 'all', produces: [], dropped: 'consumed' }),
 	},
 	// default ( -- )
 	default: {
@@ -346,12 +343,7 @@ export const instructionSpecs = {
 		['T']
 	),
 	// drop (T -- )
-	drop: withDocsAndStack(
-		{ ...unaryModuleOrFunctionSpec, analysis: fixedStack(1) },
-		'Removes the top value from the stack.',
-		['T'],
-		[]
-	),
+	drop: withDocsAndStack(unaryModuleOrFunctionSpec, 'Removes the top value from the stack.', ['T'], [], fixedStack(1)),
 	// else ( -- )
 	else: {
 		scope: 'moduleOrFunction',
@@ -361,24 +353,27 @@ export const instructionSpecs = {
 	},
 	// ensureNonZero (int -- int), ensureNonZero (float -- float), ensureNonZero (float64 -- float64)
 	ensureNonZero: withDocsAndStack(
-		{ ...unaryModuleOrFunctionSpec, analysis: fixedStack(1, [{ kind: 'same', isNonZero: true }]) },
+		unaryModuleOrFunctionSpec,
 		'Ensures the top stack value is non-zero before continuing.',
 		['T'],
-		['T']
+		['T'],
+		fixedStack(1, [{ kind: 'same', isNonZero: true }])
 	),
 	// equal (int int -- int), equal (float float -- int), equal (float64 float64 -- int)
 	equal: withDocsAndStack(
-		{ ...binaryMatchingSpec, analysis: fixedStack(2, [{ kind: 'int', isNonZero: false }]) },
+		binaryMatchingSpec,
 		'Compares two values and pushes 1 when they are equal, otherwise 0.',
 		['T', 'T'],
-		['int']
+		['int'],
+		fixedStack(2, [{ kind: 'int', isNonZero: false }])
 	),
 	// equalToZero (int -- int), equalToZero (float -- int), equalToZero (float64 -- int)
 	equalToZero: withDocsAndStack(
-		{ ...unaryModuleOrFunctionSpec, analysis: fixedStack(1, [{ kind: 'int', isNonZero: false }]) },
+		unaryModuleOrFunctionSpec,
 		'Pushes 1 when the value is zero, otherwise 0.',
 		['T'],
-		['int']
+		['int'],
+		fixedStack(1, [{ kind: 'int', isNonZero: false }])
 	),
 	// exitIfTrue (int -- )
 	exitIfTrue: {
@@ -394,8 +389,7 @@ export const instructionSpecs = {
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Detects when a signal changes from a non-zero value to zero.' },
-		stack: stack(['T'], ['int']),
-		analysis: fixedStack(1, [{ kind: 'int', isNonZero: false }]),
+		stack: stack(['T'], ['int'], fixedStack(1, [{ kind: 'int', isNonZero: false }])),
 	},
 	// functionEnd (returns... -- )
 	functionEnd: {
@@ -406,32 +400,34 @@ export const instructionSpecs = {
 	},
 	// greaterOrEqual (int int -- int), greaterOrEqual (float float -- int), greaterOrEqual (float64 float64 -- int)
 	greaterOrEqual: withDocsAndStack(
-		{ ...binaryMatchingSpec, analysis: fixedStack(2, [{ kind: 'int', isNonZero: false }]) },
+		binaryMatchingSpec,
 		'Pushes 1 when the first value is greater than or equal to the second value.',
 		['T', 'T'],
-		['int']
+		['int'],
+		fixedStack(2, [{ kind: 'int', isNonZero: false }])
 	),
 	// greaterOrEqualUnsigned (int int -- int), greaterOrEqualUnsigned (float float -- int)
 	greaterOrEqualUnsigned: withDocsAndStack(
-		{ ...binaryMatchingSpec, analysis: fixedStack(2, [{ kind: 'int', isNonZero: false }]) },
+		binaryMatchingSpec,
 		'Compares two values as unsigned numbers and pushes the result.',
 		['T', 'T'],
-		['int']
+		['int'],
+		fixedStack(2, [{ kind: 'int', isNonZero: false }])
 	),
 	// greaterThan (int int -- int), greaterThan (float float -- int), greaterThan (float64 float64 -- int)
 	greaterThan: withDocsAndStack(
-		{ ...binaryMatchingSpec, analysis: fixedStack(2, [{ kind: 'int', isNonZero: false }]) },
+		binaryMatchingSpec,
 		'Pushes 1 when the first value is greater than the second value.',
 		['T', 'T'],
-		['int']
+		['int'],
+		fixedStack(2, [{ kind: 'int', isNonZero: false }])
 	),
 	// hasChanged (int -- int), hasChanged (float -- int)
 	hasChanged: {
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Pushes 1 when the consumed value differs from its previous value.' },
-		stack: stack(['T'], ['int']),
-		analysis: fixedStack(1, [{ kind: 'int', isNonZero: false }]),
+		stack: stack(['T'], ['int'], fixedStack(1, [{ kind: 'int', isNonZero: false }])),
 	},
 	// if (int -- )
 	if: {
@@ -439,8 +435,7 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Starts a conditional block when the condition is non-zero.' },
-		stack: stack(['int'], []),
-		analysis: fixedStack(1),
+		stack: stack(['int'], [], fixedStack(1)),
 	},
 	// ifEnd ( -- ), ifEnd (T -- T)
 	ifEnd: {
@@ -451,52 +446,59 @@ export const instructionSpecs = {
 	},
 	// lessOrEqual (int int -- int), lessOrEqual (float float -- int), lessOrEqual (float64 float64 -- int)
 	lessOrEqual: withDocsAndStack(
-		{ ...binaryMatchingSpec, analysis: fixedStack(2, [{ kind: 'int', isNonZero: false }]) },
+		binaryMatchingSpec,
 		'Pushes 1 when the first value is less than or equal to the second value.',
 		['T', 'T'],
-		['int']
+		['int'],
+		fixedStack(2, [{ kind: 'int', isNonZero: false }])
 	),
 	// lessThan (int int -- int), lessThan (float float -- int), lessThan (float64 float64 -- int)
 	lessThan: withDocsAndStack(
-		{ ...binaryMatchingSpec, analysis: fixedStack(2, [{ kind: 'int', isNonZero: false }]) },
+		binaryMatchingSpec,
 		'Pushes 1 when the first value is less than the second value.',
 		['T', 'T'],
-		['int']
+		['int'],
+		fixedStack(2, [{ kind: 'int', isNonZero: false }])
 	),
 	// load (ptr -- int)
 	load: withDocsAndStack(
 		{ ...loadSpec, analysis: memoryLoad('i32', WORD_MEMORY_ACCESS_WIDTH, 'int') },
 		'Loads a 32-bit integer value from memory.',
 		['ptr'],
-		['int']
+		['int'],
+		fixedStack(1, [{ kind: 'int', isNonZero: false }])
 	),
 	// load8u (ptr -- int)
 	load8u: withDocsAndStack(
 		{ ...loadSpec, analysis: memoryLoad('i32_8u', BYTE_MEMORY_ACCESS_WIDTH, 'int') },
 		'Loads an unsigned 8-bit integer value from memory.',
 		['ptr'],
-		['int']
+		['int'],
+		fixedStack(1, [{ kind: 'int', isNonZero: false }])
 	),
 	// load16u (ptr -- int)
 	load16u: withDocsAndStack(
 		{ ...loadSpec, analysis: memoryLoad('i32_16u', HALF_WORD_MEMORY_ACCESS_WIDTH, 'int') },
 		'Loads an unsigned 16-bit integer value from memory.',
 		['ptr'],
-		['int']
+		['int'],
+		fixedStack(1, [{ kind: 'int', isNonZero: false }])
 	),
 	// load8s (ptr -- int)
 	load8s: withDocsAndStack(
 		{ ...loadSpec, analysis: memoryLoad('i32_8s', BYTE_MEMORY_ACCESS_WIDTH, 'int') },
 		'Loads a signed 8-bit integer value from memory.',
 		['ptr'],
-		['int']
+		['int'],
+		fixedStack(1, [{ kind: 'int', isNonZero: false }])
 	),
 	// load16s (ptr -- int)
 	load16s: withDocsAndStack(
 		{ ...loadSpec, analysis: memoryLoad('i32_16s', HALF_WORD_MEMORY_ACCESS_WIDTH, 'int') },
 		'Loads a signed 16-bit integer value from memory.',
 		['ptr'],
-		['int']
+		['int'],
+		fixedStack(1, [{ kind: 'int', isNonZero: false }])
 	),
 	// loadFloat (ptr -- float)
 	loadFloat: {
@@ -504,7 +506,7 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Loads a float value from memory.' },
-		stack: stack(['ptr'], ['float']),
+		stack: stack(['ptr'], ['float'], fixedStack(1, [{ kind: 'float', isNonZero: false }])),
 		analysis: memoryLoad('f32', WORD_MEMORY_ACCESS_WIDTH, 'float'),
 	},
 	// local ( -- )
@@ -614,11 +616,8 @@ export const instructionSpecs = {
 		minOperands: 2,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Copies memory from one pointer range to another.' },
-		stack: stack(['ptr', 'ptr'], []),
-		analysis: {
-			...fixedStack(2),
-			memory: { kind: 'copy', addressOperandIndex: 0 },
-		},
+		stack: stack(['ptr', 'ptr'], [], fixedStack(2)),
+		analysis: { memory: { kind: 'copy', addressOperandIndex: 0 } },
 	},
 	// min (int int -- int), min (float float -- float), min (float64 float64 -- float64)
 	min: withDocsAndStack(binaryMatchingSpec, 'Pushes the smaller of two values of the same type.', ['T', 'T'], ['T']),
@@ -633,17 +632,19 @@ export const instructionSpecs = {
 	),
 	// notEqual (int int -- int), notEqual (float float -- int), notEqual (float64 float64 -- int)
 	notEqual: withDocsAndStack(
-		{ ...binaryMatchingSpec, analysis: fixedStack(2, [{ kind: 'int', isNonZero: false }]) },
+		binaryMatchingSpec,
 		'Compares two values and pushes 1 when they are not equal, otherwise 0.',
 		['T', 'T'],
-		['int']
+		['int'],
+		fixedStack(2, [{ kind: 'int', isNonZero: false }])
 	),
 	// notZero (int -- int), notZero (float -- int), notZero (float64 -- int)
 	notZero: withDocsAndStack(
-		{ ...unaryModuleOrFunctionSpec, analysis: fixedStack(1, [{ kind: 'int', isNonZero: 'fromInput' }]) },
+		unaryModuleOrFunctionSpec,
 		'Pushes 1 when the value is non-zero, otherwise 0.',
 		['T'],
-		['int']
+		['int'],
+		fixedStack(1, [{ kind: 'int', isNonZero: 'fromInput' }])
 	),
 	// or (int int -- int)
 	or: withDocsAndStack(binaryIntegerSpec, 'Performs a bitwise OR on two integers.', ['int', 'int'], ['int']),
@@ -679,8 +680,7 @@ export const instructionSpecs = {
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Detects when a signal changes from zero to a non-zero value.' },
-		stack: stack(['T'], ['int']),
-		analysis: fixedStack(1, [{ kind: 'int', isNonZero: false }]),
+		stack: stack(['T'], ['int'], fixedStack(1, [{ kind: 'int', isNonZero: false }])),
 	},
 	// round (float -- float)
 	round: {
@@ -688,8 +688,7 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'float',
 		docs: { shortDescription: 'Rounds a float value to the nearest whole value.' },
-		stack: stack(['float'], ['float']),
-		analysis: fixedStack(1, [{ kind: 'float', isNonZero: false }]),
+		stack: stack(['float'], ['float'], fixedStack(1, [{ kind: 'float', isNonZero: false }])),
 	},
 	// shiftLeft (int int -- int)
 	shiftLeft: withDocsAndStack(
@@ -718,8 +717,7 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'float',
 		docs: { shortDescription: 'Pushes the square root of a float value.' },
-		stack: stack(['float'], ['float']),
-		analysis: fixedStack(1, [{ kind: 'same', isNonZero: false }]),
+		stack: stack(['float'], ['float'], fixedStack(1, [{ kind: 'same', isNonZero: false }])),
 	},
 	// store (ptr int -- ), store (ptr float -- ), store (ptr float64 -- )
 	store: {
@@ -728,11 +726,8 @@ export const instructionSpecs = {
 		minOperands: 2,
 		operandTypes: ['int'],
 		docs: { shortDescription: 'Stores a value at the memory address on the stack.' },
-		stack: stack(['ptr', 'T'], []),
-		analysis: {
-			...fixedStack(2),
-			memory: { kind: 'store', addressOperandIndex: 0, valueOperandIndex: 1 },
-		},
+		stack: stack(['ptr', 'T'], [], fixedStack(2)),
+		analysis: { memory: { kind: 'store', addressOperandIndex: 0, valueOperandIndex: 1 } },
 	},
 	// storeBytes (ptr int... -- )
 	storeBytes: {
@@ -749,6 +744,7 @@ export const instructionSpecs = {
 		stack: {
 			inputs: ['ptr', 'bytes...'],
 			outputs: [],
+			analysis: { consumes: { argumentValueIndex: 0, add: 1 }, produces: [] },
 			resolve: line => {
 				const count = (line as StoreBytesLine).arguments[0]?.value;
 
@@ -759,10 +755,7 @@ export const instructionSpecs = {
 				return { inputs: ['ptr', ...new Array(count).fill('int')], outputs: [] };
 			},
 		},
-		analysis: {
-			stack: { consumes: { argumentValueIndex: 0, add: 1 }, produces: [] },
-			memory: { kind: 'storeBytes', accessByteWidth: BYTE_MEMORY_ACCESS_WIDTH },
-		},
+		analysis: { memory: { kind: 'storeBytes', accessByteWidth: BYTE_MEMORY_ACCESS_WIDTH } },
 	},
 	// sub (int int -- int), sub (float float -- float), sub (float64 float64 -- float64)
 	sub: withDocsAndStack(

--- a/packages/compiler-spec/src/instructionSpecs.ts
+++ b/packages/compiler-spec/src/instructionSpecs.ts
@@ -57,7 +57,7 @@ export interface ResolvedStackEffect {
 	outputs: readonly StackValueLabel[];
 }
 
-export type AnalysisStackConsumeSpec =
+export type StackConsumeSpec =
 	| number
 	| 'all'
 	| {
@@ -65,7 +65,7 @@ export type AnalysisStackConsumeSpec =
 			add: number;
 	  };
 
-export type AnalysisProducedStackItemSpec =
+export type StackProducedItemSpec =
 	| {
 			kind: 'int';
 			isNonZero?: boolean | 'fromInput';
@@ -87,18 +87,18 @@ export type AnalysisProducedStackItemSpec =
 			isNonZero?: boolean | 'fromInput';
 	  };
 
-export interface AnalysisStackEffectSpec {
-	consumes: AnalysisStackConsumeSpec;
-	produces?: readonly AnalysisProducedStackItemSpec[];
+export interface StackMutationSpec {
+	consumes: StackConsumeSpec;
+	produces?: readonly StackProducedItemSpec[];
 	dropped?: 'consumed';
 }
 
 export interface StackEffectSpec<TLine extends AST[number] = AST[number]> extends ResolvedStackEffect {
 	resolve?: (line: TLine) => ResolvedStackEffect;
-	analysis?: AnalysisStackEffectSpec;
+	effect?: StackMutationSpec;
 }
 
-export interface AnalysisBlockCloseSpec {
+export interface BlockCloseEffectSpec {
 	blockType: BlockTypeValue;
 	restoreResult?: boolean;
 	validateFloatResult?: boolean;
@@ -106,7 +106,7 @@ export interface AnalysisBlockCloseSpec {
 
 export type MemoryLoadVariant = 'i32' | 'i32_8s' | 'i32_8u' | 'i32_16s' | 'i32_16u' | 'f32';
 
-export type AnalysisMemoryOperationSpec =
+export type MemoryOperationEffectSpec =
 	| {
 			kind: 'load';
 			accessByteWidth: number;
@@ -128,47 +128,46 @@ export type AnalysisMemoryOperationSpec =
 			addressOperandIndex: number;
 	  };
 
-export interface InstructionAnalysisSpec {
-	blockClose?: AnalysisBlockCloseSpec;
-	memory?: AnalysisMemoryOperationSpec;
+export interface InstructionEffectsSpec {
+	blockClose?: BlockCloseEffectSpec;
+	memory?: MemoryOperationEffectSpec;
 }
 
 export interface InstructionSpec<TLine extends AST[number] = AST[number]> extends ValidationSpec<TLine> {
 	docs?: InstructionDocumentation;
 	stack?: StackEffectSpec<TLine>;
-	analysis?: InstructionAnalysisSpec;
+	effects?: InstructionEffectsSpec;
 }
 
 interface DocsAndStackOptions {
 	shortDescription: string;
 	inputs: readonly StackValueLabel[];
 	outputs: readonly StackValueLabel[];
-	analysis?: AnalysisStackEffectSpec;
+	effect?: StackMutationSpec;
+}
+
+interface StackOptions {
+	inputs: readonly StackValueLabel[];
+	outputs: readonly StackValueLabel[];
+	effect?: StackMutationSpec;
 }
 
 function withDocsAndStack<TSpec extends ValidationSpec>(
 	spec: TSpec,
-	{ shortDescription, inputs, outputs, analysis }: DocsAndStackOptions
+	{ shortDescription, inputs, outputs, effect }: DocsAndStackOptions
 ): TSpec & { docs: InstructionDocumentation; stack: StackEffectSpec } {
 	return {
 		...spec,
 		docs: { shortDescription },
-		stack: { inputs, outputs, ...(analysis ? { analysis } : {}) },
+		stack: { inputs, outputs, ...(effect ? { effect } : {}) },
 	};
 }
 
-function stack(
-	inputs: readonly StackValueLabel[],
-	outputs: readonly StackValueLabel[],
-	analysis?: AnalysisStackEffectSpec
-): StackEffectSpec {
-	return { inputs, outputs, ...(analysis ? { analysis } : {}) };
+function stack({ inputs, outputs, effect }: StackOptions): StackEffectSpec {
+	return { inputs, outputs, ...(effect ? { effect } : {}) };
 }
 
-function stackAnalysis(
-	consumes: AnalysisStackConsumeSpec,
-	produces: readonly AnalysisProducedStackItemSpec[] = []
-): AnalysisStackEffectSpec {
+function stackMutation(consumes: StackConsumeSpec, produces: readonly StackProducedItemSpec[] = []): StackMutationSpec {
 	return { consumes, produces };
 }
 
@@ -177,7 +176,7 @@ function memoryLoad<TLoadVariant extends MemoryLoadVariant, TResultType extends 
 	accessByteWidth: number,
 	resultType: TResultType
 ): {
-	memory: Extract<AnalysisMemoryOperationSpec, { kind: 'load' }> & {
+	memory: Extract<MemoryOperationEffectSpec, { kind: 'load' }> & {
 		loadVariant: TLoadVariant;
 		resultType: TResultType;
 	};
@@ -199,7 +198,7 @@ interface LoadInstructionOptions<TLoadVariant extends MemoryLoadVariant, TResult
 	resultType: TResultType;
 	shortDescription: string;
 	output: StackValueLabel;
-	analysis: AnalysisStackEffectSpec;
+	effect: StackMutationSpec;
 }
 
 function loadInstruction<TLoadVariant extends MemoryLoadVariant, TResultType extends 'int' | 'float'>({
@@ -208,18 +207,18 @@ function loadInstruction<TLoadVariant extends MemoryLoadVariant, TResultType ext
 	resultType,
 	shortDescription,
 	output,
-	analysis,
+	effect,
 }: LoadInstructionOptions<TLoadVariant, TResultType>) {
 	return withDocsAndStack(
-		{ ...loadSpec, analysis: memoryLoad(loadVariant, accessByteWidth, resultType) },
-		{ shortDescription, inputs: ['ptr'], outputs: [output], analysis }
+		{ ...loadSpec, effects: memoryLoad(loadVariant, accessByteWidth, resultType) },
+		{ shortDescription, inputs: ['ptr'], outputs: [output], effect }
 	);
 }
 
 function blockClose(
 	blockType: BlockTypeValue,
 	{ restoreResult = false, validateFloatResult = false } = {}
-): { blockClose: AnalysisBlockCloseSpec } {
+): { blockClose: BlockCloseEffectSpec } {
 	return { blockClose: { blockType, restoreResult, validateFloatResult } };
 }
 
@@ -288,20 +287,20 @@ export const instructionSpecs = {
 	block: {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Starts a block that can be exited with branch instructions.' },
-		stack: stack([], []),
+		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// blockEnd ( -- ), blockEnd (T -- T)
 	blockEnd: {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Ends a block and validates its optional result value.' },
-		stack: stack(['T?'], ['T?']),
-		analysis: blockClose(BlockType.BLOCK, { restoreResult: true }),
+		stack: stack({ inputs: ['T?'], outputs: ['T?'] }),
+		effects: blockClose(BlockType.BLOCK, { restoreResult: true }),
 	},
 	// branch ( -- )
 	branch: {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Branches out of one or more enclosing blocks.' },
-		stack: stack([], []),
+		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// branchIfTrue (int -- )
 	branchIfTrue: {
@@ -309,21 +308,21 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Branches out of enclosing blocks when the condition is non-zero.' },
-		stack: stack(['int'], [], stackAnalysis(1)),
+		stack: stack({ inputs: ['int'], outputs: [], effect: stackMutation(1) }),
 	},
 	// branchIfUnchanged (T -- )
 	branchIfUnchanged: {
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Branches when the consumed value matches the previous value seen by this instruction.' },
-		stack: stack(['T'], [], stackAnalysis(1)),
+		stack: stack({ inputs: ['T'], outputs: [], effect: stackMutation(1) }),
 	},
 	// call (args... -- returns...)
 	call: {
 		scope: 'moduleOrFunction',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_BLOCK,
 		docs: { shortDescription: 'Calls a function, consuming its parameters and pushing its return values.' },
-		stack: stack(['args...'], ['returns...']),
+		stack: stack({ inputs: ['args...'], outputs: ['returns...'] }),
 	},
 	// castToFloat (int -- float)
 	castToFloat: {
@@ -331,14 +330,18 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Converts an integer stack value to a float.' },
-		stack: stack(['int'], ['float'], stackAnalysis(1, [{ kind: 'float', isNonZero: 'fromInput' }])),
+		stack: stack({
+			inputs: ['int'],
+			outputs: ['float'],
+			effect: stackMutation(1, [{ kind: 'float', isNonZero: 'fromInput' }]),
+		}),
 	},
 	// castToFloat64 (int -- float64), castToFloat64 (float -- float64), castToFloat64 (float64 -- float64)
 	castToFloat64: withDocsAndStack(unaryModuleOrFunctionSpec, {
 		shortDescription: 'Converts a numeric stack value to float64.',
 		inputs: ['T'],
 		outputs: ['float64'],
-		analysis: stackAnalysis(1, [{ kind: 'float64', isNonZero: 'fromInput' }]),
+		effect: stackMutation(1, [{ kind: 'float64', isNonZero: 'fromInput' }]),
 	}),
 	// castToInt (float -- int), castToInt (float64 -- int)
 	castToInt: {
@@ -346,7 +349,11 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'float',
 		docs: { shortDescription: 'Converts a floating-point stack value to an integer.' },
-		stack: stack(['float'], ['int'], stackAnalysis(1, [{ kind: 'int', isNonZero: 'fromInput' }])),
+		stack: stack({
+			inputs: ['float'],
+			outputs: ['int'],
+			effect: stackMutation(1, [{ kind: 'int', isNonZero: 'fromInput' }]),
+		}),
 	},
 	// clampAddress (ptr -- ptr)
 	clampAddress: {
@@ -354,7 +361,7 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Clamps a pointer so it stays inside the active memory range.' },
-		stack: stack(['ptr'], ['ptr']),
+		stack: stack({ inputs: ['ptr'], outputs: ['ptr'] }),
 	},
 	// clampModuleAddress (ptr -- ptr)
 	clampModuleAddress: {
@@ -362,7 +369,7 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Clamps a pointer so it stays inside module memory.' },
-		stack: stack(['ptr'], ['ptr']),
+		stack: stack({ inputs: ['ptr'], outputs: ['ptr'] }),
 	},
 	// clampGlobalAddress (ptr -- ptr)
 	clampGlobalAddress: {
@@ -370,20 +377,20 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Clamps a pointer so it stays inside global memory.' },
-		stack: stack(['ptr'], ['ptr']),
+		stack: stack({ inputs: ['ptr'], outputs: ['ptr'] }),
 	},
 	// clearStack (... -- )
 	clearStack: {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Removes every value from the stack.' },
-		stack: stack(['...'], [], { consumes: 'all', produces: [], dropped: 'consumed' }),
+		stack: stack({ inputs: ['...'], outputs: [], effect: { consumes: 'all', produces: [], dropped: 'consumed' } }),
 	},
 	// default ( -- )
 	default: {
 		scope: 'map',
 		allowedInMapBlocks: true,
 		docs: { shortDescription: 'Defines the fallback value for a map block.' },
-		stack: stack([], []),
+		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// div (int int -- int), div (float float -- float), div (float64 float64 -- float64)
 	div: withDocsAndStack(binaryMatchingSpec, {
@@ -396,35 +403,35 @@ export const instructionSpecs = {
 		shortDescription: 'Removes the top value from the stack.',
 		inputs: ['T'],
 		outputs: [],
-		analysis: stackAnalysis(1),
+		effect: stackMutation(1),
 	}),
 	// else ( -- )
 	else: {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Starts the alternate branch of the current if block.' },
-		stack: stack([], []),
-		analysis: blockClose(BlockType.CONDITION, { validateFloatResult: true }),
+		stack: stack({ inputs: [], outputs: [] }),
+		effects: blockClose(BlockType.CONDITION, { validateFloatResult: true }),
 	},
 	// ensureNonZero (int -- int), ensureNonZero (float -- float), ensureNonZero (float64 -- float64)
 	ensureNonZero: withDocsAndStack(unaryModuleOrFunctionSpec, {
 		shortDescription: 'Ensures the top stack value is non-zero before continuing.',
 		inputs: ['T'],
 		outputs: ['T'],
-		analysis: stackAnalysis(1, [{ kind: 'same', isNonZero: true }]),
+		effect: stackMutation(1, [{ kind: 'same', isNonZero: true }]),
 	}),
 	// equal (int int -- int), equal (float float -- int), equal (float64 float64 -- int)
 	equal: withDocsAndStack(binaryMatchingSpec, {
 		shortDescription: 'Compares two values and pushes 1 when they are equal, otherwise 0.',
 		inputs: ['T', 'T'],
 		outputs: ['int'],
-		analysis: stackAnalysis(2, [{ kind: 'int', isNonZero: false }]),
+		effect: stackMutation(2, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// equalToZero (int -- int), equalToZero (float -- int), equalToZero (float64 -- int)
 	equalToZero: withDocsAndStack(unaryModuleOrFunctionSpec, {
 		shortDescription: 'Pushes 1 when the value is zero, otherwise 0.',
 		inputs: ['T'],
 		outputs: ['int'],
-		analysis: stackAnalysis(1, [{ kind: 'int', isNonZero: false }]),
+		effect: stackMutation(1, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// exitIfTrue (int -- )
 	exitIfTrue: {
@@ -433,49 +440,49 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Exits the enclosing module when the condition is non-zero.' },
-		stack: stack(['int'], []),
+		stack: stack({ inputs: ['int'], outputs: [] }),
 	},
 	// fallingEdge (int -- int), fallingEdge (float -- int)
 	fallingEdge: {
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Detects when a signal changes from a non-zero value to zero.' },
-		stack: stack(['T'], ['int'], stackAnalysis(1, [{ kind: 'int', isNonZero: false }])),
+		stack: stack({ inputs: ['T'], outputs: ['int'], effect: stackMutation(1, [{ kind: 'int', isNonZero: false }]) }),
 	},
 	// functionEnd (returns... -- )
 	functionEnd: {
 		scope: 'function',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_BLOCK,
 		docs: { shortDescription: 'Ends a function and records its return signature.' },
-		stack: stack(['returns...'], []),
+		stack: stack({ inputs: ['returns...'], outputs: [] }),
 	},
 	// greaterOrEqual (int int -- int), greaterOrEqual (float float -- int), greaterOrEqual (float64 float64 -- int)
 	greaterOrEqual: withDocsAndStack(binaryMatchingSpec, {
 		shortDescription: 'Pushes 1 when the first value is greater than or equal to the second value.',
 		inputs: ['T', 'T'],
 		outputs: ['int'],
-		analysis: stackAnalysis(2, [{ kind: 'int', isNonZero: false }]),
+		effect: stackMutation(2, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// greaterOrEqualUnsigned (int int -- int), greaterOrEqualUnsigned (float float -- int)
 	greaterOrEqualUnsigned: withDocsAndStack(binaryMatchingSpec, {
 		shortDescription: 'Compares two values as unsigned numbers and pushes the result.',
 		inputs: ['T', 'T'],
 		outputs: ['int'],
-		analysis: stackAnalysis(2, [{ kind: 'int', isNonZero: false }]),
+		effect: stackMutation(2, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// greaterThan (int int -- int), greaterThan (float float -- int), greaterThan (float64 float64 -- int)
 	greaterThan: withDocsAndStack(binaryMatchingSpec, {
 		shortDescription: 'Pushes 1 when the first value is greater than the second value.',
 		inputs: ['T', 'T'],
 		outputs: ['int'],
-		analysis: stackAnalysis(2, [{ kind: 'int', isNonZero: false }]),
+		effect: stackMutation(2, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// hasChanged (int -- int), hasChanged (float -- int)
 	hasChanged: {
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Pushes 1 when the consumed value differs from its previous value.' },
-		stack: stack(['T'], ['int'], stackAnalysis(1, [{ kind: 'int', isNonZero: false }])),
+		stack: stack({ inputs: ['T'], outputs: ['int'], effect: stackMutation(1, [{ kind: 'int', isNonZero: false }]) }),
 	},
 	// if (int -- )
 	if: {
@@ -483,28 +490,28 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Starts a conditional block when the condition is non-zero.' },
-		stack: stack(['int'], [], stackAnalysis(1)),
+		stack: stack({ inputs: ['int'], outputs: [], effect: stackMutation(1) }),
 	},
 	// ifEnd ( -- ), ifEnd (T -- T)
 	ifEnd: {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Ends an if block and validates its optional result value.' },
-		stack: stack(['T?'], ['T?']),
-		analysis: blockClose(BlockType.CONDITION, { restoreResult: true, validateFloatResult: true }),
+		stack: stack({ inputs: ['T?'], outputs: ['T?'] }),
+		effects: blockClose(BlockType.CONDITION, { restoreResult: true, validateFloatResult: true }),
 	},
 	// lessOrEqual (int int -- int), lessOrEqual (float float -- int), lessOrEqual (float64 float64 -- int)
 	lessOrEqual: withDocsAndStack(binaryMatchingSpec, {
 		shortDescription: 'Pushes 1 when the first value is less than or equal to the second value.',
 		inputs: ['T', 'T'],
 		outputs: ['int'],
-		analysis: stackAnalysis(2, [{ kind: 'int', isNonZero: false }]),
+		effect: stackMutation(2, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// lessThan (int int -- int), lessThan (float float -- int), lessThan (float64 float64 -- int)
 	lessThan: withDocsAndStack(binaryMatchingSpec, {
 		shortDescription: 'Pushes 1 when the first value is less than the second value.',
 		inputs: ['T', 'T'],
 		outputs: ['int'],
-		analysis: stackAnalysis(2, [{ kind: 'int', isNonZero: false }]),
+		effect: stackMutation(2, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// load (ptr -- int)
 	load: loadInstruction({
@@ -513,7 +520,7 @@ export const instructionSpecs = {
 		resultType: 'int',
 		shortDescription: 'Loads a 32-bit integer value from memory.',
 		output: 'int',
-		analysis: stackAnalysis(1, [{ kind: 'int', isNonZero: false }]),
+		effect: stackMutation(1, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// load8u (ptr -- int)
 	load8u: loadInstruction({
@@ -522,7 +529,7 @@ export const instructionSpecs = {
 		resultType: 'int',
 		shortDescription: 'Loads an unsigned 8-bit integer value from memory.',
 		output: 'int',
-		analysis: stackAnalysis(1, [{ kind: 'int', isNonZero: false }]),
+		effect: stackMutation(1, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// load16u (ptr -- int)
 	load16u: loadInstruction({
@@ -531,7 +538,7 @@ export const instructionSpecs = {
 		resultType: 'int',
 		shortDescription: 'Loads an unsigned 16-bit integer value from memory.',
 		output: 'int',
-		analysis: stackAnalysis(1, [{ kind: 'int', isNonZero: false }]),
+		effect: stackMutation(1, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// load8s (ptr -- int)
 	load8s: loadInstruction({
@@ -540,7 +547,7 @@ export const instructionSpecs = {
 		resultType: 'int',
 		shortDescription: 'Loads a signed 8-bit integer value from memory.',
 		output: 'int',
-		analysis: stackAnalysis(1, [{ kind: 'int', isNonZero: false }]),
+		effect: stackMutation(1, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// load16s (ptr -- int)
 	load16s: loadInstruction({
@@ -549,7 +556,7 @@ export const instructionSpecs = {
 		resultType: 'int',
 		shortDescription: 'Loads a signed 16-bit integer value from memory.',
 		output: 'int',
-		analysis: stackAnalysis(1, [{ kind: 'int', isNonZero: false }]),
+		effect: stackMutation(1, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// loadFloat (ptr -- float)
 	loadFloat: loadInstruction({
@@ -558,14 +565,14 @@ export const instructionSpecs = {
 		resultType: 'float',
 		shortDescription: 'Loads a float value from memory.',
 		output: 'float',
-		analysis: stackAnalysis(1, [{ kind: 'float', isNonZero: false }]),
+		effect: stackMutation(1, [{ kind: 'float', isNonZero: false }]),
 	}),
 	// local ( -- )
 	local: {
 		scope: 'moduleOrFunction',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_BLOCK,
 		docs: { shortDescription: 'Declares a local variable in the current function or module block.' },
-		stack: stack([], []),
+		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// localSet (T -- )
 	localSet: {
@@ -573,27 +580,27 @@ export const instructionSpecs = {
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_BLOCK,
 		minOperands: 1,
 		docs: { shortDescription: 'Stores the top stack value into a local variable.' },
-		stack: stack(['T'], []),
+		stack: stack({ inputs: ['T'], outputs: [] }),
 	},
 	// loop ( -- )
 	loop: {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Starts a loop block that repeats until a branch exits it.' },
-		stack: stack([], []),
+		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// #loopCap ( -- )
 	'#loopCap': {
 		scope: 'moduleOrFunction',
 		onInvalidScope: ErrorCode.COMPILER_DIRECTIVE_INVALID_CONTEXT,
 		docs: { shortDescription: 'Sets the loop iteration cap for loops in the current block.' },
-		stack: stack([], []),
+		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// #region <name|index> ( -- )
 	'#region': {
 		scope: 'module',
 		onInvalidScope: ErrorCode.COMPILER_DIRECTIVE_INVALID_CONTEXT,
 		docs: { shortDescription: 'Selects the memory region used by subsequent module declarations.' },
-		stack: stack([], []),
+		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// #export [exportName] ( -- )
 	'#export': {
@@ -602,55 +609,55 @@ export const instructionSpecs = {
 		docs: {
 			shortDescription: 'Exports the current function under the provided name, or the function name if omitted.',
 		},
-		stack: stack([], []),
+		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// #skipExecution ( -- )
 	'#skipExecution': {
 		scope: 'moduleOnly',
 		onInvalidScope: ErrorCode.COMPILER_DIRECTIVE_INVALID_CONTEXT,
 		docs: { shortDescription: 'Skips the current module during cycle execution.' },
-		stack: stack([], []),
+		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// #initOnly ( -- )
 	'#initOnly': {
 		scope: 'moduleOnly',
 		onInvalidScope: ErrorCode.COMPILER_DIRECTIVE_INVALID_CONTEXT,
 		docs: { shortDescription: 'Runs the current module only during initialization.' },
-		stack: stack([], []),
+		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// #impure ( -- )
 	'#impure': {
 		scope: 'function',
 		onInvalidScope: ErrorCode.IMPURE_DIRECTIVE_INVALID_CONTEXT,
 		docs: { shortDescription: 'Allows the current function to perform explicit memory IO.' },
-		stack: stack([], []),
+		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// loopEnd ( -- ), loopEnd (T -- T)
 	loopEnd: {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Ends a loop block and branches back to the start of the loop.' },
-		stack: stack(['T?'], ['T?']),
-		analysis: blockClose(BlockType.LOOP, { restoreResult: true }),
+		stack: stack({ inputs: ['T?'], outputs: ['T?'] }),
+		effects: blockClose(BlockType.LOOP, { restoreResult: true }),
 	},
 	// loopIndex ( -- int)
 	loopIndex: {
 		scope: 'loop',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_LOOP,
 		docs: { shortDescription: 'Pushes the current zero-based loop iteration index.' },
-		stack: stack([], ['int']),
+		stack: stack({ inputs: [], outputs: ['int'] }),
 	},
 	// map ( -- )
 	map: {
 		scope: 'map',
 		allowedInMapBlocks: true,
 		docs: { shortDescription: 'Starts a map case inside a map block.' },
-		stack: stack([], []),
+		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// mapBegin ( -- )
 	mapBegin: {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Starts a map block that chooses a value from map cases.' },
-		stack: stack([], []),
+		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// mapEnd (int -- T), mapEnd (float -- T), mapEnd (float64 -- T)
 	mapEnd: {
@@ -658,7 +665,7 @@ export const instructionSpecs = {
 		allowedInMapBlocks: true,
 		minOperands: 1,
 		docs: { shortDescription: 'Ends a map block and leaves the selected mapped value on the stack.' },
-		stack: stack(['T'], ['T']),
+		stack: stack({ inputs: ['T'], outputs: ['T'] }),
 	},
 	// memoryCopy (ptr ptr -- )
 	memoryCopy: {
@@ -667,8 +674,8 @@ export const instructionSpecs = {
 		minOperands: 2,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Copies memory from one pointer range to another.' },
-		stack: stack(['ptr', 'ptr'], [], stackAnalysis(2)),
-		analysis: { memory: { kind: 'copy', addressOperandIndex: 0 } },
+		stack: stack({ inputs: ['ptr', 'ptr'], outputs: [], effect: stackMutation(2) }),
+		effects: { memory: { kind: 'copy', addressOperandIndex: 0 } },
 	},
 	// min (int int -- int), min (float float -- float), min (float64 float64 -- float64)
 	min: withDocsAndStack(binaryMatchingSpec, {
@@ -693,14 +700,14 @@ export const instructionSpecs = {
 		shortDescription: 'Compares two values and pushes 1 when they are not equal, otherwise 0.',
 		inputs: ['T', 'T'],
 		outputs: ['int'],
-		analysis: stackAnalysis(2, [{ kind: 'int', isNonZero: false }]),
+		effect: stackMutation(2, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// notZero (int -- int), notZero (float -- int), notZero (float64 -- int)
 	notZero: withDocsAndStack(unaryModuleOrFunctionSpec, {
 		shortDescription: 'Pushes 1 when the value is non-zero, otherwise 0.',
 		inputs: ['T'],
 		outputs: ['int'],
-		analysis: stackAnalysis(1, [{ kind: 'int', isNonZero: 'fromInput' }]),
+		effect: stackMutation(1, [{ kind: 'int', isNonZero: 'fromInput' }]),
 	}),
 	// or (int int -- int)
 	or: withDocsAndStack(binaryIntegerSpec, {
@@ -713,13 +720,13 @@ export const instructionSpecs = {
 		scope: 'function',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_BLOCK,
 		docs: { shortDescription: 'Declares a parameter for the current function.' },
-		stack: stack([], []),
+		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// push ( -- T)
 	push: {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Pushes a literal, memory value, local value, address, or constant onto the stack.' },
-		stack: stack([], ['T']),
+		stack: stack({ inputs: [], outputs: ['T'] }),
 	},
 	// remainder (int int -- int)
 	remainder: withDocsAndStack(binaryIntegerSpec, {
@@ -732,14 +739,14 @@ export const instructionSpecs = {
 		scope: 'function',
 		onInvalidScope: ErrorCode.RETURN_OUTSIDE_FUNCTION,
 		docs: { shortDescription: 'Returns from the current function with the values on the stack.' },
-		stack: stack(['returns...'], ['never']),
+		stack: stack({ inputs: ['returns...'], outputs: ['never'] }),
 	},
 	// risingEdge (int -- int), risingEdge (float -- int)
 	risingEdge: {
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Detects when a signal changes from zero to a non-zero value.' },
-		stack: stack(['T'], ['int'], stackAnalysis(1, [{ kind: 'int', isNonZero: false }])),
+		stack: stack({ inputs: ['T'], outputs: ['int'], effect: stackMutation(1, [{ kind: 'int', isNonZero: false }]) }),
 	},
 	// round (float -- float)
 	round: {
@@ -747,7 +754,11 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'float',
 		docs: { shortDescription: 'Rounds a float value to the nearest whole value.' },
-		stack: stack(['float'], ['float'], stackAnalysis(1, [{ kind: 'float', isNonZero: false }])),
+		stack: stack({
+			inputs: ['float'],
+			outputs: ['float'],
+			effect: stackMutation(1, [{ kind: 'float', isNonZero: false }]),
+		}),
 	},
 	// shiftLeft (int int -- int)
 	shiftLeft: withDocsAndStack(binaryIntegerSpec, {
@@ -773,7 +784,11 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'float',
 		docs: { shortDescription: 'Pushes the square root of a float value.' },
-		stack: stack(['float'], ['float'], stackAnalysis(1, [{ kind: 'same', isNonZero: false }])),
+		stack: stack({
+			inputs: ['float'],
+			outputs: ['float'],
+			effect: stackMutation(1, [{ kind: 'same', isNonZero: false }]),
+		}),
 	},
 	// store (ptr int -- ), store (ptr float -- ), store (ptr float64 -- )
 	store: {
@@ -782,8 +797,8 @@ export const instructionSpecs = {
 		minOperands: 2,
 		operandTypes: ['int'],
 		docs: { shortDescription: 'Stores a value at the memory address on the stack.' },
-		stack: stack(['ptr', 'T'], [], stackAnalysis(2)),
-		analysis: { memory: { kind: 'store', addressOperandIndex: 0, valueOperandIndex: 1 } },
+		stack: stack({ inputs: ['ptr', 'T'], outputs: [], effect: stackMutation(2) }),
+		effects: { memory: { kind: 'store', addressOperandIndex: 0, valueOperandIndex: 1 } },
 	},
 	// storeBytes (int... ptr -- )
 	storeBytes: {
@@ -800,7 +815,7 @@ export const instructionSpecs = {
 		stack: {
 			inputs: ['bytes...', 'ptr'],
 			outputs: [],
-			analysis: { consumes: { argumentValueIndex: 0, add: 1 }, produces: [] },
+			effect: { consumes: { argumentValueIndex: 0, add: 1 }, produces: [] },
 			resolve: line => {
 				const count = (line as StoreBytesLine).arguments[0]?.value;
 
@@ -811,7 +826,7 @@ export const instructionSpecs = {
 				return { inputs: [...new Array(count).fill('int'), 'ptr'], outputs: [] };
 			},
 		},
-		analysis: { memory: { kind: 'storeBytes', accessByteWidth: BYTE_MEMORY_ACCESS_WIDTH } },
+		effects: { memory: { kind: 'storeBytes', accessByteWidth: BYTE_MEMORY_ACCESS_WIDTH } },
 	},
 	// sub (int int -- int), sub (float float -- float), sub (float64 float64 -- float64)
 	sub: withDocsAndStack(binaryMatchingSpec, {
@@ -835,9 +850,9 @@ export const instructionSpecs = {
 
 export type InstructionSpecName = keyof typeof instructionSpecs;
 
-type MemoryOperationForSpec<TSpec> = TSpec extends { analysis: { memory: infer TMemory } } ? TMemory : never;
+type MemoryOperationForSpec<TSpec> = TSpec extends { effects: { memory: infer TMemory } } ? TMemory : never;
 
-export type InstructionNamesByMemoryOperation<TOperation extends AnalysisMemoryOperationSpec> = {
+export type InstructionNamesByMemoryOperation<TOperation extends MemoryOperationEffectSpec> = {
 	[TInstruction in InstructionSpecName]: [MemoryOperationForSpec<(typeof instructionSpecs)[TInstruction]>] extends [
 		never,
 	]
@@ -848,11 +863,11 @@ export type InstructionNamesByMemoryOperation<TOperation extends AnalysisMemoryO
 }[InstructionSpecName];
 
 export type LoadInstructionSpecName = InstructionNamesByMemoryOperation<
-	Extract<AnalysisMemoryOperationSpec, { kind: 'load' }> & { resultType: 'int' }
+	Extract<MemoryOperationEffectSpec, { kind: 'load' }> & { resultType: 'int' }
 >;
 
 export type FloatLoadInstructionSpecName = InstructionNamesByMemoryOperation<
-	Extract<AnalysisMemoryOperationSpec, { kind: 'load' }> & { resultType: 'float' }
+	Extract<MemoryOperationEffectSpec, { kind: 'load' }> & { resultType: 'float' }
 >;
 
 type GetInstructionSpec = {

--- a/packages/compiler-spec/src/instructionSpecs.ts
+++ b/packages/compiler-spec/src/instructionSpecs.ts
@@ -168,11 +168,16 @@ function fixedStack(
 	return { consumes, produces };
 }
 
-function memoryLoad(
-	loadVariant: MemoryLoadVariant,
+function memoryLoad<TLoadVariant extends MemoryLoadVariant, TResultType extends 'int' | 'float'>(
+	loadVariant: TLoadVariant,
 	accessByteWidth: number,
-	resultType: 'int' | 'float'
-): { memory: Extract<AnalysisMemoryOperationSpec, { kind: 'load' }> } {
+	resultType: TResultType
+): {
+	memory: Extract<AnalysisMemoryOperationSpec, { kind: 'load' }> & {
+		loadVariant: TLoadVariant;
+		resultType: TResultType;
+	};
+} {
 	return {
 		memory: {
 			kind: 'load',
@@ -741,7 +746,7 @@ export const instructionSpecs = {
 		stack: stack(['ptr', 'T'], [], fixedStack(2)),
 		analysis: { memory: { kind: 'store', addressOperandIndex: 0, valueOperandIndex: 1 } },
 	},
-	// storeBytes (ptr int... -- )
+	// storeBytes (int... ptr -- )
 	storeBytes: {
 		scope: 'moduleOrFunction',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_BLOCK,
@@ -754,17 +759,17 @@ export const instructionSpecs = {
 		},
 		docs: { shortDescription: 'Stores a fixed number of integer bytes at the memory address on the stack.' },
 		stack: {
-			inputs: ['ptr', 'bytes...'],
+			inputs: ['bytes...', 'ptr'],
 			outputs: [],
 			analysis: { consumes: { argumentValueIndex: 0, add: 1 }, produces: [] },
 			resolve: line => {
 				const count = (line as StoreBytesLine).arguments[0]?.value;
 
 				if (!Number.isFinite(count) || count < 0) {
-					return { inputs: ['ptr', 'bytes...'], outputs: [] };
+					return { inputs: ['bytes...', 'ptr'], outputs: [] };
 				}
 
-				return { inputs: ['ptr', ...new Array(count).fill('int')], outputs: [] };
+				return { inputs: [...new Array(count).fill('int'), 'ptr'], outputs: [] };
 			},
 		},
 		analysis: { memory: { kind: 'storeBytes', accessByteWidth: BYTE_MEMORY_ACCESS_WIDTH } },
@@ -788,6 +793,26 @@ export const instructionSpecs = {
 } satisfies Record<string, InstructionSpec>;
 
 export type InstructionSpecName = keyof typeof instructionSpecs;
+
+type MemoryOperationForSpec<TSpec> = TSpec extends { analysis: { memory: infer TMemory } } ? TMemory : never;
+
+export type InstructionNamesByMemoryOperation<TOperation extends AnalysisMemoryOperationSpec> = {
+	[TInstruction in InstructionSpecName]: [MemoryOperationForSpec<(typeof instructionSpecs)[TInstruction]>] extends [
+		never,
+	]
+		? never
+		: MemoryOperationForSpec<(typeof instructionSpecs)[TInstruction]> extends TOperation
+			? TInstruction
+			: never;
+}[InstructionSpecName];
+
+export type LoadInstructionSpecName = InstructionNamesByMemoryOperation<
+	Extract<AnalysisMemoryOperationSpec, { kind: 'load' }> & { resultType: 'int' }
+>;
+
+export type FloatLoadInstructionSpecName = InstructionNamesByMemoryOperation<
+	Extract<AnalysisMemoryOperationSpec, { kind: 'load' }> & { resultType: 'float' }
+>;
 
 type GetInstructionSpec = {
 	<TInstruction extends InstructionSpecName>(instruction: TInstruction): (typeof instructionSpecs)[TInstruction];

--- a/packages/compiler-spec/src/instructionSpecs.ts
+++ b/packages/compiler-spec/src/instructionSpecs.ts
@@ -105,16 +105,28 @@ export interface AnalysisBlockCloseSpec {
 }
 
 export type MemoryLoadVariant = 'i32' | 'i32_8s' | 'i32_8u' | 'i32_16s' | 'i32_16u' | 'f32';
-export type MemoryOperationKind = 'load' | 'store' | 'storeBytes' | 'copy';
 
-export interface AnalysisMemoryOperationSpec {
-	kind: MemoryOperationKind;
-	accessByteWidth?: number;
-	loadVariant?: MemoryLoadVariant;
-	resultType?: 'int' | 'float';
-	addressOperandIndex?: number;
-	valueOperandIndex?: number;
-}
+export type AnalysisMemoryOperationSpec =
+	| {
+			kind: 'load';
+			accessByteWidth: number;
+			loadVariant: MemoryLoadVariant;
+			resultType: 'int' | 'float';
+			addressOperandIndex: number;
+	  }
+	| {
+			kind: 'store';
+			addressOperandIndex: number;
+			valueOperandIndex: number;
+	  }
+	| {
+			kind: 'storeBytes';
+			accessByteWidth: number;
+	  }
+	| {
+			kind: 'copy';
+			addressOperandIndex: number;
+	  };
 
 export interface InstructionAnalysisSpec {
 	blockClose?: AnalysisBlockCloseSpec;
@@ -160,7 +172,7 @@ function memoryLoad(
 	loadVariant: MemoryLoadVariant,
 	accessByteWidth: number,
 	resultType: 'int' | 'float'
-): InstructionAnalysisSpec {
+): { memory: Extract<AnalysisMemoryOperationSpec, { kind: 'load' }> } {
 	return {
 		memory: {
 			kind: 'load',
@@ -175,7 +187,7 @@ function memoryLoad(
 function blockClose(
 	blockType: BlockTypeValue,
 	{ restoreResult = false, validateFloatResult = false } = {}
-): InstructionAnalysisSpec {
+): { blockClose: AnalysisBlockCloseSpec } {
 	return { blockClose: { blockType, restoreResult, validateFloatResult } };
 }
 
@@ -777,7 +789,13 @@ export const instructionSpecs = {
 
 export type InstructionSpecName = keyof typeof instructionSpecs;
 
-export function getInstructionSpec(instruction: string): InstructionSpec | undefined {
+type GetInstructionSpec = {
+	<TInstruction extends InstructionSpecName>(instruction: TInstruction): (typeof instructionSpecs)[TInstruction];
+	(instruction: MemoryDeclarationInstruction): typeof instructionSpecs.memoryDeclaration;
+	(instruction: string): InstructionSpec | undefined;
+};
+
+const getInstructionSpecImplementation = (instruction: string): InstructionSpec | undefined => {
 	if (memoryDeclarationInstructions.includes(instruction as MemoryDeclarationInstruction)) {
 		return instructionSpecs.memoryDeclaration;
 	}
@@ -787,7 +805,9 @@ export function getInstructionSpec(instruction: string): InstructionSpec | undef
 	}
 
 	return undefined;
-}
+};
+
+export const getInstructionSpec = getInstructionSpecImplementation as GetInstructionSpec;
 
 export function getInstructionStackSignature(instruction: string, line?: AST[number]): string | undefined {
 	const spec = getInstructionSpec(instruction);

--- a/packages/compiler-spec/src/instructionSpecs.ts
+++ b/packages/compiler-spec/src/instructionSpecs.ts
@@ -139,12 +139,16 @@ export interface InstructionSpec<TLine extends AST[number] = AST[number]> extend
 	analysis?: InstructionAnalysisSpec;
 }
 
+interface DocsAndStackOptions {
+	shortDescription: string;
+	inputs: readonly StackValueLabel[];
+	outputs: readonly StackValueLabel[];
+	analysis?: AnalysisStackEffectSpec;
+}
+
 function withDocsAndStack<TSpec extends ValidationSpec>(
 	spec: TSpec,
-	shortDescription: string,
-	inputs: readonly StackValueLabel[],
-	outputs: readonly StackValueLabel[],
-	analysis?: AnalysisStackEffectSpec
+	{ shortDescription, inputs, outputs, analysis }: DocsAndStackOptions
 ): TSpec & { docs: InstructionDocumentation; stack: StackEffectSpec } {
 	return {
 		...spec,
@@ -161,7 +165,7 @@ function stack(
 	return { inputs, outputs, ...(analysis ? { analysis } : {}) };
 }
 
-function fixedStack(
+function stackAnalysis(
 	consumes: AnalysisStackConsumeSpec,
 	produces: readonly AnalysisProducedStackItemSpec[] = []
 ): AnalysisStackEffectSpec {
@@ -187,6 +191,29 @@ function memoryLoad<TLoadVariant extends MemoryLoadVariant, TResultType extends 
 			addressOperandIndex: 0,
 		},
 	};
+}
+
+interface LoadInstructionOptions<TLoadVariant extends MemoryLoadVariant, TResultType extends 'int' | 'float'> {
+	loadVariant: TLoadVariant;
+	accessByteWidth: number;
+	resultType: TResultType;
+	shortDescription: string;
+	output: StackValueLabel;
+	analysis: AnalysisStackEffectSpec;
+}
+
+function loadInstruction<TLoadVariant extends MemoryLoadVariant, TResultType extends 'int' | 'float'>({
+	loadVariant,
+	accessByteWidth,
+	resultType,
+	shortDescription,
+	output,
+	analysis,
+}: LoadInstructionOptions<TLoadVariant, TResultType>) {
+	return withDocsAndStack(
+		{ ...loadSpec, analysis: memoryLoad(loadVariant, accessByteWidth, resultType) },
+		{ shortDescription, inputs: ['ptr'], outputs: [output], analysis }
+	);
 }
 
 function blockClose(
@@ -240,16 +267,23 @@ const memoryDeclarationSpec = {
 
 export const instructionSpecs = {
 	// abs (int -- int), abs (float -- float), abs (float64 -- float64)
-	abs: withDocsAndStack(unaryModuleOrFunctionSpec, 'Returns the absolute value of the top stack value.', ['T'], ['T']),
+	abs: withDocsAndStack(unaryModuleOrFunctionSpec, {
+		shortDescription: 'Returns the absolute value of the top stack value.',
+		inputs: ['T'],
+		outputs: ['T'],
+	}),
 	// add (int int -- int), add (float float -- float), add (float64 float64 -- float64)
-	add: withDocsAndStack(
-		binaryMatchingSpec,
-		'Adds two numbers of the same type and pushes the result.',
-		['T', 'T'],
-		['T']
-	),
+	add: withDocsAndStack(binaryMatchingSpec, {
+		shortDescription: 'Adds two numbers of the same type and pushes the result.',
+		inputs: ['T', 'T'],
+		outputs: ['T'],
+	}),
 	// and (int int -- int)
-	and: withDocsAndStack(binaryIntegerSpec, 'Performs a bitwise AND on two integers.', ['int', 'int'], ['int']),
+	and: withDocsAndStack(binaryIntegerSpec, {
+		shortDescription: 'Performs a bitwise AND on two integers.',
+		inputs: ['int', 'int'],
+		outputs: ['int'],
+	}),
 	// block ( -- )
 	block: {
 		scope: 'moduleOrFunction',
@@ -275,14 +309,14 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Branches out of enclosing blocks when the condition is non-zero.' },
-		stack: stack(['int'], [], fixedStack(1)),
+		stack: stack(['int'], [], stackAnalysis(1)),
 	},
 	// branchIfUnchanged (T -- )
 	branchIfUnchanged: {
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Branches when the consumed value matches the previous value seen by this instruction.' },
-		stack: stack(['T'], [], fixedStack(1)),
+		stack: stack(['T'], [], stackAnalysis(1)),
 	},
 	// call (args... -- returns...)
 	call: {
@@ -297,23 +331,22 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Converts an integer stack value to a float.' },
-		stack: stack(['int'], ['float'], fixedStack(1, [{ kind: 'float', isNonZero: 'fromInput' }])),
+		stack: stack(['int'], ['float'], stackAnalysis(1, [{ kind: 'float', isNonZero: 'fromInput' }])),
 	},
 	// castToFloat64 (int -- float64), castToFloat64 (float -- float64), castToFloat64 (float64 -- float64)
-	castToFloat64: withDocsAndStack(
-		unaryModuleOrFunctionSpec,
-		'Converts a numeric stack value to float64.',
-		['T'],
-		['float64'],
-		fixedStack(1, [{ kind: 'float64', isNonZero: 'fromInput' }])
-	),
+	castToFloat64: withDocsAndStack(unaryModuleOrFunctionSpec, {
+		shortDescription: 'Converts a numeric stack value to float64.',
+		inputs: ['T'],
+		outputs: ['float64'],
+		analysis: stackAnalysis(1, [{ kind: 'float64', isNonZero: 'fromInput' }]),
+	}),
 	// castToInt (float -- int), castToInt (float64 -- int)
 	castToInt: {
 		scope: 'moduleOrFunction',
 		minOperands: 1,
 		operandTypes: 'float',
 		docs: { shortDescription: 'Converts a floating-point stack value to an integer.' },
-		stack: stack(['float'], ['int'], fixedStack(1, [{ kind: 'int', isNonZero: 'fromInput' }])),
+		stack: stack(['float'], ['int'], stackAnalysis(1, [{ kind: 'int', isNonZero: 'fromInput' }])),
 	},
 	// clampAddress (ptr -- ptr)
 	clampAddress: {
@@ -353,14 +386,18 @@ export const instructionSpecs = {
 		stack: stack([], []),
 	},
 	// div (int int -- int), div (float float -- float), div (float64 float64 -- float64)
-	div: withDocsAndStack(
-		binaryMatchingSpec,
-		'Divides the first value by the second value and pushes the quotient.',
-		['T', 'T'],
-		['T']
-	),
+	div: withDocsAndStack(binaryMatchingSpec, {
+		shortDescription: 'Divides the first value by the second value and pushes the quotient.',
+		inputs: ['T', 'T'],
+		outputs: ['T'],
+	}),
 	// drop (T -- )
-	drop: withDocsAndStack(unaryModuleOrFunctionSpec, 'Removes the top value from the stack.', ['T'], [], fixedStack(1)),
+	drop: withDocsAndStack(unaryModuleOrFunctionSpec, {
+		shortDescription: 'Removes the top value from the stack.',
+		inputs: ['T'],
+		outputs: [],
+		analysis: stackAnalysis(1),
+	}),
 	// else ( -- )
 	else: {
 		scope: 'moduleOrFunction',
@@ -369,29 +406,26 @@ export const instructionSpecs = {
 		analysis: blockClose(BlockType.CONDITION, { validateFloatResult: true }),
 	},
 	// ensureNonZero (int -- int), ensureNonZero (float -- float), ensureNonZero (float64 -- float64)
-	ensureNonZero: withDocsAndStack(
-		unaryModuleOrFunctionSpec,
-		'Ensures the top stack value is non-zero before continuing.',
-		['T'],
-		['T'],
-		fixedStack(1, [{ kind: 'same', isNonZero: true }])
-	),
+	ensureNonZero: withDocsAndStack(unaryModuleOrFunctionSpec, {
+		shortDescription: 'Ensures the top stack value is non-zero before continuing.',
+		inputs: ['T'],
+		outputs: ['T'],
+		analysis: stackAnalysis(1, [{ kind: 'same', isNonZero: true }]),
+	}),
 	// equal (int int -- int), equal (float float -- int), equal (float64 float64 -- int)
-	equal: withDocsAndStack(
-		binaryMatchingSpec,
-		'Compares two values and pushes 1 when they are equal, otherwise 0.',
-		['T', 'T'],
-		['int'],
-		fixedStack(2, [{ kind: 'int', isNonZero: false }])
-	),
+	equal: withDocsAndStack(binaryMatchingSpec, {
+		shortDescription: 'Compares two values and pushes 1 when they are equal, otherwise 0.',
+		inputs: ['T', 'T'],
+		outputs: ['int'],
+		analysis: stackAnalysis(2, [{ kind: 'int', isNonZero: false }]),
+	}),
 	// equalToZero (int -- int), equalToZero (float -- int), equalToZero (float64 -- int)
-	equalToZero: withDocsAndStack(
-		unaryModuleOrFunctionSpec,
-		'Pushes 1 when the value is zero, otherwise 0.',
-		['T'],
-		['int'],
-		fixedStack(1, [{ kind: 'int', isNonZero: false }])
-	),
+	equalToZero: withDocsAndStack(unaryModuleOrFunctionSpec, {
+		shortDescription: 'Pushes 1 when the value is zero, otherwise 0.',
+		inputs: ['T'],
+		outputs: ['int'],
+		analysis: stackAnalysis(1, [{ kind: 'int', isNonZero: false }]),
+	}),
 	// exitIfTrue (int -- )
 	exitIfTrue: {
 		scope: 'moduleOnly',
@@ -406,7 +440,7 @@ export const instructionSpecs = {
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Detects when a signal changes from a non-zero value to zero.' },
-		stack: stack(['T'], ['int'], fixedStack(1, [{ kind: 'int', isNonZero: false }])),
+		stack: stack(['T'], ['int'], stackAnalysis(1, [{ kind: 'int', isNonZero: false }])),
 	},
 	// functionEnd (returns... -- )
 	functionEnd: {
@@ -416,35 +450,32 @@ export const instructionSpecs = {
 		stack: stack(['returns...'], []),
 	},
 	// greaterOrEqual (int int -- int), greaterOrEqual (float float -- int), greaterOrEqual (float64 float64 -- int)
-	greaterOrEqual: withDocsAndStack(
-		binaryMatchingSpec,
-		'Pushes 1 when the first value is greater than or equal to the second value.',
-		['T', 'T'],
-		['int'],
-		fixedStack(2, [{ kind: 'int', isNonZero: false }])
-	),
+	greaterOrEqual: withDocsAndStack(binaryMatchingSpec, {
+		shortDescription: 'Pushes 1 when the first value is greater than or equal to the second value.',
+		inputs: ['T', 'T'],
+		outputs: ['int'],
+		analysis: stackAnalysis(2, [{ kind: 'int', isNonZero: false }]),
+	}),
 	// greaterOrEqualUnsigned (int int -- int), greaterOrEqualUnsigned (float float -- int)
-	greaterOrEqualUnsigned: withDocsAndStack(
-		binaryMatchingSpec,
-		'Compares two values as unsigned numbers and pushes the result.',
-		['T', 'T'],
-		['int'],
-		fixedStack(2, [{ kind: 'int', isNonZero: false }])
-	),
+	greaterOrEqualUnsigned: withDocsAndStack(binaryMatchingSpec, {
+		shortDescription: 'Compares two values as unsigned numbers and pushes the result.',
+		inputs: ['T', 'T'],
+		outputs: ['int'],
+		analysis: stackAnalysis(2, [{ kind: 'int', isNonZero: false }]),
+	}),
 	// greaterThan (int int -- int), greaterThan (float float -- int), greaterThan (float64 float64 -- int)
-	greaterThan: withDocsAndStack(
-		binaryMatchingSpec,
-		'Pushes 1 when the first value is greater than the second value.',
-		['T', 'T'],
-		['int'],
-		fixedStack(2, [{ kind: 'int', isNonZero: false }])
-	),
+	greaterThan: withDocsAndStack(binaryMatchingSpec, {
+		shortDescription: 'Pushes 1 when the first value is greater than the second value.',
+		inputs: ['T', 'T'],
+		outputs: ['int'],
+		analysis: stackAnalysis(2, [{ kind: 'int', isNonZero: false }]),
+	}),
 	// hasChanged (int -- int), hasChanged (float -- int)
 	hasChanged: {
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Pushes 1 when the consumed value differs from its previous value.' },
-		stack: stack(['T'], ['int'], fixedStack(1, [{ kind: 'int', isNonZero: false }])),
+		stack: stack(['T'], ['int'], stackAnalysis(1, [{ kind: 'int', isNonZero: false }])),
 	},
 	// if (int -- )
 	if: {
@@ -452,7 +483,7 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Starts a conditional block when the condition is non-zero.' },
-		stack: stack(['int'], [], fixedStack(1)),
+		stack: stack(['int'], [], stackAnalysis(1)),
 	},
 	// ifEnd ( -- ), ifEnd (T -- T)
 	ifEnd: {
@@ -462,70 +493,73 @@ export const instructionSpecs = {
 		analysis: blockClose(BlockType.CONDITION, { restoreResult: true, validateFloatResult: true }),
 	},
 	// lessOrEqual (int int -- int), lessOrEqual (float float -- int), lessOrEqual (float64 float64 -- int)
-	lessOrEqual: withDocsAndStack(
-		binaryMatchingSpec,
-		'Pushes 1 when the first value is less than or equal to the second value.',
-		['T', 'T'],
-		['int'],
-		fixedStack(2, [{ kind: 'int', isNonZero: false }])
-	),
+	lessOrEqual: withDocsAndStack(binaryMatchingSpec, {
+		shortDescription: 'Pushes 1 when the first value is less than or equal to the second value.',
+		inputs: ['T', 'T'],
+		outputs: ['int'],
+		analysis: stackAnalysis(2, [{ kind: 'int', isNonZero: false }]),
+	}),
 	// lessThan (int int -- int), lessThan (float float -- int), lessThan (float64 float64 -- int)
-	lessThan: withDocsAndStack(
-		binaryMatchingSpec,
-		'Pushes 1 when the first value is less than the second value.',
-		['T', 'T'],
-		['int'],
-		fixedStack(2, [{ kind: 'int', isNonZero: false }])
-	),
+	lessThan: withDocsAndStack(binaryMatchingSpec, {
+		shortDescription: 'Pushes 1 when the first value is less than the second value.',
+		inputs: ['T', 'T'],
+		outputs: ['int'],
+		analysis: stackAnalysis(2, [{ kind: 'int', isNonZero: false }]),
+	}),
 	// load (ptr -- int)
-	load: withDocsAndStack(
-		{ ...loadSpec, analysis: memoryLoad('i32', WORD_MEMORY_ACCESS_WIDTH, 'int') },
-		'Loads a 32-bit integer value from memory.',
-		['ptr'],
-		['int'],
-		fixedStack(1, [{ kind: 'int', isNonZero: false }])
-	),
+	load: loadInstruction({
+		loadVariant: 'i32',
+		accessByteWidth: WORD_MEMORY_ACCESS_WIDTH,
+		resultType: 'int',
+		shortDescription: 'Loads a 32-bit integer value from memory.',
+		output: 'int',
+		analysis: stackAnalysis(1, [{ kind: 'int', isNonZero: false }]),
+	}),
 	// load8u (ptr -- int)
-	load8u: withDocsAndStack(
-		{ ...loadSpec, analysis: memoryLoad('i32_8u', BYTE_MEMORY_ACCESS_WIDTH, 'int') },
-		'Loads an unsigned 8-bit integer value from memory.',
-		['ptr'],
-		['int'],
-		fixedStack(1, [{ kind: 'int', isNonZero: false }])
-	),
+	load8u: loadInstruction({
+		loadVariant: 'i32_8u',
+		accessByteWidth: BYTE_MEMORY_ACCESS_WIDTH,
+		resultType: 'int',
+		shortDescription: 'Loads an unsigned 8-bit integer value from memory.',
+		output: 'int',
+		analysis: stackAnalysis(1, [{ kind: 'int', isNonZero: false }]),
+	}),
 	// load16u (ptr -- int)
-	load16u: withDocsAndStack(
-		{ ...loadSpec, analysis: memoryLoad('i32_16u', HALF_WORD_MEMORY_ACCESS_WIDTH, 'int') },
-		'Loads an unsigned 16-bit integer value from memory.',
-		['ptr'],
-		['int'],
-		fixedStack(1, [{ kind: 'int', isNonZero: false }])
-	),
+	load16u: loadInstruction({
+		loadVariant: 'i32_16u',
+		accessByteWidth: HALF_WORD_MEMORY_ACCESS_WIDTH,
+		resultType: 'int',
+		shortDescription: 'Loads an unsigned 16-bit integer value from memory.',
+		output: 'int',
+		analysis: stackAnalysis(1, [{ kind: 'int', isNonZero: false }]),
+	}),
 	// load8s (ptr -- int)
-	load8s: withDocsAndStack(
-		{ ...loadSpec, analysis: memoryLoad('i32_8s', BYTE_MEMORY_ACCESS_WIDTH, 'int') },
-		'Loads a signed 8-bit integer value from memory.',
-		['ptr'],
-		['int'],
-		fixedStack(1, [{ kind: 'int', isNonZero: false }])
-	),
+	load8s: loadInstruction({
+		loadVariant: 'i32_8s',
+		accessByteWidth: BYTE_MEMORY_ACCESS_WIDTH,
+		resultType: 'int',
+		shortDescription: 'Loads a signed 8-bit integer value from memory.',
+		output: 'int',
+		analysis: stackAnalysis(1, [{ kind: 'int', isNonZero: false }]),
+	}),
 	// load16s (ptr -- int)
-	load16s: withDocsAndStack(
-		{ ...loadSpec, analysis: memoryLoad('i32_16s', HALF_WORD_MEMORY_ACCESS_WIDTH, 'int') },
-		'Loads a signed 16-bit integer value from memory.',
-		['ptr'],
-		['int'],
-		fixedStack(1, [{ kind: 'int', isNonZero: false }])
-	),
+	load16s: loadInstruction({
+		loadVariant: 'i32_16s',
+		accessByteWidth: HALF_WORD_MEMORY_ACCESS_WIDTH,
+		resultType: 'int',
+		shortDescription: 'Loads a signed 16-bit integer value from memory.',
+		output: 'int',
+		analysis: stackAnalysis(1, [{ kind: 'int', isNonZero: false }]),
+	}),
 	// loadFloat (ptr -- float)
-	loadFloat: {
-		scope: 'moduleOrFunction',
-		minOperands: 1,
-		operandTypes: 'int',
-		docs: { shortDescription: 'Loads a float value from memory.' },
-		stack: stack(['ptr'], ['float'], fixedStack(1, [{ kind: 'float', isNonZero: false }])),
-		analysis: memoryLoad('f32', WORD_MEMORY_ACCESS_WIDTH, 'float'),
-	},
+	loadFloat: loadInstruction({
+		loadVariant: 'f32',
+		accessByteWidth: WORD_MEMORY_ACCESS_WIDTH,
+		resultType: 'float',
+		shortDescription: 'Loads a float value from memory.',
+		output: 'float',
+		analysis: stackAnalysis(1, [{ kind: 'float', isNonZero: false }]),
+	}),
 	// local ( -- )
 	local: {
 		scope: 'moduleOrFunction',
@@ -633,38 +667,47 @@ export const instructionSpecs = {
 		minOperands: 2,
 		operandTypes: 'int',
 		docs: { shortDescription: 'Copies memory from one pointer range to another.' },
-		stack: stack(['ptr', 'ptr'], [], fixedStack(2)),
+		stack: stack(['ptr', 'ptr'], [], stackAnalysis(2)),
 		analysis: { memory: { kind: 'copy', addressOperandIndex: 0 } },
 	},
 	// min (int int -- int), min (float float -- float), min (float64 float64 -- float64)
-	min: withDocsAndStack(binaryMatchingSpec, 'Pushes the smaller of two values of the same type.', ['T', 'T'], ['T']),
+	min: withDocsAndStack(binaryMatchingSpec, {
+		shortDescription: 'Pushes the smaller of two values of the same type.',
+		inputs: ['T', 'T'],
+		outputs: ['T'],
+	}),
 	// max (int int -- int), max (float float -- float), max (float64 float64 -- float64)
-	max: withDocsAndStack(binaryMatchingSpec, 'Pushes the larger of two values of the same type.', ['T', 'T'], ['T']),
+	max: withDocsAndStack(binaryMatchingSpec, {
+		shortDescription: 'Pushes the larger of two values of the same type.',
+		inputs: ['T', 'T'],
+		outputs: ['T'],
+	}),
 	// mul (int int -- int), mul (float float -- float), mul (float64 float64 -- float64)
-	mul: withDocsAndStack(
-		binaryMatchingSpec,
-		'Multiplies two numbers of the same type and pushes the result.',
-		['T', 'T'],
-		['T']
-	),
+	mul: withDocsAndStack(binaryMatchingSpec, {
+		shortDescription: 'Multiplies two numbers of the same type and pushes the result.',
+		inputs: ['T', 'T'],
+		outputs: ['T'],
+	}),
 	// notEqual (int int -- int), notEqual (float float -- int), notEqual (float64 float64 -- int)
-	notEqual: withDocsAndStack(
-		binaryMatchingSpec,
-		'Compares two values and pushes 1 when they are not equal, otherwise 0.',
-		['T', 'T'],
-		['int'],
-		fixedStack(2, [{ kind: 'int', isNonZero: false }])
-	),
+	notEqual: withDocsAndStack(binaryMatchingSpec, {
+		shortDescription: 'Compares two values and pushes 1 when they are not equal, otherwise 0.',
+		inputs: ['T', 'T'],
+		outputs: ['int'],
+		analysis: stackAnalysis(2, [{ kind: 'int', isNonZero: false }]),
+	}),
 	// notZero (int -- int), notZero (float -- int), notZero (float64 -- int)
-	notZero: withDocsAndStack(
-		unaryModuleOrFunctionSpec,
-		'Pushes 1 when the value is non-zero, otherwise 0.',
-		['T'],
-		['int'],
-		fixedStack(1, [{ kind: 'int', isNonZero: 'fromInput' }])
-	),
+	notZero: withDocsAndStack(unaryModuleOrFunctionSpec, {
+		shortDescription: 'Pushes 1 when the value is non-zero, otherwise 0.',
+		inputs: ['T'],
+		outputs: ['int'],
+		analysis: stackAnalysis(1, [{ kind: 'int', isNonZero: 'fromInput' }]),
+	}),
 	// or (int int -- int)
-	or: withDocsAndStack(binaryIntegerSpec, 'Performs a bitwise OR on two integers.', ['int', 'int'], ['int']),
+	or: withDocsAndStack(binaryIntegerSpec, {
+		shortDescription: 'Performs a bitwise OR on two integers.',
+		inputs: ['int', 'int'],
+		outputs: ['int'],
+	}),
 	// param ( -- )
 	param: {
 		scope: 'function',
@@ -679,12 +722,11 @@ export const instructionSpecs = {
 		stack: stack([], ['T']),
 	},
 	// remainder (int int -- int)
-	remainder: withDocsAndStack(
-		binaryIntegerSpec,
-		'Divides one integer by another and pushes the remainder.',
-		['int', 'int'],
-		['int']
-	),
+	remainder: withDocsAndStack(binaryIntegerSpec, {
+		shortDescription: 'Divides one integer by another and pushes the remainder.',
+		inputs: ['int', 'int'],
+		outputs: ['int'],
+	}),
 	// return (returns... -- never)
 	return: {
 		scope: 'function',
@@ -697,7 +739,7 @@ export const instructionSpecs = {
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Detects when a signal changes from zero to a non-zero value.' },
-		stack: stack(['T'], ['int'], fixedStack(1, [{ kind: 'int', isNonZero: false }])),
+		stack: stack(['T'], ['int'], stackAnalysis(1, [{ kind: 'int', isNonZero: false }])),
 	},
 	// round (float -- float)
 	round: {
@@ -705,36 +747,33 @@ export const instructionSpecs = {
 		minOperands: 1,
 		operandTypes: 'float',
 		docs: { shortDescription: 'Rounds a float value to the nearest whole value.' },
-		stack: stack(['float'], ['float'], fixedStack(1, [{ kind: 'float', isNonZero: false }])),
+		stack: stack(['float'], ['float'], stackAnalysis(1, [{ kind: 'float', isNonZero: false }])),
 	},
 	// shiftLeft (int int -- int)
-	shiftLeft: withDocsAndStack(
-		binaryIntegerSpec,
-		'Shifts an integer left by the requested number of bits.',
-		['int', 'int'],
-		['int']
-	),
+	shiftLeft: withDocsAndStack(binaryIntegerSpec, {
+		shortDescription: 'Shifts an integer left by the requested number of bits.',
+		inputs: ['int', 'int'],
+		outputs: ['int'],
+	}),
 	// shiftRight (int int -- int)
-	shiftRight: withDocsAndStack(
-		binaryIntegerSpec,
-		'Shifts an integer right by the requested number of bits.',
-		['int', 'int'],
-		['int']
-	),
+	shiftRight: withDocsAndStack(binaryIntegerSpec, {
+		shortDescription: 'Shifts an integer right by the requested number of bits.',
+		inputs: ['int', 'int'],
+		outputs: ['int'],
+	}),
 	// shiftRightUnsigned (int int -- int)
-	shiftRightUnsigned: withDocsAndStack(
-		binaryIntegerSpec,
-		'Shifts an integer right without preserving the sign bit.',
-		['int', 'int'],
-		['int']
-	),
+	shiftRightUnsigned: withDocsAndStack(binaryIntegerSpec, {
+		shortDescription: 'Shifts an integer right without preserving the sign bit.',
+		inputs: ['int', 'int'],
+		outputs: ['int'],
+	}),
 	// sqrt (float -- float)
 	sqrt: {
 		scope: 'moduleOrFunction',
 		minOperands: 1,
 		operandTypes: 'float',
 		docs: { shortDescription: 'Pushes the square root of a float value.' },
-		stack: stack(['float'], ['float'], fixedStack(1, [{ kind: 'same', isNonZero: false }])),
+		stack: stack(['float'], ['float'], stackAnalysis(1, [{ kind: 'same', isNonZero: false }])),
 	},
 	// store (ptr int -- ), store (ptr float -- ), store (ptr float64 -- )
 	store: {
@@ -743,7 +782,7 @@ export const instructionSpecs = {
 		minOperands: 2,
 		operandTypes: ['int'],
 		docs: { shortDescription: 'Stores a value at the memory address on the stack.' },
-		stack: stack(['ptr', 'T'], [], fixedStack(2)),
+		stack: stack(['ptr', 'T'], [], stackAnalysis(2)),
 		analysis: { memory: { kind: 'store', addressOperandIndex: 0, valueOperandIndex: 1 } },
 	},
 	// storeBytes (int... ptr -- )
@@ -775,21 +814,23 @@ export const instructionSpecs = {
 		analysis: { memory: { kind: 'storeBytes', accessByteWidth: BYTE_MEMORY_ACCESS_WIDTH } },
 	},
 	// sub (int int -- int), sub (float float -- float), sub (float64 float64 -- float64)
-	sub: withDocsAndStack(
-		binaryMatchingSpec,
-		'Subtracts the second value from the first value and pushes the result.',
-		['T', 'T'],
-		['T']
-	),
+	sub: withDocsAndStack(binaryMatchingSpec, {
+		shortDescription: 'Subtracts the second value from the first value and pushes the result.',
+		inputs: ['T', 'T'],
+		outputs: ['T'],
+	}),
 	// xor (int int -- int)
-	xor: withDocsAndStack(binaryIntegerSpec, 'Performs a bitwise XOR on two integers.', ['int', 'int'], ['int']),
+	xor: withDocsAndStack(binaryIntegerSpec, {
+		shortDescription: 'Performs a bitwise XOR on two integers.',
+		inputs: ['int', 'int'],
+		outputs: ['int'],
+	}),
 	// memoryDeclaration ( -- )
-	memoryDeclaration: withDocsAndStack(
-		memoryDeclarationSpec,
-		'Declares memory storage for values used by the module.',
-		[],
-		[]
-	),
+	memoryDeclaration: withDocsAndStack(memoryDeclarationSpec, {
+		shortDescription: 'Declares memory storage for values used by the module.',
+		inputs: [],
+		outputs: [],
+	}),
 } satisfies Record<string, InstructionSpec>;
 
 export type InstructionSpecName = keyof typeof instructionSpecs;

--- a/packages/compiler-spec/src/instructionSpecs.ts
+++ b/packages/compiler-spec/src/instructionSpecs.ts
@@ -1,10 +1,12 @@
+import { BYTE_MEMORY_ACCESS_WIDTH, HALF_WORD_MEMORY_ACCESS_WIDTH, WORD_MEMORY_ACCESS_WIDTH } from './constants';
 import { ErrorCode } from './errors';
 import { memoryDeclarationInstructions } from './memory';
+import { BlockType } from './semantic';
 
 import type { AST, StoreBytesLine } from './ast';
 import type { ErrorCodeValue } from './errors';
 import type { MemoryDeclarationInstruction } from './memory';
-import type { CompilationContext } from './semantic';
+import type { BlockTypeValue, CompilationContext } from './semantic';
 
 export type OperandRule = 'int' | 'float' | 'matching';
 export type ScopeRule =
@@ -59,9 +61,70 @@ export interface StackEffectSpec<TLine extends AST[number] = AST[number]> extend
 	resolve?: (line: TLine) => ResolvedStackEffect;
 }
 
+export type AnalysisStackConsumeSpec =
+	| number
+	| 'all'
+	| {
+			argumentValueIndex: number;
+			add: number;
+	  };
+
+export type AnalysisProducedStackItemSpec =
+	| {
+			kind: 'int';
+			isNonZero?: boolean | 'fromInput';
+			inputIndex?: number;
+	  }
+	| {
+			kind: 'float';
+			isNonZero?: boolean | 'fromInput';
+			inputIndex?: number;
+	  }
+	| {
+			kind: 'float64';
+			isNonZero?: boolean | 'fromInput';
+			inputIndex?: number;
+	  }
+	| {
+			kind: 'same';
+			inputIndex?: number;
+			isNonZero?: boolean | 'fromInput';
+	  };
+
+export interface AnalysisStackEffectSpec {
+	consumes: AnalysisStackConsumeSpec;
+	produces?: readonly AnalysisProducedStackItemSpec[];
+	dropped?: 'consumed';
+}
+
+export interface AnalysisBlockCloseSpec {
+	blockType: BlockTypeValue;
+	restoreResult?: boolean;
+	validateFloatResult?: boolean;
+}
+
+export type MemoryLoadVariant = 'i32' | 'i32_8s' | 'i32_8u' | 'i32_16s' | 'i32_16u' | 'f32';
+export type MemoryOperationKind = 'load' | 'store' | 'storeBytes' | 'copy';
+
+export interface AnalysisMemoryOperationSpec {
+	kind: MemoryOperationKind;
+	accessByteWidth?: number;
+	loadVariant?: MemoryLoadVariant;
+	resultType?: 'int' | 'float';
+	addressOperandIndex?: number;
+	valueOperandIndex?: number;
+}
+
+export interface InstructionAnalysisSpec {
+	stack?: AnalysisStackEffectSpec;
+	blockClose?: AnalysisBlockCloseSpec;
+	memory?: AnalysisMemoryOperationSpec;
+}
+
 export interface InstructionSpec<TLine extends AST[number] = AST[number]> extends ValidationSpec<TLine> {
 	docs?: InstructionDocumentation;
 	stack?: StackEffectSpec<TLine>;
+	analysis?: InstructionAnalysisSpec;
 }
 
 function withDocsAndStack<TSpec extends ValidationSpec>(
@@ -79,6 +142,40 @@ function withDocsAndStack<TSpec extends ValidationSpec>(
 
 function stack(inputs: readonly StackValueLabel[], outputs: readonly StackValueLabel[]): StackEffectSpec {
 	return { inputs, outputs };
+}
+
+function fixedStack(
+	consumes: AnalysisStackConsumeSpec,
+	produces: readonly AnalysisProducedStackItemSpec[] = []
+): InstructionAnalysisSpec {
+	return { stack: { consumes, produces } };
+}
+
+function memoryLoad(
+	loadVariant: MemoryLoadVariant,
+	accessByteWidth: number,
+	resultType: 'int' | 'float'
+): InstructionAnalysisSpec {
+	return {
+		stack: {
+			consumes: 1,
+			produces: [{ kind: resultType, isNonZero: false }],
+		},
+		memory: {
+			kind: 'load',
+			accessByteWidth,
+			loadVariant,
+			resultType,
+			addressOperandIndex: 0,
+		},
+	};
+}
+
+function blockClose(
+	blockType: BlockTypeValue,
+	{ restoreResult = false, validateFloatResult = false } = {}
+): InstructionAnalysisSpec {
+	return { blockClose: { blockType, restoreResult, validateFloatResult } };
 }
 
 export function resolveInstructionStackEffect<TLine extends AST[number]>(
@@ -146,6 +243,7 @@ export const instructionSpecs = {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Ends a block and validates its optional result value.' },
 		stack: stack(['T?'], ['T?']),
+		analysis: blockClose(BlockType.BLOCK, { restoreResult: true }),
 	},
 	// branch ( -- )
 	branch: {
@@ -160,6 +258,7 @@ export const instructionSpecs = {
 		operandTypes: 'int',
 		docs: { shortDescription: 'Branches out of enclosing blocks when the condition is non-zero.' },
 		stack: stack(['int'], []),
+		analysis: fixedStack(1),
 	},
 	// branchIfUnchanged (T -- )
 	branchIfUnchanged: {
@@ -167,6 +266,7 @@ export const instructionSpecs = {
 		minOperands: 1,
 		docs: { shortDescription: 'Branches when the consumed value matches the previous value seen by this instruction.' },
 		stack: stack(['T'], []),
+		analysis: fixedStack(1),
 	},
 	// call (args... -- returns...)
 	call: {
@@ -182,10 +282,11 @@ export const instructionSpecs = {
 		operandTypes: 'int',
 		docs: { shortDescription: 'Converts an integer stack value to a float.' },
 		stack: stack(['int'], ['float']),
+		analysis: fixedStack(1, [{ kind: 'float', isNonZero: 'fromInput' }]),
 	},
 	// castToFloat64 (int -- float64), castToFloat64 (float -- float64), castToFloat64 (float64 -- float64)
 	castToFloat64: withDocsAndStack(
-		unaryModuleOrFunctionSpec,
+		{ ...unaryModuleOrFunctionSpec, analysis: fixedStack(1, [{ kind: 'float64', isNonZero: 'fromInput' }]) },
 		'Converts a numeric stack value to float64.',
 		['T'],
 		['float64']
@@ -197,6 +298,7 @@ export const instructionSpecs = {
 		operandTypes: 'float',
 		docs: { shortDescription: 'Converts a floating-point stack value to an integer.' },
 		stack: stack(['float'], ['int']),
+		analysis: fixedStack(1, [{ kind: 'int', isNonZero: 'fromInput' }]),
 	},
 	// clampAddress (ptr -- ptr)
 	clampAddress: {
@@ -227,6 +329,7 @@ export const instructionSpecs = {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Removes every value from the stack.' },
 		stack: stack(['...'], []),
+		analysis: { stack: { consumes: 'all', produces: [], dropped: 'consumed' } },
 	},
 	// default ( -- )
 	default: {
@@ -243,30 +346,36 @@ export const instructionSpecs = {
 		['T']
 	),
 	// drop (T -- )
-	drop: withDocsAndStack(unaryModuleOrFunctionSpec, 'Removes the top value from the stack.', ['T'], []),
+	drop: withDocsAndStack(
+		{ ...unaryModuleOrFunctionSpec, analysis: fixedStack(1) },
+		'Removes the top value from the stack.',
+		['T'],
+		[]
+	),
 	// else ( -- )
 	else: {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Starts the alternate branch of the current if block.' },
 		stack: stack([], []),
+		analysis: blockClose(BlockType.CONDITION, { validateFloatResult: true }),
 	},
 	// ensureNonZero (int -- int), ensureNonZero (float -- float), ensureNonZero (float64 -- float64)
 	ensureNonZero: withDocsAndStack(
-		unaryModuleOrFunctionSpec,
+		{ ...unaryModuleOrFunctionSpec, analysis: fixedStack(1, [{ kind: 'same', isNonZero: true }]) },
 		'Ensures the top stack value is non-zero before continuing.',
 		['T'],
 		['T']
 	),
 	// equal (int int -- int), equal (float float -- int), equal (float64 float64 -- int)
 	equal: withDocsAndStack(
-		binaryMatchingSpec,
+		{ ...binaryMatchingSpec, analysis: fixedStack(2, [{ kind: 'int', isNonZero: false }]) },
 		'Compares two values and pushes 1 when they are equal, otherwise 0.',
 		['T', 'T'],
 		['int']
 	),
 	// equalToZero (int -- int), equalToZero (float -- int), equalToZero (float64 -- int)
 	equalToZero: withDocsAndStack(
-		unaryModuleOrFunctionSpec,
+		{ ...unaryModuleOrFunctionSpec, analysis: fixedStack(1, [{ kind: 'int', isNonZero: false }]) },
 		'Pushes 1 when the value is zero, otherwise 0.',
 		['T'],
 		['int']
@@ -286,6 +395,7 @@ export const instructionSpecs = {
 		minOperands: 1,
 		docs: { shortDescription: 'Detects when a signal changes from a non-zero value to zero.' },
 		stack: stack(['T'], ['int']),
+		analysis: fixedStack(1, [{ kind: 'int', isNonZero: false }]),
 	},
 	// functionEnd (returns... -- )
 	functionEnd: {
@@ -296,21 +406,21 @@ export const instructionSpecs = {
 	},
 	// greaterOrEqual (int int -- int), greaterOrEqual (float float -- int), greaterOrEqual (float64 float64 -- int)
 	greaterOrEqual: withDocsAndStack(
-		binaryMatchingSpec,
+		{ ...binaryMatchingSpec, analysis: fixedStack(2, [{ kind: 'int', isNonZero: false }]) },
 		'Pushes 1 when the first value is greater than or equal to the second value.',
 		['T', 'T'],
 		['int']
 	),
 	// greaterOrEqualUnsigned (int int -- int), greaterOrEqualUnsigned (float float -- int)
 	greaterOrEqualUnsigned: withDocsAndStack(
-		binaryMatchingSpec,
+		{ ...binaryMatchingSpec, analysis: fixedStack(2, [{ kind: 'int', isNonZero: false }]) },
 		'Compares two values as unsigned numbers and pushes the result.',
 		['T', 'T'],
 		['int']
 	),
 	// greaterThan (int int -- int), greaterThan (float float -- int), greaterThan (float64 float64 -- int)
 	greaterThan: withDocsAndStack(
-		binaryMatchingSpec,
+		{ ...binaryMatchingSpec, analysis: fixedStack(2, [{ kind: 'int', isNonZero: false }]) },
 		'Pushes 1 when the first value is greater than the second value.',
 		['T', 'T'],
 		['int']
@@ -321,6 +431,7 @@ export const instructionSpecs = {
 		minOperands: 1,
 		docs: { shortDescription: 'Pushes 1 when the consumed value differs from its previous value.' },
 		stack: stack(['T'], ['int']),
+		analysis: fixedStack(1, [{ kind: 'int', isNonZero: false }]),
 	},
 	// if (int -- )
 	if: {
@@ -329,37 +440,64 @@ export const instructionSpecs = {
 		operandTypes: 'int',
 		docs: { shortDescription: 'Starts a conditional block when the condition is non-zero.' },
 		stack: stack(['int'], []),
+		analysis: fixedStack(1),
 	},
 	// ifEnd ( -- ), ifEnd (T -- T)
 	ifEnd: {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Ends an if block and validates its optional result value.' },
 		stack: stack(['T?'], ['T?']),
+		analysis: blockClose(BlockType.CONDITION, { restoreResult: true, validateFloatResult: true }),
 	},
 	// lessOrEqual (int int -- int), lessOrEqual (float float -- int), lessOrEqual (float64 float64 -- int)
 	lessOrEqual: withDocsAndStack(
-		binaryMatchingSpec,
+		{ ...binaryMatchingSpec, analysis: fixedStack(2, [{ kind: 'int', isNonZero: false }]) },
 		'Pushes 1 when the first value is less than or equal to the second value.',
 		['T', 'T'],
 		['int']
 	),
 	// lessThan (int int -- int), lessThan (float float -- int), lessThan (float64 float64 -- int)
 	lessThan: withDocsAndStack(
-		binaryMatchingSpec,
+		{ ...binaryMatchingSpec, analysis: fixedStack(2, [{ kind: 'int', isNonZero: false }]) },
 		'Pushes 1 when the first value is less than the second value.',
 		['T', 'T'],
 		['int']
 	),
 	// load (ptr -- int)
-	load: withDocsAndStack(loadSpec, 'Loads a 32-bit integer value from memory.', ['ptr'], ['int']),
+	load: withDocsAndStack(
+		{ ...loadSpec, analysis: memoryLoad('i32', WORD_MEMORY_ACCESS_WIDTH, 'int') },
+		'Loads a 32-bit integer value from memory.',
+		['ptr'],
+		['int']
+	),
 	// load8u (ptr -- int)
-	load8u: withDocsAndStack(loadSpec, 'Loads an unsigned 8-bit integer value from memory.', ['ptr'], ['int']),
+	load8u: withDocsAndStack(
+		{ ...loadSpec, analysis: memoryLoad('i32_8u', BYTE_MEMORY_ACCESS_WIDTH, 'int') },
+		'Loads an unsigned 8-bit integer value from memory.',
+		['ptr'],
+		['int']
+	),
 	// load16u (ptr -- int)
-	load16u: withDocsAndStack(loadSpec, 'Loads an unsigned 16-bit integer value from memory.', ['ptr'], ['int']),
+	load16u: withDocsAndStack(
+		{ ...loadSpec, analysis: memoryLoad('i32_16u', HALF_WORD_MEMORY_ACCESS_WIDTH, 'int') },
+		'Loads an unsigned 16-bit integer value from memory.',
+		['ptr'],
+		['int']
+	),
 	// load8s (ptr -- int)
-	load8s: withDocsAndStack(loadSpec, 'Loads a signed 8-bit integer value from memory.', ['ptr'], ['int']),
+	load8s: withDocsAndStack(
+		{ ...loadSpec, analysis: memoryLoad('i32_8s', BYTE_MEMORY_ACCESS_WIDTH, 'int') },
+		'Loads a signed 8-bit integer value from memory.',
+		['ptr'],
+		['int']
+	),
 	// load16s (ptr -- int)
-	load16s: withDocsAndStack(loadSpec, 'Loads a signed 16-bit integer value from memory.', ['ptr'], ['int']),
+	load16s: withDocsAndStack(
+		{ ...loadSpec, analysis: memoryLoad('i32_16s', HALF_WORD_MEMORY_ACCESS_WIDTH, 'int') },
+		'Loads a signed 16-bit integer value from memory.',
+		['ptr'],
+		['int']
+	),
 	// loadFloat (ptr -- float)
 	loadFloat: {
 		scope: 'moduleOrFunction',
@@ -367,6 +505,7 @@ export const instructionSpecs = {
 		operandTypes: 'int',
 		docs: { shortDescription: 'Loads a float value from memory.' },
 		stack: stack(['ptr'], ['float']),
+		analysis: memoryLoad('f32', WORD_MEMORY_ACCESS_WIDTH, 'float'),
 	},
 	// local ( -- )
 	local: {
@@ -438,6 +577,7 @@ export const instructionSpecs = {
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Ends a loop block and branches back to the start of the loop.' },
 		stack: stack(['T?'], ['T?']),
+		analysis: blockClose(BlockType.LOOP, { restoreResult: true }),
 	},
 	// loopIndex ( -- int)
 	loopIndex: {
@@ -475,6 +615,10 @@ export const instructionSpecs = {
 		operandTypes: 'int',
 		docs: { shortDescription: 'Copies memory from one pointer range to another.' },
 		stack: stack(['ptr', 'ptr'], []),
+		analysis: {
+			...fixedStack(2),
+			memory: { kind: 'copy', addressOperandIndex: 0 },
+		},
 	},
 	// min (int int -- int), min (float float -- float), min (float64 float64 -- float64)
 	min: withDocsAndStack(binaryMatchingSpec, 'Pushes the smaller of two values of the same type.', ['T', 'T'], ['T']),
@@ -489,14 +633,14 @@ export const instructionSpecs = {
 	),
 	// notEqual (int int -- int), notEqual (float float -- int), notEqual (float64 float64 -- int)
 	notEqual: withDocsAndStack(
-		binaryMatchingSpec,
+		{ ...binaryMatchingSpec, analysis: fixedStack(2, [{ kind: 'int', isNonZero: false }]) },
 		'Compares two values and pushes 1 when they are not equal, otherwise 0.',
 		['T', 'T'],
 		['int']
 	),
 	// notZero (int -- int), notZero (float -- int), notZero (float64 -- int)
 	notZero: withDocsAndStack(
-		unaryModuleOrFunctionSpec,
+		{ ...unaryModuleOrFunctionSpec, analysis: fixedStack(1, [{ kind: 'int', isNonZero: 'fromInput' }]) },
 		'Pushes 1 when the value is non-zero, otherwise 0.',
 		['T'],
 		['int']
@@ -536,6 +680,7 @@ export const instructionSpecs = {
 		minOperands: 1,
 		docs: { shortDescription: 'Detects when a signal changes from zero to a non-zero value.' },
 		stack: stack(['T'], ['int']),
+		analysis: fixedStack(1, [{ kind: 'int', isNonZero: false }]),
 	},
 	// round (float -- float)
 	round: {
@@ -544,6 +689,7 @@ export const instructionSpecs = {
 		operandTypes: 'float',
 		docs: { shortDescription: 'Rounds a float value to the nearest whole value.' },
 		stack: stack(['float'], ['float']),
+		analysis: fixedStack(1, [{ kind: 'float', isNonZero: false }]),
 	},
 	// shiftLeft (int int -- int)
 	shiftLeft: withDocsAndStack(
@@ -573,6 +719,7 @@ export const instructionSpecs = {
 		operandTypes: 'float',
 		docs: { shortDescription: 'Pushes the square root of a float value.' },
 		stack: stack(['float'], ['float']),
+		analysis: fixedStack(1, [{ kind: 'same', isNonZero: false }]),
 	},
 	// store (ptr int -- ), store (ptr float -- ), store (ptr float64 -- )
 	store: {
@@ -582,6 +729,10 @@ export const instructionSpecs = {
 		operandTypes: ['int'],
 		docs: { shortDescription: 'Stores a value at the memory address on the stack.' },
 		stack: stack(['ptr', 'T'], []),
+		analysis: {
+			...fixedStack(2),
+			memory: { kind: 'store', addressOperandIndex: 0, valueOperandIndex: 1 },
+		},
 	},
 	// storeBytes (ptr int... -- )
 	storeBytes: {
@@ -607,6 +758,10 @@ export const instructionSpecs = {
 
 				return { inputs: ['ptr', ...new Array(count).fill('int')], outputs: [] };
 			},
+		},
+		analysis: {
+			stack: { consumes: { argumentValueIndex: 0, add: 1 }, produces: [] },
+			memory: { kind: 'storeBytes', accessByteWidth: BYTE_MEMORY_ACCESS_WIDTH },
 		},
 	},
 	// sub (int int -- int), sub (float float -- float), sub (float64 float64 -- float64)

--- a/packages/compiler/src/instructionCompilers/load.ts
+++ b/packages/compiler/src/instructionCompilers/load.ts
@@ -5,7 +5,6 @@ import {
 	i32load16u,
 	i32load8s,
 	i32load8u,
-	WASM_TYPE_F32,
 	WASM_TYPE_I32,
 } from '@8f4e/compiler-wasm-utils';
 import { getInstructionSpec } from '@8f4e/compiler-spec';
@@ -15,10 +14,9 @@ import { saveByteCode } from './utils/saveByteCode';
 import { guardedLoad, isSafeMemoryAccess } from './utils/memoryAccessGuard';
 import { getAddressMemoryIndex } from './utils/memoryAccessTarget';
 
-import type { ASTLineBase, InstructionCompiler, MemoryLoadVariant } from '@8f4e/compiler-spec';
+import type { ASTLineBase, InstructionCompiler, LoadInstructionSpecName, MemoryLoadVariant } from '@8f4e/compiler-spec';
 
-type LoadInstruction = 'load' | 'load8u' | 'load16u' | 'load8s' | 'load16s';
-type LoadLine = ASTLineBase<LoadInstruction, []>;
+type LoadLine = ASTLineBase<LoadInstructionSpecName, []>;
 
 /**
  * Instruction compiler for `load` variants.
@@ -51,7 +49,7 @@ const load: InstructionCompiler<LoadLine> = (line, context) => {
 			accessByteWidth,
 			memoryIndex,
 			lineNumberAfterMacroExpansion: line.lineNumberAfterMacroExpansion,
-			resultType: operation.resultType === 'float' ? WASM_TYPE_F32 : WASM_TYPE_I32,
+			resultType: WASM_TYPE_I32,
 			loadByteCode: instructions,
 		})
 	);

--- a/packages/compiler/src/instructionCompilers/load.ts
+++ b/packages/compiler/src/instructionCompilers/load.ts
@@ -34,7 +34,7 @@ const loadVariantByteCode: Record<MemoryLoadVariant, (memoryIndex: number) => nu
 const load: InstructionCompiler<LoadLine> = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
 	const [address] = line.stackAnalysis.consumedOperands;
-	const operation = getInstructionSpec(line.instruction).analysis.memory;
+	const operation = getInstructionSpec(line.instruction).effects.memory;
 	const buildInstructions = loadVariantByteCode[operation.loadVariant];
 	const memoryIndex = getAddressMemoryIndex(address);
 	const instructions = buildInstructions(memoryIndex);

--- a/packages/compiler/src/instructionCompilers/load.ts
+++ b/packages/compiler/src/instructionCompilers/load.ts
@@ -33,15 +33,11 @@ const loadVariantByteCode: Record<MemoryLoadVariant, (memoryIndex: number) => nu
 const load: InstructionCompiler = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
 	const [address] = line.stackAnalysis.consumedOperands;
-	const operation = getInstructionSpec(line.instruction)?.analysis?.memory;
-	if (operation?.kind !== 'load' || !operation.loadVariant || !operation.accessByteWidth) {
-		throw new Error(`Missing load metadata for ${line.instruction}`);
-	}
-
-	const buildInstructions = loadVariantByteCode[operation.loadVariant];
+	const operation = getInstructionSpec(line.instruction)!.analysis!.memory!;
+	const buildInstructions = loadVariantByteCode[operation.loadVariant!];
 	const memoryIndex = getAddressMemoryIndex(address);
 	const instructions = buildInstructions(memoryIndex);
-	const accessByteWidth = operation.accessByteWidth;
+	const accessByteWidth = operation.accessByteWidth!;
 	if (isSafeMemoryAccess(address, accessByteWidth)) {
 		return saveByteCode(context, instructions);
 	}

--- a/packages/compiler/src/instructionCompilers/load.ts
+++ b/packages/compiler/src/instructionCompilers/load.ts
@@ -1,40 +1,47 @@
-import { i32load, i32load16s, i32load16u, i32load8s, i32load8u, WASM_TYPE_I32 } from '@8f4e/compiler-wasm-utils';
-import { BYTE_MEMORY_ACCESS_WIDTH, HALF_WORD_MEMORY_ACCESS_WIDTH, WORD_MEMORY_ACCESS_WIDTH } from '@8f4e/compiler-spec';
+import {
+	f32load,
+	i32load,
+	i32load16s,
+	i32load16u,
+	i32load8s,
+	i32load8u,
+	WASM_TYPE_F32,
+	WASM_TYPE_I32,
+} from '@8f4e/compiler-wasm-utils';
+import { getInstructionSpec } from '@8f4e/compiler-spec';
 
 import assertFunctionMemoryIoAllowed from './assertFunctionMemoryIoAllowed';
 import { saveByteCode } from './utils/saveByteCode';
 import { guardedLoad, isSafeMemoryAccess } from './utils/memoryAccessGuard';
 import { getAddressMemoryIndex } from './utils/memoryAccessTarget';
 
-import type { InstructionCompiler } from '@8f4e/compiler-spec';
+import type { InstructionCompiler, MemoryLoadVariant } from '@8f4e/compiler-spec';
 
 /**
  * Instruction compiler for `load` variants.
  * @see [Instruction docs](../../docs/instructions/memory.md)
  */
-const instructionToByteCodeMap: Record<string, (memoryIndex: number) => number[]> = {
-	load: memoryIndex => i32load(2, 0, memoryIndex),
-	load8s: memoryIndex => i32load8s(0, 0, memoryIndex),
-	load8u: memoryIndex => i32load8u(0, 0, memoryIndex),
-	load16s: memoryIndex => i32load16s(1, 0, memoryIndex),
-	load16u: memoryIndex => i32load16u(1, 0, memoryIndex),
-};
-
-const instructionToAccessByteWidthMap: Record<string, number> = {
-	load: WORD_MEMORY_ACCESS_WIDTH,
-	load8s: BYTE_MEMORY_ACCESS_WIDTH,
-	load8u: BYTE_MEMORY_ACCESS_WIDTH,
-	load16s: HALF_WORD_MEMORY_ACCESS_WIDTH,
-	load16u: HALF_WORD_MEMORY_ACCESS_WIDTH,
+const loadVariantByteCode: Record<MemoryLoadVariant, (memoryIndex: number) => number[]> = {
+	i32: memoryIndex => i32load(2, 0, memoryIndex),
+	i32_8s: memoryIndex => i32load8s(0, 0, memoryIndex),
+	i32_8u: memoryIndex => i32load8u(0, 0, memoryIndex),
+	i32_16s: memoryIndex => i32load16s(1, 0, memoryIndex),
+	i32_16u: memoryIndex => i32load16u(1, 0, memoryIndex),
+	f32: memoryIndex => f32load(2, 0, memoryIndex),
 };
 
 const load: InstructionCompiler = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
 	const [address] = line.stackAnalysis.consumedOperands;
-	const buildInstructions = instructionToByteCodeMap[line.instruction];
+	const operation = getInstructionSpec(line.instruction)?.analysis?.memory;
+	if (operation?.kind !== 'load' || !operation.loadVariant || !operation.accessByteWidth) {
+		throw new Error(`Missing load metadata for ${line.instruction}`);
+	}
+
+	const buildInstructions = loadVariantByteCode[operation.loadVariant];
 	const memoryIndex = getAddressMemoryIndex(address);
 	const instructions = buildInstructions(memoryIndex);
-	const accessByteWidth = instructionToAccessByteWidthMap[line.instruction];
+	const accessByteWidth = operation.accessByteWidth;
 	if (isSafeMemoryAccess(address, accessByteWidth)) {
 		return saveByteCode(context, instructions);
 	}
@@ -45,7 +52,7 @@ const load: InstructionCompiler = (line, context) => {
 			accessByteWidth,
 			memoryIndex,
 			lineNumberAfterMacroExpansion: line.lineNumberAfterMacroExpansion,
-			resultType: WASM_TYPE_I32,
+			resultType: operation.resultType === 'float' ? WASM_TYPE_F32 : WASM_TYPE_I32,
 			loadByteCode: instructions,
 		})
 	);

--- a/packages/compiler/src/instructionCompilers/load.ts
+++ b/packages/compiler/src/instructionCompilers/load.ts
@@ -15,7 +15,10 @@ import { saveByteCode } from './utils/saveByteCode';
 import { guardedLoad, isSafeMemoryAccess } from './utils/memoryAccessGuard';
 import { getAddressMemoryIndex } from './utils/memoryAccessTarget';
 
-import type { InstructionCompiler, MemoryLoadVariant } from '@8f4e/compiler-spec';
+import type { ASTLineBase, InstructionCompiler, MemoryLoadVariant } from '@8f4e/compiler-spec';
+
+type LoadInstruction = 'load' | 'load8u' | 'load16u' | 'load8s' | 'load16s';
+type LoadLine = ASTLineBase<LoadInstruction, []>;
 
 /**
  * Instruction compiler for `load` variants.
@@ -30,14 +33,14 @@ const loadVariantByteCode: Record<MemoryLoadVariant, (memoryIndex: number) => nu
 	f32: memoryIndex => f32load(2, 0, memoryIndex),
 };
 
-const load: InstructionCompiler = (line, context) => {
+const load: InstructionCompiler<LoadLine> = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
 	const [address] = line.stackAnalysis.consumedOperands;
-	const operation = getInstructionSpec(line.instruction)!.analysis!.memory!;
-	const buildInstructions = loadVariantByteCode[operation.loadVariant!];
+	const operation = getInstructionSpec(line.instruction).analysis.memory;
+	const buildInstructions = loadVariantByteCode[operation.loadVariant];
 	const memoryIndex = getAddressMemoryIndex(address);
 	const instructions = buildInstructions(memoryIndex);
-	const accessByteWidth = operation.accessByteWidth!;
+	const accessByteWidth = operation.accessByteWidth;
 	if (isSafeMemoryAccess(address, accessByteWidth)) {
 		return saveByteCode(context, instructions);
 	}

--- a/packages/compiler/src/instructionCompilers/loadFloat.ts
+++ b/packages/compiler/src/instructionCompilers/loadFloat.ts
@@ -6,9 +6,9 @@ import { saveByteCode } from './utils/saveByteCode';
 import { guardedLoad, isSafeMemoryAccess } from './utils/memoryAccessGuard';
 import { getAddressMemoryIndex } from './utils/memoryAccessTarget';
 
-import type { ASTLineBase, InstructionCompiler } from '@8f4e/compiler-spec';
+import type { ASTLineBase, FloatLoadInstructionSpecName, InstructionCompiler } from '@8f4e/compiler-spec';
 
-type LoadFloatLine = ASTLineBase<'loadFloat', []>;
+type LoadFloatLine = ASTLineBase<FloatLoadInstructionSpecName, []>;
 
 /**
  * Instruction compiler for `loadFloat`.

--- a/packages/compiler/src/instructionCompilers/loadFloat.ts
+++ b/packages/compiler/src/instructionCompilers/loadFloat.ts
@@ -15,21 +15,19 @@ import type { InstructionCompiler } from '@8f4e/compiler-spec';
 const loadFloat: InstructionCompiler = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
 	const [address] = line.stackAnalysis.consumedOperands;
-	const operation = getInstructionSpec(line.instruction)?.analysis?.memory;
-	if (operation?.kind !== 'load' || operation.loadVariant !== 'f32' || !operation.accessByteWidth) {
-		throw new Error(`Missing load metadata for ${line.instruction}`);
-	}
+	const operation = getInstructionSpec(line.instruction)!.analysis!.memory!;
+	const accessByteWidth = operation.accessByteWidth!;
 
 	const memoryIndex = getAddressMemoryIndex(address);
 	const instructions = f32load(2, 0, memoryIndex);
-	if (isSafeMemoryAccess(address, operation.accessByteWidth)) {
+	if (isSafeMemoryAccess(address, accessByteWidth)) {
 		return saveByteCode(context, instructions);
 	}
 
 	return saveByteCode(
 		context,
 		guardedLoad(context, {
-			accessByteWidth: operation.accessByteWidth,
+			accessByteWidth,
 			memoryIndex,
 			lineNumberAfterMacroExpansion: line.lineNumberAfterMacroExpansion,
 			resultType: WASM_TYPE_F32,

--- a/packages/compiler/src/instructionCompilers/loadFloat.ts
+++ b/packages/compiler/src/instructionCompilers/loadFloat.ts
@@ -1,5 +1,5 @@
 import { f32load, WASM_TYPE_F32 } from '@8f4e/compiler-wasm-utils';
-import { WORD_MEMORY_ACCESS_WIDTH } from '@8f4e/compiler-spec';
+import { getInstructionSpec } from '@8f4e/compiler-spec';
 
 import assertFunctionMemoryIoAllowed from './assertFunctionMemoryIoAllowed';
 import { saveByteCode } from './utils/saveByteCode';
@@ -15,16 +15,21 @@ import type { InstructionCompiler } from '@8f4e/compiler-spec';
 const loadFloat: InstructionCompiler = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
 	const [address] = line.stackAnalysis.consumedOperands;
+	const operation = getInstructionSpec(line.instruction)?.analysis?.memory;
+	if (operation?.kind !== 'load' || operation.loadVariant !== 'f32' || !operation.accessByteWidth) {
+		throw new Error(`Missing load metadata for ${line.instruction}`);
+	}
+
 	const memoryIndex = getAddressMemoryIndex(address);
 	const instructions = f32load(2, 0, memoryIndex);
-	if (isSafeMemoryAccess(address, WORD_MEMORY_ACCESS_WIDTH)) {
+	if (isSafeMemoryAccess(address, operation.accessByteWidth)) {
 		return saveByteCode(context, instructions);
 	}
 
 	return saveByteCode(
 		context,
 		guardedLoad(context, {
-			accessByteWidth: WORD_MEMORY_ACCESS_WIDTH,
+			accessByteWidth: operation.accessByteWidth,
 			memoryIndex,
 			lineNumberAfterMacroExpansion: line.lineNumberAfterMacroExpansion,
 			resultType: WASM_TYPE_F32,

--- a/packages/compiler/src/instructionCompilers/loadFloat.ts
+++ b/packages/compiler/src/instructionCompilers/loadFloat.ts
@@ -6,17 +6,19 @@ import { saveByteCode } from './utils/saveByteCode';
 import { guardedLoad, isSafeMemoryAccess } from './utils/memoryAccessGuard';
 import { getAddressMemoryIndex } from './utils/memoryAccessTarget';
 
-import type { InstructionCompiler } from '@8f4e/compiler-spec';
+import type { ASTLineBase, InstructionCompiler } from '@8f4e/compiler-spec';
+
+type LoadFloatLine = ASTLineBase<'loadFloat', []>;
 
 /**
  * Instruction compiler for `loadFloat`.
  * @see [Instruction docs](../../docs/instructions/memory.md)
  */
-const loadFloat: InstructionCompiler = (line, context) => {
+const loadFloat: InstructionCompiler<LoadFloatLine> = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
 	const [address] = line.stackAnalysis.consumedOperands;
-	const operation = getInstructionSpec(line.instruction)!.analysis!.memory!;
-	const accessByteWidth = operation.accessByteWidth!;
+	const operation = getInstructionSpec(line.instruction).analysis.memory;
+	const accessByteWidth = operation.accessByteWidth;
 
 	const memoryIndex = getAddressMemoryIndex(address);
 	const instructions = f32load(2, 0, memoryIndex);

--- a/packages/compiler/src/instructionCompilers/loadFloat.ts
+++ b/packages/compiler/src/instructionCompilers/loadFloat.ts
@@ -17,7 +17,7 @@ type LoadFloatLine = ASTLineBase<FloatLoadInstructionSpecName, []>;
 const loadFloat: InstructionCompiler<LoadFloatLine> = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
 	const [address] = line.stackAnalysis.consumedOperands;
-	const operation = getInstructionSpec(line.instruction).analysis.memory;
+	const operation = getInstructionSpec(line.instruction).effects.memory;
 	const accessByteWidth = operation.accessByteWidth;
 
 	const memoryIndex = getAddressMemoryIndex(address);

--- a/packages/compiler/src/instructionCompilers/memoryCopy.ts
+++ b/packages/compiler/src/instructionCompilers/memoryCopy.ts
@@ -1,4 +1,5 @@
 import { i32const, memoryCopy as wasmMemoryCopy } from '@8f4e/compiler-wasm-utils';
+import { getInstructionSpec } from '@8f4e/compiler-spec';
 
 import assertFunctionMemoryIoAllowed from './assertFunctionMemoryIoAllowed';
 import { saveByteCode } from './utils/saveByteCode';
@@ -13,6 +14,11 @@ import type { InstructionCompiler, NormalizedMemoryCopyLine } from '@8f4e/compil
  */
 const memoryCopy: InstructionCompiler<NormalizedMemoryCopyLine> = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
+	const operation = getInstructionSpec(line.instruction)?.analysis?.memory;
+	if (operation?.kind !== 'copy') {
+		throw new Error(`Missing memoryCopy metadata for ${line.instruction}`);
+	}
+
 	const [destination, source] = line.stackAnalysis.consumedOperands;
 	const byteLength = line.arguments[0].value;
 	const destinationMemoryIndex = getAddressMemoryIndex(destination);

--- a/packages/compiler/src/instructionCompilers/memoryCopy.ts
+++ b/packages/compiler/src/instructionCompilers/memoryCopy.ts
@@ -14,7 +14,7 @@ import type { InstructionCompiler, NormalizedMemoryCopyLine } from '@8f4e/compil
  */
 const memoryCopy: InstructionCompiler<NormalizedMemoryCopyLine> = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
-	const operation = getInstructionSpec(line.instruction).analysis.memory;
+	const operation = getInstructionSpec(line.instruction).effects.memory;
 	const destinationIndex = operation.addressOperandIndex;
 	const destination = line.stackAnalysis.consumedOperands[destinationIndex];
 	const source = line.stackAnalysis.consumedOperands[destinationIndex + 1];

--- a/packages/compiler/src/instructionCompilers/memoryCopy.ts
+++ b/packages/compiler/src/instructionCompilers/memoryCopy.ts
@@ -14,12 +14,10 @@ import type { InstructionCompiler, NormalizedMemoryCopyLine } from '@8f4e/compil
  */
 const memoryCopy: InstructionCompiler<NormalizedMemoryCopyLine> = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
-	const operation = getInstructionSpec(line.instruction)?.analysis?.memory;
-	if (operation?.kind !== 'copy') {
-		throw new Error(`Missing memoryCopy metadata for ${line.instruction}`);
-	}
-
-	const [destination, source] = line.stackAnalysis.consumedOperands;
+	const operation = getInstructionSpec(line.instruction)!.analysis!.memory!;
+	const destinationIndex = operation.addressOperandIndex ?? 0;
+	const destination = line.stackAnalysis.consumedOperands[destinationIndex];
+	const source = line.stackAnalysis.consumedOperands[destinationIndex + 1];
 	const byteLength = line.arguments[0].value;
 	const destinationMemoryIndex = getAddressMemoryIndex(destination);
 	const sourceMemoryIndex = getAddressMemoryIndex(source);

--- a/packages/compiler/src/instructionCompilers/memoryCopy.ts
+++ b/packages/compiler/src/instructionCompilers/memoryCopy.ts
@@ -14,8 +14,8 @@ import type { InstructionCompiler, NormalizedMemoryCopyLine } from '@8f4e/compil
  */
 const memoryCopy: InstructionCompiler<NormalizedMemoryCopyLine> = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
-	const operation = getInstructionSpec(line.instruction)!.analysis!.memory!;
-	const destinationIndex = operation.addressOperandIndex ?? 0;
+	const operation = getInstructionSpec(line.instruction).analysis.memory;
+	const destinationIndex = operation.addressOperandIndex;
 	const destination = line.stackAnalysis.consumedOperands[destinationIndex];
 	const source = line.stackAnalysis.consumedOperands[destinationIndex + 1];
 	const byteLength = line.arguments[0].value;

--- a/packages/compiler/src/instructionCompilers/store.ts
+++ b/packages/compiler/src/instructionCompilers/store.ts
@@ -16,7 +16,7 @@ type StoreLine = ASTLineBase<'store', []>;
  */
 const store: InstructionCompiler<StoreLine> = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
-	const operation = getInstructionSpec(line.instruction).analysis.memory;
+	const operation = getInstructionSpec(line.instruction).effects.memory;
 	const operand2Address = line.stackAnalysis.consumedOperands[operation.addressOperandIndex];
 	const operand1Value = line.stackAnalysis.consumedOperands[operation.valueOperandIndex];
 	const memoryIndex = getAddressMemoryIndex(operand2Address);

--- a/packages/compiler/src/instructionCompilers/store.ts
+++ b/packages/compiler/src/instructionCompilers/store.ts
@@ -14,11 +14,7 @@ import type { InstructionCompiler } from '@8f4e/compiler-spec';
  */
 const store: InstructionCompiler = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
-	const operation = getInstructionSpec(line.instruction)?.analysis?.memory;
-	if (operation?.kind !== 'store') {
-		throw new Error(`Missing store metadata for ${line.instruction}`);
-	}
-
+	const operation = getInstructionSpec(line.instruction)!.analysis!.memory!;
 	const operand2Address = line.stackAnalysis.consumedOperands[operation.addressOperandIndex ?? 0];
 	const operand1Value = line.stackAnalysis.consumedOperands[operation.valueOperandIndex ?? 1];
 	const memoryIndex = getAddressMemoryIndex(operand2Address);

--- a/packages/compiler/src/instructionCompilers/store.ts
+++ b/packages/compiler/src/instructionCompilers/store.ts
@@ -6,17 +6,19 @@ import { saveByteCode } from './utils/saveByteCode';
 import { guardedStore, isSafeMemoryAccess } from './utils/memoryAccessGuard';
 import { getAddressMemoryIndex } from './utils/memoryAccessTarget';
 
-import type { InstructionCompiler } from '@8f4e/compiler-spec';
+import type { ASTLineBase, InstructionCompiler } from '@8f4e/compiler-spec';
+
+type StoreLine = ASTLineBase<'store', []>;
 
 /**
  * Instruction compiler for `store`.
  * @see [Instruction docs](../../docs/instructions/memory.md)
  */
-const store: InstructionCompiler = (line, context) => {
+const store: InstructionCompiler<StoreLine> = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
-	const operation = getInstructionSpec(line.instruction)!.analysis!.memory!;
-	const operand2Address = line.stackAnalysis.consumedOperands[operation.addressOperandIndex ?? 0];
-	const operand1Value = line.stackAnalysis.consumedOperands[operation.valueOperandIndex ?? 1];
+	const operation = getInstructionSpec(line.instruction).analysis.memory;
+	const operand2Address = line.stackAnalysis.consumedOperands[operation.addressOperandIndex];
+	const operand1Value = line.stackAnalysis.consumedOperands[operation.valueOperandIndex];
 	const memoryIndex = getAddressMemoryIndex(operand2Address);
 	const instructions = operand1Value.isInteger
 		? i32store(undefined, undefined, 2, 0, memoryIndex)

--- a/packages/compiler/src/instructionCompilers/store.ts
+++ b/packages/compiler/src/instructionCompilers/store.ts
@@ -1,5 +1,5 @@
 import { f32store, f64store, i32store } from '@8f4e/compiler-wasm-utils';
-import { DOUBLE_WORD_MEMORY_ACCESS_WIDTH, WORD_MEMORY_ACCESS_WIDTH } from '@8f4e/compiler-spec';
+import { DOUBLE_WORD_MEMORY_ACCESS_WIDTH, WORD_MEMORY_ACCESS_WIDTH, getInstructionSpec } from '@8f4e/compiler-spec';
 
 import assertFunctionMemoryIoAllowed from './assertFunctionMemoryIoAllowed';
 import { saveByteCode } from './utils/saveByteCode';
@@ -14,7 +14,13 @@ import type { InstructionCompiler } from '@8f4e/compiler-spec';
  */
 const store: InstructionCompiler = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
-	const [operand2Address, operand1Value] = line.stackAnalysis.consumedOperands;
+	const operation = getInstructionSpec(line.instruction)?.analysis?.memory;
+	if (operation?.kind !== 'store') {
+		throw new Error(`Missing store metadata for ${line.instruction}`);
+	}
+
+	const operand2Address = line.stackAnalysis.consumedOperands[operation.addressOperandIndex ?? 0];
+	const operand1Value = line.stackAnalysis.consumedOperands[operation.valueOperandIndex ?? 1];
 	const memoryIndex = getAddressMemoryIndex(operand2Address);
 	const instructions = operand1Value.isInteger
 		? i32store(undefined, undefined, 2, 0, memoryIndex)

--- a/packages/compiler/src/instructionCompilers/storeBytes.ts
+++ b/packages/compiler/src/instructionCompilers/storeBytes.ts
@@ -1,4 +1,5 @@
 import { i32store8, localGet, localSet } from '@8f4e/compiler-wasm-utils';
+import { getInstructionSpec } from '@8f4e/compiler-spec';
 
 import assertFunctionMemoryIoAllowed from './assertFunctionMemoryIoAllowed';
 import { saveByteCode } from './utils/saveByteCode';
@@ -14,6 +15,10 @@ import type { InstructionCompiler, StoreBytesLine } from '@8f4e/compiler-spec';
 const storeBytes: InstructionCompiler<StoreBytesLine> = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
 	const count = line.arguments[0].value;
+	const operation = getInstructionSpec(line.instruction)?.analysis?.memory;
+	if (operation?.kind !== 'storeBytes' || !operation.accessByteWidth) {
+		throw new Error(`Missing storeBytes metadata for ${line.instruction}`);
+	}
 
 	const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
 	const address = line.stackAnalysis.consumedOperands[line.stackAnalysis.consumedOperands.length - 1];
@@ -34,7 +39,13 @@ const storeBytes: InstructionCompiler<StoreBytesLine> = (line, context) => {
 			...localSet(tempByteLocal.index),
 			...(addressIsSafe
 				? [...localGet(tempAddrLocal.index), ...localGet(tempByteLocal.index), ...storeByteCode]
-				: guardedStoreFromLocals(tempAddrLocal.index, tempByteLocal.index, i + 1, storeByteCode, memoryIndex))
+				: guardedStoreFromLocals(
+						tempAddrLocal.index,
+						tempByteLocal.index,
+						i + operation.accessByteWidth,
+						storeByteCode,
+						memoryIndex
+					))
 		);
 	}
 

--- a/packages/compiler/src/instructionCompilers/storeBytes.ts
+++ b/packages/compiler/src/instructionCompilers/storeBytes.ts
@@ -15,8 +15,8 @@ import type { InstructionCompiler, StoreBytesLine } from '@8f4e/compiler-spec';
 const storeBytes: InstructionCompiler<StoreBytesLine> = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
 	const count = line.arguments[0].value;
-	const operation = getInstructionSpec(line.instruction)!.analysis!.memory!;
-	const accessByteWidth = operation.accessByteWidth!;
+	const operation = getInstructionSpec(line.instruction).analysis.memory;
+	const accessByteWidth = operation.accessByteWidth;
 
 	const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
 	const address = line.stackAnalysis.consumedOperands[line.stackAnalysis.consumedOperands.length - 1];

--- a/packages/compiler/src/instructionCompilers/storeBytes.ts
+++ b/packages/compiler/src/instructionCompilers/storeBytes.ts
@@ -15,10 +15,8 @@ import type { InstructionCompiler, StoreBytesLine } from '@8f4e/compiler-spec';
 const storeBytes: InstructionCompiler<StoreBytesLine> = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
 	const count = line.arguments[0].value;
-	const operation = getInstructionSpec(line.instruction)?.analysis?.memory;
-	if (operation?.kind !== 'storeBytes' || !operation.accessByteWidth) {
-		throw new Error(`Missing storeBytes metadata for ${line.instruction}`);
-	}
+	const operation = getInstructionSpec(line.instruction)!.analysis!.memory!;
+	const accessByteWidth = operation.accessByteWidth!;
 
 	const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
 	const address = line.stackAnalysis.consumedOperands[line.stackAnalysis.consumedOperands.length - 1];
@@ -42,7 +40,7 @@ const storeBytes: InstructionCompiler<StoreBytesLine> = (line, context) => {
 				: guardedStoreFromLocals(
 						tempAddrLocal.index,
 						tempByteLocal.index,
-						i + operation.accessByteWidth,
+						i + accessByteWidth,
 						storeByteCode,
 						memoryIndex
 					))

--- a/packages/compiler/src/instructionCompilers/storeBytes.ts
+++ b/packages/compiler/src/instructionCompilers/storeBytes.ts
@@ -15,7 +15,7 @@ import type { InstructionCompiler, StoreBytesLine } from '@8f4e/compiler-spec';
 const storeBytes: InstructionCompiler<StoreBytesLine> = (line, context) => {
 	assertFunctionMemoryIoAllowed(line, context);
 	const count = line.arguments[0].value;
-	const operation = getInstructionSpec(line.instruction).analysis.memory;
+	const operation = getInstructionSpec(line.instruction).effects.memory;
 	const accessByteWidth = operation.accessByteWidth;
 
 	const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;

--- a/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
+++ b/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
@@ -1,4 +1,4 @@
-import { ArgumentType, BASE_TYPE_METADATA, BlockType, ErrorCode } from '@8f4e/compiler-spec';
+import { ArgumentType, BASE_TYPE_METADATA, BlockType, ErrorCode, getInstructionSpec } from '@8f4e/compiler-spec';
 
 import { validateInstruction } from './validateInstruction';
 
@@ -31,7 +31,9 @@ import type {
 	Stack,
 	StackAnalysisResult,
 	StackItem,
-	StoreBytesLine,
+	AnalysisProducedStackItemSpec,
+	AnalysisStackEffectSpec,
+	InstructionAnalysisSpec,
 } from '@8f4e/compiler-spec';
 
 function cloneStack(stack: Stack): Stack {
@@ -327,10 +329,105 @@ function analyzeExpectedBlockResult(
 	return { consumed, produced: consumed };
 }
 
+function resolveAnalysisConsumeCount(
+	line: AST[number],
+	context: CompilationContext,
+	consumes: AnalysisStackEffectSpec['consumes']
+): number {
+	if (consumes === 'all') {
+		return context.stack.length;
+	}
+
+	if (typeof consumes === 'number') {
+		return consumes;
+	}
+
+	const argument = line.arguments[consumes.argumentValueIndex];
+	const value = argument && 'value' in argument && typeof argument.value === 'number' ? argument.value : 0;
+
+	return value + consumes.add;
+}
+
+function resolveAnalysisNonZero(
+	consumed: Stack,
+	spec: AnalysisProducedStackItemSpec,
+	defaultValue: boolean | undefined
+): boolean | undefined {
+	if (spec.isNonZero === 'fromInput') {
+		return consumed[spec.inputIndex ?? 0]?.isNonZero;
+	}
+
+	return spec.isNonZero ?? defaultValue;
+}
+
+function resolveAnalysisProducedStackItem(consumed: Stack, spec: AnalysisProducedStackItemSpec): StackItem {
+	const input = consumed[spec.inputIndex ?? 0];
+
+	switch (spec.kind) {
+		case 'int':
+			return { isInteger: true, isNonZero: resolveAnalysisNonZero(consumed, spec, false) };
+		case 'float':
+			return { isInteger: false, isNonZero: resolveAnalysisNonZero(consumed, spec, false) };
+		case 'float64':
+			return { isInteger: false, isFloat64: true, isNonZero: resolveAnalysisNonZero(consumed, spec, false) };
+		case 'same':
+		default:
+			return {
+				isInteger: Boolean(input?.isInteger),
+				...(input?.isFloat64 ? { isFloat64: true } : {}),
+				isNonZero: resolveAnalysisNonZero(consumed, spec, input?.isNonZero),
+			};
+	}
+}
+
+function analyzeStackEffectFromSpec(
+	line: AST[number],
+	context: CompilationContext,
+	stackEffect: AnalysisStackEffectSpec
+): { consumed: Stack; produced: Stack; dropped?: Stack } {
+	const consumed = consume(context, resolveAnalysisConsumeCount(line, context, stackEffect.consumes));
+	const produced = (stackEffect.produces ?? []).map(producedSpec =>
+		resolveAnalysisProducedStackItem(consumed, producedSpec)
+	);
+
+	produce(context, produced);
+
+	return {
+		consumed,
+		produced,
+		...(stackEffect.dropped === 'consumed' ? { dropped: consumed } : {}),
+	};
+}
+
+function analyzeFromSpec(
+	line: AST[number],
+	context: CompilationContext,
+	analysis: InstructionAnalysisSpec | undefined
+): { consumed: Stack; produced: Stack; dropped?: Stack } | undefined {
+	if (analysis?.blockClose) {
+		assertTopBlock(line, context, analysis.blockClose.blockType);
+		return analyzeExpectedBlockResult(line, context, {
+			restore: analysis.blockClose.restoreResult,
+			validateFloatResult: analysis.blockClose.validateFloatResult,
+		});
+	}
+
+	if (analysis?.stack) {
+		return analyzeStackEffectFromSpec(line, context, analysis.stack);
+	}
+
+	return undefined;
+}
+
 function analyzeByInstruction(
 	line: AST[number],
 	context: CompilationContext
 ): { consumed: Stack; produced: Stack; dropped?: Stack } {
+	const specResult = analyzeFromSpec(line, context, getInstructionSpec(line.instruction)?.analysis);
+	if (specResult) {
+		return specResult;
+	}
+
 	switch (line.instruction) {
 		case 'push': {
 			return { consumed: [], produced: analyzePush(line as CodegenPushLine, context) };
@@ -382,18 +479,6 @@ function analyzeByInstruction(
 					})
 				),
 			];
-			produce(context, produced);
-			return { consumed, produced };
-		}
-		case 'equal':
-		case 'notEqual':
-		case 'greaterOrEqual':
-		case 'greaterOrEqualUnsigned':
-		case 'greaterThan':
-		case 'lessOrEqual':
-		case 'lessThan': {
-			const consumed = consume(context, 2);
-			const produced = [{ isInteger: true, isNonZero: false }];
 			produce(context, produced);
 			return { consumed, produced };
 		}
@@ -491,54 +576,6 @@ function analyzeByInstruction(
 			produce(context, produced);
 			return { consumed, produced };
 		}
-		case 'castToFloat':
-		case 'castToFloat64':
-		case 'castToInt':
-		case 'sqrt':
-		case 'round':
-		case 'equalToZero':
-		case 'notZero':
-		case 'fallingEdge':
-		case 'risingEdge':
-		case 'hasChanged':
-		case 'ensureNonZero': {
-			const consumed = consume(context, 1);
-			const operand = consumed[0];
-			const producedByInstruction: Record<string, StackItem> = {
-				castToFloat: { isInteger: false, isNonZero: operand.isNonZero },
-				castToFloat64: { isInteger: false, isFloat64: true, isNonZero: operand.isNonZero },
-				castToInt: { isInteger: true, isNonZero: operand.isNonZero },
-				sqrt: { isInteger: false, ...(operand.isFloat64 ? { isFloat64: true } : {}), isNonZero: false },
-				round: { isInteger: false, isNonZero: false },
-				equalToZero: { isInteger: true, isNonZero: false },
-				notZero: { isInteger: true, isNonZero: operand.isNonZero },
-				fallingEdge: { isInteger: true, isNonZero: false },
-				risingEdge: { isInteger: true, isNonZero: false },
-				hasChanged: { isInteger: true, isNonZero: false },
-				ensureNonZero: operand.isInteger
-					? { isInteger: true, isNonZero: true }
-					: { isInteger: false, ...(operand.isFloat64 ? { isFloat64: true } : {}), isNonZero: true },
-			};
-			const produced = [producedByInstruction[line.instruction]];
-			produce(context, produced);
-			return { consumed, produced };
-		}
-		case 'load':
-		case 'load8s':
-		case 'load8u':
-		case 'load16s':
-		case 'load16u': {
-			const consumed = consume(context, 1);
-			const produced = [{ isInteger: true, isNonZero: false }];
-			produce(context, produced);
-			return { consumed, produced };
-		}
-		case 'loadFloat': {
-			const consumed = consume(context, 1);
-			const produced = [{ isInteger: false, isNonZero: false }];
-			produce(context, produced);
-			return { consumed, produced };
-		}
 		case 'clampAddress':
 		case 'clampModuleAddress':
 		case 'clampGlobalAddress': {
@@ -563,25 +600,8 @@ function analyzeByInstruction(
 			produce(context, produced);
 			return { consumed, produced };
 		}
-		case 'drop':
-		case 'branchIfTrue':
-		case 'branchIfUnchanged':
-		case 'if': {
-			return { consumed: consume(context, 1), produced: [] };
-		}
 		case 'localSet': {
 			return analyzeLocalSet(line, context);
-		}
-		case 'store':
-		case 'memoryCopy': {
-			return { consumed: consume(context, 2), produced: [] };
-		}
-		case 'storeBytes': {
-			return { consumed: consume(context, (line as StoreBytesLine).arguments[0].value + 1), produced: [] };
-		}
-		case 'clearStack': {
-			const consumed = consume(context, context.stack.length);
-			return { consumed, produced: [], dropped: consumed };
 		}
 		case 'exitIfTrue': {
 			const consumed = consume(context, 1);
@@ -602,22 +622,6 @@ function analyzeByInstruction(
 		}
 		case 'mapEnd': {
 			return analyzeMapEnd(line as MapEndLine, context);
-		}
-		case 'else': {
-			assertTopBlock(line, context, BlockType.CONDITION);
-			return analyzeExpectedBlockResult(line, context, { validateFloatResult: true });
-		}
-		case 'blockEnd': {
-			assertTopBlock(line, context, BlockType.BLOCK);
-			return analyzeExpectedBlockResult(line, context, { restore: true });
-		}
-		case 'loopEnd': {
-			assertTopBlock(line, context, BlockType.LOOP);
-			return analyzeExpectedBlockResult(line, context, { restore: true });
-		}
-		case 'ifEnd': {
-			assertTopBlock(line, context, BlockType.CONDITION);
-			return analyzeExpectedBlockResult(line, context, { restore: true, validateFloatResult: true });
 		}
 		default:
 			return { consumed: [], produced: [] };

--- a/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
+++ b/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
@@ -31,8 +31,8 @@ import type {
 	Stack,
 	StackAnalysisResult,
 	StackItem,
-	AnalysisProducedStackItemSpec,
-	AnalysisStackEffectSpec,
+	StackProducedItemSpec,
+	StackMutationSpec,
 	InstructionSpec,
 } from '@8f4e/compiler-spec';
 
@@ -329,10 +329,10 @@ function analyzeExpectedBlockResult(
 	return { consumed, produced: consumed };
 }
 
-function resolveAnalysisConsumeCount(
+function resolveStackConsumeCount(
 	line: AST[number],
 	context: CompilationContext,
-	consumes: AnalysisStackEffectSpec['consumes']
+	consumes: StackMutationSpec['consumes']
 ): number {
 	if (consumes === 'all') {
 		return context.stack.length;
@@ -348,9 +348,9 @@ function resolveAnalysisConsumeCount(
 	return value + consumes.add;
 }
 
-function resolveAnalysisNonZero(
+function resolveProducedStackItemNonZero(
 	consumed: Stack,
-	spec: AnalysisProducedStackItemSpec,
+	spec: StackProducedItemSpec,
 	defaultValue: boolean | undefined
 ): boolean | undefined {
 	if (spec.isNonZero === 'fromInput') {
@@ -360,22 +360,22 @@ function resolveAnalysisNonZero(
 	return spec.isNonZero ?? defaultValue;
 }
 
-function resolveAnalysisProducedStackItem(consumed: Stack, spec: AnalysisProducedStackItemSpec): StackItem {
+function resolveStackProducedItem(consumed: Stack, spec: StackProducedItemSpec): StackItem {
 	const input = consumed[spec.inputIndex ?? 0];
 
 	switch (spec.kind) {
 		case 'int':
-			return { isInteger: true, isNonZero: resolveAnalysisNonZero(consumed, spec, false) };
+			return { isInteger: true, isNonZero: resolveProducedStackItemNonZero(consumed, spec, false) };
 		case 'float':
-			return { isInteger: false, isNonZero: resolveAnalysisNonZero(consumed, spec, false) };
+			return { isInteger: false, isNonZero: resolveProducedStackItemNonZero(consumed, spec, false) };
 		case 'float64':
-			return { isInteger: false, isFloat64: true, isNonZero: resolveAnalysisNonZero(consumed, spec, false) };
+			return { isInteger: false, isFloat64: true, isNonZero: resolveProducedStackItemNonZero(consumed, spec, false) };
 		case 'same':
 		default:
 			return {
 				isInteger: Boolean(input?.isInteger),
 				...(input?.isFloat64 ? { isFloat64: true } : {}),
-				isNonZero: resolveAnalysisNonZero(consumed, spec, input?.isNonZero),
+				isNonZero: resolveProducedStackItemNonZero(consumed, spec, input?.isNonZero),
 			};
 	}
 }
@@ -383,12 +383,10 @@ function resolveAnalysisProducedStackItem(consumed: Stack, spec: AnalysisProduce
 function analyzeStackEffectFromSpec(
 	line: AST[number],
 	context: CompilationContext,
-	stackEffect: AnalysisStackEffectSpec
+	stackEffect: StackMutationSpec
 ): { consumed: Stack; produced: Stack; dropped?: Stack } {
-	const consumed = consume(context, resolveAnalysisConsumeCount(line, context, stackEffect.consumes));
-	const produced = (stackEffect.produces ?? []).map(producedSpec =>
-		resolveAnalysisProducedStackItem(consumed, producedSpec)
-	);
+	const consumed = consume(context, resolveStackConsumeCount(line, context, stackEffect.consumes));
+	const produced = (stackEffect.produces ?? []).map(producedSpec => resolveStackProducedItem(consumed, producedSpec));
 
 	produce(context, produced);
 
@@ -404,17 +402,17 @@ function analyzeFromSpec(
 	context: CompilationContext,
 	spec: InstructionSpec | undefined
 ): { consumed: Stack; produced: Stack; dropped?: Stack } | undefined {
-	const analysis = spec?.analysis;
-	if (analysis?.blockClose) {
-		assertTopBlock(line, context, analysis.blockClose.blockType);
+	const effects = spec?.effects;
+	if (effects?.blockClose) {
+		assertTopBlock(line, context, effects.blockClose.blockType);
 		return analyzeExpectedBlockResult(line, context, {
-			restore: analysis.blockClose.restoreResult,
-			validateFloatResult: analysis.blockClose.validateFloatResult,
+			restore: effects.blockClose.restoreResult,
+			validateFloatResult: effects.blockClose.validateFloatResult,
 		});
 	}
 
-	if (spec?.stack?.analysis) {
-		return analyzeStackEffectFromSpec(line, context, spec.stack.analysis);
+	if (spec?.stack?.effect) {
+		return analyzeStackEffectFromSpec(line, context, spec.stack.effect);
 	}
 
 	return undefined;

--- a/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
+++ b/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
@@ -33,7 +33,7 @@ import type {
 	StackItem,
 	AnalysisProducedStackItemSpec,
 	AnalysisStackEffectSpec,
-	InstructionAnalysisSpec,
+	InstructionSpec,
 } from '@8f4e/compiler-spec';
 
 function cloneStack(stack: Stack): Stack {
@@ -402,8 +402,9 @@ function analyzeStackEffectFromSpec(
 function analyzeFromSpec(
 	line: AST[number],
 	context: CompilationContext,
-	analysis: InstructionAnalysisSpec | undefined
+	spec: InstructionSpec | undefined
 ): { consumed: Stack; produced: Stack; dropped?: Stack } | undefined {
+	const analysis = spec?.analysis;
 	if (analysis?.blockClose) {
 		assertTopBlock(line, context, analysis.blockClose.blockType);
 		return analyzeExpectedBlockResult(line, context, {
@@ -412,8 +413,8 @@ function analyzeFromSpec(
 		});
 	}
 
-	if (analysis?.stack) {
-		return analyzeStackEffectFromSpec(line, context, analysis.stack);
+	if (spec?.stack?.analysis) {
+		return analyzeStackEffectFromSpec(line, context, spec.stack.analysis);
 	}
 
 	return undefined;
@@ -423,7 +424,7 @@ function analyzeByInstruction(
 	line: AST[number],
 	context: CompilationContext
 ): { consumed: Stack; produced: Stack; dropped?: Stack } {
-	const specResult = analyzeFromSpec(line, context, getInstructionSpec(line.instruction)?.analysis);
+	const specResult = analyzeFromSpec(line, context, getInstructionSpec(line.instruction));
 	if (specResult) {
 		return specResult;
 	}

--- a/packages/editor/packages/editor-state/src/features/tooltip/sourceLine.test.ts
+++ b/packages/editor/packages/editor-state/src/features/tooltip/sourceLine.test.ts
@@ -19,7 +19,7 @@ describe('tooltip source line helpers', () => {
 		expect(getStackSignatureFromSourceLine('branchIfTrue 1')).toBe('branchIfTrue (int -- )');
 		expect(getStackSignatureFromSourceLine('load')).toBe('load (ptr -- int)');
 		expect(getStackSignatureFromSourceLine('store')).toBe('store (ptr T -- )');
-		expect(getStackSignatureFromSourceLine('storeBytes 3')).toBe('storeBytes (ptr int int int -- )');
+		expect(getStackSignatureFromSourceLine('storeBytes 3')).toBe('storeBytes (int int int ptr -- )');
 		expect(getStackSignatureFromSourceLine('int value')).toBe('int ( -- )');
 	});
 


### PR DESCRIPTION
## Summary
- add declarative instruction analysis metadata for generic stack effects, block-close behavior, and memory operations
- teach stack analysis to consume spec metadata before falling back to custom algorithmic cases
- wire memory instruction codegen to read load/store/copy metadata from instruction specs and mark TODO 411 complete

## Rationale
This finishes the spec-first cleanup from TODO 411 while keeping dynamic function, map, clamp, and arithmetic metadata behavior explicit in compiler code.

## Verification
- npx nx run compiler-spec:typecheck
- npx nx run compiler:typecheck
- npx nx run compiler:test
- git diff --check
- pre-commit hook: npx nx run-many --target=typecheck --all