### PR TITLE
Merge instruction source argument specs

### DIFF
--- a/docs/maintenance_checks/reviewing-compatibility-layers.md
+++ b/docs/maintenance_checks/reviewing-compatibility-layers.md
@@ -99,8 +99,9 @@ These searches are intentionally noisy. Review matches by intent, not by keyword
    Ask whether it is:
 
    - a real independent concept;
-   - a temporary migration tool with an active removal plan;
    - a compatibility layer that only preserves the old interface.
+
+   If it is a compatibility layer, remove it. Do not keep migration shims, aliases, fallbacks, or alternate names for future cleanup.
 
 5. Prefer metadata over exception lists.
 
@@ -132,16 +133,11 @@ These searches are intentionally noisy. Review matches by intent, not by keyword
 
    In the final answer or PR description, list the compatibility layers removed and mention any old names that intentionally remain. If an old name remains, explain the current owner and why it is not a compatibility layer.
 
-## Keep Or Delete
+## Removal Rule
 
-Keep a compatibility layer only when:
+Never keep a compatibility layer. This project is unreleased, and the repository owns its callers, tests, fixtures, package exports, and docs. When a compatibility layer is found, delete it and update every caller to the intended interface in the same change.
 
-- it is required by a released public API or external file format;
-- external consumers cannot be updated in the same change;
-- there is a dated removal plan and tests specifically cover the transition;
-- the compatibility path is explicitly part of the product behavior.
-
-Delete it when:
+Compatibility layers must be removed when:
 
 - all callers live in this repository;
 - the old name only exists to avoid updating imports, tests, snapshots, or fixtures;

--- a/docs/maintenance_checks/reviewing-compatibility-layers.md
+++ b/docs/maintenance_checks/reviewing-compatibility-layers.md
@@ -38,31 +38,45 @@ Watch for these especially after AI-assisted edits:
 
 ## Search Prompts
 
-Start with explicit compatibility language:
+Do not rely on explicit compatibility language. Most leftover compatibility layers are not labeled as compatibility. Start from the contract that should now have one owner, then search for duplicate shapes around that contract.
+
+Search for duplicate metadata, registries, and derived lists near the owning spec:
 
 ```sh
-rg -n "compat|compatibility|legacy|deprecated|shim|adapter|backward|backwards|temporary|transitional|old" packages src docs -g '*.ts' -g '*.md'
+rg -n "Spec|Specs|Names|List|Map|Registry|Table|Record<|Set<|ReadonlySet" packages/compiler-spec/src packages/compiler/src packages/compiler/packages/tokenizer/src -g '*.ts'
 ```
 
-Search for alias-only type layers:
+Search for alias-only type layers and renamed shapes that may only preserve an old interface:
 
 ```sh
 rg -n "export type .* = .*;|type .* = .*;" packages/compiler-spec/src packages/compiler/src packages/compiler/packages/tokenizer/src -g '*.ts'
 ```
 
-Look for duplicate old/new metadata sources:
+Search for broad input types that may keep runtime code responsible for ambiguity:
 
 ```sh
-rg -n "Spec|Specs|Names|List|Map|Registry|Table" packages/compiler-spec/src packages/compiler/src packages/compiler/packages/tokenizer/src -g '*.ts'
+rg -n "unknown|any|string \\||\\| string|Partial<|Record<string|\\?:" packages/compiler-spec/src packages/compiler/src packages/compiler/packages/tokenizer/src -g '*.ts'
 ```
 
-Look for fallback-style control flow:
+Search for pass-through wrappers and old-to-new conversion functions:
 
 ```sh
-rg -n "fallback|default.*old|if \\(!.*\\)|\\?\\?|as unknown|as any|Exclude<|Extract<" packages/compiler-spec/src packages/compiler/src packages/compiler/packages/tokenizer/src -g '*.ts'
+rg -n "normalize|resolve|to[A-Z]|from[A-Z]|create|build|parse" packages/compiler-spec/src packages/compiler/src packages/compiler/packages/tokenizer/src -g '*.ts'
 ```
 
-These searches are intentionally noisy. Review matches by intent, not by keyword alone.
+Search for fallback-style control flow and runtime checks that might exist only because the type interface is still too loose:
+
+```sh
+rg -n "fallback|if \\(!.*\\)|\\?\\?|as unknown|as any|Exclude<|Extract<|throw getError|throw new" packages/compiler-spec/src packages/compiler/src packages/compiler/packages/tokenizer/src -g '*.ts'
+```
+
+Only after structural searches, do a low-confidence sweep for explicit labels:
+
+```sh
+rg -n "compat|compatibility|legacy|deprecated|shim|adapter|backward|backwards|temporary|transitional" packages src docs -g '*.ts' -g '*.md'
+```
+
+These searches are intentionally noisy. Review matches by intent, not by keyword alone. A clean explicit-label search does not mean the cleanup is complete.
 
 ## Review Steps
 

--- a/docs/maintenance_checks/reviewing-compatibility-layers.md
+++ b/docs/maintenance_checks/reviewing-compatibility-layers.md
@@ -1,0 +1,133 @@
+# Reviewing Compatibility Layers
+
+Use this check when a refactor is meant to replace an old interface, tighten types, remove ambiguity, or make one source of truth own a contract.
+
+## Goal
+
+Find and remove compatibility layers that preserve old shapes after the repository has moved to a stricter interface.
+
+## Why This Matters
+
+This project is not released yet and we own the whole codebase. Compatibility layers often make AI-generated refactors look smaller while leaving duplicate contracts behind. They also make future work harder because contributors must reason about both the intended interface and the legacy path that still accepts stale shapes.
+
+Common costs:
+
+- old and new APIs drift apart;
+- tests keep passing through fallback behavior instead of proving the new contract;
+- runtime code keeps accepting states that strict types should rule out;
+- future agents copy the compatibility layer as if it were part of the design.
+
+## Typical Compatibility Layers
+
+Watch for these especially after AI-assisted edits:
+
+- **Alias-only types**: `OldThing = NewThing`, `ParsedThing = TokenizedThing`, `CodegenThing = ResolvedThing` where the names no longer represent distinct shapes.
+- **Compatibility re-exports**: old module paths that re-export the new path only to avoid updating imports.
+- **Adapter wrappers**: functions whose only job is to translate old argument order, field names, or return shape into the new API.
+- **Duplicated spec tables**: a new central metadata object plus an old local map, list, or enum that mirrors part of the same contract.
+- **Hardcoded exception lists**: `if (name !== 'oldSpecialCase')` or `Exclude<NewUnion, 'oldSyntheticName'>` when the new metadata could describe the difference directly.
+- **Fallback parsers or readers**: code that accepts old syntax, old JSON keys, old config names, or old serialized formats after sources/tests should have been migrated.
+- **Optional fields kept for old shapes**: fields made optional only because old construction sites were not updated.
+- **Broad unions kept during migration**: `Old | New`, `string | StrictName`, or `unknown` inputs that remain after all callers could use the strict type.
+- **No-op wrapper functions**: `normalizeX`, `toNewX`, or `fromLegacyX` implementations that return their input unchanged.
+- **Deprecated names without removal plan**: comments, names, or tests that say "legacy", "temporary", "backward compatible", or "for compatibility" without an active migration boundary.
+- **Test-only shims**: helper branches that exist only to avoid updating fixtures, snapshots, or mocks.
+- **Silent default fallbacks**: code that fabricates placeholder values for missing data that should now be required by type or earlier validation.
+
+## Search Prompts
+
+Start with explicit compatibility language:
+
+```sh
+rg -n "compat|compatibility|legacy|deprecated|shim|adapter|backward|backwards|temporary|transitional|old" packages src docs -g '*.ts' -g '*.md'
+```
+
+Search for alias-only type layers:
+
+```sh
+rg -n "export type .* = .*;|type .* = .*;" packages/compiler-spec/src packages/compiler/src packages/compiler/packages/tokenizer/src -g '*.ts'
+```
+
+Look for duplicate old/new metadata sources:
+
+```sh
+rg -n "Spec|Specs|Names|List|Map|Registry|Table" packages/compiler-spec/src packages/compiler/src packages/compiler/packages/tokenizer/src -g '*.ts'
+```
+
+Look for fallback-style control flow:
+
+```sh
+rg -n "fallback|default.*old|if \\(!.*\\)|\\?\\?|as unknown|as any|Exclude<|Extract<" packages/compiler-spec/src packages/compiler/src packages/compiler/packages/tokenizer/src -g '*.ts'
+```
+
+These searches are intentionally noisy. Review matches by intent, not by keyword alone.
+
+## Review Steps
+
+1. Identify the new intended source of truth.
+
+   Examples: an instruction spec table, a discriminated union, a parsed AST line shape, an Nx project target, or a single package export.
+
+2. Trace all old names and paths.
+
+   ```sh
+   rg -n "OldName|old-path|legacyField" .
+   ```
+
+3. Classify each old surface.
+
+   Ask whether it is:
+
+   - a real independent concept;
+   - a temporary migration tool with an active removal plan;
+   - a compatibility layer that only preserves the old interface.
+
+4. Prefer metadata over exception lists.
+
+   If a name is excluded because it is synthetic, internal, non-codegen, non-source, or otherwise special, add explicit metadata to the owning spec instead of keeping a hardcoded exclusion list elsewhere.
+
+5. Delete the compatibility path and update callers.
+
+   Since the project is unreleased, prefer direct API moves over shims. Update imports, tests, snapshots, fixtures, docs, and helper types to the new interface.
+
+6. Verify old names are gone.
+
+   ```sh
+   rg -n "OldName|LegacyName|compat|shim|backward" packages docs
+   ```
+
+7. Run the smallest meaningful verification, then broaden if shared contracts moved.
+
+   For compiler/type-interface changes, prefer:
+
+   ```sh
+   npx nx run compiler-spec:typecheck
+   npx nx run @8f4e/tokenizer:typecheck
+   npx nx run compiler:typecheck
+   npx nx run @8f4e/tokenizer:test
+   npx nx run compiler:test
+   ```
+
+## Keep Or Delete
+
+Keep a compatibility layer only when:
+
+- it is required by a released public API or external file format;
+- external consumers cannot be updated in the same change;
+- there is a dated removal plan and tests specifically cover the transition;
+- the compatibility path is explicitly part of the product behavior.
+
+Delete it when:
+
+- all callers live in this repository;
+- the old name only exists to avoid updating imports, tests, snapshots, or fixtures;
+- the old shape is now impossible after tokenizer, semantic, or type validation;
+- the compatibility layer duplicates metadata that now has one owner;
+- the layer makes runtime code handle ambiguity that strict types can remove.
+
+## Review Notes
+
+- Small-looking PRs are not the goal. A larger honest rename is better than a small PR that hides a stale interface.
+- Do not preserve old and new spellings unless the user explicitly asks for a migration window.
+- Do not add runtime fallbacks for states that the parser, semantic pass, or type system should make impossible.
+- When in doubt, write down the owner of the contract. If two places own it, one is probably a compatibility layer.

--- a/docs/maintenance_checks/reviewing-compatibility-layers.md
+++ b/docs/maintenance_checks/reviewing-compatibility-layers.md
@@ -8,22 +8,6 @@ This document is meant to be an agent aid. When a cleanup request is broad or un
 
 Find and remove compatibility layers that preserve old shapes after the repository has moved to a stricter interface.
 
-## Agent Trigger
-
-Apply this check when the user says things like:
-
-- "clean this up";
-- "remove compatibility layers";
-- "we do not need backward compatibility";
-- "tighten the types";
-- "finish the refactor";
-- "remove old aliases/re-exports";
-- "why is this old path/name still here?";
-- "make this use one source of truth";
-- "remove runtime ambiguity".
-
-If the cleanup touches compiler, tokenizer, AST, instruction specs, package exports, or config schemas, assume compatibility layers are a real risk and search for them before deciding the work is done.
-
 ## Why This Matters
 
 This project is not released yet and we own the whole codebase. Compatibility layers often make AI-generated refactors look smaller while leaving duplicate contracts behind. They also make future work harder because contributors must reason about both the intended interface and the legacy path that still accepts stale shapes.

--- a/docs/maintenance_checks/reviewing-compatibility-layers.md
+++ b/docs/maintenance_checks/reviewing-compatibility-layers.md
@@ -1,10 +1,28 @@
 # Reviewing Compatibility Layers
 
-Use this check when a refactor is meant to replace an old interface, tighten types, remove ambiguity, or make one source of truth own a contract.
+Use this check when a user asks an AI agent to do cleanup, simplify after a refactor, remove old APIs, tighten types, remove ambiguity, or make one source of truth own a contract.
+
+This document is meant to be an agent aid. When a cleanup request is broad or underspecified, use it to look for compatibility layers that may have been left behind by previous AI-generated work.
 
 ## Goal
 
 Find and remove compatibility layers that preserve old shapes after the repository has moved to a stricter interface.
+
+## Agent Trigger
+
+Apply this check when the user says things like:
+
+- "clean this up";
+- "remove compatibility layers";
+- "we do not need backward compatibility";
+- "tighten the types";
+- "finish the refactor";
+- "remove old aliases/re-exports";
+- "why is this old path/name still here?";
+- "make this use one source of truth";
+- "remove runtime ambiguity".
+
+If the cleanup touches compiler, tokenizer, AST, instruction specs, package exports, or config schemas, assume compatibility layers are a real risk and search for them before deciding the work is done.
 
 ## Why This Matters
 
@@ -64,17 +82,21 @@ These searches are intentionally noisy. Review matches by intent, not by keyword
 
 ## Review Steps
 
-1. Identify the new intended source of truth.
+1. Restate the cleanup target in concrete terms.
+
+   Name the old interface, broad type, duplicated metadata, runtime fallback, or transitional path that should disappear.
+
+2. Identify the new intended source of truth.
 
    Examples: an instruction spec table, a discriminated union, a parsed AST line shape, an Nx project target, or a single package export.
 
-2. Trace all old names and paths.
+3. Trace all old names and paths.
 
    ```sh
    rg -n "OldName|old-path|legacyField" .
    ```
 
-3. Classify each old surface.
+4. Classify each old surface.
 
    Ask whether it is:
 
@@ -82,21 +104,21 @@ These searches are intentionally noisy. Review matches by intent, not by keyword
    - a temporary migration tool with an active removal plan;
    - a compatibility layer that only preserves the old interface.
 
-4. Prefer metadata over exception lists.
+5. Prefer metadata over exception lists.
 
    If a name is excluded because it is synthetic, internal, non-codegen, non-source, or otherwise special, add explicit metadata to the owning spec instead of keeping a hardcoded exclusion list elsewhere.
 
-5. Delete the compatibility path and update callers.
+6. Delete the compatibility path and update callers.
 
    Since the project is unreleased, prefer direct API moves over shims. Update imports, tests, snapshots, fixtures, docs, and helper types to the new interface.
 
-6. Verify old names are gone.
+7. Verify old names are gone.
 
    ```sh
    rg -n "OldName|LegacyName|compat|shim|backward" packages docs
    ```
 
-7. Run the smallest meaningful verification, then broaden if shared contracts moved.
+8. Run the smallest meaningful verification, then broaden if shared contracts moved.
 
    For compiler/type-interface changes, prefer:
 
@@ -107,6 +129,10 @@ These searches are intentionally noisy. Review matches by intent, not by keyword
    npx nx run @8f4e/tokenizer:test
    npx nx run compiler:test
    ```
+
+9. Report what was removed.
+
+   In the final answer or PR description, list the compatibility layers removed and mention any old names that intentionally remain. If an old name remains, explain the current owner and why it is not a compatibility layer.
 
 ## Keep Or Delete
 

--- a/docs/todos/420-add-typed-compiler-ast-group-indexes.md
+++ b/docs/todos/420-add-typed-compiler-ast-group-indexes.md
@@ -1,0 +1,154 @@
+---
+title: 'TODO: Add typed compiler AST group indexes'
+priority: Medium
+effort: 1-2d
+created: 2026-05-26
+issue: null
+status: Open
+completed: null
+---
+
+# TODO: Add typed compiler AST group indexes
+
+## Problem Description
+
+Compiler passes still rediscover facts by traversing AST line arrays with searches such as `.find(...)`, `.some(...)`, and repeated full-array loops. That keeps compiler code responsible for answering questions that the parser or AST construction phase could answer once.
+
+The current AST contract is primarily line-array based: `AST = CompilerASTLine[]`, with tuple aliases such as `ModuleAst`, `FunctionAst`, and `ConstantsAst`. Those tuple types help with start/end line shape, but they do not give the compiler a typed top-level object with required metadata for the group being compiled.
+
+This matters because repeated AST scans tend to preserve ambiguity:
+
+- a module compiler can end up searching for the module id instead of receiving a `ModuleAST` object that already has one;
+- function compilation can rediscover function id, parameters, results, or directives from lines instead of reading required `FunctionAST` metadata;
+- cross-module orchestration can rebuild function id lists or lookup maps instead of receiving them from a parser-owned or AST-construction-owned index;
+- defensive runtime checks remain tempting because the type interface does not prove which top-level group is being compiled.
+
+## Proposed Solution
+
+Introduce specific discriminated AST object types for compiler-owned top-level groups. Each group type should carry only the metadata that is required and valid for that group.
+
+The intended direction is conceptually:
+
+```ts
+type CompilerASTGroup =
+	| ModuleAST
+	| FunctionAST
+	| ConstantsAST;
+
+type ModuleAST = {
+	type: 'module';
+	id: string;
+	lines: ModuleAst;
+	// other module-only indexes that remove real compiler searches
+};
+
+type FunctionAST = {
+	type: 'function';
+	id: string;
+	lines: FunctionAst;
+	params: readonly FunctionParam[];
+	results: readonly FunctionResult[];
+	// other function-only metadata that remove real compiler searches
+};
+
+type CompilerASTBatch = {
+	modules: readonly ModuleAST[];
+	functions: readonly FunctionAST[];
+	functionsById: ReadonlyMap<string, FunctionAST>;
+};
+```
+
+The final names and exact fields should follow the current compiler-spec style. The important constraint is the shape: use discriminated, group-specific objects with required metadata, not one generic AST object with optional fields.
+
+Useful metadata candidates:
+
+- top-level group id;
+- function parameter and result metadata;
+- function lookup by id where current orchestration searches parsed function arrays;
+- compiler directive metadata that is already validated as prologue-only;
+- memory declaration indexes for module compilation, if current passes repeatedly rediscover them;
+- constants/use metadata, if current namespace work repeatedly scans the same lines.
+
+## Anti-Patterns
+
+- Do not create a generic `CompilerAST` object with optional fields such as `id?`, `functionIds?`, `signature?`, or `metadata?: Record<string, unknown>`.
+- Do not add metadata for group types that the compiler does not actually parse or own.
+- Do not put cross-group lookup metadata on an individual group object unless that group truly owns it; use a typed batch/program parse result for cross-group indexes.
+- Do not keep line-array-only APIs as compatibility layers once the typed group objects are introduced.
+- Do not hide metadata on AST arrays through non-enumerable properties or test-avoidance tricks.
+- Do not add runtime fallback searches for metadata that should be required by the relevant AST group type.
+- Do not duplicate indexes that can be derived once from the owning AST construction step.
+
+## Implementation Plan
+
+### Step 1: Inventory repeated AST scans
+
+- Review compiler and compiler-spec code for `.find(...)`, `.some(...)`, `.filter(...)`, `.map(...)`, and manual `for` loops over AST lines.
+- Classify each scan as either necessary sequential compilation work or metadata/index discovery that can move to typed AST construction.
+- Record the concrete fields needed by `ModuleAST`, `FunctionAST`, and any other real compiler-owned group type.
+
+### Step 2: Define typed top-level AST group objects
+
+- Add discriminated AST group object types in `packages/compiler-spec/src/ast.ts` or a focused adjacent module.
+- Keep existing line tuple types as the `lines` payload where they remain useful.
+- Make group-specific metadata required on the group that owns it.
+
+### Step 3: Build group objects during parsing or AST construction
+
+- Update tokenizer/parser APIs or add a focused AST grouping helper so compiler orchestration receives typed group objects.
+- Preserve cache behavior deliberately: cached AST data should include the typed group object or a clearly equivalent typed payload.
+- Update tests and snapshots directly instead of keeping old line-array compatibility paths.
+
+### Step 4: Remove compiler rediscovery paths
+
+- Replace compiler searches for group id, function signature, function lookup, and repeated declaration/directive discovery with reads from the typed AST group.
+- Delete fallback helpers, old aliases, and transitional adapters once callers move to the new type.
+- Keep runtime validation only for semantic facts that cannot be known from AST construction.
+
+## Validation Checkpoints
+
+- `rg -n "\\.find\\(|\\.some\\(|\\.filter\\(|\\.map\\(|for \\(.* of .*ast" packages/compiler/src packages/compiler-spec/src packages/compiler/packages/tokenizer/src -g '*.ts'`
+- `rg -n "id\\?|functionIds\\?|signature\\?|metadata\\?:|Record<string, unknown>" packages/compiler-spec/src packages/compiler/src packages/compiler/packages/tokenizer/src -g '*.ts'`
+- `npx nx run compiler-spec:typecheck`
+- `npx nx run @8f4e/tokenizer:typecheck`
+- `npx nx run compiler:typecheck`
+- `npx nx run @8f4e/tokenizer:test`
+- `npx nx run compiler:test`
+
+## Success Criteria
+
+- [ ] Compiler-owned top-level AST groups are represented as discriminated object types, not only raw line arrays.
+- [ ] Module and function AST objects expose required ids and group-specific metadata through their types.
+- [ ] Compiler code no longer re-traverses AST lines to rediscover metadata that belongs to typed AST group construction.
+- [ ] No generic optional metadata bag or compatibility line-array wrapper remains.
+- [ ] Tests and snapshots reflect the new AST contract directly.
+
+## Affected Components
+
+- `packages/compiler-spec/src/ast.ts` - AST group object types and exported contracts.
+- `packages/compiler/packages/tokenizer/src/parser.ts` - AST construction and cache integration.
+- `packages/compiler-spec/src/cache.ts` - cached AST payload shape if the public cache stores grouped AST objects.
+- `packages/compiler/src/index.ts` - module/function parse orchestration and compile entry point.
+- `packages/compiler/src/compiler.ts` - compilation entry points that currently accept line arrays.
+- `packages/compiler/src/semantic/` - namespace/prepass code that may rediscover group metadata.
+- `packages/compiler/src/graphOptimizer.ts` - module metadata extraction and dependency sorting.
+- `packages/compiler/tests/` and `packages/compiler/packages/tokenizer/src/` - AST snapshots and compiler/tokenizer coverage.
+
+## Risks & Considerations
+
+- **Scope control**: Only move metadata that removes real compiler rediscovery. Do not turn AST objects into broad compiler context containers.
+- **Type clarity**: Every metadata field should belong to exactly one group type. If a field is optional on every group, the model is probably too generic.
+- **Cache shape**: AST cache changes should be made intentionally and tested, because cache entries currently store `AST`.
+- **Related prepass work**: This may simplify TODO 406, but it should stay focused on AST group structure rather than solving all namespace/prepass repetition at once.
+
+## Related Items
+
+- **Related**: `docs/todos/406-review-compiler-namespace-prepass-repetition.md`
+- **Related**: `docs/todos/378-make-parser-stateful-for-block-pairing-and-owning-block-context.md`
+- **Related**: `docs/todos/377-batch-parse-modules-and-validate-shared-ids.md`
+- **Related**: `docs/todos/archived/417-tighten-compiler-ast-union-and-source-block-types.md`
+
+## Notes
+
+- The goal is to remove code by making the compiler's input types stronger. If the implementation adds more runtime checks, fallback paths, or compatibility layers, it is moving in the wrong direction.
+- This todo follows the broader project rule that compatibility layers should not be kept. Update callers, fixtures, snapshots, and tests to the new typed AST group contract in the same change.

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -64,7 +64,6 @@ Active todo files are listed below.
 | 408 | Reduce tokenizer identifier classification work | 🟡 | 1-2d | 2026-05-19 | `classifyIdentifier` runs many ordered reference-shape checks for every identifier; cheap prefix/suffix dispatch could avoid most checks for plain identifiers. |
 | 409 | Track block context flags during stack analysis | 🟡 | 2-4h | 2026-05-19 | Stack validation repeatedly scans block stack to detect constants/map scope; maintained context flags or counters would avoid per-instruction scans. |
 | 410 | Consolidate release action commits | 🟡 | 2-4h | 2026-05-19 | The release workflow currently creates separate version, bundle-size, bytecode-size, and compiler-coverage commits; collapse these into one release commit or one version commit plus one metrics commit. |
-| 419 | Merge instruction source argument specs into instruction specs | 🟡 | 1-2d | 2026-05-26 | Source argument arity and shape rules currently live in tokenizer-local `instructionArgumentSpecs`; move them into `instructionSpecs.ts` so tokenizer validation and derived no-argument helpers share one strict instruction contract. |
 
 ### 🟢 Low Priority
 
@@ -82,6 +81,7 @@ Active todo files are listed below.
 
 | ID | Title | Completed | Notes |
 | ---- | ----- | --------- | ----- |
+| 419 | Merge instruction source argument specs into instruction specs | 2026-05-26 | Source argument arity and shape metadata now lives in compiler-spec instruction specs; tokenizer validation consumes the shared contract, and duplicated argument/no-argument tables were removed without compatibility shims. |
 | 417 | Tighten compiler AST union and source block types | 2026-05-25 | Compiler AST lines are now a discriminated union with source-block tuple types; tokenizer validation owns fixed arity, and namespace metadata no longer revalidates syntax-guaranteed prologue or return shapes. |
 | 416 | Add resolved identifier line forms | 2026-05-25 | Semantic normalization now carries resolved memory, local, pointer, function, and local-set targets through stack analysis and codegen; old push-target rediscovery was removed. |
 | 415 | Discriminate compiler block stack frames | 2026-05-25 | Block stack frames are now a discriminated union; map frames require `mapState`, loop frames require counter metadata, and codegen consumers no longer use the old block-frame non-null assertions. |

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -64,6 +64,7 @@ Active todo files are listed below.
 | 408 | Reduce tokenizer identifier classification work | 🟡 | 1-2d | 2026-05-19 | `classifyIdentifier` runs many ordered reference-shape checks for every identifier; cheap prefix/suffix dispatch could avoid most checks for plain identifiers. |
 | 409 | Track block context flags during stack analysis | 🟡 | 2-4h | 2026-05-19 | Stack validation repeatedly scans block stack to detect constants/map scope; maintained context flags or counters would avoid per-instruction scans. |
 | 410 | Consolidate release action commits | 🟡 | 2-4h | 2026-05-19 | The release workflow currently creates separate version, bundle-size, bytecode-size, and compiler-coverage commits; collapse these into one release commit or one version commit plus one metrics commit. |
+| 420 | Add typed compiler AST group indexes | 🟡 | 1-2d | 2026-05-26 | Compiler passes still rediscover group metadata by traversing AST line arrays; typed module/function AST objects should carry required ids and indexes directly. |
 
 ### 🟢 Low Priority
 

--- a/docs/todos/archived/419-merge-instruction-source-argument-specs.md
+++ b/docs/todos/archived/419-merge-instruction-source-argument-specs.md
@@ -4,8 +4,8 @@ priority: Medium
 effort: 1-2d
 created: 2026-05-26
 issue: null
-status: Open
-completed: null
+status: Completed
+completed: 2026-05-26
 ---
 
 # TODO: Merge instruction source argument specs into instruction specs
@@ -87,12 +87,12 @@ It is acceptable for this to be an API move. The project is not released yet, an
 
 ## Success Criteria
 
-- [ ] Source argument metadata lives in `packages/compiler-spec/src/instructionSpecs.ts`.
-- [ ] Tokenizer validation reads source argument contracts from compiler-spec.
-- [ ] The tokenizer-local `instructionArgumentSpecs` table is removed.
-- [ ] No-source-argument helper data is derived from source argument metadata or no longer needed.
-- [ ] Existing language behavior is preserved, including optional arguments such as `ensureNonZero <literal>` and `clampAddress <width>`.
-- [ ] No compatibility layer keeps old duplicated specs alive.
+- [x] Source argument metadata lives in `packages/compiler-spec/src/instructionSpecs.ts`.
+- [x] Tokenizer validation reads source argument contracts from compiler-spec.
+- [x] The tokenizer-local `instructionArgumentSpecs` table is removed.
+- [x] No-source-argument helper data is derived from source argument metadata or no longer needed.
+- [x] Existing language behavior is preserved, including optional arguments such as `ensureNonZero <literal>` and `clampAddress <width>`.
+- [x] No compatibility layer keeps old duplicated specs alive.
 
 ## Affected Components
 

--- a/packages/compiler-spec/src/ast.ts
+++ b/packages/compiler-spec/src/ast.ts
@@ -71,8 +71,6 @@ export interface BlockEndBlockMetadata {
 export type BlockLine = ASTLineBase<'block', []>;
 export type BlockEndLine = ASTLineBase<'blockEnd', [] | [ArgumentIdentifier]>;
 export type LocalSetLine = ASTLineBase<'localSet', [ArgumentIdentifier]>;
-export type LocalVariableAccessLine = LocalSetLine;
-export type TokenizedLocalVariableAccessLine = LocalVariableAccessLine;
 
 export type FunctionLine = ASTLineBase<'function', [ArgumentIdentifier]>;
 export type FunctionEndLine = ASTLineBase<'functionEnd', ArgumentIdentifier[]>;

--- a/packages/compiler-spec/src/ast.ts
+++ b/packages/compiler-spec/src/ast.ts
@@ -14,52 +14,9 @@ import type {
 	ArgumentLiteral,
 	ArgumentStringLiteral,
 } from './arguments';
+import type { NoSourceArgumentInstructionName } from './instructionSpecs';
 import type { DocumentOnlyInstructionName, MacroInstructionName } from './instructions';
 
-export const noArgumentCodegenInstructionNames = [
-	'abs',
-	'add',
-	'and',
-	'castToFloat',
-	'castToFloat64',
-	'castToInt',
-	'clearStack',
-	'div',
-	'drop',
-	'equal',
-	'equalToZero',
-	'fallingEdge',
-	'greaterOrEqual',
-	'greaterOrEqualUnsigned',
-	'greaterThan',
-	'hasChanged',
-	'lessOrEqual',
-	'lessThan',
-	'load',
-	'load8u',
-	'load16u',
-	'load8s',
-	'load16s',
-	'loadFloat',
-	'min',
-	'max',
-	'mul',
-	'notEqual',
-	'notZero',
-	'or',
-	'remainder',
-	'risingEdge',
-	'round',
-	'shiftLeft',
-	'shiftRight',
-	'shiftRightUnsigned',
-	'sqrt',
-	'store',
-	'sub',
-	'xor',
-] as const;
-
-type NoArgumentCodegenInstructionName = (typeof noArgumentCodegenInstructionNames)[number];
 type ClampAddressInstructionName = 'clampAddress' | 'clampModuleAddress' | 'clampGlobalAddress';
 
 export type ASTLineBase<Instruction extends string, Arguments extends Array<Argument>> = {
@@ -159,7 +116,7 @@ export type RegionLine = ASTLineBase<'#region', [ArgumentIdentifier | ArgumentLi
 export type SkipExecutionLine = ASTLineBase<'#skipExecution', []>;
 export type InitOnlyLine = ASTLineBase<'#initOnly', []>;
 export type ClampAddressLine = ASTLineBase<ClampAddressInstructionName, [] | [CompileTimeValueArgument]>;
-export type NoArgumentCodegenLine = ASTLineBase<NoArgumentCodegenInstructionName, []>;
+export type NoSourceArgumentLine = ASTLineBase<NoSourceArgumentInstructionName, []>;
 
 export type MemoryDeclarationArgument =
 	| ArgumentLiteral
@@ -220,7 +177,7 @@ type ExplicitCompilerASTLine =
 	| SkipExecutionLine
 	| InitOnlyLine
 	| ClampAddressLine
-	| NoArgumentCodegenLine
+	| NoSourceArgumentLine
 	| MemoryDeclarationLine;
 
 export type CompilerASTLine =

--- a/packages/compiler-spec/src/instructionSpecs.ts
+++ b/packages/compiler-spec/src/instructionSpecs.ts
@@ -155,6 +155,7 @@ export interface SourceArgumentsSpec {
 
 export interface InstructionSpec<TLine = unknown> extends ValidationSpec<TLine> {
 	codegen?: false;
+	sourceInstruction?: false;
 	sourceArguments?: SourceArgumentsSpec;
 	docs?: InstructionDocumentation;
 	stack?: StackEffectSpec<TLine>;
@@ -292,6 +293,7 @@ const loadSpec = {
 
 const memoryDeclarationSpec = {
 	codegen: false,
+	sourceInstruction: false,
 	scope: 'module',
 } satisfies InstructionSpec;
 
@@ -984,6 +986,13 @@ export const instructionSpecs = {
 export type InstructionSpecName = keyof typeof instructionSpecs;
 export type CodegenInstructionSpecName = {
 	[TInstruction in InstructionSpecName]: (typeof instructionSpecs)[TInstruction] extends { codegen: false }
+		? never
+		: TInstruction;
+}[InstructionSpecName];
+
+export type NonCodegenInstructionSpecName = Exclude<InstructionSpecName, CodegenInstructionSpecName>;
+export type SourceInstructionSpecName = {
+	[TInstruction in InstructionSpecName]: (typeof instructionSpecs)[TInstruction] extends { sourceInstruction: false }
 		? never
 		: TInstruction;
 }[InstructionSpecName];

--- a/packages/compiler-spec/src/instructionSpecs.ts
+++ b/packages/compiler-spec/src/instructionSpecs.ts
@@ -3,12 +3,23 @@ import { ErrorCode } from './errors';
 import { memoryDeclarationInstructions } from './memory';
 import { BlockType } from './semantic';
 
-import type { AST, StoreBytesLine } from './ast';
 import type { ErrorCodeValue } from './errors';
 import type { MemoryDeclarationInstruction } from './memory';
 import type { BlockTypeValue, CompilationContext } from './semantic';
 
 export type OperandRule = 'int' | 'float' | 'matching';
+export type SourceArgumentShapeRule =
+	| 'identifier'
+	| 'constantIdentifier'
+	| 'literal'
+	| 'nonNegativeIntegerLiteral'
+	| 'nonNegativeCompileTimeValue'
+	| 'compileTimeValue'
+	| 'mapValue'
+	| 'typeIdentifier'
+	| 'functionTypeIdentifier'
+	| 'ifResultType'
+	| 'regionReference';
 export type ScopeRule =
 	| 'module'
 	| 'moduleOnly'
@@ -19,7 +30,10 @@ export type ScopeRule =
 	| 'map'
 	| 'loop';
 
-export interface ValidationSpec<TLine extends AST[number] = AST[number]> {
+type StoreBytesSourceLine = { arguments: [{ value: number }] };
+const noSourceArguments = { maxArguments: 0 } as const satisfies SourceArgumentsSpec;
+
+export interface ValidationSpec<TLine = unknown> {
 	scope?: ScopeRule;
 	minOperands?: number;
 	operandTypes?: OperandRule[] | OperandRule;
@@ -93,7 +107,7 @@ export interface StackMutationSpec {
 	dropped?: 'consumed';
 }
 
-export interface StackEffectSpec<TLine extends AST[number] = AST[number]> extends ResolvedStackEffect {
+export interface StackEffectSpec<TLine = unknown> extends ResolvedStackEffect {
 	resolve?: (line: TLine) => ResolvedStackEffect;
 	effect?: StackMutationSpec;
 }
@@ -133,7 +147,15 @@ export interface InstructionEffectsSpec {
 	memory?: MemoryOperationEffectSpec;
 }
 
-export interface InstructionSpec<TLine extends AST[number] = AST[number]> extends ValidationSpec<TLine> {
+export interface SourceArgumentsSpec {
+	minArguments?: number;
+	maxArguments?: number;
+	argumentTypes?: SourceArgumentShapeRule[] | SourceArgumentShapeRule;
+}
+
+export interface InstructionSpec<TLine = unknown> extends ValidationSpec<TLine> {
+	codegen?: false;
+	sourceArguments?: SourceArgumentsSpec;
 	docs?: InstructionDocumentation;
 	stack?: StackEffectSpec<TLine>;
 	effects?: InstructionEffectsSpec;
@@ -152,7 +174,7 @@ interface StackOptions {
 	effect?: StackMutationSpec;
 }
 
-function withDocsAndStack<TSpec extends ValidationSpec>(
+function withDocsAndStack<TSpec extends Partial<InstructionSpec>>(
 	spec: TSpec,
 	{ shortDescription, inputs, outputs, effect }: DocsAndStackOptions
 ): TSpec & { docs: InstructionDocumentation; stack: StackEffectSpec } {
@@ -222,7 +244,7 @@ function blockClose(
 	return { blockClose: { blockType, restoreResult, validateFloatResult } };
 }
 
-export function resolveInstructionStackEffect<TLine extends AST[number]>(
+export function resolveInstructionStackEffect<TLine>(
 	spec: InstructionSpec<TLine>,
 	line: TLine
 ): ResolvedStackEffect | undefined {
@@ -238,35 +260,44 @@ export function formatStackSignature(instruction: string, stackEffect: ResolvedS
 }
 
 const binaryMatchingSpec = {
+	sourceArguments: noSourceArguments,
 	scope: 'moduleOrFunction',
 	minOperands: 2,
 	operandTypes: 'matching',
-} satisfies ValidationSpec;
+} satisfies InstructionSpec;
 
 const binaryIntegerSpec = {
+	sourceArguments: noSourceArguments,
 	scope: 'moduleOrFunction',
 	minOperands: 2,
 	operandTypes: 'int',
-} satisfies ValidationSpec;
+} satisfies InstructionSpec;
 
 const unaryModuleOrFunctionSpec = {
 	scope: 'moduleOrFunction',
 	minOperands: 1,
 } satisfies ValidationSpec;
 
+const unaryNoSourceModuleOrFunctionSpec = {
+	...unaryModuleOrFunctionSpec,
+	sourceArguments: noSourceArguments,
+} satisfies InstructionSpec;
+
 const loadSpec = {
+	sourceArguments: noSourceArguments,
 	scope: 'moduleOrFunction',
 	minOperands: 1,
 	operandTypes: 'int',
-} satisfies ValidationSpec;
+} satisfies InstructionSpec;
 
 const memoryDeclarationSpec = {
+	codegen: false,
 	scope: 'module',
-} satisfies ValidationSpec;
+} satisfies InstructionSpec;
 
 export const instructionSpecs = {
 	// abs (int -- int), abs (float -- float), abs (float64 -- float64)
-	abs: withDocsAndStack(unaryModuleOrFunctionSpec, {
+	abs: withDocsAndStack(unaryNoSourceModuleOrFunctionSpec, {
 		shortDescription: 'Returns the absolute value of the top stack value.',
 		inputs: ['T'],
 		outputs: ['T'],
@@ -285,12 +316,14 @@ export const instructionSpecs = {
 	}),
 	// block ( -- )
 	block: {
+		sourceArguments: noSourceArguments,
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Starts a block that can be exited with branch instructions.' },
 		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// blockEnd ( -- ), blockEnd (T -- T)
 	blockEnd: {
+		sourceArguments: { maxArguments: 1, argumentTypes: 'ifResultType' },
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Ends a block and validates its optional result value.' },
 		stack: stack({ inputs: ['T?'], outputs: ['T?'] }),
@@ -298,12 +331,14 @@ export const instructionSpecs = {
 	},
 	// branch ( -- )
 	branch: {
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'literal' },
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Branches out of one or more enclosing blocks.' },
 		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// branchIfTrue (int -- )
 	branchIfTrue: {
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'literal' },
 		scope: 'moduleOrFunction',
 		minOperands: 1,
 		operandTypes: 'int',
@@ -312,6 +347,7 @@ export const instructionSpecs = {
 	},
 	// branchIfUnchanged (T -- )
 	branchIfUnchanged: {
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'literal' },
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Branches when the consumed value matches the previous value seen by this instruction.' },
@@ -319,6 +355,7 @@ export const instructionSpecs = {
 	},
 	// call (args... -- returns...)
 	call: {
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'identifier' },
 		scope: 'moduleOrFunction',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_BLOCK,
 		docs: { shortDescription: 'Calls a function, consuming its parameters and pushing its return values.' },
@@ -326,6 +363,7 @@ export const instructionSpecs = {
 	},
 	// castToFloat (int -- float)
 	castToFloat: {
+		sourceArguments: noSourceArguments,
 		scope: 'moduleOrFunction',
 		minOperands: 1,
 		operandTypes: 'int',
@@ -337,7 +375,7 @@ export const instructionSpecs = {
 		}),
 	},
 	// castToFloat64 (int -- float64), castToFloat64 (float -- float64), castToFloat64 (float64 -- float64)
-	castToFloat64: withDocsAndStack(unaryModuleOrFunctionSpec, {
+	castToFloat64: withDocsAndStack(unaryNoSourceModuleOrFunctionSpec, {
 		shortDescription: 'Converts a numeric stack value to float64.',
 		inputs: ['T'],
 		outputs: ['float64'],
@@ -345,6 +383,7 @@ export const instructionSpecs = {
 	}),
 	// castToInt (float -- int), castToInt (float64 -- int)
 	castToInt: {
+		sourceArguments: noSourceArguments,
 		scope: 'moduleOrFunction',
 		minOperands: 1,
 		operandTypes: 'float',
@@ -357,6 +396,7 @@ export const instructionSpecs = {
 	},
 	// clampAddress (ptr -- ptr)
 	clampAddress: {
+		sourceArguments: { maxArguments: 1, argumentTypes: 'nonNegativeCompileTimeValue' },
 		scope: 'moduleOrFunction',
 		minOperands: 1,
 		operandTypes: 'int',
@@ -365,6 +405,7 @@ export const instructionSpecs = {
 	},
 	// clampModuleAddress (ptr -- ptr)
 	clampModuleAddress: {
+		sourceArguments: { maxArguments: 1, argumentTypes: 'nonNegativeCompileTimeValue' },
 		scope: 'module',
 		minOperands: 1,
 		operandTypes: 'int',
@@ -373,6 +414,7 @@ export const instructionSpecs = {
 	},
 	// clampGlobalAddress (ptr -- ptr)
 	clampGlobalAddress: {
+		sourceArguments: { maxArguments: 1, argumentTypes: 'nonNegativeCompileTimeValue' },
 		scope: 'moduleOrFunction',
 		minOperands: 1,
 		operandTypes: 'int',
@@ -381,12 +423,38 @@ export const instructionSpecs = {
 	},
 	// clearStack (... -- )
 	clearStack: {
+		sourceArguments: noSourceArguments,
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Removes every value from the stack.' },
 		stack: stack({ inputs: ['...'], outputs: [], effect: { consumes: 'all', produces: [], dropped: 'consumed' } }),
 	},
+	// const <NAME> <value> ( -- )
+	const: {
+		codegen: false,
+		sourceArguments: {
+			minArguments: 2,
+			maxArguments: 2,
+			argumentTypes: ['constantIdentifier', 'compileTimeValue'],
+		},
+		allowedInConstantsBlocks: true,
+		docs: { shortDescription: 'Declares a compile-time constant.' },
+	},
+	// constants <id> ( -- )
+	constants: {
+		codegen: false,
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'identifier' },
+		docs: { shortDescription: 'Starts a constants block.' },
+	},
+	// constantsEnd ( -- )
+	constantsEnd: {
+		codegen: false,
+		sourceArguments: noSourceArguments,
+		allowedInConstantsBlocks: true,
+		docs: { shortDescription: 'Ends a constants block.' },
+	},
 	// default ( -- )
 	default: {
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'compileTimeValue' },
 		scope: 'map',
 		allowedInMapBlocks: true,
 		docs: { shortDescription: 'Defines the fallback value for a map block.' },
@@ -399,7 +467,7 @@ export const instructionSpecs = {
 		outputs: ['T'],
 	}),
 	// drop (T -- )
-	drop: withDocsAndStack(unaryModuleOrFunctionSpec, {
+	drop: withDocsAndStack(unaryNoSourceModuleOrFunctionSpec, {
 		shortDescription: 'Removes the top value from the stack.',
 		inputs: ['T'],
 		outputs: [],
@@ -407,18 +475,22 @@ export const instructionSpecs = {
 	}),
 	// else ( -- )
 	else: {
+		sourceArguments: noSourceArguments,
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Starts the alternate branch of the current if block.' },
 		stack: stack({ inputs: [], outputs: [] }),
 		effects: blockClose(BlockType.CONDITION, { validateFloatResult: true }),
 	},
 	// ensureNonZero (int -- int), ensureNonZero (float -- float), ensureNonZero (float64 -- float64)
-	ensureNonZero: withDocsAndStack(unaryModuleOrFunctionSpec, {
-		shortDescription: 'Ensures the top stack value is non-zero before continuing.',
-		inputs: ['T'],
-		outputs: ['T'],
-		effect: stackMutation(1, [{ kind: 'same', isNonZero: true }]),
-	}),
+	ensureNonZero: withDocsAndStack(
+		{ ...unaryModuleOrFunctionSpec, sourceArguments: { maxArguments: 1, argumentTypes: 'literal' } },
+		{
+			shortDescription: 'Ensures the top stack value is non-zero before continuing.',
+			inputs: ['T'],
+			outputs: ['T'],
+			effect: stackMutation(1, [{ kind: 'same', isNonZero: true }]),
+		}
+	),
 	// equal (int int -- int), equal (float float -- int), equal (float64 float64 -- int)
 	equal: withDocsAndStack(binaryMatchingSpec, {
 		shortDescription: 'Compares two values and pushes 1 when they are equal, otherwise 0.',
@@ -427,7 +499,7 @@ export const instructionSpecs = {
 		effect: stackMutation(2, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// equalToZero (int -- int), equalToZero (float -- int), equalToZero (float64 -- int)
-	equalToZero: withDocsAndStack(unaryModuleOrFunctionSpec, {
+	equalToZero: withDocsAndStack(unaryNoSourceModuleOrFunctionSpec, {
 		shortDescription: 'Pushes 1 when the value is zero, otherwise 0.',
 		inputs: ['T'],
 		outputs: ['int'],
@@ -435,6 +507,7 @@ export const instructionSpecs = {
 	}),
 	// exitIfTrue (int -- )
 	exitIfTrue: {
+		sourceArguments: noSourceArguments,
 		scope: 'moduleOnly',
 		onInvalidScope: ErrorCode.EXIT_IF_TRUE_OUTSIDE_MODULE,
 		minOperands: 1,
@@ -444,13 +517,20 @@ export const instructionSpecs = {
 	},
 	// fallingEdge (int -- int), fallingEdge (float -- int)
 	fallingEdge: {
+		sourceArguments: noSourceArguments,
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Detects when a signal changes from a non-zero value to zero.' },
 		stack: stack({ inputs: ['T'], outputs: ['int'], effect: stackMutation(1, [{ kind: 'int', isNonZero: false }]) }),
 	},
+	// function <id> ( -- )
+	function: {
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'identifier' },
+		docs: { shortDescription: 'Starts a function block.' },
+	},
 	// functionEnd (returns... -- )
 	functionEnd: {
+		sourceArguments: { argumentTypes: 'functionTypeIdentifier' },
 		scope: 'function',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_BLOCK,
 		docs: { shortDescription: 'Ends a function and records its return signature.' },
@@ -479,6 +559,7 @@ export const instructionSpecs = {
 	}),
 	// hasChanged (int -- int), hasChanged (float -- int)
 	hasChanged: {
+		sourceArguments: noSourceArguments,
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Pushes 1 when the consumed value differs from its previous value.' },
@@ -486,6 +567,7 @@ export const instructionSpecs = {
 	},
 	// if (int -- )
 	if: {
+		sourceArguments: noSourceArguments,
 		scope: 'moduleOrFunction',
 		minOperands: 1,
 		operandTypes: 'int',
@@ -494,6 +576,7 @@ export const instructionSpecs = {
 	},
 	// ifEnd ( -- ), ifEnd (T -- T)
 	ifEnd: {
+		sourceArguments: { maxArguments: 1, argumentTypes: 'ifResultType' },
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Ends an if block and validates its optional result value.' },
 		stack: stack({ inputs: ['T?'], outputs: ['T?'] }),
@@ -569,6 +652,11 @@ export const instructionSpecs = {
 	}),
 	// local ( -- )
 	local: {
+		sourceArguments: {
+			minArguments: 2,
+			maxArguments: 2,
+			argumentTypes: ['functionTypeIdentifier', 'identifier'],
+		},
 		scope: 'moduleOrFunction',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_BLOCK,
 		docs: { shortDescription: 'Declares a local variable in the current function or module block.' },
@@ -576,6 +664,7 @@ export const instructionSpecs = {
 	},
 	// localSet (T -- )
 	localSet: {
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'identifier' },
 		scope: 'moduleOrFunction',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_BLOCK,
 		minOperands: 1,
@@ -584,12 +673,14 @@ export const instructionSpecs = {
 	},
 	// loop ( -- )
 	loop: {
+		sourceArguments: { maxArguments: 1, argumentTypes: 'nonNegativeIntegerLiteral' },
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Starts a loop block that repeats until a branch exits it.' },
 		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// #loopCap ( -- )
 	'#loopCap': {
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'nonNegativeIntegerLiteral' },
 		scope: 'moduleOrFunction',
 		onInvalidScope: ErrorCode.COMPILER_DIRECTIVE_INVALID_CONTEXT,
 		docs: { shortDescription: 'Sets the loop iteration cap for loops in the current block.' },
@@ -597,6 +688,8 @@ export const instructionSpecs = {
 	},
 	// #region <name|index> ( -- )
 	'#region': {
+		codegen: false,
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'regionReference' },
 		scope: 'module',
 		onInvalidScope: ErrorCode.COMPILER_DIRECTIVE_INVALID_CONTEXT,
 		docs: { shortDescription: 'Selects the memory region used by subsequent module declarations.' },
@@ -604,6 +697,7 @@ export const instructionSpecs = {
 	},
 	// #export [exportName] ( -- )
 	'#export': {
+		sourceArguments: { maxArguments: 1, argumentTypes: 'identifier' },
 		scope: 'function',
 		onInvalidScope: ErrorCode.EXPORT_DIRECTIVE_INVALID_CONTEXT,
 		docs: {
@@ -613,6 +707,7 @@ export const instructionSpecs = {
 	},
 	// #skipExecution ( -- )
 	'#skipExecution': {
+		sourceArguments: noSourceArguments,
 		scope: 'moduleOnly',
 		onInvalidScope: ErrorCode.COMPILER_DIRECTIVE_INVALID_CONTEXT,
 		docs: { shortDescription: 'Skips the current module during cycle execution.' },
@@ -620,6 +715,7 @@ export const instructionSpecs = {
 	},
 	// #initOnly ( -- )
 	'#initOnly': {
+		sourceArguments: noSourceArguments,
 		scope: 'moduleOnly',
 		onInvalidScope: ErrorCode.COMPILER_DIRECTIVE_INVALID_CONTEXT,
 		docs: { shortDescription: 'Runs the current module only during initialization.' },
@@ -627,6 +723,7 @@ export const instructionSpecs = {
 	},
 	// #impure ( -- )
 	'#impure': {
+		sourceArguments: noSourceArguments,
 		scope: 'function',
 		onInvalidScope: ErrorCode.IMPURE_DIRECTIVE_INVALID_CONTEXT,
 		docs: { shortDescription: 'Allows the current function to perform explicit memory IO.' },
@@ -634,6 +731,7 @@ export const instructionSpecs = {
 	},
 	// loopEnd ( -- ), loopEnd (T -- T)
 	loopEnd: {
+		sourceArguments: noSourceArguments,
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Ends a loop block and branches back to the start of the loop.' },
 		stack: stack({ inputs: ['T?'], outputs: ['T?'] }),
@@ -641,6 +739,7 @@ export const instructionSpecs = {
 	},
 	// loopIndex ( -- int)
 	loopIndex: {
+		sourceArguments: noSourceArguments,
 		scope: 'loop',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_LOOP,
 		docs: { shortDescription: 'Pushes the current zero-based loop iteration index.' },
@@ -648,6 +747,7 @@ export const instructionSpecs = {
 	},
 	// map ( -- )
 	map: {
+		sourceArguments: { minArguments: 2, maxArguments: 2, argumentTypes: ['mapValue', 'mapValue'] },
 		scope: 'map',
 		allowedInMapBlocks: true,
 		docs: { shortDescription: 'Starts a map case inside a map block.' },
@@ -655,12 +755,14 @@ export const instructionSpecs = {
 	},
 	// mapBegin ( -- )
 	mapBegin: {
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'typeIdentifier' },
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Starts a map block that chooses a value from map cases.' },
 		stack: stack({ inputs: [], outputs: [] }),
 	},
 	// mapEnd (int -- T), mapEnd (float -- T), mapEnd (float64 -- T)
 	mapEnd: {
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'typeIdentifier' },
 		scope: 'map',
 		allowedInMapBlocks: true,
 		minOperands: 1,
@@ -669,6 +771,7 @@ export const instructionSpecs = {
 	},
 	// memoryCopy (ptr ptr -- )
 	memoryCopy: {
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'nonNegativeCompileTimeValue' },
 		scope: 'moduleOrFunction',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_BLOCK,
 		minOperands: 2,
@@ -695,6 +798,18 @@ export const instructionSpecs = {
 		inputs: ['T', 'T'],
 		outputs: ['T'],
 	}),
+	// module <id> ( -- )
+	module: {
+		codegen: false,
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'identifier' },
+		docs: { shortDescription: 'Starts a module block.' },
+	},
+	// moduleEnd ( -- )
+	moduleEnd: {
+		codegen: false,
+		sourceArguments: noSourceArguments,
+		docs: { shortDescription: 'Ends a module block.' },
+	},
 	// notEqual (int int -- int), notEqual (float float -- int), notEqual (float64 float64 -- int)
 	notEqual: withDocsAndStack(binaryMatchingSpec, {
 		shortDescription: 'Compares two values and pushes 1 when they are not equal, otherwise 0.',
@@ -703,7 +818,7 @@ export const instructionSpecs = {
 		effect: stackMutation(2, [{ kind: 'int', isNonZero: false }]),
 	}),
 	// notZero (int -- int), notZero (float -- int), notZero (float64 -- int)
-	notZero: withDocsAndStack(unaryModuleOrFunctionSpec, {
+	notZero: withDocsAndStack(unaryNoSourceModuleOrFunctionSpec, {
 		shortDescription: 'Pushes 1 when the value is non-zero, otherwise 0.',
 		inputs: ['T'],
 		outputs: ['int'],
@@ -717,6 +832,11 @@ export const instructionSpecs = {
 	}),
 	// param ( -- )
 	param: {
+		sourceArguments: {
+			minArguments: 2,
+			maxArguments: 2,
+			argumentTypes: ['functionTypeIdentifier', 'identifier'],
+		},
 		scope: 'function',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_BLOCK,
 		docs: { shortDescription: 'Declares a parameter for the current function.' },
@@ -724,6 +844,7 @@ export const instructionSpecs = {
 	},
 	// push ( -- T)
 	push: {
+		sourceArguments: { minArguments: 1, maxArguments: 1 },
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Pushes a literal, memory value, local value, address, or constant onto the stack.' },
 		stack: stack({ inputs: [], outputs: ['T'] }),
@@ -736,6 +857,7 @@ export const instructionSpecs = {
 	}),
 	// return (returns... -- never)
 	return: {
+		sourceArguments: noSourceArguments,
 		scope: 'function',
 		onInvalidScope: ErrorCode.RETURN_OUTSIDE_FUNCTION,
 		docs: { shortDescription: 'Returns from the current function with the values on the stack.' },
@@ -743,6 +865,7 @@ export const instructionSpecs = {
 	},
 	// risingEdge (int -- int), risingEdge (float -- int)
 	risingEdge: {
+		sourceArguments: noSourceArguments,
 		scope: 'module',
 		minOperands: 1,
 		docs: { shortDescription: 'Detects when a signal changes from zero to a non-zero value.' },
@@ -750,6 +873,7 @@ export const instructionSpecs = {
 	},
 	// round (float -- float)
 	round: {
+		sourceArguments: noSourceArguments,
 		scope: 'moduleOrFunction',
 		minOperands: 1,
 		operandTypes: 'float',
@@ -780,6 +904,7 @@ export const instructionSpecs = {
 	}),
 	// sqrt (float -- float)
 	sqrt: {
+		sourceArguments: noSourceArguments,
 		scope: 'moduleOrFunction',
 		minOperands: 1,
 		operandTypes: 'float',
@@ -792,6 +917,7 @@ export const instructionSpecs = {
 	},
 	// store (ptr int -- ), store (ptr float -- ), store (ptr float64 -- )
 	store: {
+		sourceArguments: noSourceArguments,
 		scope: 'moduleOrFunction',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_BLOCK,
 		minOperands: 2,
@@ -802,10 +928,11 @@ export const instructionSpecs = {
 	},
 	// storeBytes (int... ptr -- )
 	storeBytes: {
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'nonNegativeIntegerLiteral' },
 		scope: 'moduleOrFunction',
 		onInvalidScope: ErrorCode.INSTRUCTION_INVALID_OUTSIDE_BLOCK,
 		validateOperands: line => {
-			const count = (line as StoreBytesLine).arguments[0].value;
+			const count = (line as StoreBytesSourceLine).arguments[0].value;
 			return {
 				minOperands: count + 1,
 				operandTypes: new Array(count + 1).fill('int'),
@@ -817,7 +944,7 @@ export const instructionSpecs = {
 			outputs: [],
 			effect: { consumes: { argumentValueIndex: 0, add: 1 }, produces: [] },
 			resolve: line => {
-				const count = (line as StoreBytesLine).arguments[0]?.value;
+				const count = (line as StoreBytesSourceLine).arguments[0]?.value;
 
 				if (!Number.isFinite(count) || count < 0) {
 					return { inputs: ['bytes...', 'ptr'], outputs: [] };
@@ -834,6 +961,12 @@ export const instructionSpecs = {
 		inputs: ['T', 'T'],
 		outputs: ['T'],
 	}),
+	// use <moduleId> ( -- )
+	use: {
+		codegen: false,
+		sourceArguments: { minArguments: 1, maxArguments: 1, argumentTypes: 'identifier' },
+		docs: { shortDescription: 'Imports declarations from another module or constants block.' },
+	},
 	// xor (int int -- int)
 	xor: withDocsAndStack(binaryIntegerSpec, {
 		shortDescription: 'Performs a bitwise XOR on two integers.',
@@ -849,6 +982,19 @@ export const instructionSpecs = {
 } satisfies Record<string, InstructionSpec>;
 
 export type InstructionSpecName = keyof typeof instructionSpecs;
+export type CodegenInstructionSpecName = {
+	[TInstruction in InstructionSpecName]: (typeof instructionSpecs)[TInstruction] extends { codegen: false }
+		? never
+		: TInstruction;
+}[InstructionSpecName];
+
+export type NoSourceArgumentInstructionName = {
+	[TInstruction in CodegenInstructionSpecName]: (typeof instructionSpecs)[TInstruction] extends {
+		sourceArguments: typeof noSourceArguments;
+	}
+		? TInstruction
+		: never;
+}[CodegenInstructionSpecName];
 
 type MemoryOperationForSpec<TSpec> = TSpec extends { effects: { memory: infer TMemory } } ? TMemory : never;
 
@@ -890,7 +1036,7 @@ const getInstructionSpecImplementation = (instruction: string): InstructionSpec 
 
 export const getInstructionSpec = getInstructionSpecImplementation as GetInstructionSpec;
 
-export function getInstructionStackSignature(instruction: string, line?: AST[number]): string | undefined {
+export function getInstructionStackSignature(instruction: string, line?: unknown): string | undefined {
 	const spec = getInstructionSpec(instruction);
 
 	if (!spec?.stack) {

--- a/packages/compiler-spec/src/instructions.ts
+++ b/packages/compiler-spec/src/instructions.ts
@@ -1,19 +1,28 @@
 import { instructionSpecs } from './instructionSpecs';
 import { memoryDeclarationInstructions } from './memory';
 
-import type { CodegenInstructionSpecName, InstructionSpec } from './instructionSpecs';
+import type {
+	CodegenInstructionSpecName,
+	InstructionSpec,
+	InstructionSpecName,
+	NonCodegenInstructionSpecName,
+	SourceInstructionSpecName,
+} from './instructionSpecs';
 import type { MemoryDeclarationInstruction } from './memory';
 
-export const semanticInstructionNames = [
-	'const',
-	'use',
-	'module',
-	'moduleEnd',
-	'constants',
-	'constantsEnd',
-	'#region',
-] as const;
-export type SemanticInstructionName = (typeof semanticInstructionNames)[number];
+function getInstructionSpecByName(instruction: string): InstructionSpec {
+	return instructionSpecs[instruction as InstructionSpecName] as InstructionSpec;
+}
+
+function isSourceInstructionSpec(instruction: string): boolean {
+	return getInstructionSpecByName(instruction).sourceInstruction !== false;
+}
+
+export type SemanticInstructionName = Extract<NonCodegenInstructionSpecName, SourceInstructionSpecName>;
+export const semanticInstructionNames = Object.keys(instructionSpecs).filter(
+	(instruction): instruction is SemanticInstructionName =>
+		isSourceInstructionSpec(instruction) && getInstructionSpecByName(instruction).codegen === false
+);
 
 export const macroInstructionNames = ['defineMacro', 'defineMacroEnd', 'macro'] as const;
 export type MacroInstructionName = (typeof macroInstructionNames)[number];
@@ -90,12 +99,11 @@ export const compilableBlockTypes = documentBlockInstructionPairs
 	.map(({ type }) => type)
 	.filter((type): type is CompilableBlockType => type !== 'note');
 
-export type CodegenInstructionName = Exclude<CodegenInstructionSpecName, 'memoryDeclaration'>;
+export type CodegenInstructionName = Extract<CodegenInstructionSpecName, SourceInstructionSpecName>;
 
 export const codegenInstructionNames = Object.keys(instructionSpecs).filter(
 	(instruction): instruction is CodegenInstructionName =>
-		instruction !== 'memoryDeclaration' &&
-		(instructionSpecs[instruction as keyof typeof instructionSpecs] as InstructionSpec).codegen !== false
+		isSourceInstructionSpec(instruction) && getInstructionSpecByName(instruction).codegen !== false
 );
 
 export type Instruction =

--- a/packages/compiler-spec/src/instructions.ts
+++ b/packages/compiler-spec/src/instructions.ts
@@ -1,7 +1,7 @@
 import { instructionSpecs } from './instructionSpecs';
 import { memoryDeclarationInstructions } from './memory';
 
-import type { InstructionSpecName } from './instructionSpecs';
+import type { CodegenInstructionSpecName, InstructionSpec } from './instructionSpecs';
 import type { MemoryDeclarationInstruction } from './memory';
 
 export const semanticInstructionNames = [
@@ -90,10 +90,12 @@ export const compilableBlockTypes = documentBlockInstructionPairs
 	.map(({ type }) => type)
 	.filter((type): type is CompilableBlockType => type !== 'note');
 
-export type CodegenInstructionName = Exclude<InstructionSpecName, 'memoryDeclaration'>;
+export type CodegenInstructionName = Exclude<CodegenInstructionSpecName, 'memoryDeclaration'>;
 
 export const codegenInstructionNames = Object.keys(instructionSpecs).filter(
-	(instruction): instruction is CodegenInstructionName => instruction !== 'memoryDeclaration'
+	(instruction): instruction is CodegenInstructionName =>
+		instruction !== 'memoryDeclaration' &&
+		(instructionSpecs[instruction as keyof typeof instructionSpecs] as InstructionSpec).codegen !== false
 );
 
 export type Instruction =

--- a/packages/compiler-spec/src/semantic.ts
+++ b/packages/compiler-spec/src/semantic.ts
@@ -20,7 +20,6 @@ import type {
 	ModuleLine,
 	PushLine,
 	RegionLine,
-	TokenizedLocalVariableAccessLine,
 	UseLine,
 } from './ast';
 import type { FunctionMetadata, FunctionMetadataLookup, FunctionSignature, FunctionTypeRegistry } from './compiled';
@@ -247,15 +246,12 @@ export type ParsedSemanticInstructionLine =
 	| ConstantsLine
 	| ConstantsEndLine;
 
-export type ParsedLocalVariableAccessLine = TokenizedLocalVariableAccessLine;
 export type ResolvedLocalSetLine = LocalSetLine & {
 	local: LocalBinding;
 };
-export type CodegenLocalSetLine = ResolvedLocalSetLine;
-export type CodegenArgumentLiteral = NormalizedArgumentLiteral;
 
 export type LiteralPushLine = Omit<PushLine, 'arguments'> & {
-	arguments: [CodegenArgumentLiteral | ArgumentStringLiteral];
+	arguments: [NormalizedArgumentLiteral | ArgumentStringLiteral];
 };
 
 export type DeferredPushLine = Omit<PushLine, 'arguments'> & {
@@ -319,7 +315,7 @@ export type NormalizedLine<TLine extends AST[number]> = TLine extends ConstLine
 			: TLine extends MapLine
 				? NormalizedMapLine | MapLine
 				: TLine extends LocalSetLine
-					? CodegenLocalSetLine
+					? ResolvedLocalSetLine
 					: TLine extends PushLine
 						? NormalizedPushLine
 						: TLine extends MemoryCopyLine

--- a/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.ts
+++ b/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.ts
@@ -2,91 +2,21 @@ import {
 	ArgumentType,
 	FUNCTION_TYPE_IDENTIFIERS,
 	SCALAR_TYPE_IDENTIFIERS,
-	noArgumentCodegenInstructionNames,
+	getInstructionSpec,
 } from '@8f4e/compiler-spec';
 
 import isConstantName from './isConstantName';
 import isArrayDeclarationInstruction from './isArrayDeclarationInstruction';
+import isMemoryDeclarationInstruction from './isMemoryDeclarationInstruction';
 import { SyntaxErrorCode, SyntaxRulesError } from './syntaxError';
 
-import type { Argument } from '@8f4e/compiler-spec';
-
-type ArgumentShapeRule =
-	| 'identifier'
-	| 'constantIdentifier'
-	| 'literal'
-	| 'nonNegativeIntegerLiteral'
-	| 'nonNegativeCompileTimeValue'
-	| 'compileTimeValue'
-	| 'mapValue'
-	| 'typeIdentifier'
-	| 'functionTypeIdentifier'
-	| 'ifResultType'
-	| 'regionReference';
-
-type InstructionArgumentSpec = {
-	minArguments?: number;
-	maxArguments?: number;
-	argumentTypes?: ArgumentShapeRule[] | ArgumentShapeRule;
-};
+import type { Argument, SourceArgumentsSpec, SourceArgumentShapeRule } from '@8f4e/compiler-spec';
 
 const supportedScalarTypeIdentifiers: ReadonlySet<string> = new Set(SCALAR_TYPE_IDENTIFIERS);
 const supportedFunctionTypeIdentifiers: ReadonlySet<string> = new Set(FUNCTION_TYPE_IDENTIFIERS);
 const supportedIfResultTypeIdentifiers = new Set(['int', 'float']);
 
-const noArgumentInstructionSpecs = Object.fromEntries(
-	noArgumentCodegenInstructionNames.map(instruction => [instruction, { maxArguments: 0 }])
-) as Partial<Record<string, InstructionArgumentSpec>>;
-
-const instructionArgumentSpecs: Partial<Record<string, InstructionArgumentSpec>> = {
-	...noArgumentInstructionSpecs,
-	push: { minArguments: 1, maxArguments: 1 },
-	branch: { minArguments: 1, maxArguments: 1, argumentTypes: ['literal'] },
-	branchIfTrue: { minArguments: 1, maxArguments: 1, argumentTypes: ['literal'] },
-	branchIfUnchanged: { minArguments: 1, maxArguments: 1, argumentTypes: ['literal'] },
-	exitIfTrue: { maxArguments: 0 },
-	ensureNonZero: { maxArguments: 1, argumentTypes: 'literal' },
-	block: { maxArguments: 0 },
-	blockEnd: { maxArguments: 1, argumentTypes: 'ifResultType' },
-	local: { minArguments: 2, maxArguments: 2, argumentTypes: ['functionTypeIdentifier', 'identifier'] },
-	param: { minArguments: 2, maxArguments: 2, argumentTypes: ['functionTypeIdentifier', 'identifier'] },
-	localSet: { minArguments: 1, maxArguments: 1, argumentTypes: ['identifier'] },
-	function: { minArguments: 1, maxArguments: 1, argumentTypes: ['identifier'] },
-	functionEnd: { argumentTypes: 'functionTypeIdentifier' },
-	call: { minArguments: 1, maxArguments: 1, argumentTypes: ['identifier'] },
-	mapBegin: { minArguments: 1, maxArguments: 1, argumentTypes: ['typeIdentifier'] },
-	mapEnd: { minArguments: 1, maxArguments: 1, argumentTypes: ['typeIdentifier'] },
-	map: { minArguments: 2, maxArguments: 2, argumentTypes: ['mapValue', 'mapValue'] },
-	default: { minArguments: 1, maxArguments: 1, argumentTypes: ['compileTimeValue'] },
-	storeBytes: { minArguments: 1, maxArguments: 1, argumentTypes: ['nonNegativeIntegerLiteral'] },
-	memoryCopy: { minArguments: 1, maxArguments: 1, argumentTypes: ['nonNegativeCompileTimeValue'] },
-	clampAddress: { maxArguments: 1, argumentTypes: ['nonNegativeCompileTimeValue'] },
-	clampModuleAddress: { maxArguments: 1, argumentTypes: ['nonNegativeCompileTimeValue'] },
-	clampGlobalAddress: { maxArguments: 1, argumentTypes: ['nonNegativeCompileTimeValue'] },
-	else: { maxArguments: 0 },
-	loop: { maxArguments: 1, argumentTypes: ['nonNegativeIntegerLiteral'] },
-	loopEnd: { maxArguments: 0 },
-	loopIndex: { maxArguments: 0 },
-	'#loopCap': { minArguments: 1, maxArguments: 1, argumentTypes: ['nonNegativeIntegerLiteral'] },
-	'#region': { minArguments: 1, maxArguments: 1, argumentTypes: ['regionReference'] },
-	'#impure': { maxArguments: 0 },
-	'#export': { maxArguments: 1, argumentTypes: ['identifier'] },
-	'#skipExecution': { maxArguments: 0 },
-	'#initOnly': { maxArguments: 0 },
-	module: { minArguments: 1, maxArguments: 1, argumentTypes: ['identifier'] },
-	constants: { minArguments: 1, maxArguments: 1, argumentTypes: ['identifier'] },
-	use: { minArguments: 1, maxArguments: 1, argumentTypes: ['identifier'] },
-	const: {
-		minArguments: 2,
-		maxArguments: 2,
-		argumentTypes: ['constantIdentifier', 'compileTimeValue'],
-	},
-	if: { maxArguments: 0 },
-	ifEnd: { maxArguments: 1, argumentTypes: 'ifResultType' },
-	return: { maxArguments: 0 },
-};
-
-function getInstructionArgumentSpec(instruction: string): InstructionArgumentSpec | undefined {
+function getInstructionArgumentSpec(instruction: string): SourceArgumentsSpec | undefined {
 	if (isArrayDeclarationInstruction(instruction)) {
 		return {
 			minArguments: 2,
@@ -94,7 +24,11 @@ function getInstructionArgumentSpec(instruction: string): InstructionArgumentSpe
 		};
 	}
 
-	return instructionArgumentSpecs[instruction];
+	if (isMemoryDeclarationInstruction(instruction)) {
+		return undefined;
+	}
+
+	return getInstructionSpec(instruction)?.sourceArguments;
 }
 
 function isCompileTimeValue(argument: Argument): boolean {
@@ -105,7 +39,7 @@ function isCompileTimeValue(argument: Argument): boolean {
 	);
 }
 
-function validateArgumentShape(argument: Argument, rule: ArgumentShapeRule, instruction: string): void {
+function validateArgumentShape(argument: Argument, rule: SourceArgumentShapeRule, instruction: string): void {
 	const invalid = (message: string) => {
 		throw new SyntaxRulesError(SyntaxErrorCode.INVALID_ARGUMENT, message);
 	};

--- a/packages/compiler/src/instructionCompilers/localSet.ts
+++ b/packages/compiler/src/instructionCompilers/localSet.ts
@@ -2,13 +2,13 @@ import { localSet } from '@8f4e/compiler-wasm-utils';
 
 import { saveByteCode } from './utils/saveByteCode';
 
-import type { CodegenLocalSetLine, InstructionCompiler } from '@8f4e/compiler-spec';
+import type { InstructionCompiler, ResolvedLocalSetLine } from '@8f4e/compiler-spec';
 
 /**
  * Instruction compiler for `localSet`.
  * @see [Instruction docs](../../docs/instructions/declarations-and-locals.md)
  */
-const _localSet: InstructionCompiler<CodegenLocalSetLine> = (line, context) => {
+const _localSet: InstructionCompiler<ResolvedLocalSetLine> = (line, context) => {
 	const [operand] = line.stackAnalysis.consumedOperands;
 	const { local } = line;
 

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushLiteral.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushLiteral.ts
@@ -1,9 +1,9 @@
 import { saveByteCode } from '../../utils/saveByteCode';
 import { constOpcode, resolveArgumentValueKind } from '../shared';
 
-import type { CodegenArgumentLiteral, CodegenContext } from '@8f4e/compiler-spec';
+import type { CodegenContext, NormalizedArgumentLiteral } from '@8f4e/compiler-spec';
 
-export default function pushLiteral(argument: CodegenArgumentLiteral, context: CodegenContext): CodegenContext {
+export default function pushLiteral(argument: NormalizedArgumentLiteral, context: CodegenContext): CodegenContext {
 	const kind = resolveArgumentValueKind(argument);
 	return saveByteCode(context, constOpcode[kind](argument.value));
 }

--- a/packages/compiler/src/semantic/normalization/localVariable.ts
+++ b/packages/compiler/src/semantic/normalization/localVariable.ts
@@ -1,8 +1,4 @@
-import {
-	type CompilationContext,
-	type ParsedLocalVariableAccessLine,
-	type ResolvedLocalSetLine,
-} from '@8f4e/compiler-spec';
+import { type CompilationContext, type LocalSetLine, type ResolvedLocalSetLine } from '@8f4e/compiler-spec';
 import { ErrorCode } from '@8f4e/compiler-spec';
 
 import { getError } from '../../compilerError';
@@ -12,7 +8,7 @@ import { getError } from '../../compilerError';
  * This keeps local existence checks in semantic normalization instead of the dispatcher/codegen layers.
  */
 export default function normalizeLocalVariableAccess(
-	line: ParsedLocalVariableAccessLine,
+	line: LocalSetLine,
 	context: CompilationContext
 ): ResolvedLocalSetLine {
 	const nameArg = line.arguments[0];


### PR DESCRIPTION
## Summary
- move source argument arity and shape metadata into compiler-spec instruction specs
- make tokenizer argument validation consume the shared instruction metadata
- remove the duplicated tokenizer-local argument table and derived no-argument AST list
- archive TODO 419 after completion

## Rationale
This keeps instruction syntax contracts with the rest of the instruction metadata so future changes update one strict source of truth instead of broadening runtime handling or maintaining compatibility shims.

## Validation
- npx eslint --fix packages/compiler-spec/src/instructionSpecs.ts packages/compiler-spec/src/instructions.ts packages/compiler-spec/src/ast.ts packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.ts
- npx nx run compiler-spec:typecheck
- npx nx run @8f4e/tokenizer:typecheck
- npx nx run compiler:typecheck
- npx nx run @8f4e/tokenizer:test
- npx nx run compiler:test
- rg -n "instructionArgumentSpecs|noArgumentCodegenInstructionNames|NoArgumentCodegenLine" packages/compiler-spec packages/compiler packages/compiler/packages/tokenizer
- git diff --check
