### PR TITLE
feat(compiler): add pointer-aware metadata queries

### DIFF
--- a/docs/todos/427-add-depth-aware-pointer-metadata-query-dereferencing.md
+++ b/docs/todos/427-add-depth-aware-pointer-metadata-query-dereferencing.md
@@ -100,8 +100,8 @@ Expected semantics:
 
 ## Related Items
 
-- **Related**: `docs/todos/323-add-pointee-min-value-prefix-for-pointers.md`
-- **Related**: `docs/todos/428-add-pointer-aware-count-and-min-metadata-queries.md`
+- **Related**: `docs/todos/archived/323-add-pointee-min-value-prefix-for-pointers.md`
+- **Related**: `docs/todos/archived/428-add-pointer-aware-count-and-min-metadata-queries.md`
 
 ## Notes
 

--- a/docs/todos/429-unify-metadata-query-argument-shape.md
+++ b/docs/todos/429-unify-metadata-query-argument-shape.md
@@ -1,0 +1,113 @@
+---
+title: 'TODO: Unify metadata query argument shape'
+priority: Medium
+effort: 2-4h
+created: 2026-05-27
+issue: null
+status: Open
+completed: null
+---
+
+# TODO: Unify metadata query argument shape
+
+## Problem Description
+
+Metadata query parsing currently has separate argument variants and classifier branches for each helper family:
+`count(name)`, `sizeof(name)`, `max(name)`, `min(name)`, and their pointer-aware forms.
+
+Current state:
+- tokenizer code repeats the same local/intermodule/pointee branching for each query
+- compiler-spec has many reference kinds for one conceptual operation family
+- semantic resolution has matching repeated branches for each query and pointer variant
+- adding `count(*name)` and `min(*name)` required touching several parallel paths
+
+Why this is a problem:
+- duplicated branches make it easy to place logic in the wrong classifier
+- adding `**` metadata support will multiply the same shapes again
+- tests need broad snapshot churn for a small metadata query extension
+
+## Proposed Solution
+
+Replace the per-helper reference-kind explosion with one structured metadata-query argument shape.
+
+Suggested shape:
+
+```ts
+{
+	type: ArgumentType.IDENTIFIER;
+	referenceKind: 'metadata-query';
+	query: 'count' | 'sizeof' | 'max' | 'min';
+	scope: 'local' | 'intermodule';
+	targetMemoryId: string;
+	targetModuleId?: string;
+	dereferenceDepth: 0 | 1 | 2;
+}
+```
+
+The exact field names can change, but the important part is that the query kind, target, scope, and requested dereference depth are data, not separate TypeScript union variants.
+
+## Anti-Patterns
+
+- Do not add another round of query-specific variants for `**` forms.
+- Do not keep compatibility aliases for old internal reference kinds after the migration.
+- Do not parse pointer metadata queries by stripping only one leading `*`.
+- Do not leave local and intermodule metadata queries represented by unrelated shapes.
+
+## Implementation Plan
+
+### Step 1: Add the unified argument shape
+- Replace metadata-specific reference kinds in `packages/compiler-spec/src/arguments.ts`.
+- Include explicit `query` and `dereferenceDepth` fields.
+- Keep address references, plain identifiers, constants, and runtime pointer dereferences as separate concepts.
+
+### Step 2: Collapse tokenizer classification
+- Replace `classifyCountQuery`, `classifyWordSizeQuery`, `classifyMaxQuery`, and `classifyMinQuery` with one table-driven classifier.
+- Parse leading `*` count once and enforce the current `**` cap.
+- Preserve intermodule query parsing.
+
+### Step 3: Update semantic consumers
+- Update compile-time resolution and normalization to consume the unified shape.
+- Remove old per-query reference-kind branches.
+
+### Step 4: Refresh tests and docs
+- Update parser classification tests to assert the new shape.
+- Update semantic tests and snapshots.
+- Keep language docs focused on behavior, not internal reference kinds.
+
+## Validation Checkpoints
+
+- `npx nx run compiler:test -- --run packages/tokenizer/src/syntax/parseArgument.test.ts src/semantic/resolveCompileTimeArgument.test.ts`
+- `npx nx run @8f4e/compiler-spec:typecheck`
+- `npx nx run @8f4e/compiler:typecheck`
+
+## Success Criteria
+
+- [ ] Metadata queries use one compiler-spec argument variant.
+- [ ] Parser logic for `count`, `sizeof`, `max`, and `min` is table-driven or otherwise centralized.
+- [ ] Pointer metadata queries carry explicit dereference depth.
+- [ ] Old metadata reference kinds are removed.
+- [ ] Existing supported query behavior remains covered by tests.
+
+## Affected Components
+
+- `packages/compiler-spec/src/arguments.ts`
+- `packages/compiler/packages/tokenizer/src/syntax/parseArgument.ts`
+- `packages/compiler/src/semantic/resolveCompileTimeArgument.ts`
+- `packages/compiler/src/semantic/normalizeCompileTimeArguments.ts`
+- `packages/compiler/tests/instructions/`
+
+## Risks & Considerations
+
+- **Wide snapshot churn**: AST snapshots will change because query argument metadata becomes structurally different.
+- **TODO 427 overlap**: This is the clean foundation for depth-aware `**` metadata queries.
+- **No compatibility burden**: The project has not been released, so remove old internal shapes directly.
+
+## Related Items
+
+- **Related**: `docs/todos/427-add-depth-aware-pointer-metadata-query-dereferencing.md`
+- **Related**: `docs/todos/archived/428-add-pointer-aware-count-and-min-metadata-queries.md`
+- **Related**: `docs/todos/426-decide-compiler-broad-type-splitting-strategy.md`
+
+## Notes
+
+- Created after implementing `count(*name)` and `min(*name)` on 2026-05-27. The implementation worked, but the repeated classifier and resolver branches made the next metadata extension feel unnecessarily fragile.

--- a/docs/todos/430-nest-pointer-metadata-shape.md
+++ b/docs/todos/430-nest-pointer-metadata-shape.md
@@ -1,0 +1,114 @@
+---
+title: 'TODO: Nest pointer metadata shape'
+priority: Medium
+effort: 4-8h
+created: 2026-05-27
+issue: null
+status: Open
+completed: null
+---
+
+# TODO: Nest pointer metadata shape
+
+## Problem Description
+
+Pointer facts are currently represented by scattered optional fields across multiple compiler-spec types.
+
+Current state:
+- `DataStructure` uses fields such as `pointeeBaseType`, `pointerDepth`, `pointeeMemoryIndex`, `pointeeMemoryRegionName`, and `pointeeElementCount`
+- `PointerLocalBinding` repeats a similar set of fields
+- `StackAddress.pointsTo` represents similar facts with different names such as `baseType`, `memoryIndex`, and `elementCount`
+- helper types in `memoryData.ts` use adapter unions to paper over those shape differences
+
+Why this is a problem:
+- each phase uses a slightly different vocabulary for the same pointer facts
+- adding new pointer metadata requires updating several optional-field lists
+- optional fields obscure which facts exist for all pointers and which are provenance-only
+
+## Proposed Solution
+
+Introduce a shared nested pointer metadata shape and use it consistently across memory, locals, and stack address metadata.
+
+Possible shape:
+
+```ts
+interface PointerMetadata {
+	depth: 1 | 2;
+	pointeeType: BaseTypeMetadataKey;
+	pointee?: PointerPointeeMetadata;
+}
+
+interface PointerPointeeMetadata {
+	memoryIndex: number;
+	memoryRegionName?: string;
+	elementCount?: number;
+	provenance: 'memory-start' | 'unknown';
+}
+```
+
+The precise names should follow compiler-spec style, but pointer facts should live under one `pointer` field instead of many top-level optional fields.
+
+## Anti-Patterns
+
+- Do not add a nested shape while leaving the old top-level pointer fields active indefinitely.
+- Do not use broad casts to bridge old and new pointer metadata.
+- Do not keep separate memory/local/stack pointer vocabularies if they can share one compiler-spec type.
+- Do not mix pointer type facts and provenance facts without naming the distinction.
+
+## Implementation Plan
+
+### Step 1: Define shared pointer metadata types
+- Add shared `PointerMetadata` and `PointerPointeeMetadata` types to `packages/compiler-spec/src/semantic.ts` or another appropriate compiler-spec file.
+- Decide whether `depth` should be a numeric literal union using the current `**` cap.
+
+### Step 2: Migrate producers
+- Update memory declaration compilers to populate `pointer`.
+- Update function param/local pointer creation to use the nested shape.
+- Update stack analysis to propagate the nested shape directly.
+
+### Step 3: Migrate consumers
+- Update `memoryData.ts`, push handlers, localSet, address guards, and stack analysis consumers.
+- Remove adapter unions and top-level pointer optional fields.
+
+### Step 4: Update tests and snapshots
+- Refresh unit tests around pointer declarations, stack analysis, and compile-time metadata.
+- Update public AST/memory map snapshots.
+
+## Validation Checkpoints
+
+- `rg -n "pointeeBaseType|pointeeMemoryIndex|pointeeMemoryRegionName|pointeeElementCount|pointsTo" packages/compiler packages/compiler-spec -g '*.ts'`
+- `npx nx run @8f4e/compiler-spec:typecheck`
+- `npx nx run @8f4e/compiler:typecheck`
+- `npx nx run compiler:test -- --run src/utils/memoryData.test.ts src/stackAnalysis/analyzeInstruction.test.ts tests/instructions/constantExpressions.test.ts`
+
+## Success Criteria
+
+- [ ] Pointer metadata lives under one nested shape.
+- [ ] `DataStructure`, pointer locals, and stack address metadata share the same pointer vocabulary.
+- [ ] Old top-level pointer optional fields are removed.
+- [ ] Pointer metadata helper code no longer needs shape-adapter unions.
+
+## Affected Components
+
+- `packages/compiler-spec/src/memory.ts`
+- `packages/compiler-spec/src/semantic.ts`
+- `packages/compiler/src/semantic/declarations/`
+- `packages/compiler/src/stackAnalysis/`
+- `packages/compiler/src/utils/memoryData.ts`
+- `packages/compiler/src/instructionCompilers/`
+
+## Risks & Considerations
+
+- **Compiler-spec blast radius**: editor/runtime tooling may consume memory-map shapes and need updates.
+- **Snapshot churn**: expected and acceptable because the project has not been released.
+- **Ordering**: best done near the metadata-query refactor so `**` support can target the final shape.
+
+## Related Items
+
+- **Related**: `docs/todos/425-split-stack-item-value-and-address.md`
+- **Related**: `docs/todos/426-decide-compiler-broad-type-splitting-strategy.md`
+- **Related**: `docs/todos/429-unify-metadata-query-argument-shape.md`
+
+## Notes
+
+- Created after adding pointer-aware `count(*name)` and `min(*name)`. The feature added one more top-level pointer metadata field, which made the existing optional-field model feel close to its limit.

--- a/docs/todos/431-separate-pointer-type-and-provenance-facts.md
+++ b/docs/todos/431-separate-pointer-type-and-provenance-facts.md
@@ -1,0 +1,117 @@
+---
+title: 'TODO: Separate pointer type and provenance facts'
+priority: Medium
+effort: 2-4h
+created: 2026-05-27
+issue: null
+status: Open
+completed: null
+---
+
+# TODO: Separate pointer type and provenance facts
+
+## Problem Description
+
+Pointer declarations combine two different kinds of information:
+
+- type facts from the declaration, such as pointer depth and pointee base type
+- provenance facts from a particular value, such as "this pointer was initialized from `&samples`"
+
+Current state:
+- `float* ptr` and `float* ptr &samples` share the same broad metadata surface
+- `count(*ptr)` needs provenance/count facts, while `sizeof(*ptr)` and `min(*ptr)` mostly need type facts
+- pointer metadata currently falls back to defaults when provenance is unknown
+- memory-start and memory-end address initializers must be interpreted carefully to avoid overstating count metadata
+
+Why this is a problem:
+- helper semantics become harder to explain when type and provenance live side by side
+- future pointer assignment/localSet behavior may accidentally preserve stale provenance
+- `count(*name)` is inherently provenance-sensitive, unlike `sizeof(*name)` or `min(*name)`
+
+## Proposed Solution
+
+Model pointer type facts and pointer provenance facts separately.
+
+Suggested split:
+
+```ts
+pointer: {
+	type: {
+		depth: 1 | 2;
+		pointeeBaseType: BaseTypeMetadataKey;
+	};
+	provenance?: {
+		source: 'memory-start';
+		memoryId: string;
+		moduleId?: string;
+		memoryIndex: number;
+		memoryRegionName?: string;
+		elementCount?: number;
+	};
+}
+```
+
+Only memory-start provenance should carry allocation-level element count unless a future range system proves a more precise subrange.
+
+## Anti-Patterns
+
+- Do not treat pointer type declarations as proof of array length.
+- Do not keep pointee count metadata after pointer arithmetic or assignment from an unknown address.
+- Do not infer whole-array count from `name&` end-address initializers.
+- Do not make `count(*name)` depend on raw pointer numeric values.
+
+## Implementation Plan
+
+### Step 1: Define semantics
+- Document which operations preserve provenance and which clear it.
+- Define current behavior for memory-start, memory-end, intermodule memory-start, locals, params, pointer arithmetic, and localSet.
+
+### Step 2: Encode provenance explicitly
+- Add a dedicated provenance field or nested shape.
+- Store memory-start element count only when the address is known to be a memory start.
+- Clear or narrow provenance when the compiler cannot prove the value still points to the same range.
+
+### Step 3: Update pointer-aware helpers
+- Make `sizeof(*name)`, `min(*name)`, and `max(*name)` use pointer type facts.
+- Make `count(*name)` use provenance facts and fall back only by explicit rule.
+
+### Step 4: Add regression tests
+- Cover `&buffer`, `buffer&`, intermodule memory starts, localSet from known and unknown addresses, and pointer arithmetic.
+
+## Validation Checkpoints
+
+- `npx nx run compiler:test -- --run src/semantic/resolveCompileTimeArgument.test.ts src/stackAnalysis/analyzeInstruction.test.ts tests/instructions/constantExpressions.test.ts`
+- `npx nx run @8f4e/compiler:typecheck`
+- `rg -n "pointeeElementCount|safeRange|clampRange|localSet|pointsTo" packages/compiler packages/compiler-spec -g '*.ts'`
+
+## Success Criteria
+
+- [ ] Pointer type facts and provenance facts are represented separately.
+- [ ] `count(*name)` only uses explicit provenance/count metadata.
+- [ ] Pointer operations clearly preserve, narrow, or clear provenance.
+- [ ] Tests cover memory-start versus memory-end pointer initialization.
+
+## Affected Components
+
+- `packages/compiler-spec/src/semantic.ts`
+- `packages/compiler-spec/src/memory.ts`
+- `packages/compiler/src/semantic/declarations/createDeclarationCompiler.ts`
+- `packages/compiler/src/stackAnalysis/analyzeInstruction.ts`
+- `packages/compiler/src/instructionCompilers/localSet.ts`
+- `packages/compiler/src/utils/memoryData.ts`
+
+## Risks & Considerations
+
+- **Semantic precision**: This may reveal places where the compiler currently carries provenance too optimistically.
+- **Local mutation**: Pointer locals can change values, so provenance updates must follow assignments.
+- **TODO 430 overlap**: This is easier if pointer metadata is nested first, but it can also guide that nested shape.
+
+## Related Items
+
+- **Related**: `docs/todos/430-nest-pointer-metadata-shape.md`
+- **Related**: `docs/todos/archived/428-add-pointer-aware-count-and-min-metadata-queries.md`
+- **Related**: `docs/todos/425-split-stack-item-value-and-address.md`
+
+## Notes
+
+- Created after adding `count(*name)`. Count made the type/provenance split visible because pointer type alone does not imply a reachable element count.

--- a/docs/todos/432-centralize-compile-time-metadata-query-resolution.md
+++ b/docs/todos/432-centralize-compile-time-metadata-query-resolution.md
@@ -1,0 +1,104 @@
+---
+title: 'TODO: Centralize compile-time metadata query resolution'
+priority: Medium
+effort: 2-4h
+created: 2026-05-27
+issue: null
+status: Open
+completed: null
+---
+
+# TODO: Centralize compile-time metadata query resolution
+
+## Problem Description
+
+Compile-time metadata query resolution is currently implemented as many sequential branches in
+`resolveCompileTimeArgument.ts`.
+
+Current state:
+- local and intermodule `count`, `sizeof`, `max`, and `min` branches repeat target lookup logic
+- pointer-aware query branches repeat memory/local pointer lookup logic
+- each new helper requires edits in multiple nearby branches
+- unresolved target behavior is implicit in repeated `return undefined` paths
+
+Why this is a problem:
+- behavior is harder to audit as helper count grows
+- adding depth-aware `**` support will need the same lookup and validation logic again
+- pointer locals and pointer memory declarations can drift if handled in separate branches
+
+## Proposed Solution
+
+Split metadata resolution into two phases:
+
+1. Resolve the metadata target into a common `ResolvedMetadataTarget`.
+2. Evaluate a query kind against that target.
+
+Example:
+
+```ts
+type ResolvedMetadataTarget =
+	| { kind: 'memory'; memory: DataStructure; memoryMap: MemoryMap }
+	| { kind: 'pointer'; pointer: PointerMetadata };
+```
+
+Then `count`, `sizeof`, `max`, and `min` become small query evaluators rather than large parser-shape branches.
+
+## Anti-Patterns
+
+- Do not keep query evaluation interleaved with target lookup.
+- Do not add more sequential `if (operand.referenceKind === ...)` branches for each new pointer helper.
+- Do not let memory-backed and local-backed pointer helpers use separate semantic rules.
+- Do not return `undefined` for known targets with invalid dereference depth once TODO 427 is implemented.
+
+## Implementation Plan
+
+### Step 1: Extract target resolution
+- Add a helper that resolves local memory, intermodule memory, local pointer, and pointer memory targets.
+- Make unresolved identifiers explicit at the call site.
+
+### Step 2: Extract query evaluation
+- Add small evaluators for `count`, `sizeof`, `max`, and `min`.
+- Route pointer and non-pointer cases through shared metadata helper functions.
+
+### Step 3: Add depth and validation hooks
+- Accept requested dereference depth from the parsed argument shape.
+- Validate excessive pointer depth consistently.
+
+### Step 4: Simplify tests
+- Keep behavior tests, but add focused unit tests for target resolution and query evaluation if useful.
+
+## Validation Checkpoints
+
+- `npx nx run compiler:test -- --run src/semantic/resolveCompileTimeArgument.test.ts src/utils/memoryData.test.ts tests/instructions/constantExpressions.test.ts`
+- `npx nx run @8f4e/compiler:typecheck`
+- `rg -n "referenceKind === '.*element|pointee-element|intermodular-element" packages/compiler/src/semantic/resolveCompileTimeArgument.ts`
+
+## Success Criteria
+
+- [ ] Metadata target lookup is centralized.
+- [ ] Query evaluation is centralized by query kind.
+- [ ] Memory-backed and local-backed pointer metadata use the same rules.
+- [ ] TODO 427 can add `**` support without duplicating resolver branches.
+
+## Affected Components
+
+- `packages/compiler/src/semantic/resolveCompileTimeArgument.ts`
+- `packages/compiler/src/utils/memoryData.ts`
+- `packages/compiler-spec/src/arguments.ts`
+- `packages/compiler/src/semantic/resolveCompileTimeArgument.test.ts`
+
+## Risks & Considerations
+
+- **Ordering**: This pairs naturally with TODO 429. Doing both together may reduce churn.
+- **Error behavior**: Moving from `undefined` to explicit errors for known-invalid pointer depth should follow the compiler error-domain guidance.
+- **Test churn**: Expected if the parsed argument shape changes first.
+
+## Related Items
+
+- **Related**: `docs/todos/429-unify-metadata-query-argument-shape.md`
+- **Related**: `docs/todos/427-add-depth-aware-pointer-metadata-query-dereferencing.md`
+- **Related**: `docs/todos/archived/428-add-pointer-aware-count-and-min-metadata-queries.md`
+
+## Notes
+
+- Created after reviewing the `count(*name)` and `min(*name)` implementation. The feature is small, but the resolver code grew by another set of parallel branches.

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -43,7 +43,6 @@ Active todo files are listed below.
 | 315 | Optimize global editor directive recomputation | 🟡 | 3-6h | 2026-03-16 | The global editor directives effect currently rescans every code block whenever: |
 | 320 | Add `&*name` pointee start address prefix for pointers | 🟡 | 2-4h | 2026-03-26 | 8f4e already supports `&name` to push the start byte address of a memory item and `*name` to dereference a pointer. However, there is no compile-time identifier form for "start... |
 | 321 | Add `*name&` pointee end address suffix for pointers | 🟡 | 2-4h | 2026-03-26 | 8f4e supports `name&` to push the start byte address of the last word-aligned chunk covering a memory item. That gives users an address-oriented way to reference the end of an a... |
-| 323 | Add `min(*name)` pointee min value prefix for pointers | 🟡 | 2-4h | 2026-03-26 | 8f4e already supports `min(name)` to push the minimum finite value for the element type of a memory item. For pointer-typed memory items, that currently reflects the pointer sto... |
 | 376 | Add ASCII scene renderer for editor snapshot tests | 🟡 | 1-2d | 2026-04-08 | The editor currently has strong unit coverage for directive parsing, layout derivation, and individual widget geometry, but it does not have a cheap whole-scene regression layer... |
 | 377 | Batch-parse modules and validate shared ids | 🟡 | 4-8h | 2026-04-08 | The compiler currently parses each module independently by mapping `compileToAST(...)` over the module list in `packages/compiler/src/index.ts`. |
 | 378 | Make parser stateful for block pairing and owning block context | 🟡 | 4-8h | 2026-04-08 | The tokenizer/parser already owns some cross-line structural syntax concerns such as `if` pairing and block-closure validation, but that statefulness is still too narrow in two... |
@@ -64,7 +63,10 @@ Active todo files are listed below.
 | 425 | Split StackItem into value and address variants | 🟡 | 1-2d | 2026-05-26 | Replace the broad optional-field `StackItem` shape with a discriminated `value | address` union so memory codegen can use narrowed address metadata without optional-chain fallbacks. |
 | 426 | Decide compiler broad type splitting strategy | 🟡 | 2-4h | 2026-05-26 | Decide migration boundaries for broad compiler-spec shapes such as `DataStructure`, `LocalBinding`, `CompilationContext`, `MapBlockState`, `CollectedNamespace`, and address-bearing constants before implementing more type splits. |
 | 427 | Add depth-aware pointer metadata query dereferencing | 🟡 | 2-4h | 2026-05-27 | `sizeof(**ptr)` and `max(**ptr)` should carry explicit dereference depth and resolve against double-pointer metadata instead of targeting a literal `*ptr` identifier. |
-| 428 | Add pointer-aware count and min metadata queries | 🟡 | 2-4h | 2026-05-27 | `min(*ptr)` and `count(*ptr)` currently classify as plain metadata queries against target `*ptr`; define and implement explicit pointer-aware behavior. |
+| 429 | Unify metadata query argument shape | 🟡 | 2-4h | 2026-05-27 | Replace per-helper metadata query reference kinds with one structured query shape carrying query kind, target scope, and dereference depth. |
+| 430 | Nest pointer metadata shape | 🟡 | 4-8h | 2026-05-27 | Move scattered pointer fields into a shared nested pointer metadata shape used consistently by memory, locals, and stack address metadata. |
+| 431 | Separate pointer type and provenance facts | 🟡 | 2-4h | 2026-05-27 | Model declared pointer type facts separately from value provenance facts so helpers like `count(*ptr)` only use explicit count provenance. |
+| 432 | Centralize compile-time metadata query resolution | 🟡 | 2-4h | 2026-05-27 | Split metadata query resolution into target lookup and query evaluation so local, intermodule, and pointer helpers share one resolver path. |
 
 ### 🟢 Low Priority
 
@@ -82,6 +84,8 @@ Active todo files are listed below.
 
 | ID | Title | Completed | Notes |
 | ---- | ----- | --------- | ----- |
+| 428 | Add pointer-aware count and min metadata queries | 2026-05-27 | `min(*ptr)` and `count(*ptr)` now classify explicitly and resolve from pointer metadata; pointer count uses tracked memory-start pointee element counts when available and falls back to `1`. |
+| 323 | Add `min(*name)` pointee min value prefix for pointers | 2026-05-27 | Completed as part of pointer-aware metadata query work; `min(*name)` now has parser, semantic, helper, docs, and public compiler coverage. |
 | 423 | Narrow AST line metadata interfaces | 2026-05-26 | `ASTLineBase` now only carries core line identity; memory, semantic, directive, and block metadata live on concrete line interfaces, and snapshots were updated to show the narrower public AST shape. |
 | 410 | Consolidate release action commits | 2026-05-19 | Release workflow now uses the two-commit fallback: Nx keeps the version commit, and bundle-size, bytecode-size, compiler-coverage, and docs-coverage logs are committed together as release metrics before the atomic tag push. |
 | 409 | Track block context flags during stack analysis | 2026-05-19 | Stack analysis now carries cached block-context flags, `validateInstruction` reads them directly, and shared block-stack helpers maintain the flags with focused test coverage. |

--- a/docs/todos/archived/323-add-pointee-min-value-prefix-for-pointers.md
+++ b/docs/todos/archived/323-add-pointee-min-value-prefix-for-pointers.md
@@ -4,8 +4,8 @@ priority: Medium
 effort: 2-4h
 created: 2026-03-26
 issue: https://github.com/andorthehood/8f4e/issues/449
-status: Open
-completed: null
+status: Completed
+completed: 2026-05-27
 ---
 
 # TODO: Add `min(*name)` pointee min value prefix for pointers
@@ -100,3 +100,4 @@ Expected semantics with current type system:
 
 - This TODO assumes pointee numeric-range metadata can be derived entirely from the declared pointer type.
 - If typed narrow pointers are added later, `min(*name)` should follow the narrowed pointee type.
+- Completed on 2026-05-27 as part of TODO 428. `min(*name)` now has explicit parser, semantic, helper, docs, and public compiler coverage.

--- a/docs/todos/archived/324-add-int16-pointer-types-to-compiler-and-runtime.md
+++ b/docs/todos/archived/324-add-int16-pointer-types-to-compiler-and-runtime.md
@@ -91,7 +91,7 @@ Follow-up work can add richer pointer-to-buffer metadata later if the language n
 
 - **Related**: `docs/todos/archived/319-add-pointee-element-word-size-prefix-for-pointers.md`
 - **Related**: `docs/todos/archived/322-add-pointee-max-value-prefix-for-pointers.md`
-- **Related**: `docs/todos/323-add-pointee-min-value-prefix-for-pointers.md`
+- **Related**: `docs/todos/archived/323-add-pointee-min-value-prefix-for-pointers.md`
 
 ## Notes
 

--- a/docs/todos/archived/428-add-pointer-aware-count-and-min-metadata-queries.md
+++ b/docs/todos/archived/428-add-pointer-aware-count-and-min-metadata-queries.md
@@ -4,8 +4,8 @@ priority: Medium
 effort: 2-4h
 created: 2026-05-27
 issue: null
-status: Open
-completed: null
+status: Completed
+completed: 2026-05-27
 ---
 
 # TODO: Add pointer-aware count and min metadata queries
@@ -94,10 +94,11 @@ For `count(*name)`, choose one of these behaviors and document it:
 
 ## Related Items
 
-- **Related**: `docs/todos/323-add-pointee-min-value-prefix-for-pointers.md`
+- **Related**: `docs/todos/archived/323-add-pointee-min-value-prefix-for-pointers.md`
 - **Related**: `docs/todos/427-add-depth-aware-pointer-metadata-query-dereferencing.md`
 
 ## Notes
 
-- Created after reviewing helper behavior on 2026-05-27. `min(*ptr)` and `count(*ptr)` currently classify
-  as plain metadata queries against target `*ptr`, which is almost certainly not the intended long-term UX.
+- Created after reviewing helper behavior on 2026-05-27. At creation time, `min(*ptr)` and `count(*ptr)` classified
+  as plain metadata queries against target `*ptr`, which was almost certainly not the intended long-term UX.
+- Completed on 2026-05-27. Single-dereference `min(*ptr)` and `count(*ptr)` now classify explicitly and resolve from pointer metadata; `count(*ptr)` uses tracked memory-start pointee element counts when available and falls back to `1` for pointer values without count provenance.

--- a/packages/compiler-spec/src/arguments.ts
+++ b/packages/compiler-spec/src/arguments.ts
@@ -20,8 +20,10 @@ export type ReferenceKind =
 	| 'element-word-size'
 	| 'element-max'
 	| 'element-min'
+	| 'pointee-element-count'
 	| 'pointee-element-word-size'
 	| 'pointee-element-max'
+	| 'pointee-element-min'
 	| 'intermodular-reference'
 	| 'intermodular-module-reference'
 	| 'intermodular-module-nth-reference'
@@ -65,11 +67,19 @@ type ElementMaxIdentifier = IdentifierBase<'element-max', 'local'> & {
 type ElementMinIdentifier = IdentifierBase<'element-min', 'local'> & {
 	targetMemoryId: string;
 };
+type PointeeElementCountIdentifier = IdentifierBase<'pointee-element-count', 'local'> & {
+	targetMemoryId: string;
+	isPointee: true;
+};
 type PointeeElementWordSizeIdentifier = IdentifierBase<'pointee-element-word-size', 'local'> & {
 	targetMemoryId: string;
 	isPointee: true;
 };
 type PointeeElementMaxIdentifier = IdentifierBase<'pointee-element-max', 'local'> & {
+	targetMemoryId: string;
+	isPointee: true;
+};
+type PointeeElementMinIdentifier = IdentifierBase<'pointee-element-min', 'local'> & {
 	targetMemoryId: string;
 	isPointee: true;
 };
@@ -112,8 +122,10 @@ export type ArgumentIdentifier =
 	| ElementWordSizeIdentifier
 	| ElementMaxIdentifier
 	| ElementMinIdentifier
+	| PointeeElementCountIdentifier
 	| PointeeElementWordSizeIdentifier
 	| PointeeElementMaxIdentifier
+	| PointeeElementMinIdentifier
 	| IntermodularReferenceIdentifier
 	| IntermodularModuleReferenceIdentifier
 	| IntermodularModuleNthReferenceIdentifier

--- a/packages/compiler-spec/src/memory.ts
+++ b/packages/compiler-spec/src/memory.ts
@@ -155,6 +155,8 @@ export interface DataStructure {
 	pointeeMemoryIndex?: number;
 	/** Configured logical region name for this pointer's pointee memory. */
 	pointeeMemoryRegionName?: string;
+	/** Element count of the known pointee memory item, when initialized from a tracked memory address. */
+	pointeeElementCount?: number;
 	id: string;
 	/** Number of pointer layers in the declaration. Non-pointers have depth 0. */
 	pointerDepth: number;

--- a/packages/compiler-spec/src/semantic.ts
+++ b/packages/compiler-spec/src/semantic.ts
@@ -101,6 +101,7 @@ export interface PointerLocalBinding {
 	pointerDepth: number;
 	pointeeMemoryIndex?: number;
 	pointeeMemoryRegionName?: string;
+	pointeeElementCount?: number;
 	index: number;
 }
 
@@ -204,6 +205,7 @@ export interface PointeeMetadata {
 	memoryIndex: number;
 	memoryRegionName?: string;
 	pointerDepth: number;
+	elementCount?: number;
 }
 
 /** Type and value facts known about one ordinary value on the compiler analysis stack. */

--- a/packages/compiler/docs/instructions/declarations-and-locals.md
+++ b/packages/compiler/docs/instructions/declarations-and-locals.md
@@ -108,8 +108,10 @@ The pointer slot itself occupies 4 bytes (one word), identical to `int*` in allo
 
 Dereferencing with `push *name` emits a signed 8-bit load (`i32.load8_s`), which sign-extends the 8-bit value to a 32-bit integer on the stack.
 
-Pointer-aware metadata reflects the 1-byte pointee width:
+Pointer-aware metadata reflects the 1-byte pointee type and tracked pointee count:
 - `sizeof(*name)` returns `1` for `int8*` (pointee element word size)
+- `min(*name)` returns `-128` for `int8*` (pointee minimum value)
+- `count(*name)` returns the target element count when the pointer is initialized from a known memory start address, or `1` without tracked count metadata
 
 #### Examples
 
@@ -123,6 +125,8 @@ push *pptr       ; pushes the address stored in ptr
 push **pptr      ; loads a signed 8-bit value through the double pointer
 
 push sizeof(*ptr) ; 1 — pointee element word size
+push min(*ptr)    ; -128 — pointee minimum value
+push count(*ptr)  ; 64 — tracked pointee element count
 ```
 
 ### int16*
@@ -133,8 +137,10 @@ The pointer slot itself occupies 4 bytes (one word), identical to `int*` in allo
 
 Dereferencing with `push *name` emits a signed 16-bit load (`i32.load16_s`), which sign-extends the 16-bit value to a 32-bit integer on the stack.
 
-Pointer-aware metadata reflects the 2-byte pointee width:
+Pointer-aware metadata reflects the 2-byte pointee type and tracked pointee count:
 - `sizeof(*name)` returns `2` for `int16*` (pointee element word size)
+- `min(*name)` returns `-32768` for `int16*` (pointee minimum value)
+- `count(*name)` returns the target element count when the pointer is initialized from a known memory start address, or `1` without tracked count metadata
 
 #### Examples
 
@@ -148,6 +154,8 @@ push *pptr       ; pushes the address stored in ptr
 push **pptr      ; loads a signed 16-bit value through the double pointer
 
 push sizeof(*ptr) ; 2 — pointee element word size
+push min(*ptr)    ; -32768 — pointee minimum value
+push count(*ptr)  ; 64 — tracked pointee element count
 ```
 
 ### float

--- a/packages/compiler/docs/prefixes.md
+++ b/packages/compiler/docs/prefixes.md
@@ -47,13 +47,18 @@ push **pptr   ; loads target
 ## Element count
 
 - `count(name)` pushes the element count for a buffer (or 1 for scalars).
-- `count(*name)` is not supported currently.
+- `count(*name)` pushes the known element count of the value pointed to by a pointer-typed memory item when the pointer is initialized from a tracked memory start address.
+- If the pointer has no tracked pointee element count, `count(*name)` resolves to `1`. On a non-pointer memory identifier, current compiler behavior resolves `count(*name)` to `0`.
+- Metadata queries currently support one leading `*`. For double pointers, `count(*name)` describes the intermediate pointer slot. `count(**name)` is not supported yet.
 
 Example:
 
 ```
 int[] buffer 4
 push count(buffer)
+
+int* ptr &buffer
+push count(*ptr) ; 4
 ```
 
 ## Element word size
@@ -154,7 +159,10 @@ push max(*fptr)  ; 1.7976931348623157e+308  — max of the float64 it points to
 ## Element min value
 
 - `min(name)` pushes the lowest finite value (most negative) for the element type of a memory item.
-- `min(*name)` is not supported yet; it is tracked separately from the current `min(name)` form.
+- `min(*name)` pushes the lowest finite value for the type pointed to by a pointer-typed memory item.
+- On a non-pointer memory identifier, current compiler behavior resolves `min(*name)` to `0`.
+- `min(name)` keeps its existing meaning (min of the memory item's own element type).
+- Metadata queries currently support one leading `*`. For double pointers, `min(*name)` describes the intermediate pointer slot. `min(**name)` is not supported yet.
 
 For signed integers:
 - `int32` / `int` / `int[]`: -2,147,483,648
@@ -176,6 +184,10 @@ push min(buffer)
 
 int8u[] unsignedBuffer 10 0
 push min(unsignedBuffer)
+
+int8* ptr &buffer
+push min(ptr)    ; -2,147,483,648  — min of the pointer slot type (i32)
+push min(*ptr)   ; -128            — min of the int8 it points to
 ```
 
 ---
@@ -193,7 +205,7 @@ Supported operators:
 | `/`      | Division       | `SIZE/2`      |
 | `^`      | Exponentiation | `2^16`        |
 
-Each side can be a numeric literal, a constant name, or a supported metadata query such as `sizeof(name)`, `sizeof(*name)`, `count(name)`, `max(name)`, `max(*name)`, or `min(name)`.
+Each side can be a numeric literal, a constant name, or a supported metadata query such as `sizeof(name)`, `sizeof(*name)`, `count(name)`, `count(*name)`, `max(name)`, `max(*name)`, `min(name)`, or `min(*name)`.
 Exactly one operator is allowed; chained forms like `2^3^4` or `SIZE*2/4` are not valid.
 
 **Note**: `^` means exponentiation in compile-time expressions, not bitwise XOR (which is the runtime `xor` instruction).

--- a/packages/compiler/packages/tokenizer/src/syntax/parseArgument.test.ts
+++ b/packages/compiler/packages/tokenizer/src/syntax/parseArgument.test.ts
@@ -78,8 +78,10 @@ describe('classifyIdentifier – check ordering regression', () => {
 			classifyIdentifier('*buffer&'),
 			classifyIdentifier('*buffer'),
 			classifyIdentifier('**buffer'),
+			classifyIdentifier('count(*buffer)'),
 			classifyIdentifier('sizeof(*buffer)'),
 			classifyIdentifier('max(*buffer)'),
+			classifyIdentifier('min(*buffer)'),
 			classifyIdentifier('count(buffer)'),
 			classifyIdentifier('sizeof(buffer)'),
 			classifyIdentifier('max(buffer)'),
@@ -153,6 +155,14 @@ describe('classifyIdentifier – check ordering regression', () => {
 			},
 			{
 				type: ArgumentType.IDENTIFIER,
+				value: 'count(*buffer)',
+				referenceKind: 'pointee-element-count',
+				scope: 'local',
+				targetMemoryId: 'buffer',
+				isPointee: true,
+			},
+			{
+				type: ArgumentType.IDENTIFIER,
 				value: 'sizeof(*buffer)',
 				referenceKind: 'pointee-element-word-size',
 				scope: 'local',
@@ -163,6 +173,14 @@ describe('classifyIdentifier – check ordering regression', () => {
 				type: ArgumentType.IDENTIFIER,
 				value: 'max(*buffer)',
 				referenceKind: 'pointee-element-max',
+				scope: 'local',
+				targetMemoryId: 'buffer',
+				isPointee: true,
+			},
+			{
+				type: ArgumentType.IDENTIFIER,
+				value: 'min(*buffer)',
+				referenceKind: 'pointee-element-min',
 				scope: 'local',
 				targetMemoryId: 'buffer',
 				isPointee: true,
@@ -320,6 +338,8 @@ describe('parseArgument', () => {
 	it('rejects empty pointee metadata query targets', () => {
 		expect(() => parseArgument('sizeof(*)')).toThrow('Pointee metadata query target is missing');
 		expect(() => parseArgument('max(*)')).toThrow('Pointee metadata query target is missing');
+		expect(() => parseArgument('min(*)')).toThrow('Pointee metadata query target is missing');
+		expect(() => parseArgument('count(*)')).toThrow('Pointee metadata query target is missing');
 	});
 
 	it('rejects identifiers that start with numbers', () => {

--- a/packages/compiler/packages/tokenizer/src/syntax/parseArgument.ts
+++ b/packages/compiler/packages/tokenizer/src/syntax/parseArgument.ts
@@ -204,6 +204,18 @@ function classifyCountQuery(value: string): ArgumentIdentifier | null {
 		};
 	}
 
+	if (targetMemoryId.startsWith('*')) {
+		const pointeeTargetMemoryId = getPointeeQueryTarget(value, targetMemoryId);
+		return {
+			type: ArgumentType.IDENTIFIER,
+			value,
+			referenceKind: 'pointee-element-count',
+			scope: 'local',
+			targetMemoryId: pointeeTargetMemoryId,
+			isPointee: true,
+		};
+	}
+
 	return {
 		type: ArgumentType.IDENTIFIER,
 		value,
@@ -306,6 +318,18 @@ function classifyMinQuery(value: string): ArgumentIdentifier | null {
 			scope: 'intermodule',
 			targetModuleId: intermodule.targetModuleId,
 			targetMemoryId: intermodule.targetMemoryId,
+		};
+	}
+
+	if (targetMemoryId.startsWith('*')) {
+		const pointeeTargetMemoryId = getPointeeQueryTarget(value, targetMemoryId);
+		return {
+			type: ArgumentType.IDENTIFIER,
+			value,
+			referenceKind: 'pointee-element-min',
+			scope: 'local',
+			targetMemoryId: pointeeTargetMemoryId,
+			isPointee: true,
 		};
 	}
 

--- a/packages/compiler/src/semantic/declarations/createDeclarationCompiler.ts
+++ b/packages/compiler/src/semantic/declarations/createDeclarationCompiler.ts
@@ -5,7 +5,13 @@ import getMemoryFlags from '../../utils/memoryFlags';
 import { alignAbsoluteWordOffset, getAbsoluteWordOffset, getByteAddressFromWordOffset } from '../layoutAddresses';
 import { getMemoryRegionFields } from '../memoryRegions';
 
-import type { CompilationContext, MemoryDeclarationLine, MemoryType } from '@8f4e/compiler-spec';
+import type {
+	AddressMetadata,
+	CompilationContext,
+	DataStructure,
+	MemoryDeclarationLine,
+	MemoryType,
+} from '@8f4e/compiler-spec';
 
 export type MemoryDeclarationCompiler<TLine extends MemoryDeclarationLine = MemoryDeclarationLine> = (
 	line: TLine,
@@ -27,6 +33,42 @@ interface DeclarationCompilerOptions {
 	nonPointerElementWordSize: 4 | 8;
 }
 
+function getPointeeMemoryItem(
+	safeRange: NonNullable<AddressMetadata['safeRange']>,
+	context: CompilationContext
+): DataStructure | undefined {
+	const memoryId = safeRange.memoryId;
+	if (!memoryId) {
+		return undefined;
+	}
+
+	if (safeRange.moduleId) {
+		const namespace = context.namespace.namespaces[safeRange.moduleId];
+		return namespace?.kind === 'module' ? namespace.memory?.[memoryId] : undefined;
+	}
+
+	return context.namespace.memory[memoryId];
+}
+
+function getPointeeElementCount(
+	defaultAddress: AddressMetadata | undefined,
+	context: CompilationContext
+): number | undefined {
+	const safeRange = defaultAddress?.safeRange;
+	if (!safeRange || safeRange.source !== 'memory-start') {
+		return undefined;
+	}
+
+	const memoryItem = getPointeeMemoryItem(safeRange, context);
+	if (!memoryItem) {
+		return undefined;
+	}
+
+	const byteOffset = Math.max(0, safeRange.byteAddress - memoryItem.byteAddress);
+	const byteLength = memoryItem.numberOfElements * memoryItem.elementWordSize;
+	return Math.max(0, Math.floor((byteLength - byteOffset) / memoryItem.elementWordSize));
+}
+
 /**
  * Factory that produces a compiler for a scalar/pointer memory
  * declaration instruction (int, int8, int16, float, float64 and their pointer
@@ -46,11 +88,13 @@ export default function createDeclarationCompiler(options: DeclarationCompilerOp
 		const memoryIndex = context.currentMemoryIndex;
 		const memoryRegionName = context.currentMemoryRegionName;
 		const memoryRegionFields = getMemoryRegionFields(memoryIndex, memoryRegionName);
+		const pointeeElementCount = getPointeeElementCount(defaultAddress, context);
 		const pointerPointeeRegion =
 			pointerDepth > 0
 				? {
 						pointeeMemoryIndex: defaultAddress?.memoryIndex ?? 0,
 						...(defaultAddress?.memoryRegionName ? { pointeeMemoryRegionName: defaultAddress.memoryRegionName } : {}),
+						...(pointeeElementCount !== undefined && pointeeElementCount !== 1 ? { pointeeElementCount } : {}),
 					}
 				: {};
 

--- a/packages/compiler/src/semantic/resolveCompileTimeArgument.test.ts
+++ b/packages/compiler/src/semantic/resolveCompileTimeArgument.test.ts
@@ -35,6 +35,7 @@ describe('tryResolveCompileTimeArgument', () => {
 					isInteger: true,
 					pointeeBaseType: 'float',
 					pointerDepth: 1,
+					pointeeElementCount: 4,
 				},
 			},
 			namespaces: {},
@@ -115,12 +116,20 @@ describe('tryResolveCompileTimeArgument', () => {
 	});
 
 	it('resolves local memory metadata queries', () => {
+		expect(tryResolveCompileTimeArgument(mockContext, parseArgument('count(*floatPtr)'))).toEqual({
+			value: 4,
+			isInteger: true,
+		});
 		expect(tryResolveCompileTimeArgument(mockContext, parseArgument('sizeof(*floatPtr)'))).toEqual({
 			value: 4,
 			isInteger: true,
 		});
 		expect(tryResolveCompileTimeArgument(mockContext, parseArgument('max(*floatPtr)'))).toEqual({
 			value: 3.4028234663852886e38,
+			isInteger: false,
+		});
+		expect(tryResolveCompileTimeArgument(mockContext, parseArgument('min(*floatPtr)'))).toEqual({
+			value: -3.4028234663852886e38,
 			isInteger: false,
 		});
 		expect(tryResolveCompileTimeArgument(mockContext, parseArgument('max(samples)'))).toEqual({
@@ -140,6 +149,8 @@ describe('tryResolveCompileTimeArgument', () => {
 		expect(tryResolveCompileTimeArgument(mockContext, parseArgument('min(missing)'))).toBeUndefined();
 		expect(tryResolveCompileTimeArgument(mockContext, parseArgument('sizeof(*missing)'))).toBeUndefined();
 		expect(tryResolveCompileTimeArgument(mockContext, parseArgument('max(*missing)'))).toBeUndefined();
+		expect(tryResolveCompileTimeArgument(mockContext, parseArgument('min(*missing)'))).toBeUndefined();
+		expect(tryResolveCompileTimeArgument(mockContext, parseArgument('count(*missing)'))).toBeUndefined();
 	});
 
 	it('keeps float64 width for expression results', () => {
@@ -200,28 +211,41 @@ describe('tryResolveCompileTimeArgument', () => {
 			value: 2147483647,
 			isInteger: true,
 		});
+		expect(tryResolveCompileTimeArgument(localPointerContext, parseArgument('min(*floatPtrPtr)'))).toEqual({
+			value: -2147483648,
+			isInteger: true,
+		});
 	});
 
 	it('resolves pointee metadata from local pointer bindings', () => {
 		const localPointerContext = {
 			...mockContext,
 			locals: {
-				floatPtr: {
+				localFloatPtr: {
 					kind: 'value',
 					valueType: 'int',
 					pointeeBaseType: 'float',
 					pointerDepth: 1,
+					pointeeElementCount: 7,
 					index: 0,
 				},
 			},
 		} as unknown as CompilationContext;
 
-		expect(tryResolveCompileTimeArgument(localPointerContext, parseArgument('sizeof(*floatPtr)'))).toEqual({
+		expect(tryResolveCompileTimeArgument(localPointerContext, parseArgument('count(*localFloatPtr)'))).toEqual({
+			value: 7,
+			isInteger: true,
+		});
+		expect(tryResolveCompileTimeArgument(localPointerContext, parseArgument('sizeof(*localFloatPtr)'))).toEqual({
 			value: 4,
 			isInteger: true,
 		});
-		expect(tryResolveCompileTimeArgument(localPointerContext, parseArgument('max(*floatPtr)'))).toEqual({
+		expect(tryResolveCompileTimeArgument(localPointerContext, parseArgument('max(*localFloatPtr)'))).toEqual({
 			value: 3.4028234663852886e38,
+			isInteger: false,
+		});
+		expect(tryResolveCompileTimeArgument(localPointerContext, parseArgument('min(*localFloatPtr)'))).toEqual({
+			value: -3.4028234663852886e38,
 			isInteger: false,
 		});
 	});

--- a/packages/compiler/src/semantic/resolveCompileTimeArgument.ts
+++ b/packages/compiler/src/semantic/resolveCompileTimeArgument.ts
@@ -8,9 +8,13 @@ import {
 	getElementMaxValue,
 	getElementMinValue,
 	getElementWordSize,
+	getPointeeElementCount,
+	getPointeeElementCountFromMetadata,
 	getPointeeElementIsIntegerFromMetadata,
 	getPointeeElementMaxValue,
 	getPointeeElementMaxValueFromMetadata,
+	getPointeeElementMinValue,
+	getPointeeElementMinValueFromMetadata,
 	getPointeeElementWordSize,
 	getPointeeElementWordSizeFromMetadata,
 } from '../utils/memoryData';
@@ -194,6 +198,19 @@ function resolveCompileTimeOperand(operand: CompileTimeOperand, context: Compila
 		return undefined;
 	}
 
+	// count(*name) — known pointee element count, or 1 for pointer values without count provenance
+	if (operand.referenceKind === 'pointee-element-count') {
+		const base = operand.targetMemoryId;
+		if (Object.hasOwn(memory, base)) {
+			return { value: getPointeeElementCount(memory, base), isInteger: true };
+		}
+		const local = context.locals[base];
+		if (local?.pointeeBaseType) {
+			return { value: getPointeeElementCountFromMetadata(local), isInteger: true };
+		}
+		return undefined;
+	}
+
 	// sizeof(*name) — pointee element word size
 	if (operand.referenceKind === 'pointee-element-word-size') {
 		const base = operand.targetMemoryId;
@@ -256,6 +273,26 @@ function resolveCompileTimeOperand(operand: CompileTimeOperand, context: Compila
 			return {
 				value: getElementMaxValue(memory, base),
 				isInteger: !!memoryItem?.isInteger,
+			};
+		}
+		return undefined;
+	}
+
+	// min(*name) — pointee element min value
+	if (operand.referenceKind === 'pointee-element-min') {
+		const base = operand.targetMemoryId;
+		if (Object.hasOwn(memory, base)) {
+			const memoryItem = memory[base];
+			return {
+				value: getPointeeElementMinValue(memory, base),
+				isInteger: getPointeeElementIsIntegerFromMetadata(memoryItem),
+			};
+		}
+		const local = context.locals[base];
+		if (local?.pointeeBaseType) {
+			return {
+				value: getPointeeElementMinValueFromMetadata(local),
+				isInteger: getPointeeElementIsIntegerFromMetadata(local),
 			};
 		}
 		return undefined;

--- a/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
+++ b/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
@@ -135,6 +135,9 @@ function getPointeeMetadata(pointerMetadata: DataStructure | LocalBinding): Poin
 					? { memoryRegionName: pointerMetadata.pointeeMemoryRegionName }
 					: {}),
 				pointerDepth: getPointerDepthFromMetadata(pointerMetadata),
+				...(pointerMetadata.pointeeElementCount !== undefined
+					? { elementCount: pointerMetadata.pointeeElementCount }
+					: {}),
 			}
 		: undefined;
 }
@@ -169,6 +172,9 @@ function pushDereferencedPointerStackItems(
 						? { memoryRegionName: pointerMetadata.pointeeMemoryRegionName }
 						: {}),
 					pointerDepth: remainingPointerDepth,
+					...(pointerMetadata.pointeeElementCount !== undefined
+						? { elementCount: pointerMetadata.pointeeElementCount }
+						: {}),
 				},
 			}),
 		];

--- a/packages/compiler/src/utils/memoryData.test.ts
+++ b/packages/compiler/src/utils/memoryData.test.ts
@@ -11,8 +11,10 @@ import {
 	getElementMinValue,
 	getElementWordSize,
 	getMemoryStringLastByteAddress,
+	getPointeeElementCount,
 	getPointeeElementIsIntegerFromMetadata,
 	getPointeeElementMaxValue,
+	getPointeeElementMinValue,
 	getPointeeElementWordSize,
 	getPointeeValueKindFromMetadata,
 } from './memoryData';
@@ -77,6 +79,39 @@ describe('memoryData utilities', () => {
 
 		it('returns 0 for non-existing identifier', () => {
 			expect(getElementCount(mockMemory, 'nonExisting')).toBe(0);
+		});
+	});
+
+	describe('getPointeeElementCount', () => {
+		it('returns known pointee count for pointer metadata with count provenance', () => {
+			const memory: MemoryMap = {
+				ptr: {
+					pointeeBaseType: 'float',
+					pointerDepth: 1,
+					pointeeElementCount: 16,
+				} as unknown as MemoryMap[string],
+			};
+
+			expect(getPointeeElementCount(memory, 'ptr')).toBe(16);
+		});
+
+		it('returns 1 for pointer metadata without count provenance', () => {
+			const memory: MemoryMap = {
+				ptr: {
+					pointeeBaseType: 'float',
+					pointerDepth: 1,
+				} as unknown as MemoryMap[string],
+			};
+
+			expect(getPointeeElementCount(memory, 'ptr')).toBe(1);
+		});
+
+		it('returns 0 for non-pointer identifiers', () => {
+			const memory: MemoryMap = {
+				value: {} as unknown as MemoryMap[string],
+			};
+
+			expect(getPointeeElementCount(memory, 'value')).toBe(0);
 		});
 	});
 
@@ -549,6 +584,49 @@ describe('memoryData utilities', () => {
 
 		it('returns 0 for non-existing identifier', () => {
 			expect(getPointeeElementMaxValue(mockMemory, 'nonExisting')).toBe(0);
+		});
+	});
+
+	describe('getPointeeElementMinValue', () => {
+		it('returns min int8 value for int8* pointer', () => {
+			const memory: MemoryMap = {
+				ptr: {
+					pointeeBaseType: 'int8',
+					pointerDepth: 1,
+				} as unknown as MemoryMap[string],
+			};
+
+			expect(getPointeeElementMinValue(memory, 'ptr')).toBe(-128);
+		});
+
+		it('returns min value 0 for unsigned integer pointers', () => {
+			const memory: MemoryMap = {
+				ptr: {
+					pointeeBaseType: 'int16u',
+					pointerDepth: 1,
+				} as unknown as MemoryMap[string],
+			};
+
+			expect(getPointeeElementMinValue(memory, 'ptr')).toBe(0);
+		});
+
+		it('returns pointer-slot min value for double pointers', () => {
+			const memory: MemoryMap = {
+				ptr: {
+					pointeeBaseType: 'float64',
+					pointerDepth: 2,
+				} as unknown as MemoryMap[string],
+			};
+
+			expect(getPointeeElementMinValue(memory, 'ptr')).toBe(-2147483648);
+		});
+
+		it('returns 0 for non-pointer identifiers', () => {
+			const memory: MemoryMap = {
+				value: {} as unknown as MemoryMap[string],
+			};
+
+			expect(getPointeeElementMinValue(memory, 'value')).toBe(0);
 		});
 	});
 });

--- a/packages/compiler/src/utils/memoryData.ts
+++ b/packages/compiler/src/utils/memoryData.ts
@@ -13,13 +13,18 @@ export type PointerMetadata =
 			| 'pointerDepth'
 			| 'pointeeMemoryIndex'
 			| 'pointeeMemoryRegionName'
+			| 'pointeeElementCount'
 	  >
-	| Pick<PointerLocalBinding, 'pointeeBaseType' | 'pointerDepth' | 'pointeeMemoryIndex' | 'pointeeMemoryRegionName'>
+	| Pick<
+			PointerLocalBinding,
+			'pointeeBaseType' | 'pointerDepth' | 'pointeeMemoryIndex' | 'pointeeMemoryRegionName' | 'pointeeElementCount'
+	  >
 	| {
 			pointeeBaseType: NonNullable<StackAddress['pointsTo']>['baseType'];
 			pointerDepth: NonNullable<StackAddress['pointsTo']>['pointerDepth'];
 			pointeeMemoryIndex: NonNullable<StackAddress['pointsTo']>['memoryIndex'];
 			pointeeMemoryRegionName?: NonNullable<StackAddress['pointsTo']>['memoryRegionName'];
+			pointeeElementCount?: NonNullable<StackAddress['pointsTo']>['elementCount'];
 	  };
 
 function getDeclaredBaseTypeMetadata(memoryItem: DataStructure) {
@@ -64,6 +69,15 @@ export function getMemoryStringLastByteAddress(memoryMap: MemoryMap, id: string)
 export function getElementCount(memoryMap: MemoryMap, id: string): number {
 	const memoryItem = getDataStructure(memoryMap, id);
 	return memoryItem ? memoryItem.numberOfElements : 0;
+}
+
+export function getPointeeElementCountFromMetadata(pointerMetadata: PointerMetadata | undefined): number {
+	if (!pointerMetadata?.pointeeBaseType) return 0;
+	return pointerMetadata.pointeeElementCount ?? 1;
+}
+
+export function getPointeeElementCount(memoryMap: MemoryMap, id: string): number {
+	return getPointeeElementCountFromMetadata(getDataStructure(memoryMap, id));
 }
 
 export function getElementWordSize(memoryMap: MemoryMap, id: string): number {
@@ -136,4 +150,15 @@ export function getElementMinValue(memoryMap: MemoryMap, id: string): number {
 
 	const metadata = getDeclaredBaseTypeMetadata(memoryItem);
 	return memoryItem.isUnsigned ? (metadata.unsignedMin ?? metadata.min) : metadata.min;
+}
+
+export function getPointeeElementMinValueFromMetadata(pointerMetadata: PointerMetadata | undefined): number {
+	if (!pointerMetadata?.pointeeBaseType) return 0;
+
+	if (getPointerDepthFromMetadata(pointerMetadata) > 1) return BASE_TYPE_METADATA.pointer.min;
+	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).min;
+}
+
+export function getPointeeElementMinValue(memoryMap: MemoryMap, id: string): number {
+	return getPointeeElementMinValueFromMetadata(getDataStructure(memoryMap, id));
 }

--- a/packages/compiler/tests/instructions/__snapshots__/constantExpressions.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/constantExpressions.test.ts.snap
@@ -3859,6 +3859,515 @@ exports[`push: constant expression > if the generated AST, WAT and memory map ma
 }
 `;
 
+exports[`push: count(*end pointer) falls back to scalar pointee count > if the generated AST, WAT and memory map match the snapshot 1`] = `
+{
+  "id": "test",
+  "lines": [
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "test",
+        },
+      ],
+      "instruction": "module",
+      "lineNumberAfterMacroExpansion": 0,
+      "lineNumberBeforeMacroExpansion": 0,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "samples",
+        },
+        {
+          "isInteger": true,
+          "type": "literal",
+          "value": 8,
+        },
+      ],
+      "hasExplicitMemoryDefault": false,
+      "instruction": "float[]",
+      "lineNumberAfterMacroExpansion": 1,
+      "lineNumberBeforeMacroExpansion": 1,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "ptr",
+        },
+        {
+          "isEndAddress": true,
+          "referenceKind": "memory-reference",
+          "scope": "local",
+          "targetMemoryId": "samples",
+          "type": "identifier",
+          "value": "samples&",
+        },
+      ],
+      "hasExplicitMemoryDefault": true,
+      "instruction": "float*",
+      "lineNumberAfterMacroExpansion": 2,
+      "lineNumberBeforeMacroExpansion": 2,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "output",
+        },
+      ],
+      "hasExplicitMemoryDefault": false,
+      "instruction": "int",
+      "lineNumberAfterMacroExpansion": 3,
+      "lineNumberBeforeMacroExpansion": 3,
+    },
+    {
+      "arguments": [
+        {
+          "isEndAddress": false,
+          "referenceKind": "memory-reference",
+          "scope": "local",
+          "targetMemoryId": "output",
+          "type": "identifier",
+          "value": "&output",
+        },
+      ],
+      "instruction": "push",
+      "lineNumberAfterMacroExpansion": 4,
+      "lineNumberBeforeMacroExpansion": 4,
+    },
+    {
+      "arguments": [
+        {
+          "isPointee": true,
+          "referenceKind": "pointee-element-count",
+          "scope": "local",
+          "targetMemoryId": "ptr",
+          "type": "identifier",
+          "value": "count(*ptr)",
+        },
+      ],
+      "instruction": "push",
+      "lineNumberAfterMacroExpansion": 5,
+      "lineNumberBeforeMacroExpansion": 5,
+    },
+    {
+      "arguments": [],
+      "instruction": "store",
+      "lineNumberAfterMacroExpansion": 6,
+      "lineNumberBeforeMacroExpansion": 6,
+    },
+    {
+      "arguments": [],
+      "instruction": "moduleEnd",
+      "lineNumberAfterMacroExpansion": 7,
+      "lineNumberBeforeMacroExpansion": 7,
+    },
+  ],
+  "memoryDeclarationLines": [
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "samples",
+        },
+        {
+          "isInteger": true,
+          "type": "literal",
+          "value": 8,
+        },
+      ],
+      "hasExplicitMemoryDefault": false,
+      "instruction": "float[]",
+      "lineNumberAfterMacroExpansion": 1,
+      "lineNumberBeforeMacroExpansion": 1,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "ptr",
+        },
+        {
+          "isEndAddress": true,
+          "referenceKind": "memory-reference",
+          "scope": "local",
+          "targetMemoryId": "samples",
+          "type": "identifier",
+          "value": "samples&",
+        },
+      ],
+      "hasExplicitMemoryDefault": true,
+      "instruction": "float*",
+      "lineNumberAfterMacroExpansion": 2,
+      "lineNumberBeforeMacroExpansion": 2,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "output",
+        },
+      ],
+      "hasExplicitMemoryDefault": false,
+      "instruction": "int",
+      "lineNumberAfterMacroExpansion": 3,
+      "lineNumberBeforeMacroExpansion": 3,
+    },
+  ],
+  "moduleLine": {
+    "arguments": [
+      {
+        "referenceKind": "plain",
+        "scope": "local",
+        "type": "identifier",
+        "value": "test",
+      },
+    ],
+    "instruction": "module",
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
+  },
+  "referencedModuleIds": [],
+  "type": "module",
+}
+`;
+
+exports[`push: count(*end pointer) falls back to scalar pointee count > if the generated AST, WAT and memory map match the snapshot 2`] = `
+"(module
+  (type (;0;) (func))
+  (import "js" "memory" (memory (;0;) 1))
+  (func (;0;) (type 0)
+    i32.const 36
+    i32.const 1
+    i32.store)
+  (export "test" (func 0)))
+"
+`;
+
+exports[`push: count(*end pointer) falls back to scalar pointee count > if the generated AST, WAT and memory map match the snapshot 3`] = `
+{
+  "output": {
+    "byteAddress": 36,
+    "default": 0,
+    "elementWordSize": 4,
+    "hasExplicitDefault": false,
+    "id": "output",
+    "isInteger": true,
+    "isUnsigned": false,
+    "memoryIndex": 0,
+    "numberOfElements": 1,
+    "pointerDepth": 0,
+    "type": "int",
+    "wordAlignedAddress": 9,
+    "wordAlignedSize": 1,
+  },
+  "ptr": {
+    "byteAddress": 32,
+    "default": 28,
+    "elementWordSize": 4,
+    "hasExplicitDefault": true,
+    "id": "ptr",
+    "isInteger": true,
+    "isUnsigned": false,
+    "memoryIndex": 0,
+    "numberOfElements": 1,
+    "pointeeBaseType": "float",
+    "pointeeMemoryIndex": 0,
+    "pointerDepth": 1,
+    "type": "float*",
+    "wordAlignedAddress": 8,
+    "wordAlignedSize": 1,
+  },
+  "samples": {
+    "byteAddress": 0,
+    "default": {},
+    "elementWordSize": 4,
+    "hasExplicitDefault": false,
+    "id": "samples",
+    "isInteger": false,
+    "isUnsigned": false,
+    "memoryIndex": 0,
+    "numberOfElements": 8,
+    "pointerDepth": 0,
+    "type": "float",
+    "wordAlignedAddress": 0,
+    "wordAlignedSize": 8,
+  },
+}
+`;
+
+exports[`push: count(*pointer) resolves known pointee element count > if the generated AST, WAT and memory map match the snapshot 1`] = `
+{
+  "id": "test",
+  "lines": [
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "test",
+        },
+      ],
+      "instruction": "module",
+      "lineNumberAfterMacroExpansion": 0,
+      "lineNumberBeforeMacroExpansion": 0,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "samples",
+        },
+        {
+          "isInteger": true,
+          "type": "literal",
+          "value": 8,
+        },
+      ],
+      "hasExplicitMemoryDefault": false,
+      "instruction": "float[]",
+      "lineNumberAfterMacroExpansion": 1,
+      "lineNumberBeforeMacroExpansion": 1,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "ptr",
+        },
+        {
+          "isEndAddress": false,
+          "referenceKind": "memory-reference",
+          "scope": "local",
+          "targetMemoryId": "samples",
+          "type": "identifier",
+          "value": "&samples",
+        },
+      ],
+      "hasExplicitMemoryDefault": true,
+      "instruction": "float*",
+      "lineNumberAfterMacroExpansion": 2,
+      "lineNumberBeforeMacroExpansion": 2,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "output",
+        },
+      ],
+      "hasExplicitMemoryDefault": false,
+      "instruction": "int",
+      "lineNumberAfterMacroExpansion": 3,
+      "lineNumberBeforeMacroExpansion": 3,
+    },
+    {
+      "arguments": [
+        {
+          "isEndAddress": false,
+          "referenceKind": "memory-reference",
+          "scope": "local",
+          "targetMemoryId": "output",
+          "type": "identifier",
+          "value": "&output",
+        },
+      ],
+      "instruction": "push",
+      "lineNumberAfterMacroExpansion": 4,
+      "lineNumberBeforeMacroExpansion": 4,
+    },
+    {
+      "arguments": [
+        {
+          "isPointee": true,
+          "referenceKind": "pointee-element-count",
+          "scope": "local",
+          "targetMemoryId": "ptr",
+          "type": "identifier",
+          "value": "count(*ptr)",
+        },
+      ],
+      "instruction": "push",
+      "lineNumberAfterMacroExpansion": 5,
+      "lineNumberBeforeMacroExpansion": 5,
+    },
+    {
+      "arguments": [],
+      "instruction": "store",
+      "lineNumberAfterMacroExpansion": 6,
+      "lineNumberBeforeMacroExpansion": 6,
+    },
+    {
+      "arguments": [],
+      "instruction": "moduleEnd",
+      "lineNumberAfterMacroExpansion": 7,
+      "lineNumberBeforeMacroExpansion": 7,
+    },
+  ],
+  "memoryDeclarationLines": [
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "samples",
+        },
+        {
+          "isInteger": true,
+          "type": "literal",
+          "value": 8,
+        },
+      ],
+      "hasExplicitMemoryDefault": false,
+      "instruction": "float[]",
+      "lineNumberAfterMacroExpansion": 1,
+      "lineNumberBeforeMacroExpansion": 1,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "ptr",
+        },
+        {
+          "isEndAddress": false,
+          "referenceKind": "memory-reference",
+          "scope": "local",
+          "targetMemoryId": "samples",
+          "type": "identifier",
+          "value": "&samples",
+        },
+      ],
+      "hasExplicitMemoryDefault": true,
+      "instruction": "float*",
+      "lineNumberAfterMacroExpansion": 2,
+      "lineNumberBeforeMacroExpansion": 2,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "output",
+        },
+      ],
+      "hasExplicitMemoryDefault": false,
+      "instruction": "int",
+      "lineNumberAfterMacroExpansion": 3,
+      "lineNumberBeforeMacroExpansion": 3,
+    },
+  ],
+  "moduleLine": {
+    "arguments": [
+      {
+        "referenceKind": "plain",
+        "scope": "local",
+        "type": "identifier",
+        "value": "test",
+      },
+    ],
+    "instruction": "module",
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
+  },
+  "referencedModuleIds": [],
+  "type": "module",
+}
+`;
+
+exports[`push: count(*pointer) resolves known pointee element count > if the generated AST, WAT and memory map match the snapshot 2`] = `
+"(module
+  (type (;0;) (func))
+  (import "js" "memory" (memory (;0;) 1))
+  (func (;0;) (type 0)
+    i32.const 36
+    i32.const 8
+    i32.store)
+  (export "test" (func 0)))
+"
+`;
+
+exports[`push: count(*pointer) resolves known pointee element count > if the generated AST, WAT and memory map match the snapshot 3`] = `
+{
+  "output": {
+    "byteAddress": 36,
+    "default": 0,
+    "elementWordSize": 4,
+    "hasExplicitDefault": false,
+    "id": "output",
+    "isInteger": true,
+    "isUnsigned": false,
+    "memoryIndex": 0,
+    "numberOfElements": 1,
+    "pointerDepth": 0,
+    "type": "int",
+    "wordAlignedAddress": 9,
+    "wordAlignedSize": 1,
+  },
+  "ptr": {
+    "byteAddress": 32,
+    "default": 0,
+    "elementWordSize": 4,
+    "hasExplicitDefault": true,
+    "id": "ptr",
+    "isInteger": true,
+    "isUnsigned": false,
+    "memoryIndex": 0,
+    "numberOfElements": 1,
+    "pointeeBaseType": "float",
+    "pointeeElementCount": 8,
+    "pointeeMemoryIndex": 0,
+    "pointerDepth": 1,
+    "type": "float*",
+    "wordAlignedAddress": 8,
+    "wordAlignedSize": 1,
+  },
+  "samples": {
+    "byteAddress": 0,
+    "default": {},
+    "elementWordSize": 4,
+    "hasExplicitDefault": false,
+    "id": "samples",
+    "isInteger": false,
+    "isUnsigned": false,
+    "memoryIndex": 0,
+    "numberOfElements": 8,
+    "pointerDepth": 0,
+    "type": "float",
+    "wordAlignedAddress": 0,
+    "wordAlignedSize": 8,
+  },
+}
+`;
+
 exports[`push: literal * constant (literal on lhs) > if the generated AST, WAT and memory map match the snapshot 1`] = `
 {
   "id": "test",
@@ -4387,6 +4896,261 @@ exports[`push: literal ^ constant expression > if the generated AST, WAT and mem
     "numberOfElements": 1,
     "pointerDepth": 0,
     "type": "int",
+    "wordAlignedAddress": 0,
+    "wordAlignedSize": 1,
+  },
+}
+`;
+
+exports[`push: min(*pointer) resolves pointee min value > if the generated AST, WAT and memory map match the snapshot 1`] = `
+{
+  "id": "test",
+  "lines": [
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "test",
+        },
+      ],
+      "instruction": "module",
+      "lineNumberAfterMacroExpansion": 0,
+      "lineNumberBeforeMacroExpansion": 0,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "samples",
+        },
+        {
+          "isInteger": true,
+          "type": "literal",
+          "value": 4,
+        },
+      ],
+      "hasExplicitMemoryDefault": false,
+      "instruction": "int8[]",
+      "lineNumberAfterMacroExpansion": 1,
+      "lineNumberBeforeMacroExpansion": 1,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "ptr",
+        },
+        {
+          "isEndAddress": false,
+          "referenceKind": "memory-reference",
+          "scope": "local",
+          "targetMemoryId": "samples",
+          "type": "identifier",
+          "value": "&samples",
+        },
+      ],
+      "hasExplicitMemoryDefault": true,
+      "instruction": "int8*",
+      "lineNumberAfterMacroExpansion": 2,
+      "lineNumberBeforeMacroExpansion": 2,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "output",
+        },
+      ],
+      "hasExplicitMemoryDefault": false,
+      "instruction": "int",
+      "lineNumberAfterMacroExpansion": 3,
+      "lineNumberBeforeMacroExpansion": 3,
+    },
+    {
+      "arguments": [
+        {
+          "isEndAddress": false,
+          "referenceKind": "memory-reference",
+          "scope": "local",
+          "targetMemoryId": "output",
+          "type": "identifier",
+          "value": "&output",
+        },
+      ],
+      "instruction": "push",
+      "lineNumberAfterMacroExpansion": 4,
+      "lineNumberBeforeMacroExpansion": 4,
+    },
+    {
+      "arguments": [
+        {
+          "isPointee": true,
+          "referenceKind": "pointee-element-min",
+          "scope": "local",
+          "targetMemoryId": "ptr",
+          "type": "identifier",
+          "value": "min(*ptr)",
+        },
+      ],
+      "instruction": "push",
+      "lineNumberAfterMacroExpansion": 5,
+      "lineNumberBeforeMacroExpansion": 5,
+    },
+    {
+      "arguments": [],
+      "instruction": "store",
+      "lineNumberAfterMacroExpansion": 6,
+      "lineNumberBeforeMacroExpansion": 6,
+    },
+    {
+      "arguments": [],
+      "instruction": "moduleEnd",
+      "lineNumberAfterMacroExpansion": 7,
+      "lineNumberBeforeMacroExpansion": 7,
+    },
+  ],
+  "memoryDeclarationLines": [
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "samples",
+        },
+        {
+          "isInteger": true,
+          "type": "literal",
+          "value": 4,
+        },
+      ],
+      "hasExplicitMemoryDefault": false,
+      "instruction": "int8[]",
+      "lineNumberAfterMacroExpansion": 1,
+      "lineNumberBeforeMacroExpansion": 1,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "ptr",
+        },
+        {
+          "isEndAddress": false,
+          "referenceKind": "memory-reference",
+          "scope": "local",
+          "targetMemoryId": "samples",
+          "type": "identifier",
+          "value": "&samples",
+        },
+      ],
+      "hasExplicitMemoryDefault": true,
+      "instruction": "int8*",
+      "lineNumberAfterMacroExpansion": 2,
+      "lineNumberBeforeMacroExpansion": 2,
+    },
+    {
+      "arguments": [
+        {
+          "referenceKind": "plain",
+          "scope": "local",
+          "type": "identifier",
+          "value": "output",
+        },
+      ],
+      "hasExplicitMemoryDefault": false,
+      "instruction": "int",
+      "lineNumberAfterMacroExpansion": 3,
+      "lineNumberBeforeMacroExpansion": 3,
+    },
+  ],
+  "moduleLine": {
+    "arguments": [
+      {
+        "referenceKind": "plain",
+        "scope": "local",
+        "type": "identifier",
+        "value": "test",
+      },
+    ],
+    "instruction": "module",
+    "lineNumberAfterMacroExpansion": 0,
+    "lineNumberBeforeMacroExpansion": 0,
+  },
+  "referencedModuleIds": [],
+  "type": "module",
+}
+`;
+
+exports[`push: min(*pointer) resolves pointee min value > if the generated AST, WAT and memory map match the snapshot 2`] = `
+"(module
+  (type (;0;) (func))
+  (import "js" "memory" (memory (;0;) 1))
+  (func (;0;) (type 0)
+    i32.const 8
+    i32.const -128
+    i32.store)
+  (export "test" (func 0)))
+"
+`;
+
+exports[`push: min(*pointer) resolves pointee min value > if the generated AST, WAT and memory map match the snapshot 3`] = `
+{
+  "output": {
+    "byteAddress": 8,
+    "default": 0,
+    "elementWordSize": 4,
+    "hasExplicitDefault": false,
+    "id": "output",
+    "isInteger": true,
+    "isUnsigned": false,
+    "memoryIndex": 0,
+    "numberOfElements": 1,
+    "pointerDepth": 0,
+    "type": "int",
+    "wordAlignedAddress": 2,
+    "wordAlignedSize": 1,
+  },
+  "ptr": {
+    "byteAddress": 4,
+    "default": 0,
+    "elementWordSize": 4,
+    "hasExplicitDefault": true,
+    "id": "ptr",
+    "isInteger": true,
+    "isUnsigned": false,
+    "memoryIndex": 0,
+    "numberOfElements": 1,
+    "pointeeBaseType": "int8",
+    "pointeeElementCount": 4,
+    "pointeeMemoryIndex": 0,
+    "pointerDepth": 1,
+    "type": "int8*",
+    "wordAlignedAddress": 1,
+    "wordAlignedSize": 1,
+  },
+  "samples": {
+    "byteAddress": 0,
+    "default": {},
+    "elementWordSize": 1,
+    "hasExplicitDefault": false,
+    "id": "samples",
+    "isInteger": true,
+    "isUnsigned": false,
+    "memoryIndex": 0,
+    "numberOfElements": 4,
+    "pointerDepth": 0,
+    "type": "int8",
     "wordAlignedAddress": 0,
     "wordAlignedSize": 1,
   },

--- a/packages/compiler/tests/instructions/constantExpressions.test.ts
+++ b/packages/compiler/tests/instructions/constantExpressions.test.ts
@@ -184,6 +184,48 @@ moduleEnd
 );
 
 moduleTester(
+	'push: count(*pointer) resolves known pointee element count',
+	`module test
+float[] samples 8
+float* ptr &samples
+int output
+push &output
+push count(*ptr)
+store
+moduleEnd
+`,
+	[[{}, { output: 8 }]]
+);
+
+moduleTester(
+	'push: count(*end pointer) falls back to scalar pointee count',
+	`module test
+float[] samples 8
+float* ptr samples&
+int output
+push &output
+push count(*ptr)
+store
+moduleEnd
+`,
+	[[{}, { output: 1 }]]
+);
+
+moduleTester(
+	'push: min(*pointer) resolves pointee min value',
+	`module test
+int8[] samples 4
+int8* ptr &samples
+int output
+push &output
+push min(*ptr)
+store
+moduleEnd
+`,
+	[[{}, { output: -128 }]]
+);
+
+moduleTester(
 	'int[]: buffer size from sizeof expression',
 	`module test
 int16[] samples 4


### PR DESCRIPTION
## Summary
- add explicit tokenizer/spec/semantic support for `count(*ptr)` and `min(*ptr)` metadata queries
- track pointee element count provenance for pointers initialized from memory-start addresses, with scalar fallback behavior when provenance is unavailable
- update compiler docs, archive completed pointer metadata TODOs, and add follow-up refactor TODOs for the metadata query/pointer metadata shapes

## Validation
- `npx nx run compiler:test -- --run packages/tokenizer/src/syntax/parseArgument.test.ts src/semantic/resolveCompileTimeArgument.test.ts src/utils/memoryData.test.ts tests/instructions/constantExpressions.test.ts`
- `npx nx run @8f4e/compiler-spec:typecheck`
- `npx nx run @8f4e/compiler:typecheck`
- pre-commit hook: `npx nx run-many --target=typecheck --all`
