### PR TITLE
fix(compiler): discriminate block stack frames

### DIFF
--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -64,7 +64,6 @@ Active todo files are listed below.
 | 408 | Reduce tokenizer identifier classification work | 🟡 | 1-2d | 2026-05-19 | `classifyIdentifier` runs many ordered reference-shape checks for every identifier; cheap prefix/suffix dispatch could avoid most checks for plain identifiers. |
 | 409 | Track block context flags during stack analysis | 🟡 | 2-4h | 2026-05-19 | Stack validation repeatedly scans block stack to detect constants/map scope; maintained context flags or counters would avoid per-instruction scans. |
 | 410 | Consolidate release action commits | 🟡 | 2-4h | 2026-05-19 | The release workflow currently creates separate version, bundle-size, bytecode-size, and compiler-coverage commits; collapse these into one release commit or one version commit plus one metrics commit. |
-| 415 | Discriminate compiler block stack frames | 🟡 | 4-8h | 2026-05-25 | Make block stack frames a discriminated union so map and loop consumers can access required frame metadata without defensive assertions. |
 | 416 | Add resolved identifier line forms | 🟡 | 1-2d | 2026-05-25 | Carry validated memory, local, pointer, and function targets from semantic normalization into stack analysis and codegen. |
 | 417 | Tighten compiler AST union and source block types | 🟡 | 2-4d | 2026-05-25 | Replace the broad `ASTLineBase<string, Argument[]>` compiler contract with typed AST unions and source-block types. |
 
@@ -84,6 +83,7 @@ Active todo files are listed below.
 
 | ID | Title | Completed | Notes |
 | ---- | ----- | --------- | ----- |
+| 415 | Discriminate compiler block stack frames | 2026-05-25 | Block stack frames are now a discriminated union; map frames require `mapState`, loop frames require counter metadata, and codegen consumers no longer use the old block-frame non-null assertions. |
 | 418 | Replace serialized function type registry keys | 2026-05-25 | Function type registry signatures are now typed records with structural equality through a registry helper; serialized JSON keys and `signatureMap` were removed without compatibility shims. |
 | 414 | Split compiler context phase types | 2026-05-25 | Namespace prepass, module compilation, and function compilation now use phase-specific context types; function codegen receives required signature/type-registry state and module layout fallbacks were removed. |
 | 413 | Split compiled function lifecycle types | 2026-05-25 | Pre-codegen function metadata is now separate from final compiled function output; final functions require `wasmIndex`, `typeIndex`, and `ast`, removing lifecycle-field non-null assertions from compiler assembly. |

--- a/docs/todos/archived/415-discriminate-compiler-block-stack-frames.md
+++ b/docs/todos/archived/415-discriminate-compiler-block-stack-frames.md
@@ -4,8 +4,8 @@ priority: Medium
 effort: 4-8h
 created: 2026-05-25
 issue: https://github.com/andorthehood/8f4e/issues/684
-status: Open
-completed: null
+status: Done
+completed: 2026-05-25
 ---
 
 # TODO: Discriminate compiler block stack frames
@@ -40,27 +40,28 @@ The important distinction is between validating user block structure and defendi
 
 ### Step 1: Define Frame Union
 
-- Replace the single broad `BlockStack[number]` shape with named frame types.
-- Keep shared result-shape fields in a base frame type.
-- Require `mapState` on map frames.
+- [x] Replace the single broad `BlockStack[number]` shape with named frame types.
+- [x] Keep shared result-shape fields in a base frame type.
+- [x] Require `mapState` on map frames.
 
 ### Step 2: Add Typed Helpers
 
-- Add typed access helpers only where they delete existing code or assertions without adding new runtime error paths in codegen.
-- Keep user-facing block mismatch errors in existing validation phases.
-- Keep `popBlock(...)` for generic codegen behavior where no type-specific fields are needed.
+- [x] Add typed access helpers only where they delete existing code or assertions without adding new runtime error paths in codegen.
+- [x] Keep user-facing block mismatch errors in existing validation phases.
+- [x] Keep `popBlock(...)` for generic codegen behavior where no type-specific fields are needed.
 
 ### Step 3: Update Map and Loop Consumers
 
-- Update `map`, `default`, `mapEnd`, `loopIndex`, and stack-analysis map/loop paths to consume narrowed data.
-- Prefer pushing map row/default collection out of codegen so `map` and `default` codegen can shrink or disappear.
-- Remove `mapState!`, `loopBlock!`, and similar assertions only when the replacement removes ambiguity without adding new codegen checks.
+- [x] Update `map`, `default`, `mapEnd`, `loopIndex`, and stack-analysis map/loop paths to consume narrowed data.
+- [x] Remove `mapState!`, `loopBlock!`, and similar assertions only when the replacement removes ambiguity without adding new codegen checks.
+
+Deferred note: pushing map row/default collection out of codegen belongs to the larger stack-analysis/codegen separation work; this refactor deliberately avoided expanding scope beyond the frame shape.
 
 ### Step 4: Delete, Do Not Relocate, Defensive Code
 
-- Confirm the implementation has fewer codegen branches/checks than before.
-- Do not replace non-null assertions with codegen `if (!...) throw ...` guards.
-- If a narrowed type cannot be expressed without a new codegen check, leave that part for a later typed-line or phase-separation task instead of worsening runtime behavior.
+- [x] Confirm the implementation has fewer codegen branches/checks than before.
+- [x] Do not replace non-null assertions with codegen `if (!...) throw ...` guards.
+- [x] If a narrowed type cannot be expressed without a new codegen check, leave that part for a later typed-line or phase-separation task instead of worsening runtime behavior.
 
 ## Validation Checkpoints
 
@@ -72,12 +73,22 @@ The important distinction is between validating user block structure and defendi
 
 ## Success Criteria
 
-- [ ] Map block consumers can access `mapState` without non-null assertions.
-- [ ] Loop metadata consumers are narrowed through a typed frame.
-- [ ] Invalid block nesting still produces the same compiler errors.
-- [ ] Codegen does not gain new user-facing runtime checks for block structure.
-- [ ] Codegen code size/branch count is reduced or unchanged; the refactor does not merely wrap existing ambiguity in helper calls.
-- [ ] Compiler tests and typechecks pass.
+- [x] Map block consumers can access `mapState` without non-null assertions.
+- [x] Loop metadata consumers are narrowed through a typed frame.
+- [x] Invalid block nesting still produces the same compiler errors.
+- [x] Codegen does not gain new user-facing runtime checks for block structure.
+- [x] Codegen code size/branch count is reduced or unchanged; the refactor does not merely wrap existing ambiguity in helper calls.
+- [x] Compiler tests and typechecks pass.
+
+## Completion Notes
+
+Completed in PR followup branch `ai/discriminate-compiler-block-stack-frames`.
+
+- `BlockStack` is now a discriminated union with required `mapState` on map frames and required loop counter metadata on loop frames.
+- Codegen uses narrow invariant helpers for map/loop frames without adding user-facing validation branches.
+- Existing block-structure errors remain in stack analysis and validation paths.
+- `mapState!`, `loopBlock!`, `loopCounterLocalName!`, and close-block `popBlock(context)!` assertions were removed from compiler sources.
+- Moving map row/default collection out of codegen remains part of the larger stack-analysis/codegen separation work rather than this frame-shape refactor.
 
 ## Affected Components
 

--- a/packages/compiler-spec/src/semantic.ts
+++ b/packages/compiler-spec/src/semantic.ts
@@ -302,13 +302,51 @@ export interface MapBlockState {
 	defaultSet: boolean;
 }
 
-export type BlockStack = Array<{
+interface BlockStackFrameBase {
 	expectedResultIsInteger: boolean;
 	hasExpectedResult: boolean;
-	blockType: BlockTypeValue;
-	loopCounterLocalName?: string;
-	mapState?: MapBlockState;
-}>;
+}
+
+export interface ModuleBlockStackFrame extends BlockStackFrameBase {
+	blockType: typeof BlockType.MODULE;
+}
+
+export interface FunctionBlockStackFrame extends BlockStackFrameBase {
+	blockType: typeof BlockType.FUNCTION;
+}
+
+export interface GenericBlockStackFrame extends BlockStackFrameBase {
+	blockType: typeof BlockType.BLOCK;
+}
+
+export interface ConditionBlockStackFrame extends BlockStackFrameBase {
+	blockType: typeof BlockType.CONDITION;
+}
+
+export interface ConstantsBlockStackFrame extends BlockStackFrameBase {
+	blockType: typeof BlockType.CONSTANTS;
+}
+
+export interface LoopBlockStackFrame extends BlockStackFrameBase {
+	blockType: typeof BlockType.LOOP;
+	loopCounterLocalName: string;
+}
+
+export interface MapBlockStackFrame extends BlockStackFrameBase {
+	blockType: typeof BlockType.MAP;
+	mapState: MapBlockState;
+}
+
+export type BlockStackFrame =
+	| ModuleBlockStackFrame
+	| FunctionBlockStackFrame
+	| GenericBlockStackFrame
+	| ConditionBlockStackFrame
+	| ConstantsBlockStackFrame
+	| LoopBlockStackFrame
+	| MapBlockStackFrame;
+
+export type BlockStack = BlockStackFrame[];
 
 export type InstructionCompiler<
 	TLine extends AST[number] = AST[number],

--- a/packages/compiler/src/instructionCompilers/blockEnd.ts
+++ b/packages/compiler/src/instructionCompilers/blockEnd.ts
@@ -11,7 +11,7 @@ import type { InstructionCompiler } from '@8f4e/compiler-spec';
  * @see [Instruction docs](../../docs/instructions/control-flow.md)
  */
 const blockEnd: InstructionCompiler = (line, context) => {
-	popBlock(context)!;
+	popBlock(context);
 
 	return saveByteCode(context, [WASM_END]);
 };

--- a/packages/compiler/src/instructionCompilers/default.ts
+++ b/packages/compiler/src/instructionCompilers/default.ts
@@ -1,3 +1,5 @@
+import { peekMapBlock } from '../utils/blockStack';
+
 import type { InstructionCompiler, NormalizedDefaultLine } from '@8f4e/compiler-spec';
 
 /**
@@ -7,7 +9,7 @@ import type { InstructionCompiler, NormalizedDefaultLine } from '@8f4e/compiler-
  * @see [Instruction docs](../../docs/instructions/control-flow.md)
  */
 const _default: InstructionCompiler<NormalizedDefaultLine> = (line: NormalizedDefaultLine, context) => {
-	const mapState = context.blockStack[context.blockStack.length - 1].mapState!;
+	const { mapState } = peekMapBlock(context);
 
 	const valueArg = line.arguments[0];
 	const defaultValue = valueArg.value;

--- a/packages/compiler/src/instructionCompilers/else.ts
+++ b/packages/compiler/src/instructionCompilers/else.ts
@@ -4,14 +4,14 @@ import { saveByteCode } from './utils/saveByteCode';
 
 import { popBlock, pushBlock } from '../utils/blockStack';
 
-import type { InstructionCompiler } from '@8f4e/compiler-spec';
+import type { ConditionBlockStackFrame, InstructionCompiler } from '@8f4e/compiler-spec';
 
 /**
  * Instruction compiler for `else`.
  * @see [Instruction docs](../../docs/instructions/control-flow.md)
  */
 const _else: InstructionCompiler = (line, context) => {
-	const block = popBlock(context)!;
+	const block = popBlock(context) as ConditionBlockStackFrame;
 
 	pushBlock(context, block);
 

--- a/packages/compiler/src/instructionCompilers/functionEnd.ts
+++ b/packages/compiler/src/instructionCompilers/functionEnd.ts
@@ -11,7 +11,7 @@ import type { AST, FunctionCodegenContext, FunctionSignature, InstructionCompile
  * @see [Instruction docs](../../docs/instructions/program-structure-and-functions.md)
  */
 const functionEnd: InstructionCompiler<AST[number], FunctionCodegenContext> = (line, context) => {
-	popBlock(context)!;
+	popBlock(context);
 
 	// Parse return types: functionEnd [<returnType1> <returnType2> ...]
 	const returnTypes = line.arguments.map(

--- a/packages/compiler/src/instructionCompilers/ifEnd.ts
+++ b/packages/compiler/src/instructionCompilers/ifEnd.ts
@@ -11,7 +11,7 @@ import type { InstructionCompiler } from '@8f4e/compiler-spec';
  * @see [Instruction docs](../../docs/instructions/control-flow.md)
  */
 const ifEnd: InstructionCompiler = (line, context) => {
-	popBlock(context)!;
+	popBlock(context);
 
 	return saveByteCode(context, [WASM_END]);
 };

--- a/packages/compiler/src/instructionCompilers/loopEnd.test.ts
+++ b/packages/compiler/src/instructionCompilers/loopEnd.test.ts
@@ -16,6 +16,7 @@ describe('loopEnd instruction compiler', () => {
 					blockType: BlockType.LOOP,
 					expectedResultIsInteger: false,
 					hasExpectedResult: false,
+					loopCounterLocalName: '__loopCounter1',
 				},
 			],
 		});

--- a/packages/compiler/src/instructionCompilers/loopEnd.ts
+++ b/packages/compiler/src/instructionCompilers/loopEnd.ts
@@ -11,7 +11,7 @@ import type { InstructionCompiler } from '@8f4e/compiler-spec';
  * @see [Instruction docs](../../docs/instructions/control-flow.md)
  */
 const loopEnd: InstructionCompiler = (line, context) => {
-	popBlock(context)!;
+	popBlock(context);
 
 	return saveByteCode(context, [...br(0), WASM_END, WASM_END]);
 };

--- a/packages/compiler/src/instructionCompilers/loopIndex.ts
+++ b/packages/compiler/src/instructionCompilers/loopIndex.ts
@@ -1,13 +1,14 @@
 import { i32const, localGet, WASM_I32_SUB } from '@8f4e/compiler-wasm-utils';
-import { BlockType } from '@8f4e/compiler-spec';
 
 import { saveByteCode } from './utils/saveByteCode';
+
+import { findNearestLoopBlock } from '../utils/blockStack';
 
 import type { InstructionCompiler, LoopIndexLine } from '@8f4e/compiler-spec';
 
 const loopIndex: InstructionCompiler<LoopIndexLine> = (line, context) => {
-	const loopBlock = [...context.blockStack].reverse().find(block => block.blockType === BlockType.LOOP);
-	const local = context.locals[loopBlock!.loopCounterLocalName!]!;
+	const loopBlock = findNearestLoopBlock(context);
+	const local = context.locals[loopBlock.loopCounterLocalName]!;
 
 	return saveByteCode(context, [...localGet(local.index), ...i32const(1), WASM_I32_SUB]);
 };

--- a/packages/compiler/src/instructionCompilers/map.test.ts
+++ b/packages/compiler/src/instructionCompilers/map.test.ts
@@ -5,7 +5,17 @@ import map from './map';
 
 import createInstructionCompilerTestContext, { analyzeAndCompileInstruction } from '../utils/testUtils';
 
-import type { AST } from '@8f4e/compiler-spec';
+import type { AST, CompilationContext, MapBlockState } from '@8f4e/compiler-spec';
+
+function getTopMapState(context: CompilationContext): MapBlockState {
+	const block = context.blockStack[context.blockStack.length - 1];
+
+	if (block?.blockType !== BlockType.MAP) {
+		throw new Error('Expected top block to be a map block');
+	}
+
+	return block.mapState;
+}
 
 describe('map instruction compiler', () => {
 	it('records an int key→int value row', () => {
@@ -44,7 +54,7 @@ describe('map instruction compiler', () => {
 			context
 		);
 
-		expect(context.blockStack[context.blockStack.length - 1].mapState!.rows).toMatchSnapshot();
+		expect(getTopMapState(context).rows).toMatchSnapshot();
 	});
 
 	it('accepts single-character string literals as ASCII int key/value', () => {
@@ -83,7 +93,7 @@ describe('map instruction compiler', () => {
 			context
 		);
 
-		expect(context.blockStack[context.blockStack.length - 1].mapState!.rows).toEqual([
+		expect(getTopMapState(context).rows).toEqual([
 			{
 				keyValue: 65,
 				valueValue: 66,

--- a/packages/compiler/src/instructionCompilers/map.ts
+++ b/packages/compiler/src/instructionCompilers/map.ts
@@ -2,6 +2,7 @@ import { ArgumentType } from '@8f4e/compiler-spec';
 import { ErrorCode } from '@8f4e/compiler-spec';
 
 import { getError } from '../compilerError';
+import { peekMapBlock } from '../utils/blockStack';
 
 import type { InstructionCompiler, NormalizedMapLine } from '@8f4e/compiler-spec';
 
@@ -12,7 +13,7 @@ import type { InstructionCompiler, NormalizedMapLine } from '@8f4e/compiler-spec
  * @see [Instruction docs](../../docs/instructions/control-flow.md)
  */
 const map: InstructionCompiler<NormalizedMapLine> = (line: NormalizedMapLine, context) => {
-	const mapState = context.blockStack[context.blockStack.length - 1].mapState!;
+	const { mapState } = peekMapBlock(context);
 	const keyArg = line.arguments[0];
 	const valueArg = line.arguments[1];
 

--- a/packages/compiler/src/instructionCompilers/mapEnd.ts
+++ b/packages/compiler/src/instructionCompilers/mapEnd.ts
@@ -17,7 +17,7 @@ import {
 import { saveByteCode } from './utils/saveByteCode';
 
 import { resolveMapKind } from '../utils/mapValueKind';
-import { popBlock } from '../utils/blockStack';
+import { popMapBlock } from '../utils/blockStack';
 
 import type { WASMInstructionCode } from '@8f4e/compiler-wasm-utils';
 import type { MapKind } from '../utils/mapValueKind';
@@ -60,9 +60,7 @@ const mapEnd: InstructionCompiler<MapEndLine> = (line: MapEndLine, context) => {
 	const outputIsFloat64 = outputType === 'float64';
 	const outputKind = resolveMapKind({ isInteger: outputIsInteger, isFloat64: outputIsFloat64 });
 
-	// Pop the MAP block from blockStack and read its state
-	const block = popBlock(context)!;
-	const mapState = block.mapState!;
+	const { mapState } = popMapBlock(context);
 
 	const inputKind = resolveMapKind({ isInteger: mapState.inputIsInteger, isFloat64: mapState.inputIsFloat64 });
 

--- a/packages/compiler/src/instructionCompilers/utils/createResultBlockState.ts
+++ b/packages/compiler/src/instructionCompilers/utils/createResultBlockState.ts
@@ -1,26 +1,31 @@
 import { WASM_TYPE_F32, WASM_TYPE_I32, WASM_TYPE_VOID } from '@8f4e/compiler-wasm-utils';
+import { BlockType } from '@8f4e/compiler-spec';
 
 import type { WasmTypeValue } from '@8f4e/compiler-wasm-utils';
-import type { BlockStack, BlockTypeValue } from '@8f4e/compiler-spec';
+import type { BlockStack } from '@8f4e/compiler-spec';
 
 type ResultType = 'float' | 'int' | null | undefined;
+type ResultBlockType = typeof BlockType.BLOCK | typeof BlockType.CONDITION;
 
-interface ResultBlockState {
-	blockState: BlockStack[number];
+interface ResultBlockState<TBlockType extends ResultBlockType> {
+	blockState: Extract<BlockStack[number], { blockType: TBlockType }>;
 	wasmType: WasmTypeValue;
 }
 
 /**
  * Creates the compiler block-stack metadata and matching WASM block result type.
  */
-export default function createResultBlockState(resultType: ResultType, blockType: BlockTypeValue): ResultBlockState {
+export default function createResultBlockState<TBlockType extends ResultBlockType>(
+	resultType: ResultType,
+	blockType: TBlockType
+): ResultBlockState<TBlockType> {
 	if (resultType === 'float') {
 		return {
 			blockState: {
 				expectedResultIsInteger: false,
 				hasExpectedResult: true,
 				blockType,
-			},
+			} as Extract<BlockStack[number], { blockType: TBlockType }>,
 			wasmType: WASM_TYPE_F32,
 		};
 	}
@@ -31,7 +36,7 @@ export default function createResultBlockState(resultType: ResultType, blockType
 				expectedResultIsInteger: true,
 				hasExpectedResult: true,
 				blockType,
-			},
+			} as Extract<BlockStack[number], { blockType: TBlockType }>,
 			wasmType: WASM_TYPE_I32,
 		};
 	}
@@ -41,7 +46,7 @@ export default function createResultBlockState(resultType: ResultType, blockType
 			expectedResultIsInteger: false,
 			hasExpectedResult: false,
 			blockType,
-		},
+		} as Extract<BlockStack[number], { blockType: TBlockType }>,
 		wasmType: WASM_TYPE_VOID,
 	};
 }

--- a/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
+++ b/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
@@ -199,7 +199,7 @@ function analyzeCall(line: CallLine, context: CompilationContext): { consumed: S
 function analyzeMapEnd(line: MapEndLine, context: CompilationContext): { consumed: Stack; produced: Stack } {
 	const block = context.blockStack[context.blockStack.length - 1];
 
-	if (!block || block.blockType !== BlockType.MAP || !block.mapState) {
+	if (!block || block.blockType !== BlockType.MAP) {
 		throw getError(ErrorCode.MISSING_BLOCK_START_INSTRUCTION, line, context);
 	}
 
@@ -286,7 +286,7 @@ function analyzeLocalSet(line: AST[number], context: CompilationContext): { cons
 function analyzeLoopIndex(line: AST[number], context: CompilationContext): { consumed: Stack; produced: Stack } {
 	const loopBlock = [...context.blockStack].reverse().find(block => block.blockType === BlockType.LOOP);
 
-	if (!loopBlock?.loopCounterLocalName || !context.locals[loopBlock.loopCounterLocalName]) {
+	if (!loopBlock || !context.locals[loopBlock.loopCounterLocalName]) {
 		throw getError(ErrorCode.INSTRUCTION_INVALID_OUTSIDE_LOOP, line, context);
 	}
 

--- a/packages/compiler/src/stackAnalysis/validateInstruction.test.ts
+++ b/packages/compiler/src/stackAnalysis/validateInstruction.test.ts
@@ -50,6 +50,12 @@ describe('validateInstruction', () => {
 					blockType: BlockType.MAP,
 					expectedResultIsInteger: false,
 					hasExpectedResult: false,
+					mapState: {
+						inputIsInteger: true,
+						inputIsFloat64: false,
+						rows: [],
+						defaultSet: false,
+					},
 				},
 			],
 			insideMapBlock: true,

--- a/packages/compiler/src/utils/blockStack.test.ts
+++ b/packages/compiler/src/utils/blockStack.test.ts
@@ -21,6 +21,7 @@ describe('blockStack utilities', () => {
 		blockType: BlockType.LOOP,
 		expectedResultIsInteger: false,
 		hasExpectedResult: false,
+		loopCounterLocalName: '__loopCounter1',
 	};
 	const mockGenericBlock: BlockStack[number] = {
 		blockType: BlockType.BLOCK,

--- a/packages/compiler/src/utils/blockStack.ts
+++ b/packages/compiler/src/utils/blockStack.ts
@@ -1,6 +1,13 @@
 import { BlockType } from '@8f4e/compiler-spec';
 
-import type { BlockStack, BlockTypeValue, CodegenContext, CompilationContext } from '@8f4e/compiler-spec';
+import type {
+	BlockStack,
+	BlockTypeValue,
+	CodegenContext,
+	CompilationContext,
+	LoopBlockStackFrame,
+	MapBlockStackFrame,
+} from '@8f4e/compiler-spec';
 
 type BlockContext = CodegenContext | CompilationContext;
 
@@ -17,6 +24,18 @@ export function popBlock(context: BlockContext) {
 	}
 
 	return block;
+}
+
+export function peekMapBlock(context: BlockContext): MapBlockStackFrame {
+	return context.blockStack[context.blockStack.length - 1] as MapBlockStackFrame;
+}
+
+export function popMapBlock(context: BlockContext): MapBlockStackFrame {
+	return popBlock(context) as MapBlockStackFrame;
+}
+
+export function findNearestLoopBlock(context: BlockContext): LoopBlockStackFrame {
+	return [...context.blockStack].reverse().find(block => block.blockType === BlockType.LOOP) as LoopBlockStackFrame;
 }
 
 function updateBlockContextFlag(context: BlockContext, blockType: BlockTypeValue, isInside: boolean) {


### PR DESCRIPTION
## Summary
- replace the broad block stack frame shape with a discriminated union
- require `mapState` on map frames and loop counter metadata on loop frames
- update map and loop codegen consumers to use narrowed invariant helpers without adding block-structure error branches
- archive TODO 415

## Rationale
The compiler owns these internal frame shapes and the project is unreleased, so this tightens the type contract directly instead of preserving optional compatibility fields. Codegen continues to trust block structure validated earlier; this removes non-null assertions without relocating validation into codegen.

## Validation
- `npx nx run compiler-spec:typecheck`
- `npx nx run compiler:typecheck`
- `npx nx run compiler:test`
- `npx nx run compiler:lint`
- pre-commit `npx nx run-many --target=typecheck --all`
- `rg -n "mapState!|loopBlock!|loopCounterLocalName!|popBlock\(context\)!" packages/compiler/src packages/compiler-spec/src -S` returned no matches
- `rg -n "peekExpectedBlock|popExpectedBlock|MISSING_BLOCK_START_INSTRUCTION|INSTRUCTION_INVALID_OUTSIDE_LOOP" packages/compiler/src/instructionCompilers -g "!*.test.ts" -S` returned no matches

Closes #684