### PR TITLE
Split namespace discovery and layout prepass

### DIFF
--- a/docs/todos/422-split-namespace-discovery-and-layout-prepass.md
+++ b/docs/todos/422-split-namespace-discovery-and-layout-prepass.md
@@ -4,8 +4,8 @@ priority: Medium
 effort: 2-4h
 created: 2026-05-26
 issue: null
-status: Open
-completed: null
+status: Done
+completed: 2026-05-26
 ---
 
 # TODO: Split namespace discovery and layout prepass
@@ -69,10 +69,10 @@ Keep the parsed AST objects untouched. If a phase needs a simplified memory decl
 
 ## Success Criteria
 
-- [ ] Namespace discovery and full layout/default resolution are separate, clearly named internal functions.
-- [ ] `prepassNamespace(...)` no longer has a mode flag.
-- [ ] No typed AST object is rebuilt with replacement `lines`.
-- [ ] Behavior remains covered by compiler namespace, intermodule-reference, and memory declaration tests.
+- [x] Namespace discovery and full layout/default resolution are separate, clearly named internal functions.
+- [x] `prepassNamespace(...)` no longer has a mode flag.
+- [x] No typed AST object is rebuilt with replacement `lines`.
+- [x] Behavior remains covered by compiler namespace, intermodule-reference, and memory declaration tests.
 
 ## Affected Components
 

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -65,7 +65,6 @@ Active todo files are listed below.
 | 409 | Track block context flags during stack analysis | 🟡 | 2-4h | 2026-05-19 | Stack validation repeatedly scans block stack to detect constants/map scope; maintained context flags or counters would avoid per-instruction scans. |
 | 410 | Consolidate release action commits | 🟡 | 2-4h | 2026-05-19 | The release workflow currently creates separate version, bundle-size, bytecode-size, and compiler-coverage commits; collapse these into one release commit or one version commit plus one metrics commit. |
 | 421 | Clean up AST construction helper scans | 🟡 | 4-8h | 2026-05-26 | Typed AST metadata should be owned by source-block-specific construction, not by scattered post-processing helpers that re-scan `CompilerASTLine[]`. |
-| 422 | Split namespace discovery and layout prepass | 🟡 | 2-4h | 2026-05-26 | Namespace discovery and full layout/default resolution should be explicit phase-specific functions, not one prepass with a behavior mode flag. |
 
 ### 🟢 Low Priority
 
@@ -83,6 +82,7 @@ Active todo files are listed below.
 
 | ID | Title | Completed | Notes |
 | ---- | ----- | --------- | ----- |
+| 422 | Split namespace discovery and layout prepass | 2026-05-26 | Namespace discovery now uses an explicit internal discovery path, final layout/default resolution uses `layoutNamespace(...)`, and the old mode flag/prepass naming was removed without typed-AST compatibility wrappers. |
 | 419 | Merge instruction source argument specs into instruction specs | 2026-05-26 | Source argument arity and shape metadata now lives in compiler-spec instruction specs; tokenizer validation consumes the shared contract, and duplicated argument/no-argument tables were removed without compatibility shims. |
 | 420 | Add typed compiler AST group indexes | 2026-05-26 | Compiler-owned AST inputs now use typed module/function/constants group objects with required ids and derived metadata, so compiler passes no longer rediscover those facts from raw line arrays. |
 | 417 | Tighten compiler AST union and source block types | 2026-05-25 | Compiler AST lines are now a discriminated union with source-block tuple types; tokenizer validation owns fixed arity, and namespace metadata no longer revalidates syntax-guaranteed prologue or return shapes. |

--- a/packages/compiler-spec/src/semantic.ts
+++ b/packages/compiler-spec/src/semantic.ts
@@ -157,7 +157,7 @@ export interface ModuleCompilationContext extends CompilationContext {
 	currentModuleWordAlignedSize: number;
 }
 
-export interface NamespacePrepassContext extends CompilationContext {
+export interface NamespaceBuildContext extends CompilationContext {
 	mode: 'module';
 	codeBlockType: CompiledModuleBlockType;
 	currentModuleNextWordOffset: number;

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -52,9 +52,9 @@ Core compiler that transforms 8f4e source into WebAssembly plus runtime metadata
                                 |
                                 v
                   +-----------------------------+
-                  |  6. Namespace prepass       |
+                  |  6. Namespace collection    |
                   |  collectNamespacesFromASTs()|
-                  |  prepassNamespace()         |
+                  |  discovery + layout         |
                   |                             |
                   |  resolves module memory,    |
                   |  consts, addresses, sizes   |

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -11,7 +11,7 @@ import { ErrorCode } from '@8f4e/compiler-spec';
 import instructions from './instructionCompilers';
 import { getError } from './compilerError';
 import normalizeCompileTimeArguments from './semantic/normalizeCompileTimeArguments';
-import { applySemanticLine, prepassNamespace } from './semantic/buildNamespace';
+import { applySemanticLine, layoutNamespace } from './semantic/buildNamespace';
 import { analyzeInstruction } from './stackAnalysis/analyzeInstruction';
 import { getMemoryRegionFields } from './semantic/memoryRegions';
 import { createCompilationContext } from './semantic/createCompilationContext';
@@ -95,17 +95,17 @@ export function compileModule(
 	internalAllocator = { nextByteAddress: 0 },
 	options: Pick<CompileOptions, 'includeStackAnalysis' | 'memoryRegions'> = {}
 ): CompiledModule {
-	// Prepass establishes the memory layout (byte addresses, sizes) for this module.
+	// Namespace layout establishes memory byte addresses and sizes for this module.
 	// Semantic instructions (const, use, module/moduleEnd) are applied during
-	// the compilation loop below, so consts are not copied from the prepass context.
-	const prepassContext = prepassNamespace(ast, namespaces, startingByteAddress, functions, options);
+	// the compilation loop below, so consts are not copied from the layout context.
+	const layoutContext = layoutNamespace(ast, namespaces, startingByteAddress, functions, options);
 	const namespace = namespaces[ast.id];
-	const memoryIndex = namespace?.memoryIndex ?? prepassContext.currentMemoryIndex;
-	const memoryRegionName = namespace?.memoryRegionName ?? prepassContext.currentMemoryRegionName;
+	const memoryIndex = namespace?.memoryIndex ?? layoutContext.currentMemoryIndex;
+	const memoryRegionName = namespace?.memoryRegionName ?? layoutContext.currentMemoryRegionName;
 	const context = createCompilationContext<ModuleCompilationContext>({
 		namespace: {
 			namespaces,
-			memory: prepassContext.namespace.memory,
+			memory: layoutContext.namespace.memory,
 			consts: {},
 			moduleName: undefined,
 			functions,
@@ -117,8 +117,8 @@ export function compileModule(
 		stack: [],
 		blockStack: [],
 		startingByteAddress,
-		currentModuleNextWordOffset: prepassContext.currentModuleNextWordOffset,
-		currentModuleWordAlignedSize: prepassContext.currentModuleWordAlignedSize,
+		currentModuleNextWordOffset: layoutContext.currentModuleNextWordOffset,
+		currentModuleWordAlignedSize: layoutContext.currentModuleWordAlignedSize,
 		currentMemoryIndex: memoryIndex,
 		...(memoryRegionName ? { currentMemoryRegionName: memoryRegionName } : {}),
 		memoryRegions: options.memoryRegions ?? [],

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -55,7 +55,7 @@ import type {
 
 export { default as instructions } from './instructionCompilers';
 export {
-	prepassNamespace,
+	layoutNamespace,
 	assertUniqueModuleIds,
 	collectFunctionMetadataFromAsts,
 	collectNamespacesFromASTs,

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -55,7 +55,6 @@ import type {
 
 export { default as instructions } from './instructionCompilers';
 export {
-	layoutNamespace,
 	assertUniqueModuleIds,
 	collectFunctionMetadataFromAsts,
 	collectNamespacesFromASTs,

--- a/packages/compiler/src/semantic/buildNamespace.ts
+++ b/packages/compiler/src/semantic/buildNamespace.ts
@@ -13,7 +13,7 @@ import {
 	type FunctionAST,
 	type ModuleAST,
 	type Namespaces,
-	type NamespacePrepassContext,
+	type NamespaceBuildContext,
 	type ParsedSemanticInstructionLine,
 } from '@8f4e/compiler-spec';
 import { ErrorCode } from '@8f4e/compiler-spec';
@@ -35,8 +35,6 @@ import { getError } from '../compilerError';
 import parseMemoryInstructionArguments from '../utils/memoryInstructionParser';
 
 const moduleBlock = compilerSourceBlockInstructionByType.module;
-
-type NamespacePrepassMode = 'full' | 'namespace-discovery';
 
 /**
  * Scans function ASTs and collects pre-codegen function metadata.
@@ -90,16 +88,15 @@ export function applySemanticLine(line: CompilerASTLine, context: CompilationCon
 	applySemanticInstruction(normalizeCompileTimeArguments(line as ParsedSemanticInstructionLine, context), context);
 }
 
-export function prepassNamespace(
+function createNamespaceBuildContext(
 	ast: ModuleAST | ConstantsAST,
 	namespaces: Namespaces,
 	startingByteAddress = 0,
 	functions?: FunctionMetadataLookup,
-	options: Pick<CompileOptions, 'memoryRegions'> = {},
-	mode: NamespacePrepassMode = 'full'
-): NamespacePrepassContext {
+	options: Pick<CompileOptions, 'memoryRegions'> = {}
+): NamespaceBuildContext {
 	const defaultRegion = getDefaultMemoryRegion();
-	const context = createCompilationContext<NamespacePrepassContext>({
+	return createCompilationContext<NamespaceBuildContext>({
 		namespace: {
 			namespaces,
 			memory: {},
@@ -123,23 +120,26 @@ export function prepassNamespace(
 		mode: moduleBlock.type,
 		codeBlockType: ast.type,
 	});
+}
 
+function applyNamespaceDeclarationLines(
+	ast: ModuleAST | ConstantsAST,
+	context: NamespaceBuildContext,
+	resolveDeclarationLine: (line: CompilerASTLine) => CompilerASTLine
+): void {
 	ast.lines.forEach(originalLine => {
 		if (originalLine.isSemanticOnly) {
 			applySemanticLine(originalLine, context);
 		} else if (originalLine.isMemoryDeclaration) {
-			const declarationLine =
-				mode === 'namespace-discovery' ? toNamespaceDiscoveryMemoryDeclarationLine(originalLine) : originalLine;
+			const declarationLine = resolveDeclarationLine(originalLine);
 			applyMemoryDeclarationLine(normalizeCompileTimeArguments(declarationLine, context), context);
 		}
 	});
 
 	context.currentModuleWordAlignedSize = context.currentModuleNextWordOffset;
+}
 
-	if (mode === 'namespace-discovery') {
-		return context;
-	}
-
+function resolveScalarMemoryDefaults(ast: ModuleAST | ConstantsAST, context: NamespaceBuildContext): void {
 	ast.lines.forEach(originalLine => {
 		if (!originalLine.isMemoryDeclaration || originalLine.instruction.endsWith('[]')) {
 			return;
@@ -154,6 +154,31 @@ export function prepassNamespace(
 
 		memoryItem.default = memoryItem.isInteger ? Math.trunc(defaultValue) : defaultValue;
 	});
+}
+
+function discoverNamespace(
+	ast: ModuleAST | ConstantsAST,
+	namespaces: Namespaces,
+	startingByteAddress = 0,
+	functions?: FunctionMetadataLookup,
+	options: Pick<CompileOptions, 'memoryRegions'> = {}
+): NamespaceBuildContext {
+	const context = createNamespaceBuildContext(ast, namespaces, startingByteAddress, functions, options);
+	applyNamespaceDeclarationLines(ast, context, toNamespaceDiscoveryMemoryDeclarationLine);
+
+	return context;
+}
+
+export function layoutNamespace(
+	ast: ModuleAST | ConstantsAST,
+	namespaces: Namespaces,
+	startingByteAddress = 0,
+	functions?: FunctionMetadataLookup,
+	options: Pick<CompileOptions, 'memoryRegions'> = {}
+): NamespaceBuildContext {
+	const context = createNamespaceBuildContext(ast, namespaces, startingByteAddress, functions, options);
+	applyNamespaceDeclarationLines(ast, context, line => line);
+	resolveScalarMemoryDefaults(ast, context);
 
 	return context;
 }
@@ -251,14 +276,7 @@ export function collectNamespacesFromASTs(
 
 		for (const ast of pendingAsts) {
 			try {
-				const context = prepassNamespace(
-					ast,
-					namespaces,
-					startingByteAddress,
-					compiledFunctions,
-					options,
-					'namespace-discovery'
-				);
+				const context = discoverNamespace(ast, namespaces, startingByteAddress, compiledFunctions, options);
 				if (!context.namespace.moduleName) {
 					continue;
 				}
@@ -290,7 +308,7 @@ export function collectNamespacesFromASTs(
 	}
 
 	if (pendingAsts.length > 0) {
-		prepassNamespace(pendingAsts[0], namespaces, startingByteAddress, compiledFunctions, options);
+		layoutNamespace(pendingAsts[0], namespaces, startingByteAddress, compiledFunctions, options);
 	}
 
 	const nextStartingByteAddressByMemoryIndex: Record<number, number> = {
@@ -299,7 +317,7 @@ export function collectNamespacesFromASTs(
 	for (const ast of layoutAsts) {
 		const region = getModuleRegionFromAst(ast, options);
 		const nextStartingByteAddress = nextStartingByteAddressByMemoryIndex[region.memoryIndex] ?? startingByteAddress;
-		const context = prepassNamespace(ast, namespaces, nextStartingByteAddress, compiledFunctions, options);
+		const context = layoutNamespace(ast, namespaces, nextStartingByteAddress, compiledFunctions, options);
 		if (!context.namespace.moduleName) {
 			continue;
 		}

--- a/packages/compiler/src/semantic/instructions/const.ts
+++ b/packages/compiler/src/semantic/instructions/const.ts
@@ -6,7 +6,7 @@ import { type CompilationContext, type NormalizedConstLine } from '@8f4e/compile
  * This is the sole owner of all writes to `context.namespace.consts`. It is
  * invoked via applySemanticInstruction, which is reached through two paths:
  *
- * 1. Namespace prepass (prepassNamespace → applySemanticLine): runs normalize + this function
+ * 1. Namespace layout (layoutNamespace -> applySemanticLine): runs normalize + this function
  *    for every const line to populate the local namespace before codegen.
  * 2. Module/function compilation (compileLine → applySemanticLine): same path, allowing
  *    functions to declare their own const-scoped names during their compilation pass.

--- a/packages/compiler/src/semantic/instructions/use.ts
+++ b/packages/compiler/src/semantic/instructions/use.ts
@@ -7,7 +7,7 @@ import { getError } from '../../compilerError';
  * Applies a `use` instruction by importing all consts from the target namespace into
  * the current compilation context.
  *
- * `use` reads exclusively from validated namespace data produced by the namespace prepass.
+ * `use` reads exclusively from validated namespace data produced by namespace collection.
  * It does not parse or validate const values itself; those are guaranteed to be literal
  * values already by the time the namespace is registered. Declaration order matters:
  * only consts imported by a `use` that appears before a subsequent `const` reference

--- a/packages/compiler/src/semantic/normalization/const.ts
+++ b/packages/compiler/src/semantic/normalization/const.ts
@@ -6,7 +6,7 @@ import { normalizeArgumentsAtIndexes } from './helpers';
 import { getError } from '../../compilerError';
 
 // Throws UNDECLARED_IDENTIFIER when the value cannot be folded to a literal.
-// During namespace prepass, collectNamespacesFromASTs catches this to defer the AST
+// During namespace discovery, collectNamespacesFromASTs catches this to defer the AST
 // until the referenced identifiers are available.
 export default function normalizeConst(line: ConstLine, context: CompilationContext): NormalizedConstLine {
 	const { line: result } = normalizeArgumentsAtIndexes(line, context, [1]);

--- a/packages/compiler/src/semantic/normalization/helpers.ts
+++ b/packages/compiler/src/semantic/normalization/helpers.ts
@@ -35,7 +35,7 @@ export function isIntermoduleReferenceKind(referenceKind: ReferenceKind): boolea
 /**
  * Validates that intermodule address references, including metadata-query forms,
  * target existing modules and memory once namespace collection is complete.
- * It does not evaluate the query value itself during prepass; numeric resolution
+ * It does not evaluate the query value itself during namespace discovery; numeric resolution
  * of sizeof/count/max/min forms is handled by tryResolveCompileTimeArgument.
  */
 export function validateIntermoduleAddressReference(
@@ -43,7 +43,7 @@ export function validateIntermoduleAddressReference(
 	line: CompilerASTLine,
 	context: CompilationContext
 ): void {
-	// Only validate if we're post-prepass (namespaces collected)
+	// Only validate once namespace collection has established target modules.
 	if (!hasCollectedNamespaces(context)) {
 		return;
 	}
@@ -119,9 +119,9 @@ export function normalizeArgument(
 }
 
 /**
- * Validates an unresolved compile-time expression argument, deferring for prepass intermodule refs.
+ * Validates an unresolved compile-time expression argument, deferring namespace references during discovery.
  * Throws UNDECLARED_IDENTIFIER if the expression cannot be deferred and cannot be resolved.
- * Returns true if the argument was deferred (prepass intermodule), false if it should continue processing.
+ * Returns true if the argument was deferred, false if it should continue processing.
  */
 export function validateOrDeferCompileTimeExpression(
 	argument: Extract<Argument, { type: typeof ArgumentType.COMPILE_TIME_EXPRESSION }>,
@@ -145,8 +145,8 @@ export function validateOrDeferCompileTimeExpression(
 /**
  * Validates an unresolved identifier argument for instructions that require full resolution
  * (e.g. map, default). Throws UNDECLARED_IDENTIFIER unless the identifier is deferred
- * as a prepass intermodule reference.
- * Returns true if the argument was deferred (prepass intermodule), false if processing should continue.
+ * as a namespace reference during discovery.
+ * Returns true if the argument was deferred, false if processing should continue.
  */
 export function validateOrDeferUnresolvedIdentifier(
 	argument: Extract<Argument, { type: typeof ArgumentType.IDENTIFIER }>,
@@ -191,7 +191,7 @@ export function normalizeArgumentsAtIndexes<TLine extends CompilerASTLine>(
 
 /**
  * Normalizes arguments at the given indexes, then validates any remaining unresolved
- * compile-time expressions or identifiers as either deferrable prepass references or errors.
+ * compile-time expressions or identifiers as either deferrable namespace references or errors.
  */
 export function normalizeAndValidateResolvableArgs<TLine extends CompilerASTLine>(
 	line: TLine,

--- a/packages/compiler/src/semantic/normalizeCompileTimeArguments.test.ts
+++ b/packages/compiler/src/semantic/normalizeCompileTimeArguments.test.ts
@@ -456,7 +456,7 @@ describe('normalizeCompileTimeArguments', () => {
 		expect(normalizeCompileTimeArguments(line, context)).toEqual(line);
 	});
 
-	it('does not validate intermodule references when namespaces dict is empty (prepass)', () => {
+	it('does not validate intermodule references before namespaces are collected', () => {
 		const context = {
 			namespace: { memory: {}, consts: {}, moduleName: 'test', namespaces: {} },
 			locals: {},
@@ -633,7 +633,7 @@ describe('normalizeCompileTimeArguments', () => {
 		expect(() => normalizeCompileTimeArguments(line, context)).toThrow(`${ErrorCode.UNDEFINED_FUNCTION}`);
 	});
 
-	it('does not throw for call when functions registry is undefined (prepass context)', () => {
+	it('does not throw for call when functions registry is undefined', () => {
 		const context = {
 			namespace: { memory: {}, consts: {}, moduleName: 'test', namespaces: {} },
 			locals: {},


### PR DESCRIPTION
## Summary
- split namespace discovery from final namespace layout/default resolution
- replace the exported prepass helper with layoutNamespace and remove prepass/mode naming from compiler/spec code
- mark TODO 422 complete

## Validation
- rg -n "prepassNamespace|NamespacePrepassMode|NamespacePrepassContext|namespace-discovery|toNamespaceDiscoveryAst|\.\.\.ast,\s*lines" packages/compiler/src packages/compiler-spec/src -g '*.ts'
- rg -n "prepass" packages/compiler/src packages/compiler-spec/src -g '*.ts'
- git diff --check
- npx nx run compiler:typecheck
- npx nx run compiler:test
- npx nx run-many --target=typecheck --all