### PR TITLE
fix(compiler): replace serialized function type registry keys

### DIFF
--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -67,7 +67,6 @@ Active todo files are listed below.
 | 415 | Discriminate compiler block stack frames | 🟡 | 4-8h | 2026-05-25 | Make block stack frames a discriminated union so map and loop consumers can access required frame metadata without defensive assertions. |
 | 416 | Add resolved identifier line forms | 🟡 | 1-2d | 2026-05-25 | Carry validated memory, local, pointer, and function targets from semantic normalization into stack analysis and codegen. |
 | 417 | Tighten compiler AST union and source block types | 🟡 | 2-4d | 2026-05-25 | Replace the broad `ASTLineBase<string, Argument[]>` compiler contract with typed AST unions and source-block types. |
-| 418 | Replace serialized function type registry keys | 🟡 | 2-4h | 2026-05-25 | Replace `JSON.stringify({ params, results })` function type registry keys with typed signature identity or a dedicated registry helper. |
 
 ### 🟢 Low Priority
 
@@ -85,6 +84,7 @@ Active todo files are listed below.
 
 | ID | Title | Completed | Notes |
 | ---- | ----- | --------- | ----- |
+| 418 | Replace serialized function type registry keys | 2026-05-25 | Function type registry signatures are now typed records with structural equality through a registry helper; serialized JSON keys and `signatureMap` were removed without compatibility shims. |
 | 414 | Split compiler context phase types | 2026-05-25 | Namespace prepass, module compilation, and function compilation now use phase-specific context types; function codegen receives required signature/type-registry state and module layout fallbacks were removed. |
 | 413 | Split compiled function lifecycle types | 2026-05-25 | Pre-codegen function metadata is now separate from final compiled function output; final functions require `wasmIndex`, `typeIndex`, and `ast`, removing lifecycle-field non-null assertions from compiler assembly. |
 | 411 | Move compiler analysis metadata into instruction specs | 2026-05-25 | Generic fixed stack effects, block-close behavior, and memory operation metadata now live in `instructionSpecs.ts`; stack analysis and memory codegen consume the metadata while dynamic function, map, and arithmetic metadata algorithms stay explicit. |

--- a/docs/todos/archived/418-replace-serialized-function-type-registry-keys.md
+++ b/docs/todos/archived/418-replace-serialized-function-type-registry-keys.md
@@ -4,8 +4,8 @@ priority: Medium
 effort: 2-4h
 created: 2026-05-25
 issue: https://github.com/andorthehood/8f4e/issues/688
-status: Open
-completed: null
+status: Done
+completed: 2026-05-25
 ---
 
 # TODO: Replace serialized function type registry keys
@@ -38,20 +38,20 @@ Prefer the approach that removes ad hoc serialization while keeping the registry
 
 ### Step 1: Centralize Type Registration
 
-- Add a helper for registering or looking up a function type.
-- Move the current key creation and `signatureMap` manipulation behind that helper.
-- Keep `functionEnd` as the single registration point for user function signatures.
+- [x] Add a helper for registering or looking up a function type.
+- [x] Replace the current key creation and `signatureMap` manipulation with that helper.
+- [x] Keep `functionEnd` as the single registration point for user function signatures.
 
 ### Step 2: Replace JSON Serialization
 
-- Replace `JSON.stringify({ params, results })` with a typed key/equality strategy.
-- Update `FunctionTypeRegistry` in `packages/compiler-spec/src/compiled.ts` if its shape needs to change.
-- Avoid broadening types or adding runtime fallback checks just to preserve the existing map shape.
+- [x] Replace `JSON.stringify({ params, results })` with a typed key/equality strategy.
+- [x] Update `FunctionTypeRegistry` in `packages/compiler-spec/src/compiled.ts` if its shape needs to change.
+- [x] Avoid broadening types or adding runtime fallback checks just to preserve the existing map shape.
 
 ### Step 3: Keep Final Assembly Simple
 
-- Preserve the current direction where `functionEnd` stores the registered `typeIndex` on function compilation state.
-- Do not reintroduce a second signature serialization or registry lookup in `compileFunction`.
+- [x] Preserve the current direction where `functionEnd` stores the registered `typeIndex` on function compilation state.
+- [x] Do not reintroduce a second signature serialization or registry lookup in `compileFunction`.
 
 ## Validation Checkpoints
 
@@ -62,11 +62,20 @@ Prefer the approach that removes ad hoc serialization while keeping the registry
 
 ## Success Criteria
 
-- [ ] Function type registry deduplication no longer relies on `JSON.stringify({ params, results })`.
-- [ ] Function type identity is represented by typed compiler data or a dedicated registry helper.
-- [ ] `functionEnd` remains the single registration point for function type indices.
-- [ ] `compileFunction` continues to consume the registered `currentFunctionTypeIndex` directly.
-- [ ] Compiler tests and typechecks pass.
+- [x] Function type registry deduplication no longer relies on `JSON.stringify({ params, results })`.
+- [x] Function type identity is represented by typed compiler data or a dedicated registry helper.
+- [x] `functionEnd` remains the single registration point for function type indices.
+- [x] `compileFunction` continues to consume the registered `currentFunctionTypeIndex` directly.
+- [x] Compiler tests and typechecks pass.
+
+## Completion Notes
+
+Completed in PR followup branch `ai/replace-function-type-registry-keys`.
+
+- `FunctionTypeRegistry` now stores typed registered signatures instead of `signatureMap`.
+- `functionEnd` delegates lookup/registration to `getOrRegisterFunctionType`.
+- Matching param/result Wasm type arrays share one type index through structural equality.
+- No compatibility layer was kept for the removed serialized key contract.
 
 ## Affected Components
 

--- a/packages/compiler-spec/src/compiled.ts
+++ b/packages/compiler-spec/src/compiled.ts
@@ -1,3 +1,4 @@
+import type { FunctionType, WasmTypeValue } from '@8f4e/compiler-wasm-utils';
 import type { AST } from './ast';
 import type { ASTCache } from './cache';
 import type { FunctionTypeIdentifier } from './functionTypes';
@@ -38,9 +39,18 @@ export interface FunctionSignature {
 	returns: FunctionValueType[];
 }
 
+export interface FunctionTypeSignature {
+	params: WasmTypeValue[];
+	results: WasmTypeValue[];
+}
+
+export interface RegisteredFunctionTypeSignature extends FunctionTypeSignature {
+	typeIndex: number;
+}
+
 export interface FunctionTypeRegistry {
-	types: Array<ReturnType<typeof import('@8f4e/compiler-wasm-utils').createFunctionType>>;
-	signatureMap: Map<string, number>;
+	types: FunctionType[];
+	signatures: RegisteredFunctionTypeSignature[];
 	baseTypeIndex: number;
 }
 

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -219,7 +219,7 @@ export default function compile(
 	// Base type index is 3 (after the 3 built-in types)
 	const functionTypeRegistry: FunctionTypeRegistry = {
 		types: [],
-		signatureMap: new Map(),
+		signatures: [],
 		baseTypeIndex: 3,
 	};
 

--- a/packages/compiler/src/instructionCompilers/__snapshots__/functionEnd.test.ts.snap
+++ b/packages/compiler/src/instructionCompilers/__snapshots__/functionEnd.test.ts.snap
@@ -19,7 +19,7 @@ exports[`functionEnd instruction compiler > accepts float64 return type and emit
   },
   "functionTypeRegistry": {
     "baseTypeIndex": 0,
-    "signatureMapSize": 1,
+    "signatureCount": 1,
     "typesLength": 1,
   },
   "stack": [],
@@ -45,7 +45,7 @@ exports[`functionEnd instruction compiler > updates function signature and clear
   },
   "functionTypeRegistry": {
     "baseTypeIndex": 0,
-    "signatureMapSize": 1,
+    "signatureCount": 1,
     "typesLength": 1,
   },
   "stack": [],

--- a/packages/compiler/src/instructionCompilers/functionEnd.test.ts
+++ b/packages/compiler/src/instructionCompilers/functionEnd.test.ts
@@ -23,7 +23,7 @@ describe('functionEnd instruction compiler', () => {
 			currentFunctionSignature: { parameters: ['int'], returns: [] },
 			functionTypeRegistry: {
 				baseTypeIndex: 0,
-				signatureMap: new Map<string, number>(),
+				signatures: [],
 				types: [],
 			} as FunctionTypeRegistry,
 		});
@@ -46,7 +46,7 @@ describe('functionEnd instruction compiler', () => {
 			currentFunctionSignature: context.currentFunctionSignature,
 			functionTypeRegistry: {
 				baseTypeIndex: context.functionTypeRegistry?.baseTypeIndex,
-				signatureMapSize: context.functionTypeRegistry?.signatureMap.size,
+				signatureCount: context.functionTypeRegistry?.signatures.length,
 				typesLength: context.functionTypeRegistry?.types.length,
 			},
 		}).toMatchSnapshot();
@@ -66,7 +66,7 @@ describe('functionEnd instruction compiler', () => {
 			currentFunctionSignature: { parameters: ['float64'], returns: [] },
 			functionTypeRegistry: {
 				baseTypeIndex: 0,
-				signatureMap: new Map<string, number>(),
+				signatures: [],
 				types: [],
 			} as FunctionTypeRegistry,
 		});
@@ -89,11 +89,50 @@ describe('functionEnd instruction compiler', () => {
 			currentFunctionSignature: context.currentFunctionSignature,
 			functionTypeRegistry: {
 				baseTypeIndex: context.functionTypeRegistry?.baseTypeIndex,
-				signatureMapSize: context.functionTypeRegistry?.signatureMap.size,
+				signatureCount: context.functionTypeRegistry?.signatures.length,
 				typesLength: context.functionTypeRegistry?.types.length,
 			},
 		}).toMatchSnapshot();
 		expect(context.currentFunctionTypeIndex).toBe(0);
+	});
+
+	it('reuses a registered function type for matching signatures', () => {
+		const functionTypeRegistry: FunctionTypeRegistry = {
+			baseTypeIndex: 3,
+			signatures: [],
+			types: [],
+		};
+		const createFunctionContext = () =>
+			createInstructionCompilerTestContext({
+				blockStack: [
+					...createInstructionCompilerTestContext().blockStack,
+					{
+						blockType: BlockType.FUNCTION,
+						expectedResultIsInteger: false,
+						hasExpectedResult: false,
+					},
+				],
+				currentFunctionSignature: { parameters: ['int'], returns: [] },
+				functionTypeRegistry,
+			});
+		const line = {
+			lineNumberBeforeMacroExpansion: 1,
+			lineNumberAfterMacroExpansion: 1,
+			instruction: 'functionEnd',
+			arguments: [classifyIdentifier('int')],
+		} as AST[number];
+		const firstContext = createFunctionContext();
+		const secondContext = createFunctionContext();
+		firstContext.stack.push({ isInteger: true, isNonZero: false });
+		secondContext.stack.push({ isInteger: true, isNonZero: false });
+
+		analyzeAndCompileInstruction(functionEnd, line, firstContext);
+		analyzeAndCompileInstruction(functionEnd, line, secondContext);
+
+		expect(firstContext.currentFunctionTypeIndex).toBe(3);
+		expect(secondContext.currentFunctionTypeIndex).toBe(3);
+		expect(functionTypeRegistry.signatures).toHaveLength(1);
+		expect(functionTypeRegistry.types).toHaveLength(1);
 	});
 
 	it('throws when missing function block', () => {

--- a/packages/compiler/src/instructionCompilers/functionEnd.ts
+++ b/packages/compiler/src/instructionCompilers/functionEnd.ts
@@ -1,7 +1,7 @@
-import { createFunctionType } from '@8f4e/compiler-wasm-utils';
 import { ArgumentType } from '@8f4e/compiler-spec';
 
 import { functionValueTypeToWasmType } from '../utils/functionValueType';
+import { getOrRegisterFunctionType } from '../utils/functionTypeRegistry';
 import { popBlock } from '../utils/blockStack';
 
 import type { AST, FunctionCodegenContext, FunctionSignature, InstructionCompiler } from '@8f4e/compiler-spec';
@@ -31,16 +31,7 @@ const functionEnd: InstructionCompiler<AST[number], FunctionCodegenContext> = (l
 	const params = context.currentFunctionSignature.parameters.map(functionValueTypeToWasmType);
 	const results = returnTypes.map(functionValueTypeToWasmType);
 
-	const signature = JSON.stringify({ params, results });
-	let typeIndex = context.functionTypeRegistry.signatureMap.get(signature);
-
-	if (typeIndex === undefined) {
-		typeIndex = context.functionTypeRegistry.baseTypeIndex + context.functionTypeRegistry.types.length;
-		context.functionTypeRegistry.signatureMap.set(signature, typeIndex);
-		context.functionTypeRegistry.types.push(createFunctionType(params, results));
-	}
-
-	context.currentFunctionTypeIndex = typeIndex;
+	context.currentFunctionTypeIndex = getOrRegisterFunctionType(context.functionTypeRegistry, { params, results });
 
 	return context;
 };

--- a/packages/compiler/src/utils/functionTypeRegistry.ts
+++ b/packages/compiler/src/utils/functionTypeRegistry.ts
@@ -1,0 +1,30 @@
+import { createFunctionType } from '@8f4e/compiler-wasm-utils';
+
+import type { FunctionTypeRegistry, FunctionTypeSignature } from '@8f4e/compiler-spec';
+import type { WasmTypeValue } from '@8f4e/compiler-wasm-utils';
+
+function wasmTypeListsEqual(left: WasmTypeValue[], right: WasmTypeValue[]): boolean {
+	return left.length === right.length && left.every((type, index) => type === right[index]);
+}
+
+function functionTypeSignaturesEqual(left: FunctionTypeSignature, right: FunctionTypeSignature): boolean {
+	return wasmTypeListsEqual(left.params, right.params) && wasmTypeListsEqual(left.results, right.results);
+}
+
+export function getOrRegisterFunctionType(registry: FunctionTypeRegistry, signature: FunctionTypeSignature): number {
+	const registeredSignature = registry.signatures.find(existing => functionTypeSignaturesEqual(existing, signature));
+
+	if (registeredSignature) {
+		return registeredSignature.typeIndex;
+	}
+
+	const typeIndex = registry.baseTypeIndex + registry.types.length;
+	registry.signatures.push({
+		params: [...signature.params],
+		results: [...signature.results],
+		typeIndex,
+	});
+	registry.types.push(createFunctionType(signature.params, signature.results));
+
+	return typeIndex;
+}


### PR DESCRIPTION
## Summary
- replace the function type registry string-key map with typed registered signatures
- centralize function type lookup/registration in `getOrRegisterFunctionType`
- archive TODO 418 and add coverage that matching signatures reuse one type index

## Rationale
The compiler owns all consumers and the project is unreleased, so this removes the old broad `signatureMap` contract directly instead of keeping a compatibility layer. Function signature identity now stays as typed compiler data rather than being serialized with `JSON.stringify({ params, results })`.

## Validation
- `npx nx run compiler-spec:typecheck`
- `npx nx run compiler:typecheck`
- `npx nx run compiler:test`
- `npx nx run compiler:lint`
- pre-commit `npx nx run-many --target=typecheck --all`
- `rg -n "JSON.stringify\(\{ params, results \}\)|signatureMap|signatureMapSize" packages/compiler/src packages/compiler-spec/src -S` returned no source matches

Closes #688