### PR TITLE
Build AST metadata during tokenizer parsing

### DIFF
--- a/docs/todos/421-clean-up-ast-construction-helper-scans.md
+++ b/docs/todos/421-clean-up-ast-construction-helper-scans.md
@@ -4,8 +4,8 @@ priority: Medium
 effort: 4-8h
 created: 2026-05-26
 issue: null
-status: Open
-completed: null
+status: Done
+completed: 2026-05-26
 ---
 
 # TODO: Clean up AST construction helper scans
@@ -83,11 +83,11 @@ If a field can be accumulated while parsing each line, prefer accumulating it th
 
 ## Success Criteria
 
-- [ ] Top-level AST metadata is constructed through source-block-specific code, not scattered generic line-array helper scans.
-- [ ] Helpers whose only job is post-processing `CompilerASTLine[]` for module/function metadata are removed.
-- [ ] Compiler phases continue reading typed AST fields rather than rediscovering ids, directives, declarations, signatures, or references.
-- [ ] No compatibility layers, hidden metadata, or fallback runtime checks are introduced.
-- [ ] The AST construction code makes the ownership of module/function/constants metadata obvious to a new agent.
+- [x] Top-level AST metadata is constructed through source-block-specific code, not scattered generic line-array helper scans.
+- [x] Helpers whose only job is post-processing `CompilerASTLine[]` for module/function metadata are removed.
+- [x] Compiler phases continue reading typed AST fields rather than rediscovering ids, directives, declarations, signatures, or references.
+- [x] No compatibility layers, hidden metadata, or fallback runtime checks are introduced.
+- [x] The AST construction code makes the ownership of module/function/constants metadata obvious to a new agent.
 
 ## Affected Components
 

--- a/docs/todos/423-narrow-ast-line-metadata-interfaces.md
+++ b/docs/todos/423-narrow-ast-line-metadata-interfaces.md
@@ -1,0 +1,137 @@
+---
+title: 'TODO: Narrow AST line metadata interfaces'
+priority: Medium
+effort: 4-8h
+created: 2026-05-26
+issue: null
+status: Open
+---
+
+# TODO: Narrow AST line metadata interfaces
+
+## Problem Description
+
+Recent compiler AST cleanup moved several facts earlier into tokenizer/parser-owned AST metadata so later compiler phases do not rediscover them by looping over AST lines or arguments. That direction is correct, but `ASTLineBase` in `packages/compiler-spec/src/ast.ts` is still carrying metadata fields that only apply to specific instruction lines.
+
+Examples include:
+
+- `isSemanticOnly`
+- `isMemoryDeclaration`
+- `isBlockPrologue`
+- `hasExplicitMemoryDefault`
+- `ifBlock`
+- `ifEndBlock`
+- `blockBlock`
+- `blockEndBlock`
+
+Keeping these fields on the shared base type makes every line appear capable of carrying every kind of metadata. That weakens the type interface and encourages runtime ambiguity checks such as `if (line.isMemoryDeclaration)` or optional metadata reads on unrelated instructions.
+
+The overall goal is to use strict, specific types where applicable instead of handling ambiguity during runtime. AST metadata should live on the line interface that owns it. Agents picking up this task should not solve it by hiding fields, adding compatibility wrappers, or creating a generic metadata bag.
+
+## Proposed Solution
+
+Move line metadata out of `ASTLineBase` and into the instruction-specific line interfaces that can actually carry that metadata.
+
+Suggested ownership:
+
+- `hasExplicitMemoryDefault` belongs on memory declaration lines.
+- `referencedModuleIds` belongs on memory declaration lines.
+- `referencedNamespaceIds` belongs only on namespace-referencing semantic/declaration lines such as `use`, `const`, and memory declaration lines.
+- `ifBlock` belongs on `IfLine`.
+- `ifEndBlock` belongs on `IfEndLine`.
+- `blockBlock` belongs on `BlockLine`.
+- `blockEndBlock` belongs on `BlockEndLine`.
+- `isBlockPrologue` belongs on compiler directive lines that can appear in source-block prologues.
+- `isSemanticOnly` should become a type guard or narrower line union instead of a base optional flag.
+- `isMemoryDeclaration` should be replaced at consumers with the existing `isMemoryDeclarationLine(...)` type guard where possible.
+
+This should make the compiler interfaces say what is true rather than relying on broad optional fields and runtime checks.
+
+## Anti-Patterns
+
+- Do not keep compatibility aliases, wrapper types, or re-exports for the old broad base-field shape.
+- Do not create `metadata?: { ... }` as a generic bag for unrelated line facts.
+- Do not hide new or moved fields from snapshots to make the PR look smaller.
+- Do not replace one broad runtime check with another broad runtime check under a helper name.
+- Do not add fallback codegen checks for facts that tokenizer/parser typing should guarantee.
+
+## Implementation Plan
+
+### Step 1: Inventory base metadata fields
+
+- Review every field on `ASTLineBase`.
+- Classify each field as either core line identity or instruction-specific metadata.
+- Keep only core identity on the base: line numbers, instruction, and typed arguments.
+
+### Step 2: Move block metadata to block line types
+
+- Move `ifBlock` to `IfLine`.
+- Move `ifEndBlock` to `IfEndLine`.
+- Move `blockBlock` to `BlockLine`.
+- Move `blockEndBlock` to `BlockEndLine`.
+- Update parser assignments to use the narrowed line types rather than base-line writes.
+- Update consumers such as block instruction compilers to receive/read the narrowed line types.
+
+### Step 3: Move memory metadata to memory declaration lines
+
+- Move `hasExplicitMemoryDefault` fully onto `MemoryDeclarationLine`.
+- Keep `referencedModuleIds` and memory-line namespace reference metadata on memory declaration lines.
+- Replace broad `line.isMemoryDeclaration` checks with `isMemoryDeclarationLine(line)` where a type guard is the actual contract.
+
+### Step 4: Move semantic/prologue metadata to specific semantic/directive lines
+
+- Replace broad `line.isSemanticOnly` checks with a type guard or semantic-line union.
+- Move `isBlockPrologue` to compiler directive line types that can actually be prologue metadata.
+- Update semantic application and namespace/layout loops to consume the narrowed contracts.
+
+### Step 5: Update tests and snapshots honestly
+
+- Update parser tests to assert the narrower line-specific metadata.
+- Update AST snapshots if visible serialized line shape changes.
+- Do not hide metadata or skip snapshot updates for cosmetic reasons.
+
+## Validation Checkpoints
+
+- `rg -n "isSemanticOnly|isMemoryDeclaration|isBlockPrologue|hasExplicitMemoryDefault|ifBlock|ifEndBlock|blockBlock|blockEndBlock" packages/compiler-spec/src/ast.ts packages/compiler/src packages/compiler/packages/tokenizer/src -g '*.ts'`
+- `npx nx run @8f4e/tokenizer:typecheck`
+- `npx nx run compiler:typecheck`
+- `npx nx run @8f4e/tokenizer:test`
+- `npx nx run compiler:test`
+
+## Success Criteria
+
+- [ ] `ASTLineBase` only contains core line identity fields.
+- [ ] Instruction-specific metadata lives on instruction-specific line interfaces.
+- [ ] Compiler consumers use type guards or narrowed line types instead of broad optional base fields.
+- [ ] Parser assignments are typed against the specific line shape that owns each metadata field.
+- [ ] No compatibility layers, hidden metadata, or generic metadata bags are introduced.
+- [ ] Snapshot changes are updated honestly when the public AST shape changes.
+
+## Affected Components
+
+- `packages/compiler-spec/src/ast.ts` - AST line type definitions and type guards.
+- `packages/compiler/packages/tokenizer/src/parser.ts` - parser-owned metadata assignment.
+- `packages/compiler/packages/tokenizer/src/parser.test.ts` - parser metadata coverage.
+- `packages/compiler/src/compiler.ts` - semantic/memory routing in compile loops.
+- `packages/compiler/src/semantic/` - namespace discovery/layout and normalization routing.
+- `packages/compiler/src/instructionCompilers/` - block instruction metadata consumers.
+
+## Risks & Considerations
+
+- **Diff size**: Moving `isSemanticOnly` and `isMemoryDeclaration` may update many snapshots because false fields can disappear from unrelated lines. This is acceptable if the new type contract is clearer.
+- **Avoid half-cleaning**: Moving only one metadata field leaves `ASTLineBase` as a broad optional-field surface. Treat the remaining fields consistently.
+- **No compatibility preservation**: The project is not released yet. Update callers directly and delete old paths rather than keeping shims.
+- **Type guards should express ownership**: A helper is acceptable when it narrows to a real line subset. It should not merely hide the same broad optional-field check.
+
+## Related Items
+
+- **Follows up**: `docs/todos/421-clean-up-ast-construction-helper-scans.md`
+- **Related**: `docs/todos/420-add-typed-compiler-ast-group-indexes.md`
+- **Related**: `docs/todos/378-make-parser-stateful-for-block-pairing-and-owning-block-context.md`
+- **Related**: `docs/agent_failure_notes/043-hidden-metadata-to-avoid-snapshot-updates.md`
+- **Related**: `docs/agent_failure_notes/054-moving-runtime-discovery-into-ast-construction.md`
+
+## Notes
+
+- This todo exists because moving facts earlier into the AST is not enough by itself. The AST type interface must also become more precise.
+- Future agents should optimize for the correct type boundary, not for a smaller-looking PR.

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -64,7 +64,6 @@ Active todo files are listed below.
 | 408 | Reduce tokenizer identifier classification work | 🟡 | 1-2d | 2026-05-19 | `classifyIdentifier` runs many ordered reference-shape checks for every identifier; cheap prefix/suffix dispatch could avoid most checks for plain identifiers. |
 | 409 | Track block context flags during stack analysis | 🟡 | 2-4h | 2026-05-19 | Stack validation repeatedly scans block stack to detect constants/map scope; maintained context flags or counters would avoid per-instruction scans. |
 | 410 | Consolidate release action commits | 🟡 | 2-4h | 2026-05-19 | The release workflow currently creates separate version, bundle-size, bytecode-size, and compiler-coverage commits; collapse these into one release commit or one version commit plus one metrics commit. |
-| 421 | Clean up AST construction helper scans | 🟡 | 4-8h | 2026-05-26 | Typed AST metadata should be owned by source-block-specific construction, not by scattered post-processing helpers that re-scan `CompilerASTLine[]`. |
 
 ### 🟢 Low Priority
 
@@ -82,6 +81,7 @@ Active todo files are listed below.
 
 | ID | Title | Completed | Notes |
 | ---- | ----- | --------- | ----- |
+| 421 | Clean up AST construction helper scans | 2026-05-26 | Tokenizer AST construction now accumulates module/function/constants metadata through source-block-specific builders during parsing; generic post-processing scans over `CompilerASTLine[]` were removed. |
 | 422 | Split namespace discovery and layout prepass | 2026-05-26 | Namespace discovery now uses an explicit internal discovery path, final layout/default resolution uses `layoutNamespace(...)`, and the old mode flag/prepass naming was removed without typed-AST compatibility wrappers. |
 | 419 | Merge instruction source argument specs into instruction specs | 2026-05-26 | Source argument arity and shape metadata now lives in compiler-spec instruction specs; tokenizer validation consumes the shared contract, and duplicated argument/no-argument tables were removed without compatibility shims. |
 | 420 | Add typed compiler AST group indexes | 2026-05-26 | Compiler-owned AST inputs now use typed module/function/constants group objects with required ids and derived metadata, so compiler passes no longer rediscover those facts from raw line arrays. |

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -64,6 +64,7 @@ Active todo files are listed below.
 | 408 | Reduce tokenizer identifier classification work | 🟡 | 1-2d | 2026-05-19 | `classifyIdentifier` runs many ordered reference-shape checks for every identifier; cheap prefix/suffix dispatch could avoid most checks for plain identifiers. |
 | 409 | Track block context flags during stack analysis | 🟡 | 2-4h | 2026-05-19 | Stack validation repeatedly scans block stack to detect constants/map scope; maintained context flags or counters would avoid per-instruction scans. |
 | 410 | Consolidate release action commits | 🟡 | 2-4h | 2026-05-19 | The release workflow currently creates separate version, bundle-size, bytecode-size, and compiler-coverage commits; collapse these into one release commit or one version commit plus one metrics commit. |
+| 423 | Narrow AST line metadata interfaces | 🟡 | 4-8h | 2026-05-26 | Move instruction-specific AST metadata off `ASTLineBase` and onto the concrete line interfaces that own each field. |
 
 ### 🟢 Low Priority
 

--- a/packages/compiler-spec/src/ast.ts
+++ b/packages/compiler-spec/src/ast.ts
@@ -122,17 +122,24 @@ export type MemoryDeclarationArgument =
 	| ArgumentIdentifier
 	| ArgumentCompileTimeExpression
 	| ArgumentStringLiteral;
+
+type ReferencedModuleIdsMetadata = {
+	referencedModuleIds?: readonly string[];
+};
+
 export type ScalarMemoryDeclarationLine = ASTLineBase<
 	ScalarMemoryDeclarationInstruction,
 	[MemoryDeclarationArgument, ...MemoryDeclarationArgument[]]
->;
+> &
+	ReferencedModuleIdsMetadata;
 export type NamedScalarMemoryDeclarationLine = Omit<ScalarMemoryDeclarationLine, 'arguments'> & {
 	arguments: [ArgumentIdentifier, ...MemoryDeclarationArgument[]];
 };
 export type ArrayMemoryDeclarationLine = ASTLineBase<
 	ArrayDeclarationInstruction,
 	[ArgumentIdentifier, CompileTimeValueArgument, ...MemoryDeclarationArgument[]]
->;
+> &
+	ReferencedModuleIdsMetadata;
 export type MemoryDeclarationLine = ScalarMemoryDeclarationLine | ArrayMemoryDeclarationLine;
 
 type ExplicitCompilerASTLine =

--- a/packages/compiler-spec/src/ast.ts
+++ b/packages/compiler-spec/src/ast.ts
@@ -29,6 +29,7 @@ export type ASTLineBase<Instruction extends string, Arguments extends Array<Argu
 	isMemoryDeclaration?: boolean;
 	isBlockPrologue?: boolean;
 	hasExplicitMemoryDefault?: boolean;
+	referencedNamespaceIds?: readonly string[];
 	ifBlock?: IfBlockMetadata;
 	ifEndBlock?: IfEndBlockMetadata;
 	blockBlock?: BlockBlockMetadata;

--- a/packages/compiler-spec/src/ast.ts
+++ b/packages/compiler-spec/src/ast.ts
@@ -29,7 +29,6 @@ export type ASTLineBase<Instruction extends string, Arguments extends Array<Argu
 	isMemoryDeclaration?: boolean;
 	isBlockPrologue?: boolean;
 	hasExplicitMemoryDefault?: boolean;
-	referencedNamespaceIds?: readonly string[];
 	ifBlock?: IfBlockMetadata;
 	ifEndBlock?: IfEndBlockMetadata;
 	blockBlock?: BlockBlockMetadata;
@@ -81,7 +80,10 @@ export type ModuleLine = ASTLineBase<'module', [ArgumentIdentifier]>;
 export type ModuleEndLine = ASTLineBase<'moduleEnd', []>;
 export type ConstantsLine = ASTLineBase<'constants', [ArgumentIdentifier]>;
 export type ConstantsEndLine = ASTLineBase<'constantsEnd', []>;
-export type UseLine = ASTLineBase<'use', [ArgumentIdentifier]>;
+export type ReferencedNamespaceIdsMetadata = {
+	referencedNamespaceIds?: readonly string[];
+};
+export type UseLine = ASTLineBase<'use', [ArgumentIdentifier]> & ReferencedNamespaceIdsMetadata;
 export type LocalDeclarationLine = ASTLineBase<'local', [ArgumentIdentifier, ArgumentIdentifier]>;
 export type ParamLine = ASTLineBase<'param', [ArgumentIdentifier, ArgumentIdentifier]>;
 export type MapBeginLine = ASTLineBase<'mapBegin', [ArgumentIdentifier]>;
@@ -92,7 +94,8 @@ export type BranchIfUnchangedLine = ASTLineBase<'branchIfUnchanged', [ArgumentLi
 export type ExitIfTrueLine = ASTLineBase<'exitIfTrue', []>;
 export type StoreBytesLine = ASTLineBase<'storeBytes', [ArgumentLiteral]>;
 export type MemoryCopyLine = ASTLineBase<'memoryCopy', [CompileTimeValueArgument]>;
-export type ConstLine = ASTLineBase<'const', [ArgumentIdentifier, CompileTimeValueArgument]>;
+export type ConstLine = ASTLineBase<'const', [ArgumentIdentifier, CompileTimeValueArgument]> &
+	ReferencedNamespaceIdsMetadata;
 export type EnsureNonZeroLine = ASTLineBase<'ensureNonZero', [] | [ArgumentLiteral]>;
 
 export type MapValueArgument =
@@ -132,7 +135,8 @@ export type ScalarMemoryDeclarationLine = ASTLineBase<
 	ScalarMemoryDeclarationInstruction,
 	[MemoryDeclarationArgument, ...MemoryDeclarationArgument[]]
 > &
-	ReferencedModuleIdsMetadata;
+	ReferencedModuleIdsMetadata &
+	ReferencedNamespaceIdsMetadata;
 export type NamedScalarMemoryDeclarationLine = Omit<ScalarMemoryDeclarationLine, 'arguments'> & {
 	arguments: [ArgumentIdentifier, ...MemoryDeclarationArgument[]];
 };
@@ -140,7 +144,8 @@ export type ArrayMemoryDeclarationLine = ASTLineBase<
 	ArrayDeclarationInstruction,
 	[ArgumentIdentifier, CompileTimeValueArgument, ...MemoryDeclarationArgument[]]
 > &
-	ReferencedModuleIdsMetadata;
+	ReferencedModuleIdsMetadata &
+	ReferencedNamespaceIdsMetadata;
 export type MemoryDeclarationLine = ScalarMemoryDeclarationLine | ArrayMemoryDeclarationLine;
 
 type ExplicitCompilerASTLine =
@@ -194,6 +199,16 @@ export type CompilerASTLine =
 export type ASTLine = CompilerASTLine;
 
 export type CompilerASTLines = CompilerASTLine[];
+
+export function hasReferencedNamespaceIds(
+	line: CompilerASTLine | undefined
+): line is CompilerASTLine & { referencedNamespaceIds: readonly string[] } {
+	return (
+		line !== undefined &&
+		'referencedNamespaceIds' in line &&
+		(line as ReferencedNamespaceIdsMetadata).referencedNamespaceIds !== undefined
+	);
+}
 
 export interface ModuleAST {
 	type: 'module';

--- a/packages/compiler/packages/tokenizer/src/parser.test.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { ArgumentType } from '@8f4e/compiler-spec';
 
-import { compileToASTLines, parseLine } from './parser';
+import { compileToAST, compileToASTLines, parseLine } from './parser';
 import { classifyIdentifier } from './syntax/parseArgument';
 import { SyntaxErrorCode, SyntaxRulesError } from './syntax/syntaxError';
 
@@ -151,6 +151,66 @@ describe('parseLine', () => {
 			{ type: ArgumentType.LITERAL, value: 62, isInteger: true },
 			{ type: ArgumentType.LITERAL, value: 64, isInteger: true },
 		]);
+	});
+});
+
+describe('compileToAST', () => {
+	it('constructs module metadata from the source-block parse path', () => {
+		const ast = compileToAST([
+			'module target',
+			'#region fastMemory',
+			'int counter',
+			'int sourceStart &source:buffer',
+			'moduleEnd',
+		]);
+
+		expect(ast).toMatchObject({
+			type: 'module',
+			id: 'target',
+			moduleLine: { instruction: 'module' },
+			regionLine: { instruction: '#region' },
+		});
+		if (ast.type !== 'module') {
+			throw new Error('Expected module AST');
+		}
+		expect(ast.memoryDeclarationLines.map(line => line.arguments[0].value)).toEqual(['counter', 'sourceStart']);
+		expect(ast.referencedModuleIds).toEqual(['source']);
+	});
+
+	it('constructs function metadata from the source-block parse path', () => {
+		const ast = compileToAST([
+			'const SCALE 2',
+			'function mix',
+			'#export mixExport',
+			'param int left',
+			'param float right',
+			'push left',
+			'functionEnd int float',
+		]);
+
+		expect(ast).toMatchObject({
+			type: 'function',
+			id: 'mix',
+			functionLine: { instruction: 'function' },
+			functionEndLine: { instruction: 'functionEnd' },
+			exportLine: { instruction: '#export' },
+			exportName: 'mixExport',
+			signature: {
+				parameters: ['int', 'float'],
+				returns: ['int', 'float'],
+			},
+		});
+		expect(ast.lines[0].instruction).toBe('const');
+	});
+
+	it('constructs constants metadata from the source-block parse path', () => {
+		const ast = compileToAST(['constants sizes', 'const COUNT 4', 'constantsEnd']);
+
+		expect(ast).toMatchObject({
+			type: 'constants',
+			id: 'sizes',
+			constantsLine: { instruction: 'constants' },
+		});
 	});
 });
 

--- a/packages/compiler/packages/tokenizer/src/parser.test.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.test.ts
@@ -174,6 +174,7 @@ describe('compileToAST', () => {
 			throw new Error('Expected module AST');
 		}
 		expect(ast.memoryDeclarationLines.map(line => line.arguments[0].value)).toEqual(['counter', 'sourceStart']);
+		expect(ast.memoryDeclarationLines[1].referencedModuleIds).toEqual(['source']);
 		expect(ast.referencedModuleIds).toEqual(['source']);
 	});
 

--- a/packages/compiler/packages/tokenizer/src/parser.test.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.test.ts
@@ -175,6 +175,7 @@ describe('compileToAST', () => {
 		}
 		expect(ast.memoryDeclarationLines.map(line => line.arguments[0].value)).toEqual(['counter', 'sourceStart']);
 		expect(ast.memoryDeclarationLines[1].referencedModuleIds).toEqual(['source']);
+		expect(ast.memoryDeclarationLines[1].referencedNamespaceIds).toEqual(['source']);
 		expect(ast.referencedModuleIds).toEqual(['source']);
 	});
 
@@ -212,6 +213,12 @@ describe('compileToAST', () => {
 			id: 'sizes',
 			constantsLine: { instruction: 'constants' },
 		});
+	});
+
+	it('records namespace references from use lines while parsing lines', () => {
+		const ast = compileToAST(['module target', 'use shared', 'moduleEnd']);
+
+		expect(ast.lines[1].referencedNamespaceIds).toEqual(['shared']);
 	});
 });
 

--- a/packages/compiler/packages/tokenizer/src/parser.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.ts
@@ -171,10 +171,10 @@ function getASTCacheLookupResult<TAst>(
 	};
 }
 
-function addReferencedModuleIdsFromArgument(referencedModuleIds: Set<string>, argument: Argument): void {
+function addReferencedNamespaceIdsFromArgument(referencedNamespaceIds: Set<string>, argument: Argument): void {
 	if (argument.type === ArgumentType.COMPILE_TIME_EXPRESSION) {
 		for (const moduleId of argument.intermoduleIds) {
-			referencedModuleIds.add(moduleId);
+			referencedNamespaceIds.add(moduleId);
 		}
 		return;
 	}
@@ -184,7 +184,7 @@ function addReferencedModuleIdsFromArgument(referencedModuleIds: Set<string>, ar
 	}
 
 	if (argument.scope === 'intermodule' && argument.targetModuleId) {
-		referencedModuleIds.add(argument.targetModuleId);
+		referencedNamespaceIds.add(argument.targetModuleId);
 	}
 }
 
@@ -394,15 +394,17 @@ export function parseLine(
 		instruction = first;
 		const isMemoryDeclaration = isMemoryDeclarationInstruction(instruction);
 		const parsedArguments: Argument[] = [];
-		const referencedModuleIds = isMemoryDeclaration ? new Set<string>() : undefined;
+		const referencedNamespaceIds = new Set<string>();
 		for (const arg of args) {
 			const parsedArgument = parseArgument(arg);
 			parsedArguments.push(parsedArgument);
-			if (referencedModuleIds) {
-				addReferencedModuleIdsFromArgument(referencedModuleIds, parsedArgument);
-			}
+			addReferencedNamespaceIdsFromArgument(referencedNamespaceIds, parsedArgument);
 		}
 		validateInstructionArguments(instruction, parsedArguments);
+		const [useArgument] = parsedArguments;
+		if (instruction === 'use' && useArgument?.type === ArgumentType.IDENTIFIER) {
+			referencedNamespaceIds.add(useArgument.value);
+		}
 		const parsedLine = {
 			lineNumberBeforeMacroExpansion,
 			lineNumberAfterMacroExpansion,
@@ -410,13 +412,14 @@ export function parseLine(
 			arguments: parsedArguments,
 			isSemanticOnly: isSemanticOnlyInstruction(instruction),
 			isMemoryDeclaration,
+			...(referencedNamespaceIds.size > 0 ? { referencedNamespaceIds: [...referencedNamespaceIds] } : {}),
 		} as ASTLine;
 
 		if (isMemoryDeclaration) {
 			const memoryLine = parsedLine as MemoryDeclarationLine;
 			memoryLine.hasExplicitMemoryDefault = hasExplicitMemoryDefault(instruction, parsedArguments);
-			if (referencedModuleIds && referencedModuleIds.size > 0) {
-				memoryLine.referencedModuleIds = [...referencedModuleIds];
+			if (referencedNamespaceIds.size > 0) {
+				memoryLine.referencedModuleIds = [...referencedNamespaceIds];
 			}
 		}
 

--- a/packages/compiler/packages/tokenizer/src/parser.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.ts
@@ -171,24 +171,25 @@ function getASTCacheLookupResult<TAst>(
 	};
 }
 
-function getReferencedModuleIdsFromArgument(argument: Argument | undefined): string[] {
+function addReferencedModuleIdsFromArgument(referencedModuleIds: Set<string>, argument: Argument | undefined): void {
 	if (!argument) {
-		return [];
+		return;
 	}
 
 	if (argument.type === ArgumentType.COMPILE_TIME_EXPRESSION) {
-		return [...argument.intermoduleIds];
+		for (const moduleId of argument.intermoduleIds) {
+			referencedModuleIds.add(moduleId);
+		}
+		return;
 	}
 
 	if (argument.type !== ArgumentType.IDENTIFIER) {
-		return [];
+		return;
 	}
 
 	if (argument.scope === 'intermodule' && argument.targetModuleId) {
-		return [argument.targetModuleId];
+		referencedModuleIds.add(argument.targetModuleId);
 	}
-
-	return [];
 }
 
 function isRegionLine(line: CompilerASTLine): line is RegionLine {
@@ -205,9 +206,7 @@ function isFunctionEndLine(line: CompilerASTLine): line is FunctionEndLine {
 
 function addReferencedModuleIds(builder: ModuleASTBuilder, line: MemoryDeclarationLine): void {
 	for (const argument of line.arguments) {
-		for (const moduleId of getReferencedModuleIdsFromArgument(argument)) {
-			builder.referencedModuleIds.add(moduleId);
-		}
+		addReferencedModuleIdsFromArgument(builder.referencedModuleIds, argument);
 	}
 }
 

--- a/packages/compiler/packages/tokenizer/src/parser.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.ts
@@ -106,6 +106,10 @@ function isBlockEndInstruction(instruction: string): instruction is BlockEndInst
 	return Object.prototype.hasOwnProperty.call(blockEndToStartInstruction, instruction);
 }
 
+function canReferenceDeferredNamespace(instruction: string, isMemoryDeclaration: boolean): boolean {
+	return isMemoryDeclaration || instruction === 'const' || instruction === 'use';
+}
+
 function isCompilerDirectiveInstruction(instruction: string): boolean {
 	return instruction.startsWith('#');
 }
@@ -393,16 +397,19 @@ export function parseLine(
 		const [first = '', ...args] = tokens;
 		instruction = first;
 		const isMemoryDeclaration = isMemoryDeclarationInstruction(instruction);
+		const shouldRecordNamespaceReferences = canReferenceDeferredNamespace(instruction, isMemoryDeclaration);
 		const parsedArguments: Argument[] = [];
 		const referencedNamespaceIds = new Set<string>();
 		for (const arg of args) {
 			const parsedArgument = parseArgument(arg);
 			parsedArguments.push(parsedArgument);
-			addReferencedNamespaceIdsFromArgument(referencedNamespaceIds, parsedArgument);
+			if (shouldRecordNamespaceReferences) {
+				addReferencedNamespaceIdsFromArgument(referencedNamespaceIds, parsedArgument);
+			}
 		}
 		validateInstructionArguments(instruction, parsedArguments);
 		const [useArgument] = parsedArguments;
-		if (instruction === 'use' && useArgument?.type === ArgumentType.IDENTIFIER) {
+		if (shouldRecordNamespaceReferences && instruction === 'use' && useArgument?.type === ArgumentType.IDENTIFIER) {
 			referencedNamespaceIds.add(useArgument.value);
 		}
 		const parsedLine = {

--- a/packages/compiler/packages/tokenizer/src/parser.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.ts
@@ -171,11 +171,7 @@ function getASTCacheLookupResult<TAst>(
 	};
 }
 
-function addReferencedModuleIdsFromArgument(referencedModuleIds: Set<string>, argument: Argument | undefined): void {
-	if (!argument) {
-		return;
-	}
-
+function addReferencedModuleIdsFromArgument(referencedModuleIds: Set<string>, argument: Argument): void {
 	if (argument.type === ArgumentType.COMPILE_TIME_EXPRESSION) {
 		for (const moduleId of argument.intermoduleIds) {
 			referencedModuleIds.add(moduleId);
@@ -202,12 +198,6 @@ function isExportLine(line: CompilerASTLine): line is ExportLine {
 
 function isFunctionEndLine(line: CompilerASTLine): line is FunctionEndLine {
 	return line.instruction === 'functionEnd';
-}
-
-function addReferencedModuleIds(builder: ModuleASTBuilder, line: MemoryDeclarationLine): void {
-	for (const argument of line.arguments) {
-		addReferencedModuleIdsFromArgument(builder.referencedModuleIds, argument);
-	}
 }
 
 function createSourceBlockASTBuilder(line: CompilerASTLine): SourceBlockASTBuilder | undefined {
@@ -252,7 +242,9 @@ function applyModuleASTLine(builder: ModuleASTBuilder, line: CompilerASTLine): v
 	}
 
 	builder.memoryDeclarationLines.push(line);
-	addReferencedModuleIds(builder, line);
+	for (const moduleId of line.referencedModuleIds ?? []) {
+		builder.referencedModuleIds.add(moduleId);
+	}
 }
 
 function applyFunctionASTLine(builder: FunctionASTBuilder, line: CompilerASTLine): void {
@@ -400,9 +392,17 @@ export function parseLine(
 		const tokens = tokenizeInstruction(line);
 		const [first = '', ...args] = tokens;
 		instruction = first;
-		const parsedArguments = args.map(parseArgument);
-		validateInstructionArguments(instruction, parsedArguments);
 		const isMemoryDeclaration = isMemoryDeclarationInstruction(instruction);
+		const parsedArguments: Argument[] = [];
+		const referencedModuleIds = isMemoryDeclaration ? new Set<string>() : undefined;
+		for (const arg of args) {
+			const parsedArgument = parseArgument(arg);
+			parsedArguments.push(parsedArgument);
+			if (referencedModuleIds) {
+				addReferencedModuleIdsFromArgument(referencedModuleIds, parsedArgument);
+			}
+		}
+		validateInstructionArguments(instruction, parsedArguments);
 		const parsedLine = {
 			lineNumberBeforeMacroExpansion,
 			lineNumberAfterMacroExpansion,
@@ -413,7 +413,11 @@ export function parseLine(
 		} as ASTLine;
 
 		if (isMemoryDeclaration) {
-			parsedLine.hasExplicitMemoryDefault = hasExplicitMemoryDefault(instruction, parsedArguments);
+			const memoryLine = parsedLine as MemoryDeclarationLine;
+			memoryLine.hasExplicitMemoryDefault = hasExplicitMemoryDefault(instruction, parsedArguments);
+			if (referencedModuleIds && referencedModuleIds.size > 0) {
+				memoryLine.referencedModuleIds = [...referencedModuleIds];
+			}
 		}
 
 		return parsedLine;

--- a/packages/compiler/packages/tokenizer/src/parser.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.ts
@@ -3,7 +3,6 @@ import {
 	blockEndToStartInstruction,
 	blockStartInstructions,
 	isConstantsLine,
-	isFunctionEndLine,
 	isFunctionLine,
 	isMemoryDeclarationLine,
 	isModuleLine,
@@ -33,12 +32,15 @@ import type {
 	BlockBlockResultType,
 	CompilerASTLine,
 	CompilerASTLines,
+	ConstantsLine,
 	ExportLine,
 	FunctionEndLine,
+	FunctionLine,
 	FunctionSignature,
 	IfEndLine,
 	IfBlockResultType,
 	MemoryDeclarationLine,
+	ModuleLine,
 	ParsedLineMetadata,
 	RegionLine,
 } from '@8f4e/compiler-spec';
@@ -58,6 +60,38 @@ type SourceBlockPrologue = {
 type ASTCacheLookupResult<TAst> = {
 	ast?: TAst;
 	hash?: number;
+};
+
+type ModuleASTBuilder = {
+	type: 'module';
+	id: string;
+	moduleLine: ModuleLine;
+	regionLine?: RegionLine;
+	memoryDeclarationLines: MemoryDeclarationLine[];
+	referencedModuleIds: Set<string>;
+};
+
+type FunctionASTBuilder = {
+	type: 'function';
+	id: string;
+	functionLine: FunctionLine;
+	functionEndLine?: FunctionEndLine;
+	parameters: FunctionSignature['parameters'];
+	exportLine?: ExportLine;
+	exportName?: string;
+};
+
+type ConstantsASTBuilder = {
+	type: 'constants';
+	id: string;
+	constantsLine: ConstantsLine;
+};
+
+type SourceBlockASTBuilder = ModuleASTBuilder | FunctionASTBuilder | ConstantsASTBuilder;
+
+type ParsedCompilerSource = {
+	lines: CompilerASTLines;
+	astBuilder?: SourceBlockASTBuilder;
 };
 
 const blockStartInstructionSet = new Set<BlockStartInstruction>(blockStartInstructions);
@@ -157,92 +191,150 @@ function getReferencedModuleIdsFromArgument(argument: Argument | undefined): str
 	return [];
 }
 
-function getReferencedModuleIds(lines: readonly CompilerASTLine[]): string[] {
-	const referencedModuleIds = new Set<string>();
+function isRegionLine(line: CompilerASTLine): line is RegionLine {
+	return line.instruction === '#region';
+}
 
-	for (const line of lines) {
-		if (!isMemoryDeclarationLine(line)) {
-			continue;
-		}
+function isExportLine(line: CompilerASTLine): line is ExportLine {
+	return line.instruction === '#export';
+}
 
-		for (const argument of line.arguments) {
-			for (const moduleId of getReferencedModuleIdsFromArgument(argument)) {
-				referencedModuleIds.add(moduleId);
-			}
+function isFunctionEndLine(line: CompilerASTLine): line is FunctionEndLine {
+	return line.instruction === 'functionEnd';
+}
+
+function addReferencedModuleIds(builder: ModuleASTBuilder, line: MemoryDeclarationLine): void {
+	for (const argument of line.arguments) {
+		for (const moduleId of getReferencedModuleIdsFromArgument(argument)) {
+			builder.referencedModuleIds.add(moduleId);
 		}
 	}
-
-	return [...referencedModuleIds];
 }
 
-function getRegionLine(lines: readonly CompilerASTLine[]): RegionLine | undefined {
-	return lines.find((line): line is RegionLine => line.instruction === '#region');
-}
-
-function getMemoryDeclarationLines(lines: readonly CompilerASTLine[]): MemoryDeclarationLine[] {
-	return lines.filter(isMemoryDeclarationLine);
-}
-
-function getExportLine(lines: readonly CompilerASTLine[]): ExportLine | undefined {
-	return lines.find((line): line is ExportLine => line.instruction === '#export');
-}
-
-function getFunctionSignature(lines: readonly CompilerASTLine[], functionEndLine: FunctionEndLine): FunctionSignature {
-	return {
-		parameters: lines
-			.filter(isParamLine)
-			.map(line => line.arguments[0].value as FunctionSignature['parameters'][number]),
-		returns: functionEndLine.arguments.map(arg => arg.value as FunctionSignature['returns'][number]),
-	};
-}
-
-function toAST(lines: CompilerASTLines): AST {
-	const firstLine = lines[0];
-
-	if (isModuleLine(firstLine)) {
-		const regionLine = getRegionLine(lines);
+function createSourceBlockASTBuilder(line: CompilerASTLine): SourceBlockASTBuilder | undefined {
+	if (isModuleLine(line)) {
 		return {
 			type: 'module',
-			id: firstLine.arguments[0].value,
-			lines,
-			moduleLine: firstLine,
-			...(regionLine ? { regionLine } : {}),
-			memoryDeclarationLines: getMemoryDeclarationLines(lines),
-			referencedModuleIds: getReferencedModuleIds(lines),
+			id: line.arguments[0].value,
+			moduleLine: line,
+			memoryDeclarationLines: [],
+			referencedModuleIds: new Set<string>(),
 		};
 	}
 
-	const functionLine = lines.find(isFunctionLine);
-	if (functionLine) {
-		const functionEndLine = lines.find(isFunctionEndLine);
-		if (!functionEndLine) {
-			throw new SyntaxRulesError(SyntaxErrorCode.INVALID_BLOCK_STRUCTURE, 'Expected a matching functionEnd.', {
-				lineNumberBeforeMacroExpansion: functionLine.lineNumberBeforeMacroExpansion,
-				lineNumberAfterMacroExpansion: functionLine.lineNumberAfterMacroExpansion,
-				instruction: functionLine.instruction,
-			});
-		}
-
-		const id = functionLine.arguments[0].value;
-		const exportLine = getExportLine(lines);
+	if (isFunctionLine(line)) {
 		return {
 			type: 'function',
-			id,
-			lines,
-			functionLine,
-			functionEndLine,
-			signature: getFunctionSignature(lines, functionEndLine),
-			...(exportLine ? { exportLine, exportName: exportLine.arguments[0]?.value ?? id } : {}),
+			id: line.arguments[0].value,
+			functionLine: line,
+			parameters: [],
 		};
 	}
 
-	if (isConstantsLine(firstLine)) {
+	if (isConstantsLine(line)) {
 		return {
 			type: 'constants',
-			id: firstLine.arguments[0].value,
-			lines,
-			constantsLine: firstLine,
+			id: line.arguments[0].value,
+			constantsLine: line,
 		};
+	}
+
+	return undefined;
+}
+
+function applyModuleASTLine(builder: ModuleASTBuilder, line: CompilerASTLine): void {
+	if (isRegionLine(line)) {
+		builder.regionLine = line;
+		return;
+	}
+
+	if (!isMemoryDeclarationLine(line)) {
+		return;
+	}
+
+	builder.memoryDeclarationLines.push(line);
+	addReferencedModuleIds(builder, line);
+}
+
+function applyFunctionASTLine(builder: FunctionASTBuilder, line: CompilerASTLine): void {
+	if (isParamLine(line)) {
+		builder.parameters.push(line.arguments[0].value as FunctionSignature['parameters'][number]);
+		return;
+	}
+
+	if (isFunctionEndLine(line)) {
+		builder.functionEndLine = line;
+		return;
+	}
+
+	if (isExportLine(line)) {
+		builder.exportLine = line;
+		builder.exportName = builder.exportLine.arguments[0]?.value ?? builder.id;
+	}
+}
+
+function applySourceBlockASTLine(builder: SourceBlockASTBuilder, line: CompilerASTLine): void {
+	switch (builder.type) {
+		case 'module':
+			applyModuleASTLine(builder, line);
+			return;
+		case 'function':
+			applyFunctionASTLine(builder, line);
+			return;
+		case 'constants':
+			return;
+	}
+}
+
+function createASTFromBuilder(lines: CompilerASTLines, builder: SourceBlockASTBuilder): AST {
+	switch (builder.type) {
+		case 'module':
+			return {
+				type: 'module',
+				id: builder.id,
+				lines,
+				moduleLine: builder.moduleLine,
+				...(builder.regionLine ? { regionLine: builder.regionLine } : {}),
+				memoryDeclarationLines: builder.memoryDeclarationLines,
+				referencedModuleIds: [...builder.referencedModuleIds],
+			};
+		case 'function':
+			if (!builder.functionEndLine) {
+				throw new SyntaxRulesError(SyntaxErrorCode.INVALID_BLOCK_STRUCTURE, 'Expected a matching functionEnd.', {
+					lineNumberBeforeMacroExpansion: builder.functionLine.lineNumberBeforeMacroExpansion,
+					lineNumberAfterMacroExpansion: builder.functionLine.lineNumberAfterMacroExpansion,
+					instruction: builder.functionLine.instruction,
+				});
+			}
+
+			return {
+				type: 'function',
+				id: builder.id,
+				lines,
+				functionLine: builder.functionLine,
+				functionEndLine: builder.functionEndLine,
+				signature: {
+					parameters: builder.parameters,
+					returns: builder.functionEndLine.arguments.map(arg => arg.value as FunctionSignature['returns'][number]),
+				},
+				...(builder.exportLine ? { exportLine: builder.exportLine, exportName: builder.exportName } : {}),
+			};
+		case 'constants':
+			return {
+				type: 'constants',
+				id: builder.id,
+				lines,
+				constantsLine: builder.constantsLine,
+			};
+	}
+}
+
+function toAST(parsedSource: ParsedCompilerSource): AST {
+	const { lines, astBuilder } = parsedSource;
+	const firstLine = lines[0];
+
+	if (astBuilder) {
+		return createASTFromBuilder(lines, astBuilder);
 	}
 
 	throw new SyntaxRulesError(SyntaxErrorCode.INVALID_BLOCK_STRUCTURE, 'Expected a compiler source block.', {
@@ -339,23 +431,10 @@ export function parseLine(
 	}
 }
 
-export function compileToASTLines(
-	code: string[],
-	lineMetadata?: ParsedLineMetadata,
-	cache?: ASTCache<CompilerASTLines>,
-	cacheKey?: string
-): CompilerASTLines {
-	const cached = cacheKey !== undefined ? cache?.entries.get(cacheKey) : undefined;
-	const cachedLookup = getASTCacheLookupResult(cached, code, lineMetadata);
-	if (cachedLookup.ast) {
-		cache!.stats.hits++;
-		return cachedLookup.ast;
-	}
-	if (cache && cacheKey !== undefined) {
-		cache.stats.misses++;
-	}
-
+function parseCompilerSource(code: string[], lineMetadata?: ParsedLineMetadata): ParsedCompilerSource {
 	const ast: CompilerASTLines = [];
+	let astBuilder: SourceBlockASTBuilder | undefined;
+	let onlySemanticLinesBeforeSourceBlock = true;
 	const blockStack: OpenBlock[] = [];
 	const sourceBlockPrologueStack: SourceBlockPrologue[] = [];
 
@@ -368,6 +447,7 @@ export function compileToASTLines(
 			lineMetadata?.[lineNumberAfterMacroExpansion]?.callSiteLineNumber ?? lineNumberAfterMacroExpansion;
 		const parsedLine = parseLine(line, lineNumberBeforeMacroExpansion, lineNumberAfterMacroExpansion);
 		const astIndex = ast.length;
+		const isFirstASTLine = ast.length === 0;
 		const currentSourceBlockPrologue = sourceBlockPrologueStack[sourceBlockPrologueStack.length - 1];
 		const isCompilerDirective = isCompilerDirectiveInstruction(parsedLine.instruction);
 		const isInOpenSourceBlockPrologue =
@@ -388,6 +468,20 @@ export function compileToASTLines(
 		}
 
 		ast.push(parsedLine);
+		if (!astBuilder) {
+			const candidateBuilder = createSourceBlockASTBuilder(parsedLine);
+			if (
+				candidateBuilder &&
+				(isFirstASTLine || (candidateBuilder.type === 'function' && onlySemanticLinesBeforeSourceBlock))
+			) {
+				astBuilder = candidateBuilder;
+			}
+		}
+		if (astBuilder) {
+			applySourceBlockASTLine(astBuilder, parsedLine);
+		} else if (!parsedLine.isSemanticOnly) {
+			onlySemanticLinesBeforeSourceBlock = false;
+		}
 
 		if (isBlockStartInstruction(parsedLine.instruction)) {
 			blockStack.push({
@@ -512,6 +606,27 @@ export function compileToASTLines(
 		});
 	}
 
+	return { lines: ast, astBuilder };
+}
+
+export function compileToASTLines(
+	code: string[],
+	lineMetadata?: ParsedLineMetadata,
+	cache?: ASTCache<CompilerASTLines>,
+	cacheKey?: string
+): CompilerASTLines {
+	const cached = cacheKey !== undefined ? cache?.entries.get(cacheKey) : undefined;
+	const cachedLookup = getASTCacheLookupResult(cached, code, lineMetadata);
+	if (cachedLookup.ast) {
+		cache!.stats.hits++;
+		return cachedLookup.ast;
+	}
+	if (cache && cacheKey !== undefined) {
+		cache.stats.misses++;
+	}
+
+	const ast = parseCompilerSource(code, lineMetadata).lines;
+
 	if (cache && cacheKey !== undefined) {
 		const entry: ASTCacheEntry<CompilerASTLines> = {
 			ast,
@@ -547,8 +662,8 @@ export function compileToAST(
 		cache.stats.misses++;
 	}
 
-	const ast = compileToASTLines(code, lineMetadata);
-	const group = toAST(ast);
+	const parsedSource = parseCompilerSource(code, lineMetadata);
+	const group = toAST(parsedSource);
 
 	if (cache && cacheKey !== undefined) {
 		const entry: ASTCacheEntry<AST> = {

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/audio_audioBuffer_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/audio_audioBuffer_8f4e.snap
@@ -81,7 +81,10 @@
       }
     ],
     "isSemanticOnly": true,
-    "isMemoryDeclaration": false
+    "isMemoryDeclaration": false,
+    "referencedNamespaceIds": [
+      "env"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 26,
@@ -106,6 +109,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "phaseAccumulator"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "phaseAccumulator"
@@ -809,7 +815,10 @@
       }
     ],
     "isSemanticOnly": true,
-    "isMemoryDeclaration": false
+    "isMemoryDeclaration": false,
+    "referencedNamespaceIds": [
+      "env"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 101,
@@ -901,7 +910,10 @@
       }
     ],
     "isSemanticOnly": true,
-    "isMemoryDeclaration": false
+    "isMemoryDeclaration": false,
+    "referencedNamespaceIds": [
+      "math"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 110,
@@ -1244,7 +1256,10 @@
       }
     ],
     "isSemanticOnly": true,
-    "isMemoryDeclaration": false
+    "isMemoryDeclaration": false,
+    "referencedNamespaceIds": [
+      "math"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 153,

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/audio_audioBuffer_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/audio_audioBuffer_8f4e.snap
@@ -106,7 +106,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "phaseAccumulator"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 29,

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/digital_bistableMultivibrators_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/digital_bistableMultivibrators_8f4e.snap
@@ -88,6 +88,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "orGate"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "orGate"
@@ -132,6 +135,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "negate"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "negate"
@@ -393,6 +399,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "buttons"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "buttons"
@@ -591,6 +600,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "norGate2"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "norGate2"
@@ -635,6 +647,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "resetButton"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "resetButton"
@@ -841,6 +856,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "norGate"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "norGate"
@@ -885,6 +903,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "setButton"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "setButton"
@@ -1114,6 +1135,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "andGate"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "andGate"
@@ -1158,6 +1182,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "buttons"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "buttons"
@@ -1426,6 +1453,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "norGate"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "norGate"
@@ -1732,6 +1762,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "andGate"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "andGate"

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/digital_bistableMultivibrators_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/digital_bistableMultivibrators_8f4e.snap
@@ -88,7 +88,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "orGate"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 17,
@@ -129,7 +132,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "negate"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 21,
@@ -387,7 +393,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "buttons"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 56,
@@ -582,7 +591,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "norGate2"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 76,
@@ -623,7 +635,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "resetButton"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 81,
@@ -826,7 +841,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "norGate"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 101,
@@ -867,7 +885,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "setButton"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 106,
@@ -1093,7 +1114,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "andGate"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 136,
@@ -1134,7 +1158,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "buttons"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 140,
@@ -1399,7 +1426,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "norGate"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 177,
@@ -1702,7 +1732,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "andGate"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 207,

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/machine-learning_xorProblem_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/machine-learning_xorProblem_8f4e.snap
@@ -91,6 +91,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "perceptron"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "perceptron"
@@ -214,6 +217,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "perceptron2"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "perceptron2"
@@ -337,6 +343,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "perceptron3"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "perceptron3"
@@ -613,6 +622,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "switches"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "switches"
@@ -641,6 +653,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "switches"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "switches"
@@ -902,6 +917,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "switches"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "switches"
@@ -930,6 +948,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "switches"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "switches"
@@ -1191,6 +1212,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "activationFn"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "activationFn"
@@ -1219,6 +1243,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "activationFn2"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "activationFn2"
@@ -1480,6 +1507,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "activationFn3"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "activationFn3"

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/machine-learning_xorProblem_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/machine-learning_xorProblem_8f4e.snap
@@ -91,7 +91,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "perceptron"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 25,
@@ -211,7 +214,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "perceptron2"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 38,
@@ -331,7 +337,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "perceptron3"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 51,
@@ -604,7 +613,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "switches"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 87,
@@ -629,7 +641,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "switches"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 88,
@@ -887,7 +902,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "switches"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 113,
@@ -912,7 +930,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "switches"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 114,
@@ -1170,7 +1191,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "activationFn"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 139,
@@ -1195,7 +1219,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "activationFn2"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 140,
@@ -1453,7 +1480,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "activationFn3"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 170,

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/visuals_dancingWithTheSineLT_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/visuals_dancingWithTheSineLT_8f4e.snap
@@ -68,6 +68,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "sineLT"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "sineLT"
@@ -96,6 +99,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "sineLT"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "sineLT"
@@ -124,6 +130,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "sineLT"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "sineLT"
@@ -427,6 +436,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "sineLT"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "sineLT"
@@ -455,6 +467,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "sineLT"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "sineLT"
@@ -483,6 +498,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "sineLT"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "sineLT"
@@ -786,6 +804,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "sineLT"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "sineLT"
@@ -814,6 +835,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "sineLT"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "sineLT"
@@ -842,6 +866,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "sineLT"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "sineLT"
@@ -1145,6 +1172,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "sineLT"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "sineLT"
@@ -1173,6 +1203,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "sineLT"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "sineLT"
@@ -1201,6 +1234,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "sineLT"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "sineLT"
@@ -1229,6 +1265,9 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
+    "referencedNamespaceIds": [
+      "dancer1"
+    ],
     "hasExplicitMemoryDefault": true,
     "referencedModuleIds": [
       "dancer1"

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/visuals_dancingWithTheSineLT_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/visuals_dancingWithTheSineLT_8f4e.snap
@@ -68,7 +68,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "sineLT"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 15,
@@ -93,7 +96,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "sineLT"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 16,
@@ -118,7 +124,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "sineLT"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 17,
@@ -418,7 +427,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "sineLT"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 48,
@@ -443,7 +455,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "sineLT"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 49,
@@ -468,7 +483,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "sineLT"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 50,
@@ -768,7 +786,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "sineLT"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 82,
@@ -793,7 +814,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "sineLT"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 83,
@@ -818,7 +842,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "sineLT"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 84,
@@ -1118,7 +1145,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "sineLT"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 116,
@@ -1143,7 +1173,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "sineLT"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 117,
@@ -1168,7 +1201,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "sineLT"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 118,
@@ -1193,7 +1229,10 @@
     ],
     "isSemanticOnly": false,
     "isMemoryDeclaration": true,
-    "hasExplicitMemoryDefault": true
+    "hasExplicitMemoryDefault": true,
+    "referencedModuleIds": [
+      "dancer1"
+    ]
   },
   {
     "lineNumberBeforeMacroExpansion": 120,

--- a/packages/compiler/src/semantic/buildNamespace.ts
+++ b/packages/compiler/src/semantic/buildNamespace.ts
@@ -2,6 +2,7 @@ import {
 	ArgumentType,
 	GLOBAL_ALIGNMENT_BOUNDARY,
 	compilerSourceBlockInstructionByType,
+	hasReferencedNamespaceIds,
 	isNamedScalarMemoryDeclarationLine,
 	type ConstantsAST,
 	type CompileOptions,
@@ -212,7 +213,7 @@ function shouldDeferNamespaceCollection(
 		return false;
 	}
 
-	return (line.referencedNamespaceIds ?? []).some(namespaceId => !namespaces[namespaceId]);
+	return hasReferencedNamespaceIds(line) && line.referencedNamespaceIds.some(namespaceId => !namespaces[namespaceId]);
 }
 
 function toNamespaceDiscoveryMemoryDeclarationLine(line: CompilerASTLine): CompilerASTLine {

--- a/packages/compiler/src/semantic/buildNamespace.ts
+++ b/packages/compiler/src/semantic/buildNamespace.ts
@@ -3,8 +3,6 @@ import {
 	GLOBAL_ALIGNMENT_BOUNDARY,
 	compilerSourceBlockInstructionByType,
 	isNamedScalarMemoryDeclarationLine,
-	isUseLine,
-	type Argument,
 	type ConstantsAST,
 	type CompileOptions,
 	type CompilationContext,
@@ -201,33 +199,6 @@ function getModuleRegionFromAst(
 	return resolveMemoryRegionName(argument.value, options.memoryRegions ?? [], regionLine);
 }
 
-function getReferencedNamespaceIdsFromArgument(argument: Argument | undefined): string[] {
-	if (!argument) {
-		return [];
-	}
-
-	if (argument.type === ArgumentType.COMPILE_TIME_EXPRESSION) {
-		return [...argument.intermoduleIds];
-	}
-
-	if (argument.type !== ArgumentType.IDENTIFIER) {
-		return [];
-	}
-
-	if (argument.scope !== 'intermodule' || !argument.targetModuleId) {
-		return [];
-	}
-	return [argument.targetModuleId];
-}
-
-function getDeferredNamespaceIds(line: CompilerASTLine): string[] {
-	if (isUseLine(line)) {
-		return [line.arguments[0].value];
-	}
-
-	return line.arguments.flatMap(argument => getReferencedNamespaceIdsFromArgument(argument));
-}
-
 function shouldDeferNamespaceCollection(
 	error: unknown,
 	line: CompilerASTLine | undefined,
@@ -241,8 +212,7 @@ function shouldDeferNamespaceCollection(
 		return false;
 	}
 
-	const referencedNamespaceIds = getDeferredNamespaceIds(line);
-	return referencedNamespaceIds.some(namespaceId => !namespaces[namespaceId]);
+	return (line.referencedNamespaceIds ?? []).some(namespaceId => !namespaces[namespaceId]);
 }
 
 function toNamespaceDiscoveryMemoryDeclarationLine(line: CompilerASTLine): CompilerASTLine {


### PR DESCRIPTION
## Summary
- replace tokenizer AST post-processing scans with source-block-specific builders for module/function/constants metadata
- keep function-level leading semantic const lines working without scanning `CompilerASTLine[]`
- add parser coverage for module, function, and constants AST metadata construction
- mark TODO 421 complete

## Validation
- `rg -n "function get.*\\(lines: readonly CompilerASTLine\\[\\]|\\.find\\(|\\.filter\\(|\\.some\\(|for \\(const .* of lines\\)" packages/compiler/packages/tokenizer/src/parser.ts`
- `rg -n "ModuleCompilationAST|CompilerASTGroup|compileToASTGroup" packages/compiler-spec/src packages/compiler/src packages/compiler/packages/tokenizer/src -g '*.ts'`
- `rg -n "ast\\.lines\\.find|ast\\.lines\\.filter|ast\\.lines\\.some" packages/compiler/src packages/compiler-spec/src -g '*.ts'`
- `git diff --check`
- `npx nx run @8f4e/tokenizer:typecheck`
- `npx nx run compiler:typecheck`
- `npx nx run @8f4e/tokenizer:test`
- `npx nx run compiler:test`
- `npx nx run-many --target=typecheck --all`
