### PR TITLE
Tighten compiler AST line types

### DIFF
--- a/docs/todos/419-merge-instruction-source-argument-specs.md
+++ b/docs/todos/419-merge-instruction-source-argument-specs.md
@@ -1,0 +1,116 @@
+---
+title: 'TODO: Merge instruction source argument specs into instruction specs'
+priority: Medium
+effort: 1-2d
+created: 2026-05-26
+issue: null
+status: Open
+completed: null
+---
+
+# TODO: Merge instruction source argument specs into instruction specs
+
+## Problem Description
+
+The compiler currently has two separate instruction spec systems:
+
+- `packages/compiler-spec/src/instructionSpecs.ts` describes compiler-facing instruction behavior such as scope, stack operands, stack effects, documentation, block close behavior, and memory operation metadata.
+- `packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.ts` keeps tokenizer-owned `instructionArgumentSpecs` for source argument arity and argument-shape validation.
+
+This split means instruction contracts are not fully spec-first. A contributor must update one object for semantic/compiler behavior and a different tokenizer-local object for source syntax. That also makes it awkward to derive helper sets such as no-source-argument instruction names without maintaining extra lists.
+
+The overall goal is to use strict source and compiler types where applicable instead of handling ambiguity later during runtime or codegen. Source argument shape is part of the instruction contract, so it should live next to the rest of the instruction metadata.
+
+## Proposed Solution
+
+Move source argument specification into `instructionSpecs.ts` under a dedicated field such as `syntax` or `sourceArguments`.
+
+Example shape:
+
+```ts
+ensureNonZero: {
+	sourceArguments: {
+		maxArguments: 1,
+		argumentTypes: 'literal',
+	},
+	scope: 'moduleOrFunction',
+	minOperands: 1,
+	// existing docs/stack/effects metadata...
+}
+```
+
+The tokenizer should import and use this shared source-argument metadata for arity and argument-shape validation. After the move, remove the tokenizer-local `instructionArgumentSpecs` table.
+
+It is acceptable for this to be an API move. The project is not released yet, and we own the whole codebase, so do not preserve compatibility layers or duplicated fallback specs.
+
+## Anti-Patterns
+
+- Do not derive source argument arity from stack effects. Source arguments and stack operands are separate concepts.
+- Do not keep `instructionArgumentSpecs` as a compatibility layer after moving the metadata into compiler-spec.
+- Do not keep hand-maintained no-source-argument instruction lists when they can be derived from the shared source argument metadata.
+- Do not broaden argument shapes to avoid updating tests. Tighten tests to the intended language contract instead.
+
+## Implementation Plan
+
+### Step 1: Add Source Argument Metadata Types
+
+- Add compiler-spec types for source argument arity and shape rules.
+- Move the rule names currently used by tokenizer validation into compiler-spec if they are part of the public language contract.
+- Keep validation implementation details in tokenizer where possible; the shared spec should describe the contract, not parse tokens itself.
+
+### Step 2: Annotate Instruction Specs
+
+- Add source argument metadata to each relevant instruction in `instructionSpecs.ts`.
+- Cover no-argument instructions, required-argument instructions, optional-argument instructions, and variadic cases such as `functionEnd`.
+- Preserve intentional contracts such as `ensureNonZero` accepting no argument or one literal fallback.
+
+### Step 3: Consume Shared Specs in Tokenizer Validation
+
+- Replace tokenizer-local `instructionArgumentSpecs` with lookups against `instructionSpecs`.
+- Keep memory declaration handling explicit if needed, but prefer a shared spec path for all regular language instructions.
+- Make tokenizer syntax errors continue to own source argument shape failures.
+
+### Step 4: Remove Duplicated Lists and Specs
+
+- Remove `noArgumentCodegenInstructionNames` or derive the remaining helper from shared source argument metadata.
+- Remove duplicated tokenizer source argument spec data.
+- Update AST line typing only where the shared source metadata makes an existing manual type safer or simpler.
+
+## Validation Checkpoints
+
+- Run `npx nx run compiler-spec:typecheck`.
+- Run `npx nx run tokenizer:typecheck`.
+- Run `npx nx run tokenizer:test`.
+- Run `npx nx run compiler:typecheck`.
+- Run `npx nx run compiler:test`.
+- Use `rg -n "instructionArgumentSpecs|noArgumentCodegenInstructionNames" packages/compiler-spec packages/compiler packages/compiler/packages/tokenizer` to confirm duplicates are removed or intentionally derived.
+
+## Success Criteria
+
+- [ ] Source argument metadata lives in `packages/compiler-spec/src/instructionSpecs.ts`.
+- [ ] Tokenizer validation reads source argument contracts from compiler-spec.
+- [ ] The tokenizer-local `instructionArgumentSpecs` table is removed.
+- [ ] No-source-argument helper data is derived from source argument metadata or no longer needed.
+- [ ] Existing language behavior is preserved, including optional arguments such as `ensureNonZero <literal>` and `clampAddress <width>`.
+- [ ] No compatibility layer keeps old duplicated specs alive.
+
+## Affected Components
+
+- `packages/compiler-spec/src/instructionSpecs.ts`
+- `packages/compiler-spec/src/ast.ts`
+- `packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.ts`
+- tokenizer argument validation tests
+- compiler instruction tests that depend on source argument contracts
+
+## Risks & Considerations
+
+- **Package boundary change**: source argument rule names move from tokenizer into compiler-spec. This is acceptable, but the boundary should stay declarative.
+- **Over-derivation risk**: AST line unions may still need explicit manual types where TypeScript cannot safely infer tuple unions from metadata.
+- **Behavior drift risk**: optional and variadic source arguments must be preserved exactly.
+- **Compatibility risk**: do not add old-to-new shims; update internal callers and tests directly.
+
+## Related Items
+
+- **Related**: `417-tighten-compiler-ast-union-and-source-block-types.md`
+- **Related**: `397-finish-compiler-stack-analysis-codegen-separation.md`
+- **Related**: PR #692, which exposed the need to keep source argument contracts and AST line contracts aligned.

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -64,7 +64,6 @@ Active todo files are listed below.
 | 408 | Reduce tokenizer identifier classification work | 🟡 | 1-2d | 2026-05-19 | `classifyIdentifier` runs many ordered reference-shape checks for every identifier; cheap prefix/suffix dispatch could avoid most checks for plain identifiers. |
 | 409 | Track block context flags during stack analysis | 🟡 | 2-4h | 2026-05-19 | Stack validation repeatedly scans block stack to detect constants/map scope; maintained context flags or counters would avoid per-instruction scans. |
 | 410 | Consolidate release action commits | 🟡 | 2-4h | 2026-05-19 | The release workflow currently creates separate version, bundle-size, bytecode-size, and compiler-coverage commits; collapse these into one release commit or one version commit plus one metrics commit. |
-| 417 | Tighten compiler AST union and source block types | 🟡 | 2-4d | 2026-05-25 | Replace the broad `ASTLineBase<string, Argument[]>` compiler contract with typed AST unions and source-block types. |
 
 ### 🟢 Low Priority
 
@@ -82,6 +81,7 @@ Active todo files are listed below.
 
 | ID | Title | Completed | Notes |
 | ---- | ----- | --------- | ----- |
+| 417 | Tighten compiler AST union and source block types | 2026-05-25 | Compiler AST lines are now a discriminated union with source-block tuple types; tokenizer validation owns fixed arity, and namespace metadata no longer revalidates syntax-guaranteed prologue or return shapes. |
 | 416 | Add resolved identifier line forms | 2026-05-25 | Semantic normalization now carries resolved memory, local, pointer, function, and local-set targets through stack analysis and codegen; old push-target rediscovery was removed. |
 | 415 | Discriminate compiler block stack frames | 2026-05-25 | Block stack frames are now a discriminated union; map frames require `mapState`, loop frames require counter metadata, and codegen consumers no longer use the old block-frame non-null assertions. |
 | 418 | Replace serialized function type registry keys | 2026-05-25 | Function type registry signatures are now typed records with structural equality through a registry helper; serialized JSON keys and `signatureMap` were removed without compatibility shims. |

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -64,6 +64,7 @@ Active todo files are listed below.
 | 408 | Reduce tokenizer identifier classification work | 🟡 | 1-2d | 2026-05-19 | `classifyIdentifier` runs many ordered reference-shape checks for every identifier; cheap prefix/suffix dispatch could avoid most checks for plain identifiers. |
 | 409 | Track block context flags during stack analysis | 🟡 | 2-4h | 2026-05-19 | Stack validation repeatedly scans block stack to detect constants/map scope; maintained context flags or counters would avoid per-instruction scans. |
 | 410 | Consolidate release action commits | 🟡 | 2-4h | 2026-05-19 | The release workflow currently creates separate version, bundle-size, bytecode-size, and compiler-coverage commits; collapse these into one release commit or one version commit plus one metrics commit. |
+| 419 | Merge instruction source argument specs into instruction specs | 🟡 | 1-2d | 2026-05-26 | Source argument arity and shape rules currently live in tokenizer-local `instructionArgumentSpecs`; move them into `instructionSpecs.ts` so tokenizer validation and derived no-argument helpers share one strict instruction contract. |
 
 ### 🟢 Low Priority
 

--- a/docs/todos/archived/417-tighten-compiler-ast-union-and-source-block-types.md
+++ b/docs/todos/archived/417-tighten-compiler-ast-union-and-source-block-types.md
@@ -4,8 +4,8 @@ priority: Medium
 effort: 2-4d
 created: 2026-05-25
 issue: https://github.com/andorthehood/8f4e/issues/686
-status: Open
-completed: null
+status: Completed
+completed: 2026-05-25
 ---
 
 # TODO: Tighten compiler AST union and source block types
@@ -68,11 +68,11 @@ This is the broadest part of the hardening work: it turns tokenizer-owned guaran
 
 ## Success Criteria
 
-- [ ] Compiler AST consumers can narrow by `line.instruction` to exact argument tuple types.
-- [ ] Module/function metadata collection no longer revalidates prologue argument shape.
-- [ ] Function return type parsing no longer casts raw arguments to identifiers.
-- [ ] Existing syntax validation remains tokenizer-owned.
-- [ ] Compiler and tokenizer tests/typechecks pass.
+- [x] Compiler AST consumers can narrow by `line.instruction` to exact argument tuple types.
+- [x] Module/function metadata collection no longer revalidates prologue argument shape.
+- [x] Function return type parsing no longer casts raw arguments to identifiers.
+- [x] Existing syntax validation remains tokenizer-owned.
+- [x] Compiler and tokenizer tests/typechecks pass.
 
 ## Affected Components
 

--- a/packages/compiler-spec/src/ast.ts
+++ b/packages/compiler-spec/src/ast.ts
@@ -1,3 +1,12 @@
+import { ArgumentType } from './arguments';
+import {
+	arrayMemoryDeclarationInstructions,
+	memoryDeclarationInstructions,
+	scalarMemoryDeclarationInstructions,
+	type ArrayDeclarationInstruction,
+	type ScalarMemoryDeclarationInstruction,
+} from './memory';
+
 import type {
 	Argument,
 	ArgumentCompileTimeExpression,
@@ -5,6 +14,56 @@ import type {
 	ArgumentLiteral,
 	ArgumentStringLiteral,
 } from './arguments';
+
+type MacroInstructionName = 'defineMacro' | 'defineMacroEnd' | 'macro';
+type DocumentOnlyInstructionName = 'note' | 'noteEnd';
+
+export const noArgumentCodegenInstructionNames = [
+	'abs',
+	'add',
+	'and',
+	'castToFloat',
+	'castToFloat64',
+	'castToInt',
+	'clearStack',
+	'div',
+	'drop',
+	'ensureNonZero',
+	'equal',
+	'equalToZero',
+	'fallingEdge',
+	'greaterOrEqual',
+	'greaterOrEqualUnsigned',
+	'greaterThan',
+	'hasChanged',
+	'lessOrEqual',
+	'lessThan',
+	'load',
+	'load8u',
+	'load16u',
+	'load8s',
+	'load16s',
+	'loadFloat',
+	'min',
+	'max',
+	'mul',
+	'notEqual',
+	'notZero',
+	'or',
+	'remainder',
+	'risingEdge',
+	'round',
+	'shiftLeft',
+	'shiftRight',
+	'shiftRightUnsigned',
+	'sqrt',
+	'store',
+	'sub',
+	'xor',
+] as const;
+
+type NoArgumentCodegenInstructionName = (typeof noArgumentCodegenInstructionNames)[number];
+type ClampAddressInstructionName = 'clampAddress' | 'clampModuleAddress' | 'clampGlobalAddress';
 
 export type ASTLineBase<Instruction extends string, Arguments extends Array<Argument>> = {
 	lineNumberBeforeMacroExpansion: number;
@@ -21,13 +80,10 @@ export type ASTLineBase<Instruction extends string, Arguments extends Array<Argu
 	blockEndBlock?: BlockEndBlockMetadata;
 };
 
-export type ASTLine = ASTLineBase<string, Array<Argument>>;
-
-export type AST = ASTLine[];
-
 export type ParsedLineMetadata = Array<{ callSiteLineNumber: number; macroId?: string }>;
 
-export type PushArgument = ArgumentLiteral | ArgumentIdentifier | ArgumentCompileTimeExpression;
+export type CompileTimeValueArgument = ArgumentLiteral | ArgumentIdentifier | ArgumentCompileTimeExpression;
+export type PushArgument = ArgumentLiteral | ArgumentIdentifier | ArgumentCompileTimeExpression | ArgumentStringLiteral;
 export type PushLine = ASTLineBase<'push', [PushArgument]>;
 
 export type IfBlockResultType = 'int' | 'float' | null;
@@ -65,6 +121,7 @@ export type LocalVariableAccessLine = LocalSetLine;
 export type TokenizedLocalVariableAccessLine = LocalVariableAccessLine;
 
 export type FunctionLine = ASTLineBase<'function', [ArgumentIdentifier]>;
+export type FunctionEndLine = ASTLineBase<'functionEnd', ArgumentIdentifier[]>;
 export type CallLine = ASTLineBase<'call', [ArgumentIdentifier]>;
 export type ModuleLine = ASTLineBase<'module', [ArgumentIdentifier]>;
 export type ModuleEndLine = ASTLineBase<'moduleEnd', []>;
@@ -80,14 +137,8 @@ export type BranchIfTrueLine = ASTLineBase<'branchIfTrue', [ArgumentLiteral]>;
 export type BranchIfUnchangedLine = ASTLineBase<'branchIfUnchanged', [ArgumentLiteral]>;
 export type ExitIfTrueLine = ASTLineBase<'exitIfTrue', []>;
 export type StoreBytesLine = ASTLineBase<'storeBytes', [ArgumentLiteral]>;
-export type MemoryCopyLine = ASTLineBase<
-	'memoryCopy',
-	[ArgumentLiteral | ArgumentIdentifier | ArgumentCompileTimeExpression]
->;
-export type ConstLine = ASTLineBase<
-	'const',
-	[ArgumentIdentifier, ArgumentLiteral | ArgumentIdentifier | ArgumentCompileTimeExpression]
->;
+export type MemoryCopyLine = ASTLineBase<'memoryCopy', [CompileTimeValueArgument]>;
+export type ConstLine = ASTLineBase<'const', [ArgumentIdentifier, CompileTimeValueArgument]>;
 
 export type MapValueArgument =
 	| ArgumentLiteral
@@ -96,14 +147,146 @@ export type MapValueArgument =
 	| ArgumentStringLiteral;
 export type MapLine = ASTLineBase<'map', [MapValueArgument, MapValueArgument]>;
 
-export type DefaultLine = ASTLineBase<
-	'default',
-	[ArgumentLiteral | ArgumentIdentifier | ArgumentCompileTimeExpression]
->;
+export type DefaultLine = ASTLineBase<'default', [CompileTimeValueArgument]>;
 
 export type LoopLine = ASTLineBase<'loop', [] | [ArgumentLiteral]>;
+export type LoopEndLine = ASTLineBase<'loopEnd', []>;
 export type LoopIndexLine = ASTLineBase<'loopIndex', []>;
+export type ElseLine = ASTLineBase<'else', []>;
+export type ReturnLine = ASTLineBase<'return', []>;
 export type LoopCapLine = ASTLineBase<'#loopCap', [ArgumentLiteral]>;
 export type ImpureLine = ASTLineBase<'#impure', []>;
 export type ExportLine = ASTLineBase<'#export', [] | [ArgumentIdentifier]>;
 export type RegionLine = ASTLineBase<'#region', [ArgumentIdentifier | ArgumentLiteral]>;
+export type SkipExecutionLine = ASTLineBase<'#skipExecution', []>;
+export type InitOnlyLine = ASTLineBase<'#initOnly', []>;
+export type ClampAddressLine = ASTLineBase<ClampAddressInstructionName, [] | [CompileTimeValueArgument]>;
+export type NoArgumentCodegenLine = ASTLineBase<NoArgumentCodegenInstructionName, []>;
+
+export type MemoryDeclarationArgument =
+	| ArgumentLiteral
+	| ArgumentIdentifier
+	| ArgumentCompileTimeExpression
+	| ArgumentStringLiteral;
+export type ScalarMemoryDeclarationLine = ASTLineBase<
+	ScalarMemoryDeclarationInstruction,
+	[MemoryDeclarationArgument, ...MemoryDeclarationArgument[]]
+>;
+export type NamedScalarMemoryDeclarationLine = Omit<ScalarMemoryDeclarationLine, 'arguments'> & {
+	arguments: [ArgumentIdentifier, ...MemoryDeclarationArgument[]];
+};
+export type ArrayMemoryDeclarationLine = ASTLineBase<
+	ArrayDeclarationInstruction,
+	[ArgumentIdentifier, CompileTimeValueArgument, ...MemoryDeclarationArgument[]]
+>;
+export type MemoryDeclarationLine = ScalarMemoryDeclarationLine | ArrayMemoryDeclarationLine;
+
+type ExplicitCompilerASTLine =
+	| PushLine
+	| IfLine
+	| IfEndLine
+	| BlockLine
+	| BlockEndLine
+	| LocalSetLine
+	| FunctionLine
+	| FunctionEndLine
+	| CallLine
+	| ModuleLine
+	| ModuleEndLine
+	| ConstantsLine
+	| ConstantsEndLine
+	| UseLine
+	| LocalDeclarationLine
+	| ParamLine
+	| MapBeginLine
+	| MapEndLine
+	| BranchLine
+	| BranchIfTrueLine
+	| BranchIfUnchangedLine
+	| ExitIfTrueLine
+	| StoreBytesLine
+	| MemoryCopyLine
+	| ConstLine
+	| MapLine
+	| DefaultLine
+	| LoopLine
+	| LoopEndLine
+	| LoopIndexLine
+	| ElseLine
+	| ReturnLine
+	| LoopCapLine
+	| ImpureLine
+	| ExportLine
+	| RegionLine
+	| SkipExecutionLine
+	| InitOnlyLine
+	| ClampAddressLine
+	| NoArgumentCodegenLine
+	| MemoryDeclarationLine;
+
+export type CompilerASTLine =
+	| ExplicitCompilerASTLine
+	| ASTLineBase<MacroInstructionName | DocumentOnlyInstructionName, Array<Argument>>;
+
+export type ASTLine = CompilerASTLine;
+
+export type AST = CompilerASTLine[];
+
+export type ModuleAst = [ModuleLine, ...CompilerASTLine[], ModuleEndLine];
+export type FunctionAst = [FunctionLine, ...CompilerASTLine[], FunctionEndLine];
+export type ConstantsAst = [ConstantsLine, ...CompilerASTLine[], ConstantsEndLine];
+export type CompilerSourceAst = ModuleAst | FunctionAst | ConstantsAst;
+
+const scalarMemoryDeclarationInstructionSet = new Set<string>(scalarMemoryDeclarationInstructions);
+const arrayMemoryDeclarationInstructionSet = new Set<string>(arrayMemoryDeclarationInstructions);
+const memoryDeclarationInstructionSet = new Set<string>(memoryDeclarationInstructions);
+
+export function isFunctionLine(line: CompilerASTLine | undefined): line is FunctionLine {
+	return line?.instruction === 'function';
+}
+
+export function isFunctionEndLine(line: CompilerASTLine | undefined): line is FunctionEndLine {
+	return line?.instruction === 'functionEnd';
+}
+
+export function isParamLine(line: CompilerASTLine | undefined): line is ParamLine {
+	return line?.instruction === 'param';
+}
+
+export function isModuleLine(line: CompilerASTLine | undefined): line is ModuleLine {
+	return line?.instruction === 'module';
+}
+
+export function isConstantsLine(line: CompilerASTLine | undefined): line is ConstantsLine {
+	return line?.instruction === 'constants';
+}
+
+export function isUseLine(line: CompilerASTLine | undefined): line is UseLine {
+	return line?.instruction === 'use';
+}
+
+export function isIfEndLine(line: CompilerASTLine | undefined): line is IfEndLine {
+	return line?.instruction === 'ifEnd';
+}
+
+export function isBlockEndLine(line: CompilerASTLine | undefined): line is BlockEndLine {
+	return line?.instruction === 'blockEnd';
+}
+
+export function isMemoryDeclarationLine(line: CompilerASTLine | undefined): line is MemoryDeclarationLine {
+	return line !== undefined && memoryDeclarationInstructionSet.has(line.instruction);
+}
+
+export function isScalarMemoryDeclarationLine(line: CompilerASTLine | undefined): line is ScalarMemoryDeclarationLine {
+	return line !== undefined && scalarMemoryDeclarationInstructionSet.has(line.instruction);
+}
+
+export function isArrayMemoryDeclarationLine(line: CompilerASTLine | undefined): line is ArrayMemoryDeclarationLine {
+	return line !== undefined && arrayMemoryDeclarationInstructionSet.has(line.instruction);
+}
+
+export function isNamedScalarMemoryDeclarationLine(
+	line: CompilerASTLine | undefined
+): line is NamedScalarMemoryDeclarationLine {
+	return isScalarMemoryDeclarationLine(line) && line.arguments[0]?.type === ArgumentType.IDENTIFIER;
+}

--- a/packages/compiler-spec/src/ast.ts
+++ b/packages/compiler-spec/src/ast.ts
@@ -28,7 +28,6 @@ export const noArgumentCodegenInstructionNames = [
 	'clearStack',
 	'div',
 	'drop',
-	'ensureNonZero',
 	'equal',
 	'equalToZero',
 	'fallingEdge',
@@ -139,6 +138,7 @@ export type ExitIfTrueLine = ASTLineBase<'exitIfTrue', []>;
 export type StoreBytesLine = ASTLineBase<'storeBytes', [ArgumentLiteral]>;
 export type MemoryCopyLine = ASTLineBase<'memoryCopy', [CompileTimeValueArgument]>;
 export type ConstLine = ASTLineBase<'const', [ArgumentIdentifier, CompileTimeValueArgument]>;
+export type EnsureNonZeroLine = ASTLineBase<'ensureNonZero', [] | [ArgumentLiteral]>;
 
 export type MapValueArgument =
 	| ArgumentLiteral
@@ -207,6 +207,7 @@ type ExplicitCompilerASTLine =
 	| StoreBytesLine
 	| MemoryCopyLine
 	| ConstLine
+	| EnsureNonZeroLine
 	| MapLine
 	| DefaultLine
 	| LoopLine

--- a/packages/compiler-spec/src/ast.ts
+++ b/packages/compiler-spec/src/ast.ts
@@ -14,9 +14,7 @@ import type {
 	ArgumentLiteral,
 	ArgumentStringLiteral,
 } from './arguments';
-
-type MacroInstructionName = 'defineMacro' | 'defineMacroEnd' | 'macro';
-type DocumentOnlyInstructionName = 'note' | 'noteEnd';
+import type { DocumentOnlyInstructionName, MacroInstructionName } from './instructions';
 
 export const noArgumentCodegenInstructionNames = [
 	'abs',

--- a/packages/compiler/packages/tokenizer/src/parser.test.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.test.ts
@@ -331,6 +331,10 @@ describe('compileToAST', () => {
 		expect(() => compileToAST(['blockEnd'])).toThrowError(SyntaxRulesError);
 	});
 
+	it('does not treat inherited object keys as block end instructions', () => {
+		expect(() => compileToAST(['block', 'constructor', 'blockEnd'])).not.toThrow();
+	});
+
 	it('rejects unclosed block blocks', () => {
 		expect(() => compileToAST(['block', 'push 1'])).toThrowError(SyntaxRulesError);
 	});

--- a/packages/compiler/packages/tokenizer/src/parser.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.ts
@@ -52,7 +52,7 @@ function isBlockStartInstruction(instruction: string): instruction is BlockStart
 }
 
 function isBlockEndInstruction(instruction: string): instruction is BlockEndInstruction {
-	return instruction in blockEndToStartInstruction;
+	return Object.prototype.hasOwnProperty.call(blockEndToStartInstruction, instruction);
 }
 
 function isCompilerDirectiveInstruction(instruction: string): boolean {

--- a/packages/compiler/packages/tokenizer/src/parser.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.ts
@@ -16,9 +16,12 @@ import type {
 	ASTCache,
 	ASTCacheEntry,
 	ASTLine,
+	Argument,
+	BlockEndLine,
 	BlockEndInstruction,
 	BlockStartInstruction,
 	BlockBlockResultType,
+	IfEndLine,
 	IfBlockResultType,
 	ParsedLineMetadata,
 } from '@8f4e/compiler-spec';
@@ -44,29 +47,31 @@ const blockStartInstructionSet = new Set<BlockStartInstruction>(blockStartInstru
 const sourceBlockStartInstructionSet = new Set(['module', 'function']);
 const sourceBlockEndInstructionSet = new Set(['moduleEnd', 'functionEnd']);
 
+function isBlockStartInstruction(instruction: string): instruction is BlockStartInstruction {
+	return blockStartInstructionSet.has(instruction as BlockStartInstruction);
+}
+
+function isBlockEndInstruction(instruction: string): instruction is BlockEndInstruction {
+	return instruction in blockEndToStartInstruction;
+}
+
 function isCompilerDirectiveInstruction(instruction: string): boolean {
 	return instruction.startsWith('#');
 }
 
-function getResultTypeFromFirstArgument(line: ASTLine): IfBlockResultType {
-	const typeArgument = line.arguments[0];
-
-	if (!typeArgument || typeArgument.type !== ArgumentType.IDENTIFIER) {
-		return null;
-	}
-
-	return typeArgument.value === 'int' || typeArgument.value === 'float' ? typeArgument.value : null;
+function getResultTypeFromFirstArgument(line: IfEndLine | BlockEndLine): IfBlockResultType {
+	return (line.arguments[0]?.value ?? null) as IfBlockResultType;
 }
 
-function getIfResultType(line: ASTLine): IfBlockResultType {
+function getIfResultType(line: IfEndLine): IfBlockResultType {
 	return getResultTypeFromFirstArgument(line);
 }
 
-function getBlockEndResultType(line: ASTLine): BlockBlockResultType {
+function getBlockEndResultType(line: BlockEndLine): BlockBlockResultType {
 	return getResultTypeFromFirstArgument(line);
 }
 
-function hasExplicitMemoryDefault(instruction: string, args: ASTLine['arguments']): boolean | undefined {
+function hasExplicitMemoryDefault(instruction: string, args: Array<Argument>): boolean | undefined {
 	if (!isMemoryDeclarationInstruction(instruction)) {
 		return undefined;
 	}
@@ -175,14 +180,14 @@ export function parseLine(
 		const parsedArguments = args.map(parseArgument);
 		validateInstructionArguments(instruction, parsedArguments);
 		const isMemoryDeclaration = isMemoryDeclarationInstruction(instruction);
-		const parsedLine: ASTLine = {
+		const parsedLine = {
 			lineNumberBeforeMacroExpansion,
 			lineNumberAfterMacroExpansion,
 			instruction,
 			arguments: parsedArguments,
 			isSemanticOnly: isSemanticOnlyInstruction(instruction),
 			isMemoryDeclaration,
-		};
+		} as ASTLine;
 
 		if (isMemoryDeclaration) {
 			parsedLine.hasExplicitMemoryDefault = hasExplicitMemoryDefault(instruction, parsedArguments);
@@ -252,9 +257,9 @@ export function compileToAST(
 
 		ast.push(parsedLine);
 
-		if (blockStartInstructionSet.has(parsedLine.instruction as BlockStartInstruction)) {
+		if (isBlockStartInstruction(parsedLine.instruction)) {
 			blockStack.push({
-				instruction: parsedLine.instruction as BlockStartInstruction,
+				instruction: parsedLine.instruction,
 				astIndex,
 				hasElse: parsedLine.instruction === 'if' ? false : undefined,
 			});
@@ -300,11 +305,11 @@ export function compileToAST(
 			continue;
 		}
 
-		if (!(parsedLine.instruction in blockEndToStartInstruction)) {
+		if (!isBlockEndInstruction(parsedLine.instruction)) {
 			continue;
 		}
 
-		const endInstruction = parsedLine.instruction as BlockEndInstruction;
+		const endInstruction = parsedLine.instruction;
 		const expectedStartInstruction = blockEndToStartInstruction[endInstruction];
 		const openBlock = blockStack.pop();
 
@@ -340,8 +345,8 @@ export function compileToAST(
 			continue;
 		}
 
-		if (endInstruction === 'ifEnd') {
-			const resultType = getIfResultType(parsedLine);
+		if (parsedLine.instruction === 'ifEnd') {
+			const resultType = getIfResultType(parsedLine as IfEndLine);
 			ast[openBlock.astIndex].ifBlock = {
 				matchingIfEndIndex: astIndex,
 				resultType,
@@ -352,7 +357,7 @@ export function compileToAST(
 				resultType,
 			};
 		} else {
-			const resultType = getBlockEndResultType(parsedLine);
+			const resultType = getBlockEndResultType(parsedLine as BlockEndLine);
 			ast[openBlock.astIndex].blockBlock = {
 				matchingBlockEndIndex: astIndex,
 				resultType,

--- a/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.test.ts
+++ b/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.test.ts
@@ -15,6 +15,19 @@ describe('validateInstructionArguments', () => {
 		).toThrowError(SyntaxRulesError);
 	});
 
+	it('rejects extra arguments for fixed-arity instructions', () => {
+		expect(() =>
+			validateInstructionArguments('push', [
+				{ type: ArgumentType.LITERAL, value: 1, isInteger: true },
+				{ type: ArgumentType.LITERAL, value: 2, isInteger: true },
+			])
+		).toThrowError(SyntaxRulesError);
+		expect(() =>
+			validateInstructionArguments('module', [classifyIdentifier('main'), classifyIdentifier('extra')])
+		).toThrowError(SyntaxRulesError);
+		expect(() => validateInstructionArguments('add', [classifyIdentifier('extra')])).toThrowError(SyntaxRulesError);
+	});
+
 	it('accepts compile-time values for default', () => {
 		expect(() =>
 			validateInstructionArguments('default', [

--- a/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.test.ts
+++ b/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.test.ts
@@ -94,6 +94,22 @@ describe('validateInstructionArguments', () => {
 		expect(() => validateInstructionArguments('exitIfTrue', [classifyIdentifier('x')])).toThrowError(SyntaxRulesError);
 	});
 
+	it('accepts an optional literal fallback for ensureNonZero', () => {
+		expect(() => validateInstructionArguments('ensureNonZero', [])).not.toThrow();
+		expect(() =>
+			validateInstructionArguments('ensureNonZero', [{ type: ArgumentType.LITERAL, value: 0.000001, isInteger: false }])
+		).not.toThrow();
+		expect(() => validateInstructionArguments('ensureNonZero', [classifyIdentifier('fallback')])).toThrowError(
+			SyntaxRulesError
+		);
+		expect(() =>
+			validateInstructionArguments('ensureNonZero', [
+				{ type: ArgumentType.LITERAL, value: 1, isInteger: true },
+				{ type: ArgumentType.LITERAL, value: 2, isInteger: true },
+			])
+		).toThrowError(SyntaxRulesError);
+	});
+
 	it('requires a non-negative compile-time byte count for memoryCopy', () => {
 		expect(() =>
 			validateInstructionArguments('memoryCopy', [{ type: ArgumentType.LITERAL, value: 20, isInteger: true }])

--- a/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.ts
+++ b/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.ts
@@ -45,6 +45,7 @@ const instructionArgumentSpecs: Partial<Record<string, InstructionArgumentSpec>>
 	branchIfTrue: { minArguments: 1, maxArguments: 1, argumentTypes: ['literal'] },
 	branchIfUnchanged: { minArguments: 1, maxArguments: 1, argumentTypes: ['literal'] },
 	exitIfTrue: { maxArguments: 0 },
+	ensureNonZero: { maxArguments: 1, argumentTypes: 'literal' },
 	block: { maxArguments: 0 },
 	blockEnd: { maxArguments: 1, argumentTypes: 'ifResultType' },
 	local: { minArguments: 2, maxArguments: 2, argumentTypes: ['functionTypeIdentifier', 'identifier'] },

--- a/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.ts
+++ b/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.ts
@@ -1,4 +1,9 @@
-import { ArgumentType, FUNCTION_TYPE_IDENTIFIERS, SCALAR_TYPE_IDENTIFIERS } from '@8f4e/compiler-spec';
+import {
+	ArgumentType,
+	FUNCTION_TYPE_IDENTIFIERS,
+	SCALAR_TYPE_IDENTIFIERS,
+	noArgumentCodegenInstructionNames,
+} from '@8f4e/compiler-spec';
 
 import isConstantName from './isConstantName';
 import isArrayDeclarationInstruction from './isArrayDeclarationInstruction';
@@ -29,44 +34,55 @@ const supportedScalarTypeIdentifiers: ReadonlySet<string> = new Set(SCALAR_TYPE_
 const supportedFunctionTypeIdentifiers: ReadonlySet<string> = new Set(FUNCTION_TYPE_IDENTIFIERS);
 const supportedIfResultTypeIdentifiers = new Set(['int', 'float']);
 
+const noArgumentInstructionSpecs = Object.fromEntries(
+	noArgumentCodegenInstructionNames.map(instruction => [instruction, { maxArguments: 0 }])
+) as Partial<Record<string, InstructionArgumentSpec>>;
+
 const instructionArgumentSpecs: Partial<Record<string, InstructionArgumentSpec>> = {
-	push: { minArguments: 1 },
-	branch: { minArguments: 1, argumentTypes: ['literal'] },
-	branchIfTrue: { minArguments: 1, argumentTypes: ['literal'] },
-	branchIfUnchanged: { minArguments: 1, argumentTypes: ['literal'] },
+	...noArgumentInstructionSpecs,
+	push: { minArguments: 1, maxArguments: 1 },
+	branch: { minArguments: 1, maxArguments: 1, argumentTypes: ['literal'] },
+	branchIfTrue: { minArguments: 1, maxArguments: 1, argumentTypes: ['literal'] },
+	branchIfUnchanged: { minArguments: 1, maxArguments: 1, argumentTypes: ['literal'] },
 	exitIfTrue: { maxArguments: 0 },
 	block: { maxArguments: 0 },
 	blockEnd: { maxArguments: 1, argumentTypes: 'ifResultType' },
-	local: { minArguments: 2, argumentTypes: ['functionTypeIdentifier', 'identifier'] },
-	param: { minArguments: 2, argumentTypes: ['functionTypeIdentifier', 'identifier'] },
-	localSet: { minArguments: 1, argumentTypes: ['identifier'] },
-	function: { minArguments: 1, argumentTypes: ['identifier'] },
+	local: { minArguments: 2, maxArguments: 2, argumentTypes: ['functionTypeIdentifier', 'identifier'] },
+	param: { minArguments: 2, maxArguments: 2, argumentTypes: ['functionTypeIdentifier', 'identifier'] },
+	localSet: { minArguments: 1, maxArguments: 1, argumentTypes: ['identifier'] },
+	function: { minArguments: 1, maxArguments: 1, argumentTypes: ['identifier'] },
 	functionEnd: { argumentTypes: 'functionTypeIdentifier' },
-	call: { minArguments: 1, argumentTypes: ['identifier'] },
-	mapBegin: { minArguments: 1, argumentTypes: ['typeIdentifier'] },
-	mapEnd: { minArguments: 1, argumentTypes: ['typeIdentifier'] },
-	map: { minArguments: 2, argumentTypes: ['mapValue', 'mapValue'] },
-	default: { minArguments: 1, argumentTypes: ['compileTimeValue'] },
-	storeBytes: { minArguments: 1, argumentTypes: ['nonNegativeIntegerLiteral'] },
+	call: { minArguments: 1, maxArguments: 1, argumentTypes: ['identifier'] },
+	mapBegin: { minArguments: 1, maxArguments: 1, argumentTypes: ['typeIdentifier'] },
+	mapEnd: { minArguments: 1, maxArguments: 1, argumentTypes: ['typeIdentifier'] },
+	map: { minArguments: 2, maxArguments: 2, argumentTypes: ['mapValue', 'mapValue'] },
+	default: { minArguments: 1, maxArguments: 1, argumentTypes: ['compileTimeValue'] },
+	storeBytes: { minArguments: 1, maxArguments: 1, argumentTypes: ['nonNegativeIntegerLiteral'] },
 	memoryCopy: { minArguments: 1, maxArguments: 1, argumentTypes: ['nonNegativeCompileTimeValue'] },
 	clampAddress: { maxArguments: 1, argumentTypes: ['nonNegativeCompileTimeValue'] },
 	clampModuleAddress: { maxArguments: 1, argumentTypes: ['nonNegativeCompileTimeValue'] },
 	clampGlobalAddress: { maxArguments: 1, argumentTypes: ['nonNegativeCompileTimeValue'] },
-	loop: { argumentTypes: ['nonNegativeIntegerLiteral'] },
+	else: { maxArguments: 0 },
+	loop: { maxArguments: 1, argumentTypes: ['nonNegativeIntegerLiteral'] },
+	loopEnd: { maxArguments: 0 },
 	loopIndex: { maxArguments: 0 },
-	'#loopCap': { minArguments: 1, argumentTypes: ['nonNegativeIntegerLiteral'] },
+	'#loopCap': { minArguments: 1, maxArguments: 1, argumentTypes: ['nonNegativeIntegerLiteral'] },
 	'#region': { minArguments: 1, maxArguments: 1, argumentTypes: ['regionReference'] },
 	'#impure': { maxArguments: 0 },
 	'#export': { maxArguments: 1, argumentTypes: ['identifier'] },
-	module: { minArguments: 1, argumentTypes: ['identifier'] },
-	constants: { minArguments: 1, argumentTypes: ['identifier'] },
-	use: { minArguments: 1, argumentTypes: ['identifier'] },
+	'#skipExecution': { maxArguments: 0 },
+	'#initOnly': { maxArguments: 0 },
+	module: { minArguments: 1, maxArguments: 1, argumentTypes: ['identifier'] },
+	constants: { minArguments: 1, maxArguments: 1, argumentTypes: ['identifier'] },
+	use: { minArguments: 1, maxArguments: 1, argumentTypes: ['identifier'] },
 	const: {
 		minArguments: 2,
+		maxArguments: 2,
 		argumentTypes: ['constantIdentifier', 'compileTimeValue'],
 	},
 	if: { maxArguments: 0 },
 	ifEnd: { maxArguments: 1, argumentTypes: 'ifResultType' },
+	return: { maxArguments: 0 },
 };
 
 function getInstructionArgumentSpec(instruction: string): InstructionArgumentSpec | undefined {

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -38,6 +38,17 @@ type CompletedFunctionCompilationContext = FunctionCompilationContext & {
 	currentFunctionTypeIndex: number;
 };
 
+function getFallbackErrorLine(ast: AST): AST[number] {
+	return (
+		ast[0] ?? {
+			lineNumberBeforeMacroExpansion: 0,
+			lineNumberAfterMacroExpansion: 0,
+			instruction: 'block',
+			arguments: [],
+		}
+	);
+}
+
 export function compileCodegenLine(line: AnalyzedLine, context: CompilationContext) {
 	const instruction = line.instruction as Instruction;
 
@@ -128,19 +139,11 @@ export function compileModule(
 	});
 
 	if (!context.namespace.moduleName) {
-		throw getError(
-			ErrorCode.MISSING_MODULE_ID,
-			{ lineNumberBeforeMacroExpansion: 0, lineNumberAfterMacroExpansion: 0, instruction: 'module', arguments: [] },
-			context
-		);
+		throw getError(ErrorCode.MISSING_MODULE_ID, getFallbackErrorLine(ast), context);
 	}
 
 	if (context.stack.length > 0) {
-		throw getError(
-			ErrorCode.STACK_EXPECTED_ZERO_ELEMENTS,
-			{ lineNumberBeforeMacroExpansion: 0, lineNumberAfterMacroExpansion: 0, instruction: 'module', arguments: [] },
-			context
-		);
+		throw getError(ErrorCode.STACK_EXPECTED_ZERO_ELEMENTS, getFallbackErrorLine(ast), context);
 	}
 
 	const internalResources = Object.keys(context.internalResources).length > 0 ? context.internalResources : undefined;
@@ -220,11 +223,7 @@ export function compileFunction(
 	});
 
 	if (!context.currentFunctionId) {
-		throw getError(
-			ErrorCode.MISSING_FUNCTION_ID,
-			{ lineNumberBeforeMacroExpansion: 0, lineNumberAfterMacroExpansion: 0, instruction: 'function', arguments: [] },
-			context
-		);
+		throw getError(ErrorCode.MISSING_FUNCTION_ID, getFallbackErrorLine(ast), context);
 	}
 
 	// Collect locals (excluding parameters)

--- a/packages/compiler/src/semantic/buildNamespace.ts
+++ b/packages/compiler/src/semantic/buildNamespace.ts
@@ -2,6 +2,12 @@ import {
 	ArgumentType,
 	GLOBAL_ALIGNMENT_BOUNDARY,
 	compilerSourceBlockInstructionByType,
+	isFunctionEndLine,
+	isFunctionLine,
+	isModuleLine,
+	isNamedScalarMemoryDeclarationLine,
+	isParamLine,
+	isUseLine,
 	type AST,
 	type Argument,
 	type CompileOptions,
@@ -32,7 +38,6 @@ import { getError } from '../compilerError';
 import parseMemoryInstructionArguments from '../utils/memoryInstructionParser';
 
 const constantsBlock = compilerSourceBlockInstructionByType.constants;
-const functionBlock = compilerSourceBlockInstructionByType.function;
 const moduleBlock = compilerSourceBlockInstructionByType.module;
 
 /**
@@ -45,8 +50,8 @@ export function collectFunctionMetadataFromAsts(asts: AST[], startingWasmIndex: 
 	const result: FunctionMetadataLookup = {};
 
 	for (const [index, ast] of asts.entries()) {
-		const functionLine = ast.find(line => line.instruction === functionBlock.start);
-		if (!functionLine || functionLine.arguments[0]?.type !== ArgumentType.IDENTIFIER) {
+		const functionLine = ast.find(isFunctionLine);
+		if (!functionLine) {
 			continue;
 		}
 
@@ -55,21 +60,15 @@ export function collectFunctionMetadataFromAsts(asts: AST[], startingWasmIndex: 
 			throw getError(ErrorCode.DUPLICATE_IDENTIFIER, functionLine, undefined, { identifier: id });
 		}
 		const signature: FunctionSignature = {
-			parameters: ast.flatMap(line => {
-				if (line.instruction !== 'param' || line.arguments[0]?.type !== ArgumentType.IDENTIFIER) {
-					return [];
-				}
-
-				return [line.arguments[0].value as FunctionSignature['parameters'][number]];
-			}),
+			parameters: ast
+				.filter(isParamLine)
+				.map(line => line.arguments[0].value as FunctionSignature['parameters'][number]),
 			returns: [],
 		};
 
-		const functionEndLine = ast.find(line => line.instruction === functionBlock.end);
+		const functionEndLine = ast.find(isFunctionEndLine);
 		if (functionEndLine) {
-			signature.returns = functionEndLine.arguments.map(
-				arg => (arg as { type: typeof ArgumentType.IDENTIFIER; value: FunctionSignature['returns'][number] }).value
-			);
+			signature.returns = functionEndLine.arguments.map(arg => arg.value as FunctionSignature['returns'][number]);
 		}
 
 		result[id] = {
@@ -86,8 +85,8 @@ export function assertUniqueModuleIds(asts: AST[]): void {
 	const seenModuleIds = new Set<string>();
 
 	for (const ast of asts) {
-		const moduleLine = ast.find(line => line.instruction === moduleBlock.start);
-		if (!moduleLine || moduleLine.arguments[0]?.type !== ArgumentType.IDENTIFIER) {
+		const moduleLine = ast.find(isModuleLine);
+		if (!moduleLine) {
 			continue;
 		}
 
@@ -169,9 +168,7 @@ export function prepassNamespace(
 }
 
 export function getModuleIdFromAst(ast: AST): string | undefined {
-	const moduleLine = ast.find(line => line.instruction === moduleBlock.start);
-	const moduleId = moduleLine?.arguments[0];
-	return moduleId?.type === ArgumentType.IDENTIFIER ? moduleId.value : undefined;
+	return ast.find(isModuleLine)?.arguments[0].value;
 }
 
 function getModuleRegionFromAst(
@@ -212,7 +209,7 @@ function getReferencedNamespaceIdsFromArgument(argument: Argument | undefined): 
 }
 
 function getDeferredNamespaceIds(line: AST[number]): string[] {
-	if (line.instruction === 'use' && line.arguments[0]?.type === ArgumentType.IDENTIFIER) {
+	if (isUseLine(line)) {
 		return [line.arguments[0].value];
 	}
 
@@ -238,11 +235,7 @@ function shouldDeferNamespaceCollection(
 
 function toNamespaceDiscoveryAst(ast: AST): AST {
 	return ast.flatMap(line => {
-		if (
-			line.isMemoryDeclaration &&
-			!line.instruction.endsWith('[]') &&
-			line.arguments[0]?.type === ArgumentType.IDENTIFIER
-		) {
+		if (isNamedScalarMemoryDeclarationLine(line)) {
 			return [
 				{
 					...line,
@@ -284,7 +277,7 @@ export function collectNamespacesFromASTs(
 				if (!context.namespace.moduleName) {
 					continue;
 				}
-				const moduleLine = ast.find(line => line.instruction === moduleBlock.start);
+				const moduleLine = ast.find(isModuleLine);
 				const existingNamespace = namespaces[context.namespace.moduleName];
 				if (moduleLine && existingNamespace?.kind === moduleBlock.type) {
 					throw getError(ErrorCode.DUPLICATE_IDENTIFIER, moduleLine ?? ast[0], context, {

--- a/packages/compiler/src/semantic/memoryRegions.ts
+++ b/packages/compiler/src/semantic/memoryRegions.ts
@@ -16,7 +16,7 @@ function fallbackLine(): AST[number] {
 	return {
 		lineNumberBeforeMacroExpansion: 0,
 		lineNumberAfterMacroExpansion: 0,
-		instruction: '#region',
+		instruction: 'block',
 		arguments: [],
 	};
 }

--- a/packages/compiler/src/semantic/normalization/helpers.ts
+++ b/packages/compiler/src/semantic/normalization/helpers.ts
@@ -168,11 +168,11 @@ export function validateOrDeferUnresolvedIdentifier(
  * are responsible for invoking validateOrDefer* helpers when that behavior
  * is required.
  */
-export function normalizeArgumentsAtIndexes(
-	line: AST[number],
+export function normalizeArgumentsAtIndexes<TLine extends AST[number]>(
+	line: TLine,
 	context: CompilationContext,
 	indexes: number[]
-): { line: AST[number]; changed: boolean } {
+): { line: TLine; changed: boolean } {
 	let changed = false;
 	const nextArguments = line.arguments.map((argument, index) => {
 		if (!indexes.includes(index)) {
@@ -186,7 +186,7 @@ export function normalizeArgumentsAtIndexes(
 		return normalized;
 	});
 
-	return { line: changed ? { ...line, arguments: nextArguments } : line, changed };
+	return { line: changed ? ({ ...line, arguments: nextArguments } as TLine) : line, changed };
 }
 
 /**

--- a/packages/compiler/src/semantic/normalization/memoryDeclaration.ts
+++ b/packages/compiler/src/semantic/normalization/memoryDeclaration.ts
@@ -67,7 +67,7 @@ export default function normalizeMemoryDeclaration(line: AST[number], context: C
 				(argument.referenceKind === 'intermodular-module-reference' ||
 					argument.referenceKind === 'intermodular-reference')
 			) {
-				normalized = { ...normalized, arguments: [normalized.arguments[0]] };
+				normalized = { ...normalized, arguments: [normalized.arguments[0]] } as typeof normalized;
 			}
 		}
 	}

--- a/packages/compiler/src/semantic/normalization/memoryDeclaration.ts
+++ b/packages/compiler/src/semantic/normalization/memoryDeclaration.ts
@@ -1,4 +1,12 @@
-import { ArgumentType, type AST, type CompilationContext } from '@8f4e/compiler-spec';
+import {
+	ArgumentType,
+	isArrayMemoryDeclarationLine,
+	isScalarMemoryDeclarationLine,
+	type AST,
+	type CompilationContext,
+	type MemoryDeclarationLine,
+	type ScalarMemoryDeclarationLine,
+} from '@8f4e/compiler-spec';
 import { ErrorCode } from '@8f4e/compiler-spec';
 
 import {
@@ -32,6 +40,10 @@ function requireResolvedArrayValue(
 	}
 }
 
+function removeScalarDefault(line: ScalarMemoryDeclarationLine): ScalarMemoryDeclarationLine {
+	return { ...line, arguments: [line.arguments[0]] };
+}
+
 /**
  * Normalizes compile-time arguments for memory declaration instructions
  * (int, float, float64, array types, pointer types, etc.).
@@ -39,8 +51,11 @@ function requireResolvedArrayValue(
  * the element-count slot and all inline initializer values.
  * Validates intermodule references in default/initializer values if present.
  */
-export default function normalizeMemoryDeclaration(line: AST[number], context: CompilationContext): AST[number] {
-	const isArrayDeclaration = line.instruction.endsWith('[]');
+export default function normalizeMemoryDeclaration(
+	line: MemoryDeclarationLine,
+	context: CompilationContext
+): MemoryDeclarationLine {
+	const isArrayDeclaration = isArrayMemoryDeclarationLine(line);
 	const normalizeIndexes = isArrayDeclaration
 		? line.arguments.map((_, index) => index).filter(index => index > 0)
 		: [0, 1];
@@ -63,16 +78,16 @@ export default function normalizeMemoryDeclaration(line: AST[number], context: C
 			// from the line. The deferred state is owned here rather than relying on
 			// parseMemoryInstructionArguments to fabricate a placeholder 0.
 			if (
-				!isArrayDeclaration &&
+				isScalarMemoryDeclarationLine(normalized) &&
 				(argument.referenceKind === 'intermodular-module-reference' ||
 					argument.referenceKind === 'intermodular-reference')
 			) {
-				normalized = { ...normalized, arguments: [normalized.arguments[0]] } as typeof normalized;
+				normalized = removeScalarDefault(normalized);
 			}
 		}
 	}
 
-	if (isArrayDeclaration) {
+	if (isArrayMemoryDeclarationLine(normalized)) {
 		requireResolvedArrayValue(normalized.arguments[1], line, context);
 
 		for (let index = 2; index < normalized.arguments.length; index++) {

--- a/packages/compiler/src/utils/macroExpansion.ts
+++ b/packages/compiler/src/utils/macroExpansion.ts
@@ -3,11 +3,20 @@ import { ErrorCode, documentBlockInstructionByType } from '@8f4e/compiler-spec';
 
 import { getError } from '../compilerError';
 
-import type { AST, ExpandedLine, Instruction, MacroDefinition, Module } from '@8f4e/compiler-spec';
+import type { AST, ExpandedLine, MacroDefinition, Module } from '@8f4e/compiler-spec';
 
 const macroDefinitionInstruction = documentBlockInstructionByType.macro.start;
 const macroDefinitionEndInstruction = documentBlockInstructionByType.macro.end;
 const macroCallInstruction = documentBlockInstructionByType.macro.type;
+
+function createMacroErrorLine(lineIndex: number): AST[number] {
+	return {
+		lineNumberBeforeMacroExpansion: lineIndex,
+		lineNumberAfterMacroExpansion: lineIndex,
+		instruction: 'block',
+		arguments: [],
+	};
+}
 
 /**
  * Parse macro definitions from macro modules.
@@ -50,13 +59,7 @@ export function parseMacroDefinitions(macros: Module[]): Map<string, MacroDefini
 
 			if (instruction === macroDefinitionInstruction) {
 				if (insideMacro) {
-					const astLine: AST[number] = {
-						lineNumberBeforeMacroExpansion: lineIndex,
-						lineNumberAfterMacroExpansion: lineIndex,
-						instruction: 'push' as Instruction, // Placeholder instruction for error reporting
-						arguments: [],
-					};
-					throw getError(ErrorCode.NESTED_MACRO_DEFINITION, astLine);
+					throw getError(ErrorCode.NESTED_MACRO_DEFINITION, createMacroErrorLine(lineIndex));
 				}
 
 				if (macroCount > 0) {
@@ -71,13 +74,7 @@ export function parseMacroDefinitions(macros: Module[]): Map<string, MacroDefini
 				}
 
 				if (macroMap.has(macroName)) {
-					const astLine: AST[number] = {
-						lineNumberBeforeMacroExpansion: lineIndex,
-						lineNumberAfterMacroExpansion: lineIndex,
-						instruction: 'push' as Instruction, // Placeholder instruction for error reporting
-						arguments: [],
-					};
-					throw getError(ErrorCode.DUPLICATE_MACRO_NAME, astLine);
+					throw getError(ErrorCode.DUPLICATE_MACRO_NAME, createMacroErrorLine(lineIndex));
 				}
 
 				currentMacro = {
@@ -89,13 +86,7 @@ export function parseMacroDefinitions(macros: Module[]): Map<string, MacroDefini
 				macroCount++;
 			} else if (instruction === macroDefinitionEndInstruction) {
 				if (!insideMacro || !currentMacro) {
-					const astLine: AST[number] = {
-						lineNumberBeforeMacroExpansion: lineIndex,
-						lineNumberAfterMacroExpansion: lineIndex,
-						instruction: 'push' as Instruction, // Placeholder instruction for error reporting
-						arguments: [],
-					};
-					throw getError(ErrorCode.MISSING_MACRO_END, astLine);
+					throw getError(ErrorCode.MISSING_MACRO_END, createMacroErrorLine(lineIndex));
 				}
 
 				macroMap.set(currentMacro.name, currentMacro);
@@ -104,13 +95,7 @@ export function parseMacroDefinitions(macros: Module[]): Map<string, MacroDefini
 			} else if (insideMacro) {
 				// Check for nested macro calls or definitions inside macro body
 				if (instruction === macroCallInstruction) {
-					const astLine: AST[number] = {
-						lineNumberBeforeMacroExpansion: lineIndex,
-						lineNumberAfterMacroExpansion: lineIndex,
-						instruction: 'push' as Instruction, // Placeholder instruction for error reporting
-						arguments: [],
-					};
-					throw getError(ErrorCode.NESTED_MACRO_CALL, astLine);
+					throw getError(ErrorCode.NESTED_MACRO_CALL, createMacroErrorLine(lineIndex));
 				}
 
 				// Add line to current macro body
@@ -121,13 +106,7 @@ export function parseMacroDefinitions(macros: Module[]): Map<string, MacroDefini
 		// Check if any macro was left unclosed
 		if (insideMacro) {
 			const macro = currentMacro!;
-			const astLine: AST[number] = {
-				lineNumberBeforeMacroExpansion: macro.definitionLineNumber,
-				lineNumberAfterMacroExpansion: macro.definitionLineNumber,
-				instruction: 'push' as Instruction, // Placeholder instruction for error reporting
-				arguments: [],
-			};
-			throw getError(ErrorCode.MISSING_MACRO_END, astLine);
+			throw getError(ErrorCode.MISSING_MACRO_END, createMacroErrorLine(macro.definitionLineNumber));
 		}
 	});
 
@@ -177,13 +156,7 @@ export function expandMacros(module: Module, macroDefinitions: Map<string, Macro
 
 			const macroDef = macroDefinitions.get(macroName);
 			if (!macroDef) {
-				const astLine: AST[number] = {
-					lineNumberBeforeMacroExpansion: lineIndex,
-					lineNumberAfterMacroExpansion: lineIndex,
-					instruction: 'push' as Instruction, // Placeholder instruction for error reporting
-					arguments: [],
-				};
-				throw getError(ErrorCode.UNDEFINED_MACRO, astLine);
+				throw getError(ErrorCode.UNDEFINED_MACRO, createMacroErrorLine(lineIndex));
 			}
 
 			// Expand macro body, all lines map back to the call site


### PR DESCRIPTION
## Summary
- Replace the broad compiler AST line contract with a discriminated `CompilerASTLine` union, explicit source-block tuple types, and instruction predicates.
- Tighten tokenizer syntax validation so fixed-arity and no-source-argument instructions keep exact tuple types downstream.
- Remove namespace metadata argument-shape rechecks/casts for module/function/use/param/functionEnd lines and archive TODO 417.

## Rationale
Tokenizer validation owns raw instruction shape. Compiler phases can now rely on those parse-time facts instead of treating every line as arbitrary `string + Argument[]` and rechecking/casting syntax-guaranteed arguments later.

Closes #686

## Tests
- `npx nx run compiler-spec:typecheck`
- `npx nx run tokenizer:typecheck`
- `npx nx run compiler:typecheck`
- `npx nx run tokenizer:test`
- `npx nx run compiler:test`
- `rg -n "arguments\\[0\\]\\?\\.type|as \\{ type: typeof ArgumentType.IDENTIFIER" packages/compiler/src packages/compiler/packages/tokenizer/src`
