### PR TITLE
fix(compiler): remove stale module ordering metadata

### DIFF
--- a/packages/compiler-spec/src/ast.ts
+++ b/packages/compiler-spec/src/ast.ts
@@ -143,10 +143,6 @@ export type MemoryDeclarationArgument =
 	| ArgumentCompileTimeExpression
 	| ArgumentStringLiteral;
 
-type ReferencedModuleIdsMetadata = {
-	referencedModuleIds?: readonly string[];
-};
-
 type ExplicitMemoryDefaultMetadata = {
 	hasExplicitMemoryDefault: boolean;
 };
@@ -156,7 +152,6 @@ export type ScalarMemoryDeclarationLine = ASTLineBase<
 	[MemoryDeclarationArgument, ...MemoryDeclarationArgument[]]
 > &
 	ExplicitMemoryDefaultMetadata &
-	ReferencedModuleIdsMetadata &
 	ReferencedNamespaceIdsMetadata;
 export type NamedScalarMemoryDeclarationLine = Omit<ScalarMemoryDeclarationLine, 'arguments'> & {
 	arguments: [ArgumentIdentifier, ...MemoryDeclarationArgument[]];
@@ -166,7 +161,6 @@ export type ArrayMemoryDeclarationLine = ASTLineBase<
 	[ArgumentIdentifier, CompileTimeValueArgument, ...MemoryDeclarationArgument[]]
 > &
 	ExplicitMemoryDefaultMetadata &
-	ReferencedModuleIdsMetadata &
 	ReferencedNamespaceIdsMetadata;
 export type MemoryDeclarationLine = ScalarMemoryDeclarationLine | ArrayMemoryDeclarationLine;
 
@@ -261,7 +255,6 @@ export interface ModuleAST {
 	moduleLine: ModuleLine;
 	regionLine?: RegionLine;
 	memoryDeclarationLines: readonly MemoryDeclarationLine[];
-	referencedModuleIds: readonly string[];
 }
 
 /** Parsed AST for a function block and its resolved signature. */

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -42,12 +42,12 @@ Core compiler that transforms 8f4e source into WebAssembly plus runtime metadata
                                 |
                                 v
                   +-----------------------------+
-                  |  5. Execution ordering      |
-                  |  sortModules()              |
+                  |  5. Input-order contract    |
+                  |  caller-provided order      |
                   |                             |
-                  |  constants first, then      |
-                  |  output providers before    |
-                  |  modules using their inputs |
+                  |  module execution and       |
+                  |  memory layout preserve     |
+                  |  the incoming order         |
                   +-----------------------------+
                                 |
                                 v
@@ -118,7 +118,7 @@ Short version:
 source
   -> macros
   -> AST
-  -> execution order for module data flow
+  -> caller-provided module order
   -> namespace + memory layout
   -> semantic normalization + validation
   -> instruction codegen

--- a/packages/compiler/packages/tokenizer/src/parser.test.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.test.ts
@@ -185,9 +185,7 @@ describe('compileToAST', () => {
 			throw new Error('Expected module AST');
 		}
 		expect(ast.memoryDeclarationLines.map(line => line.arguments[0].value)).toEqual(['counter', 'sourceStart']);
-		expect(ast.memoryDeclarationLines[1].referencedModuleIds).toEqual(['source']);
 		expect(ast.memoryDeclarationLines[1].referencedNamespaceIds).toEqual(['source']);
-		expect(ast.referencedModuleIds).toEqual(['source']);
 	});
 
 	it('constructs function metadata from the source-block parse path', () => {

--- a/packages/compiler/packages/tokenizer/src/parser.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.ts
@@ -80,7 +80,6 @@ type ModuleASTBuilder = {
 	moduleLine: ModuleLine;
 	regionLine?: RegionLine;
 	memoryDeclarationLines: MemoryDeclarationLine[];
-	referencedModuleIds: Set<string>;
 };
 
 type FunctionASTBuilder = {
@@ -192,7 +191,6 @@ function createSourceBlockASTBuilder(line: CompilerASTLine): SourceBlockASTBuild
 				id: line.arguments[0].value,
 				moduleLine: line,
 				memoryDeclarationLines: [],
-				referencedModuleIds: new Set<string>(),
 			};
 		case 'function':
 			return {
@@ -224,9 +222,6 @@ function applyModuleASTLine(builder: ModuleASTBuilder, line: CompilerASTLine): v
 	}
 
 	builder.memoryDeclarationLines.push(line);
-	for (const moduleId of line.referencedModuleIds ?? []) {
-		builder.referencedModuleIds.add(moduleId);
-	}
 }
 
 function applyFunctionASTLine(builder: FunctionASTBuilder, line: CompilerASTLine): void {
@@ -266,7 +261,6 @@ function createASTFromBuilder(lines: CompilerASTLines, builder: SourceBlockASTBu
 				moduleLine: builder.moduleLine,
 				...(builder.regionLine ? { regionLine: builder.regionLine } : {}),
 				memoryDeclarationLines: builder.memoryDeclarationLines,
-				referencedModuleIds: [...builder.referencedModuleIds],
 			};
 		case 'function':
 			if (!builder.functionEndLine) {
@@ -398,9 +392,6 @@ export function parseLine(
 		if (isMemoryDeclarationLine(parsedLine)) {
 			const memoryLine: MemoryDeclarationLine = parsedLine;
 			memoryLine.hasExplicitMemoryDefault = hasExplicitMemoryDefault(instruction, parsedArguments);
-			if (referencedNamespaceIds.size > 0) {
-				memoryLine.referencedModuleIds = [...referencedNamespaceIds];
-			}
 		}
 
 		return parsedLine;

--- a/packages/compiler/packages/tokenizer/src/syntax/isIntermodularReferencePattern.ts
+++ b/packages/compiler/packages/tokenizer/src/syntax/isIntermodularReferencePattern.ts
@@ -1,7 +1,7 @@
 /**
  * Tests if a string matches the intermodular reference pattern.
  * This regex is used for detecting inter-module references in AST arguments
- * during compilation and dependency sorting.
+ * during compilation.
  *
  * Valid patterns:
  * - &module:memory (start address reference)

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/audio_audioBuffer_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/audio_audioBuffer_8f4e.snap
@@ -1354,10 +1354,7 @@
     "referencedNamespaceIds": [
       "phaseAccumulator"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "phaseAccumulator"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 162,

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/digital_bistableMultivibrators_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/digital_bistableMultivibrators_8f4e.snap
@@ -183,10 +183,7 @@
     "referencedNamespaceIds": [
       "norGate"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "norGate"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 56,
@@ -226,10 +223,7 @@
     "referencedNamespaceIds": [
       "setButton"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "setButton"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 61,
@@ -407,10 +401,7 @@
     "referencedNamespaceIds": [
       "norGate2"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "norGate2"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 81,
@@ -450,10 +441,7 @@
     "referencedNamespaceIds": [
       "resetButton"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "resetButton"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 86,
@@ -631,10 +619,7 @@
     "referencedNamespaceIds": [
       "norGate"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "norGate"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 105,
@@ -946,10 +931,7 @@
     "referencedNamespaceIds": [
       "buttons"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "buttons"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 151,
@@ -1120,10 +1102,7 @@
     "referencedNamespaceIds": [
       "andGate"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "andGate"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 171,
@@ -1163,10 +1142,7 @@
     "referencedNamespaceIds": [
       "buttons"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "buttons"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 175,
@@ -1344,10 +1320,7 @@
     "referencedNamespaceIds": [
       "orGate"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "orGate"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 195,
@@ -1387,10 +1360,7 @@
     "referencedNamespaceIds": [
       "negate"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "negate"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 199,
@@ -1568,10 +1538,7 @@
     "referencedNamespaceIds": [
       "andGate"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "andGate"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 218,

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/machine-learning_xorProblem_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/machine-learning_xorProblem_8f4e.snap
@@ -116,10 +116,7 @@
     "referencedNamespaceIds": [
       "activationFn3"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "activationFn3"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 32,
@@ -240,10 +237,7 @@
     "referencedNamespaceIds": [
       "switches"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "switches"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 61,
@@ -269,10 +263,7 @@
     "referencedNamespaceIds": [
       "switches"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "switches"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 62,
@@ -499,10 +490,7 @@
     "referencedNamespaceIds": [
       "switches"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "switches"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 87,
@@ -528,10 +516,7 @@
     "referencedNamespaceIds": [
       "switches"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "switches"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 88,
@@ -758,10 +743,7 @@
     "referencedNamespaceIds": [
       "perceptron"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "perceptron"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 112,
@@ -869,10 +851,7 @@
     "referencedNamespaceIds": [
       "perceptron2"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "perceptron2"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 125,
@@ -1087,10 +1066,7 @@
     "referencedNamespaceIds": [
       "activationFn"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "activationFn"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 155,
@@ -1116,10 +1092,7 @@
     "referencedNamespaceIds": [
       "activationFn2"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "activationFn2"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 156,
@@ -1346,10 +1319,7 @@
     "referencedNamespaceIds": [
       "perceptron3"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "perceptron3"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 180,

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/visuals_dancingWithTheSineLT_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/visuals_dancingWithTheSineLT_8f4e.snap
@@ -4999,10 +4999,7 @@
     "referencedNamespaceIds": [
       "sineLT"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "sineLT"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 288,
@@ -5028,10 +5025,7 @@
     "referencedNamespaceIds": [
       "sineLT"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "sineLT"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 289,
@@ -5057,10 +5051,7 @@
     "referencedNamespaceIds": [
       "sineLT"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "sineLT"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 290,
@@ -5318,10 +5309,7 @@
     "referencedNamespaceIds": [
       "sineLT"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "sineLT"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 321,
@@ -5347,10 +5335,7 @@
     "referencedNamespaceIds": [
       "sineLT"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "sineLT"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 322,
@@ -5376,10 +5361,7 @@
     "referencedNamespaceIds": [
       "sineLT"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "sineLT"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 323,
@@ -5637,10 +5619,7 @@
     "referencedNamespaceIds": [
       "sineLT"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "sineLT"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 355,
@@ -5666,10 +5645,7 @@
     "referencedNamespaceIds": [
       "sineLT"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "sineLT"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 356,
@@ -5695,10 +5671,7 @@
     "referencedNamespaceIds": [
       "sineLT"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "sineLT"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 357,
@@ -5956,10 +5929,7 @@
     "referencedNamespaceIds": [
       "sineLT"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "sineLT"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 389,
@@ -5985,10 +5955,7 @@
     "referencedNamespaceIds": [
       "sineLT"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "sineLT"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 390,
@@ -6014,10 +5981,7 @@
     "referencedNamespaceIds": [
       "sineLT"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "sineLT"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 391,
@@ -6043,10 +6007,7 @@
     "referencedNamespaceIds": [
       "dancer1"
     ],
-    "hasExplicitMemoryDefault": true,
-    "referencedModuleIds": [
-      "dancer1"
-    ]
+    "hasExplicitMemoryDefault": true
   },
   {
     "lineNumberBeforeMacroExpansion": 393,

--- a/packages/compiler/tests/__snapshots__/compileModules.test.ts.snap
+++ b/packages/compiler/tests/__snapshots__/compileModules.test.ts.snap
@@ -374,7 +374,6 @@ exports[`compiler > compileModules 1`] = `
         "lineNumberAfterMacroExpansion": 1,
         "lineNumberBeforeMacroExpansion": 1,
       },
-      "referencedModuleIds": [],
       "type": "module",
     },
     "byteAddress": 0,

--- a/packages/compiler/tests/__snapshots__/loopCap.test.ts.snap
+++ b/packages/compiler/tests/__snapshots__/loopCap.test.ts.snap
@@ -144,7 +144,6 @@ exports[`#loopCap changes the default cap for subsequent loops > if the generate
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -339,7 +338,6 @@ exports[`loop cap of 0 causes loop to exit immediately on first guard check > if
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -547,7 +545,6 @@ exports[`loop with explicit cap argument overrides #loopCap > if the generated A
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -742,7 +739,6 @@ exports[`loop with explicit cap argument overrides default cap > if the generate
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1035,7 +1031,6 @@ exports[`nested loops resolve their own caps independently > if the generated AS
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1262,7 +1257,6 @@ exports[`plain loop still stops at default cap of 1000 > if the generated AST, W
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/__snapshots__/moduleCompiler.test.ts.snap
+++ b/packages/compiler/tests/__snapshots__/moduleCompiler.test.ts.snap
@@ -392,7 +392,6 @@ exports[`moduleCompiler > ast 1`] = `
     "lineNumberAfterMacroExpansion": 1,
     "lineNumberBeforeMacroExpansion": 1,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/abs.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/abs.test.ts.snap
@@ -135,7 +135,6 @@ exports[`abs (float) > if the generated AST, WAT and memory map match the snapsh
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -324,7 +323,6 @@ exports[`abs (int) > if the generated AST, WAT and memory map match the snapshot
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -542,7 +540,6 @@ exports[`abs as non-zero divisor > if the generated AST, WAT and memory map matc
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/add.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/add.test.ts.snap
@@ -176,7 +176,6 @@ exports[`add (int) > if the generated AST, WAT and memory map match the snapshot
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/and.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/and.test.ts.snap
@@ -176,7 +176,6 @@ exports[`and > if the generated AST, WAT and memory map match the snapshot 1`] =
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/block.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/block.test.ts.snap
@@ -156,7 +156,6 @@ exports[`block (float) > if the generated AST, WAT and memory map match the snap
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -367,7 +366,6 @@ exports[`block (int) > if the generated AST, WAT and memory map match the snapsh
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/branch.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/branch.test.ts.snap
@@ -132,7 +132,6 @@ exports[`branch (int) > if the generated AST, WAT and memory map match the snaps
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/branchIfUnchanged.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/branchIfUnchanged.test.ts.snap
@@ -206,7 +206,6 @@ exports[`branchIfUnchanged > if the generated AST, WAT and memory map match the 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/call.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/call.test.ts.snap
@@ -113,7 +113,6 @@ exports[`call constant function > if the generated AST, WAT and memory map match
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -310,7 +309,6 @@ exports[`call float64-returning function > if the generated AST, WAT and memory 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -529,7 +527,6 @@ exports[`call function multiple times > if the generated AST, WAT and memory map
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -771,7 +768,6 @@ exports[`call function with parameter > if the generated AST, WAT and memory map
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -987,7 +983,6 @@ exports[`function can call another function with its signature and wasm index av
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/castToFloat.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/castToFloat.test.ts.snap
@@ -135,7 +135,6 @@ exports[`castToFloat > if the generated AST, WAT and memory map match the snapsh
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/castToInt.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/castToInt.test.ts.snap
@@ -135,7 +135,6 @@ exports[`castToInt > if the generated AST, WAT and memory map match the snapshot
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/clearStack.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/clearStack.test.ts.snap
@@ -68,7 +68,6 @@ exports[`clearStack > if the generated AST, WAT and memory map match the snapsho
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/const.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/const.test.ts.snap
@@ -257,7 +257,6 @@ exports[`const instruction > const with valid constant names > if the generated 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/constantExpressions.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/constantExpressions.test.ts.snap
@@ -188,7 +188,6 @@ exports[`const: constant * sizeof(name) > if the generated AST, WAT and memory m
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -388,7 +387,6 @@ exports[`const: constant ^ literal expression > if the generated AST, WAT and me
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -573,7 +571,6 @@ exports[`const: expression from another constant > if the generated AST, WAT and
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -779,7 +776,6 @@ exports[`const: literal * sizeof(name) > if the generated AST, WAT and memory ma
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -979,7 +975,6 @@ exports[`const: literal ^ constant expression > if the generated AST, WAT and me
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1113,7 +1108,6 @@ exports[`const: literal ^ literal folds to a literal value (2^16 = 65536) > if t
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1295,7 +1289,6 @@ exports[`const: signed literal / constant > if the generated AST, WAT and memory
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1501,7 +1494,6 @@ exports[`const: sizeof(name) * literal > if the generated AST, WAT and memory ma
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1722,7 +1714,6 @@ exports[`const: sizeof(name)^literal > if the generated AST, WAT and memory map 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1954,7 +1945,6 @@ exports[`int[]: buffer size from constant division expression > if the generated
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -2186,7 +2176,6 @@ exports[`int[]: buffer size from constant exponentiation expression > if the gen
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -2418,7 +2407,6 @@ exports[`int[]: buffer size from constant multiplication expression > if the gen
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -2672,7 +2660,6 @@ exports[`int[]: buffer size from count expression > if the generated AST, WAT an
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -2941,7 +2928,6 @@ exports[`int[]: buffer size from sizeof expression > if the generated AST, WAT a
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -3187,7 +3173,6 @@ exports[`memory declaration: constant ^ literal expression default > if the gene
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -3419,7 +3404,6 @@ exports[`memory declaration: constant expression default > if the generated AST,
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -3641,7 +3625,6 @@ exports[`push: constant * sizeof(name) > if the generated AST, WAT and memory ma
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -3822,7 +3805,6 @@ exports[`push: constant expression > if the generated AST, WAT and memory map ma
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -4044,7 +4026,6 @@ exports[`push: count(*end pointer) falls back to scalar pointee count > if the g
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -4298,7 +4279,6 @@ exports[`push: count(*pointer) resolves known pointee element count > if the gen
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -4497,7 +4477,6 @@ exports[`push: literal * constant (literal on lhs) > if the generated AST, WAT a
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -4684,7 +4663,6 @@ exports[`push: literal * sizeof(name) > if the generated AST, WAT and memory map
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -4865,7 +4843,6 @@ exports[`push: literal ^ constant expression > if the generated AST, WAT and mem
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -5087,7 +5064,6 @@ exports[`push: min(*pointer) resolves pointee min value > if the generated AST, 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -5307,7 +5283,6 @@ exports[`push: sizeof(name) * literal > if the generated AST, WAT and memory map
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/div.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/div.test.ts.snap
@@ -182,7 +182,6 @@ exports[`div (float) > if the generated AST, WAT and memory map match the snapsh
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -445,7 +444,6 @@ exports[`div (int) > if the generated AST, WAT and memory map match the snapshot
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/drop.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/drop.test.ts.snap
@@ -56,7 +56,6 @@ exports[`drop > if the generated AST, WAT and memory map match the snapshot 1`] 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/ensureNonZero.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/ensureNonZero.test.ts.snap
@@ -135,7 +135,6 @@ exports[`ensureNonZero (float) > if the generated AST, WAT and memory map match 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -333,7 +332,6 @@ exports[`ensureNonZero (int) > if the generated AST, WAT and memory map match th
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/equal.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/equal.test.ts.snap
@@ -176,7 +176,6 @@ exports[`equal > if the generated AST, WAT and memory map match the snapshot 1`]
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/equalToZero.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/equalToZero.test.ts.snap
@@ -135,7 +135,6 @@ exports[`equalToZero > if the generated AST, WAT and memory map match the snapsh
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/fallingEdge.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/fallingEdge.test.ts.snap
@@ -193,7 +193,6 @@ exports[`fallingEdge (float) > if the generated AST, WAT and memory map match th
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -453,7 +452,6 @@ exports[`fallingEdge > if the generated AST, WAT and memory map match the snapsh
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/float.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/float.test.ts.snap
@@ -127,7 +127,6 @@ exports[`float: anonymous float with negative literal > if the generated AST, WA
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -295,7 +294,6 @@ exports[`float: bare anonymous zero-initialized allocation > if the generated AS
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -495,7 +493,6 @@ exports[`float: with constant identifier (anonymous allocation) > if the generat
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -675,7 +672,6 @@ exports[`float: with literal (anonymous allocation) > if the generated AST, WAT 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/fractionLiterals.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/fractionLiterals.test.ts.snap
@@ -119,7 +119,6 @@ exports[`const: with fraction literal (1/8) > if the generated AST, WAT and memo
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -295,7 +294,6 @@ exports[`float: with fraction literal (1/16) > if the generated AST, WAT and mem
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -487,7 +485,6 @@ exports[`float: with negative fraction literal (-1/2) > if the generated AST, WA
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -679,7 +676,6 @@ exports[`int: with fraction literal (1/16) truncates to 0 > if the generated AST
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -871,7 +867,6 @@ exports[`int: with fraction literal (8/2) equals 4 > if the generated AST, WAT a
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1034,7 +1029,6 @@ exports[`push: with fraction literal (1/16) > if the generated AST, WAT and memo
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/function.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/function.test.ts.snap
@@ -113,7 +113,6 @@ exports[`function returns constant > if the generated AST, WAT and memory map ma
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -351,7 +350,6 @@ exports[`function with parameter > if the generated AST, WAT and memory map matc
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -649,7 +647,6 @@ exports[`function with two parameters > if the generated AST, WAT and memory map
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/functionEnd.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/functionEnd.test.ts.snap
@@ -113,7 +113,6 @@ exports[`functionEnd validates stack > if the generated AST, WAT and memory map 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -312,7 +311,6 @@ exports[`functionEnd with float return > if the generated AST, WAT and memory ma
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -509,7 +507,6 @@ exports[`functionEnd with int return > if the generated AST, WAT and memory map 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/greaterOrEqual.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/greaterOrEqual.test.ts.snap
@@ -176,7 +176,6 @@ exports[`greaterOrEqual (float) > if the generated AST, WAT and memory map match
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -423,7 +422,6 @@ exports[`greaterOrEqual (int) > if the generated AST, WAT and memory map match t
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/greaterThan.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/greaterThan.test.ts.snap
@@ -176,7 +176,6 @@ exports[`greaterThan (float) > if the generated AST, WAT and memory map match th
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -423,7 +422,6 @@ exports[`greaterThan (int) > if the generated AST, WAT and memory map match the 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/hasChanged.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/hasChanged.test.ts.snap
@@ -193,7 +193,6 @@ exports[`hasChanged with float > if the generated AST, WAT and memory map match 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -454,7 +453,6 @@ exports[`hasChanged with int > if the generated AST, WAT and memory map match th
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/if.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/if.test.ts.snap
@@ -187,7 +187,6 @@ exports[`if (float) > if the generated AST, WAT and memory map match the snapsho
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -432,7 +431,6 @@ exports[`if (int) > if the generated AST, WAT and memory map match the snapshot 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -691,7 +689,6 @@ exports[`if (void) > if the generated AST, WAT and memory map match the snapshot
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/int.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/int.test.ts.snap
@@ -115,7 +115,6 @@ exports[`int*: bare anonymous zero-initialized pointer allocation > if the gener
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -297,7 +296,6 @@ exports[`int: anonymous allocation with negative literal > if the generated AST,
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -509,7 +507,6 @@ exports[`int: anonymous byte literal and constant split-byte > if the generated 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -739,7 +736,6 @@ exports[`int: anonymous constant split-byte default (2 constants) > if the gener
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -929,7 +925,6 @@ exports[`int: anonymous split decimal default (2 bytes, right-padded) > if the g
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1123,7 +1118,6 @@ exports[`int: anonymous split hex default (2 bytes, right-padded) > if the gener
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1291,7 +1285,6 @@ exports[`int: bare anonymous zero-initialized allocation > if the generated AST,
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1573,7 +1566,6 @@ exports[`int: mix of anonymous and named allocations > if the generated AST, WAT
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1813,7 +1805,6 @@ exports[`int: mixed hex and decimal bytes in split-byte default > if the generat
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -2083,7 +2074,6 @@ exports[`int: multiple anonymous allocations > if the generated AST, WAT and mem
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -2361,7 +2351,6 @@ exports[`int: named constant split-byte default (2 constants) > if the generated
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -2585,7 +2574,6 @@ exports[`int: named mixed byte literal and constant split-byte > if the generate
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -2787,7 +2775,6 @@ exports[`int: named split decimal default (2 bytes, right-padded) > if the gener
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -3009,7 +2996,6 @@ exports[`int: named split decimal default (4 bytes) > if the generated AST, WAT 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -3215,7 +3201,6 @@ exports[`int: named split hex default (2 bytes, right-padded) > if the generated
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -3445,7 +3430,6 @@ exports[`int: named split hex default (4 bytes) > if the generated AST, WAT and 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -3635,7 +3619,6 @@ exports[`int: named string split-byte default (2 bytes, right-padded) > if the g
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -3815,7 +3798,6 @@ exports[`int: single decimal literal remains anonymous int with that value > if 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -3993,7 +3975,6 @@ exports[`int: with anonymous single-character string default > if the generated 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -4193,7 +4174,6 @@ exports[`int: with constant identifier (anonymous allocation) > if the generated
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -4373,7 +4353,6 @@ exports[`int: with literal (anonymous allocation) > if the generated AST, WAT an
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -4565,7 +4544,6 @@ exports[`int: with named identifier > if the generated AST, WAT and memory map m
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -4755,7 +4733,6 @@ exports[`int: with named single-character string default > if the generated AST,
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/literalMulDivExpressions.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/literalMulDivExpressions.test.ts.snap
@@ -119,7 +119,6 @@ exports[`const: literal-only division expression with integer result > if the ge
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -275,7 +274,6 @@ exports[`const: literal-only multiplication expression > if the generated AST, W
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -452,7 +450,6 @@ exports[`int[]: buffer size from literal multiplication expression > if the gene
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -643,7 +640,6 @@ exports[`memory declaration: literal-only multiplication expression default > if
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -796,7 +792,6 @@ exports[`push: float literal multiplication with float-typed result > if the gen
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -933,7 +928,6 @@ exports[`push: hex literal in division expression > if the generated AST, WAT an
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1070,7 +1064,6 @@ exports[`push: hex literal in multiplication expression > if the generated AST, 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1207,7 +1200,6 @@ exports[`push: literal-only division expression with float result > if the gener
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1344,7 +1336,6 @@ exports[`push: literal-only multiplication expression > if the generated AST, WA
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/loadFloat.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/loadFloat.test.ts.snap
@@ -137,7 +137,6 @@ exports[`loadFloat > if the generated AST, WAT and memory map match the snapshot
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/loop.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/loop.test.ts.snap
@@ -131,7 +131,6 @@ exports[`infinite loop protection > if the generated AST, WAT and memory map mat
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -363,7 +362,6 @@ exports[`loop > if the generated AST, WAT and memory map match the snapshot 1`] 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/map.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/map.test.ts.snap
@@ -189,7 +189,6 @@ exports[`map: first-match-wins with duplicate keys > if the generated AST, WAT a
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -470,7 +469,6 @@ exports[`map: float→float mapping > if the generated AST, WAT and memory map m
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -734,7 +732,6 @@ exports[`map: implicit default zero for int output > if the generated AST, WAT a
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -999,7 +996,6 @@ exports[`map: int→float mapping > if the generated AST, WAT and memory map mat
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1297,7 +1293,6 @@ exports[`map: int→int basic mapping > if the generated AST, WAT and memory map
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1589,7 +1584,6 @@ exports[`map: int→int with explicit default > if the generated AST, WAT and me
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -1835,7 +1829,6 @@ exports[`map: int→int with single-character literals as ASCII > if the generat
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -2066,7 +2059,6 @@ exports[`map: zero-row map returns default > if the generated AST, WAT and memor
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -2288,7 +2280,6 @@ exports[`map: zero-row map with explicit default > if the generated AST, WAT and
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/mul.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/mul.test.ts.snap
@@ -176,7 +176,6 @@ exports[`mul (float) > if the generated AST, WAT and memory map match the snapsh
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -423,7 +422,6 @@ exports[`mul (int) > if the generated AST, WAT and memory map match the snapshot
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/or.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/or.test.ts.snap
@@ -176,7 +176,6 @@ exports[`or > if the generated AST, WAT and memory map match the snapshot 1`] = 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/remainder.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/remainder.test.ts.snap
@@ -182,7 +182,6 @@ exports[`remainder with ensureNonZero > if the generated AST, WAT and memory map
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/risingEdge.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/risingEdge.test.ts.snap
@@ -193,7 +193,6 @@ exports[`risingEdge (float) > if the generated AST, WAT and memory map match the
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;
@@ -453,7 +452,6 @@ exports[`risingEdge > if the generated AST, WAT and memory map match the snapsho
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/round.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/round.test.ts.snap
@@ -135,7 +135,6 @@ exports[`round > if the generated AST, WAT and memory map match the snapshot 1`]
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/shiftLeft.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/shiftLeft.test.ts.snap
@@ -176,7 +176,6 @@ exports[`shiftLeft > if the generated AST, WAT and memory map match the snapshot
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/shiftRight.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/shiftRight.test.ts.snap
@@ -176,7 +176,6 @@ exports[`shiftRight > if the generated AST, WAT and memory map match the snapsho
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/sqrt.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/sqrt.test.ts.snap
@@ -135,7 +135,6 @@ exports[`sqrt > if the generated AST, WAT and memory map match the snapshot 1`] 
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/sub.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/sub.test.ts.snap
@@ -176,7 +176,6 @@ exports[`sub (int) > if the generated AST, WAT and memory map match the snapshot
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/instructions/__snapshots__/xor.test.ts.snap
+++ b/packages/compiler/tests/instructions/__snapshots__/xor.test.ts.snap
@@ -176,7 +176,6 @@ exports[`xor > if the generated AST, WAT and memory map match the snapshot 1`] =
     "lineNumberAfterMacroExpansion": 0,
     "lineNumberBeforeMacroExpansion": 0,
   },
-  "referencedModuleIds": [],
   "type": "module",
 }
 `;

--- a/packages/compiler/tests/intermodular-references/element-count.test.ts
+++ b/packages/compiler/tests/intermodular-references/element-count.test.ts
@@ -99,7 +99,7 @@ describe('inter-module references - element count', () => {
 		}).toThrow();
 	});
 
-	test('module dependency sorting works with element count references', () => {
+	test('resolves out-of-order element count references', () => {
 		const modules = [
 			{ code: ['module dependentModule', 'int size count(baseModule:buffer)', 'moduleEnd'] },
 			{ code: ['module baseModule', 'int[] buffer 8 0', 'moduleEnd'] },

--- a/packages/compiler/tests/intermodular-references/element-max.test.ts
+++ b/packages/compiler/tests/intermodular-references/element-max.test.ts
@@ -203,7 +203,7 @@ describe('inter-module references - element max', () => {
 		}).toThrow();
 	});
 
-	test('module dependency sorting works with element max references', () => {
+	test('resolves out-of-order element max references', () => {
 		const modules = [
 			{ code: ['module dependentModule', 'int maxValue max(baseModule:buffer)', 'moduleEnd'] },
 			{ code: ['module baseModule', 'int[] buffer 8 0', 'moduleEnd'] },

--- a/packages/compiler/tests/intermodular-references/element-min.test.ts
+++ b/packages/compiler/tests/intermodular-references/element-min.test.ts
@@ -203,7 +203,7 @@ describe('inter-module references - element min', () => {
 		}).toThrow();
 	});
 
-	test('module dependency sorting works with element min references', () => {
+	test('resolves out-of-order element min references', () => {
 		const modules = [
 			{ code: ['module dependentModule', 'int minValue min(baseModule:buffer)', 'moduleEnd'] },
 			{ code: ['module baseModule', 'int[] buffer 8 0', 'moduleEnd'] },

--- a/packages/compiler/tests/intermodular-references/element-word-size.test.ts
+++ b/packages/compiler/tests/intermodular-references/element-word-size.test.ts
@@ -120,7 +120,7 @@ describe('inter-module references - element word size', () => {
 		}).toThrow();
 	});
 
-	test('module dependency sorting works with element word size references', () => {
+	test('resolves out-of-order element word size references', () => {
 		const modules = [
 			{ code: ['module dependentModule', 'int size sizeof(baseModule:buffer)', 'moduleEnd'] },
 			{ code: ['module baseModule', 'int[] buffer 8 0', 'moduleEnd'] },

--- a/packages/compiler/tests/intermodular-references/endAddress.test.ts
+++ b/packages/compiler/tests/intermodular-references/endAddress.test.ts
@@ -69,7 +69,7 @@ describe('inter-module references - end address', () => {
 		expect(targetModule.memoryMap['ptr'].default).toBe(expectedEndAddress);
 	});
 
-	test('module dependency sorting works with end-address references', () => {
+	test('resolves out-of-order end-address references', () => {
 		const modules = [
 			{ code: ['module dependentModule', 'int* ptr baseModule:buffer&', 'moduleEnd'] },
 			{ code: ['module baseModule', 'int[] buffer 8 0', 'moduleEnd'] },

--- a/packages/compiler/tests/intermodular-references/startAddress.test.ts
+++ b/packages/compiler/tests/intermodular-references/startAddress.test.ts
@@ -57,7 +57,7 @@ describe('inter-module references - start address', () => {
 		}).toThrow();
 	});
 
-	test('module dependency sorting works with start-address references', () => {
+	test('resolves out-of-order start-address references', () => {
 		const modules = [
 			{ code: ['module dependentModule', 'int* ptr &baseModule:buffer', 'moduleEnd'] },
 			{ code: ['module baseModule', 'int[] buffer 8 0', 'moduleEnd'] },


### PR DESCRIPTION
## Summary
- remove unused `referencedModuleIds` AST metadata left behind by the old module ordering path
- update compiler docs and comments to describe the input-order contract
- rename stale intermodule reference tests and refresh affected snapshots

## Test notes
- `npx nx run tokenizer:test -- --update`
- `npx nx run compiler:test -- --update`
- `npx nx run compiler-spec:typecheck`
- `npx nx run tokenizer:typecheck`
- `npx nx run compiler:typecheck`
- pre-commit hook: `npx nx run-many --target=typecheck --all`