### PR TITLE
feat(tokenizer): add dash argument continuations

### DIFF
--- a/docs/todos/433-add-dash-argument-continuation-lines.md
+++ b/docs/todos/433-add-dash-argument-continuation-lines.md
@@ -1,0 +1,115 @@
+---
+title: 'TODO: Add dash argument continuation lines'
+priority: Medium
+effort: 2-4h
+created: 2026-05-28
+issue: null
+status: Open
+completed: null
+---
+
+# TODO: Add dash argument continuation lines
+
+## Problem Description
+
+Long source argument lists are hard to read when they must stay on one line. This is especially noticeable for memory declarations with pointer defaults or intermodule references, such as:
+
+```8f4e
+float* buffer &allpassDiffuser:buffer
+```
+
+The language currently has no syntax-level way to wrap those arguments across multiple lines while preserving the existing instruction semantics.
+
+## Proposed Solution
+
+Add parser sugar for dash-prefixed argument continuation lines:
+
+```8f4e
+float*
+- buffer
+- &allpassDiffuser:buffer
+```
+
+The tokenizer/parser should fold this into the same AST shape as:
+
+```8f4e
+float* buffer &allpassDiffuser:buffer
+```
+
+This should happen before source argument validation, semantic normalization, namespace layout, stack analysis, or codegen. The compiler should not need a new semantic instruction for this behavior.
+
+## Decisions
+
+- A continuation line uses `-` as the instruction token.
+- Each continuation line appends exactly one argument to the immediately preceding non-continuation instruction.
+- Continuation lines are allowed after any source instruction. Existing argument validation remains responsible for rejecting invalid arity or argument shapes after folding.
+- A bare `-` line is a syntax error.
+- A continuation line without a preceding non-continuation instruction is a syntax error.
+
+## Anti-Patterns
+
+- Do not implement `-` as a semantic instruction. It should be parser sugar only.
+- Do not let `float*` compile as an anonymous declaration before later continuation lines are considered.
+- Do not treat `push -1` as a continuation. Continuation only applies when the instruction token is exactly `-`.
+- Do not allow `- a b c` to append multiple arguments. One continuation line means one appended argument.
+
+## Implementation Plan
+
+### Step 1: Fold Continuation Lines During Parsing
+
+- Update the tokenizer/parser source loop so `- <arg>` lines append their parsed argument token to the previous non-continuation source line.
+- Preserve the original instruction line as the AST line identity for the merged instruction.
+- Throw `SyntaxRulesError` for a bare `-`, a multi-argument `- a b`, or a continuation with no previous non-continuation instruction.
+
+### Step 2: Validate Folded Instructions
+
+- Run existing `validateInstructionArguments(...)` behavior against the folded argument list.
+- Ensure invalid continuations produce syntax-level diagnostics because they are decidable from token and argument shape.
+
+### Step 3: Add Tests
+
+- Add tokenizer/parser tests showing that folded continuation lines produce the same AST as the equivalent single-line instruction.
+- Cover memory declarations, a generic source instruction such as `push`, and invalid cases for bare `-`, multi-argument continuation, and missing previous instruction.
+- Add or update compiler-level coverage if needed to prove semantic normalization and namespace layout receive the folded declaration correctly.
+
+### Step 4: Document The Syntax
+
+- Update the instruction/language docs to describe dash argument continuation lines.
+- Include the `float*` pointer-default example and clarify that `-` is parser sugar, not a runtime or semantic instruction.
+
+## Validation Checkpoints
+
+- `npx nx run @8f4e/tokenizer:test`
+- `npx nx run @8f4e/compiler:test`
+- `npx nx run @8f4e/compiler:typecheck`
+
+## Success Criteria
+
+- [ ] `float*` declarations can be split across dash continuation lines and compile identically to the single-line form.
+- [ ] Continuation lines work after any source instruction with source arguments.
+- [ ] Bare, multi-argument, and orphaned continuation lines fail as syntax errors.
+- [ ] Existing argument validation rejects folded instructions that exceed the target instruction's supported arity.
+- [ ] Docs explain the syntax and the parser-sugar behavior.
+
+## Affected Components
+
+- `packages/compiler/packages/tokenizer/src/parser.ts` - Fold continuation lines before AST validation.
+- `packages/compiler/packages/tokenizer/src/parser.test.ts` - Parser behavior and syntax-error coverage.
+- `packages/compiler/src/semantic` - Should remain mostly unchanged; may only need integration tests.
+- `packages/compiler/docs/instructions.md` or related docs - User-facing syntax documentation.
+
+## Risks & Considerations
+
+- **Compatibility**: The software has not been released yet, so this work may break internal and external APIs when that keeps the implementation simpler and cleaner.
+- **Diagnostics**: Folded argument errors may initially point at the original instruction line rather than the continuation line. This is acceptable for the first implementation, but argument-level source metadata could improve it later.
+- **Existing anonymous declarations**: Bare memory declarations such as `float*` are valid today, so continuation folding must happen before the declaration is interpreted semantically.
+- **Markdown-like appearance**: `-` resembles a list marker outside code blocks, so docs should show continuation syntax inside fenced code blocks.
+
+## Related Items
+
+- **Related**: `377-batch-parse-modules-and-validate-shared-ids.md`
+- **Related**: `378-make-parser-stateful-for-block-pairing-and-owning-block-context.md`
+
+## Notes
+
+- Design decision recorded on 2026-05-28: use dash continuation lines instead of an `arg` semantic instruction.

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -67,7 +67,6 @@ Active todo files are listed below.
 | 430 | Nest pointer metadata shape | 🟡 | 4-8h | 2026-05-27 | Move scattered pointer fields into a shared nested pointer metadata shape used consistently by memory, locals, and stack address metadata. |
 | 431 | Separate pointer type and provenance facts | 🟡 | 2-4h | 2026-05-27 | Model declared pointer type facts separately from value provenance facts so helpers like `count(*ptr)` only use explicit count provenance. |
 | 432 | Centralize compile-time metadata query resolution | 🟡 | 2-4h | 2026-05-27 | Split metadata query resolution into target lookup and query evaluation so local, intermodule, and pointer helpers share one resolver path. |
-| 433 | Add dash argument continuation lines | 🟡 | 2-4h | 2026-05-28 | Add parser sugar so `- <arg>` lines append one argument to the previous source instruction before validation and semantic compilation. |
 
 ### 🟢 Low Priority
 
@@ -85,6 +84,7 @@ Active todo files are listed below.
 
 | ID | Title | Completed | Notes |
 | ---- | ----- | --------- | ----- |
+| 433 | Add dash argument continuation lines | 2026-05-28 | Parser now folds `- <arg>` continuation lines into the previous source instruction before validation; docs and tokenizer coverage describe valid and invalid forms. |
 | 428 | Add pointer-aware count and min metadata queries | 2026-05-27 | `min(*ptr)` and `count(*ptr)` now classify explicitly and resolve from pointer metadata; pointer count uses tracked memory-start pointee element counts when available and falls back to `1`. |
 | 323 | Add `min(*name)` pointee min value prefix for pointers | 2026-05-27 | Completed as part of pointer-aware metadata query work; `min(*name)` now has parser, semantic, helper, docs, and public compiler coverage. |
 | 423 | Narrow AST line metadata interfaces | 2026-05-26 | `ASTLineBase` now only carries core line identity; memory, semantic, directive, and block metadata live on concrete line interfaces, and snapshots were updated to show the narrower public AST shape. |

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -67,6 +67,7 @@ Active todo files are listed below.
 | 430 | Nest pointer metadata shape | 🟡 | 4-8h | 2026-05-27 | Move scattered pointer fields into a shared nested pointer metadata shape used consistently by memory, locals, and stack address metadata. |
 | 431 | Separate pointer type and provenance facts | 🟡 | 2-4h | 2026-05-27 | Model declared pointer type facts separately from value provenance facts so helpers like `count(*ptr)` only use explicit count provenance. |
 | 432 | Centralize compile-time metadata query resolution | 🟡 | 2-4h | 2026-05-27 | Split metadata query resolution into target lookup and query evaluation so local, intermodule, and pointer helpers share one resolver path. |
+| 433 | Add dash argument continuation lines | 🟡 | 2-4h | 2026-05-28 | Add parser sugar so `- <arg>` lines append one argument to the previous source instruction before validation and semantic compilation. |
 
 ### 🟢 Low Priority
 

--- a/docs/todos/archived/433-add-dash-argument-continuation-lines.md
+++ b/docs/todos/archived/433-add-dash-argument-continuation-lines.md
@@ -15,7 +15,7 @@ completed: 2026-05-28
 Long source argument lists are hard to read when they must stay on one line. This is especially noticeable for memory declarations with pointer defaults or intermodule references, such as:
 
 ```8f4e
-float* buffer &allpassDiffuser:buffer
+float* readHead &source:samples
 ```
 
 The language currently has no syntax-level way to wrap those arguments across multiple lines while preserving the existing instruction semantics.
@@ -26,14 +26,14 @@ Add parser sugar for dash-prefixed argument continuation lines:
 
 ```8f4e
 float*
-- buffer
-- &allpassDiffuser:buffer
+- readHead
+- &source:samples
 ```
 
 The tokenizer/parser should fold this into the same AST shape as:
 
 ```8f4e
-float* buffer &allpassDiffuser:buffer
+float* readHead &source:samples
 ```
 
 This should happen before source argument validation, semantic normalization, namespace layout, stack analysis, or codegen. The compiler should not need a new semantic instruction for this behavior.

--- a/docs/todos/archived/433-add-dash-argument-continuation-lines.md
+++ b/docs/todos/archived/433-add-dash-argument-continuation-lines.md
@@ -4,8 +4,8 @@ priority: Medium
 effort: 2-4h
 created: 2026-05-28
 issue: null
-status: Open
-completed: null
+status: Completed
+completed: 2026-05-28
 ---
 
 # TODO: Add dash argument continuation lines

--- a/packages/compiler/docs/instructions.md
+++ b/packages/compiler/docs/instructions.md
@@ -1,6 +1,7 @@
 # Instructions
 
 - [Comments](comments.md)
+- [Source syntax](source-syntax.md)
 - [Identifier prefixes](prefixes.md)
 - [Best practices](best-practices.md)
 - [Compiler design](compiler-design.md)

--- a/packages/compiler/docs/source-syntax.md
+++ b/packages/compiler/docs/source-syntax.md
@@ -1,0 +1,19 @@
+# Source syntax
+
+## Argument Continuation Lines
+
+Use `- <argument>` to append one argument to the previous instruction. This is parser sugar; the compiler sees the same instruction it would have seen if the arguments had been written on one line.
+
+```8f4e
+float*
+- buffer
+- &allpassDiffuser:buffer
+```
+
+is equivalent to:
+
+```8f4e
+float* buffer &allpassDiffuser:buffer
+```
+
+Each continuation line accepts exactly one argument. A bare `-`, a continuation with multiple arguments, or a continuation without a previous instruction is a syntax error.

--- a/packages/compiler/docs/source-syntax.md
+++ b/packages/compiler/docs/source-syntax.md
@@ -6,14 +6,14 @@ Use `- <argument>` to append one argument to the previous instruction. This is p
 
 ```8f4e
 float*
-- buffer
-- &allpassDiffuser:buffer
+- readHead
+- &source:samples
 ```
 
 is equivalent to:
 
 ```8f4e
-float* buffer &allpassDiffuser:buffer
+float* readHead &source:samples
 ```
 
 Each continuation line accepts exactly one argument. A bare `-`, a continuation with multiple arguments, or a continuation without a previous instruction is a syntax error.

--- a/packages/compiler/packages/tokenizer/src/parser.test.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.test.ts
@@ -233,18 +233,18 @@ describe('compileToAST', () => {
 
 describe('compileToASTLines', () => {
 	it('folds dash argument continuation lines into the previous instruction', () => {
-		const split = compileToASTLines(['float*', '- buffer', '- &allpassDiffuser:buffer']);
-		const singleLine = compileToASTLines(['float* buffer &allpassDiffuser:buffer']);
+		const split = compileToASTLines(['float*', '- readHead', '- &source:samples']);
+		const singleLine = compileToASTLines(['float* readHead &source:samples']);
 
 		expect(split).toEqual(singleLine);
 		expect(split).toHaveLength(1);
 		expect(split[0]).toMatchObject({
 			instruction: 'float*',
 			arguments: [
-				{ type: ArgumentType.IDENTIFIER, value: 'buffer' },
-				{ type: ArgumentType.IDENTIFIER, value: '&allpassDiffuser:buffer' },
+				{ type: ArgumentType.IDENTIFIER, value: 'readHead' },
+				{ type: ArgumentType.IDENTIFIER, value: '&source:samples' },
 			],
-			referencedNamespaceIds: ['allpassDiffuser'],
+			referencedNamespaceIds: ['source'],
 			hasExplicitMemoryDefault: true,
 		});
 	});
@@ -253,6 +253,31 @@ describe('compileToASTLines', () => {
 		const ast = compileToASTLines(['push', '- 1']);
 
 		expect(ast).toEqual(compileToASTLines(['push 1']));
+	});
+
+	it.each([
+		{
+			name: 'negative numeric literal',
+			split: ['push', '- -1'],
+			singleLine: ['push -1'],
+		},
+		{
+			name: 'quoted string literal with spaces',
+			split: ['push', '- "hello world"'],
+			singleLine: ['push "hello world"'],
+		},
+		{
+			name: 'compile-time expression',
+			split: ['const SIZE', '- 2*4'],
+			singleLine: ['const SIZE 2*4'],
+		},
+		{
+			name: 'array declaration with hex and negative initializer values',
+			split: ['int[]', '- values', '- 4', '- 0xA8', '- -1'],
+			singleLine: ['int[] values 4 0xA8 -1'],
+		},
+	])('preserves $name continuation arguments', ({ split, singleLine }) => {
+		expect(compileToASTLines(split)).toEqual(compileToASTLines(singleLine));
 	});
 
 	it('rejects bare dash argument continuation lines', () => {

--- a/packages/compiler/packages/tokenizer/src/parser.test.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.test.ts
@@ -232,6 +232,47 @@ describe('compileToAST', () => {
 });
 
 describe('compileToASTLines', () => {
+	it('folds dash argument continuation lines into the previous instruction', () => {
+		const split = compileToASTLines(['float*', '- buffer', '- &allpassDiffuser:buffer']);
+		const singleLine = compileToASTLines(['float* buffer &allpassDiffuser:buffer']);
+
+		expect(split).toEqual(singleLine);
+		expect(split).toHaveLength(1);
+		expect(split[0]).toMatchObject({
+			instruction: 'float*',
+			arguments: [
+				{ type: ArgumentType.IDENTIFIER, value: 'buffer' },
+				{ type: ArgumentType.IDENTIFIER, value: '&allpassDiffuser:buffer' },
+			],
+			referencedNamespaceIds: ['allpassDiffuser'],
+			hasExplicitMemoryDefault: true,
+		});
+	});
+
+	it('allows dash argument continuation after any source instruction', () => {
+		const ast = compileToASTLines(['push', '- 1']);
+
+		expect(ast).toEqual(compileToASTLines(['push 1']));
+	});
+
+	it('rejects bare dash argument continuation lines', () => {
+		expect(() => compileToASTLines(['push 1', '-'])).toThrow(
+			expect.objectContaining({ code: SyntaxErrorCode.MISSING_ARGUMENT })
+		);
+	});
+
+	it('rejects dash argument continuation lines with multiple arguments', () => {
+		expect(() => compileToASTLines(['push', '- 1 2'])).toThrow(
+			expect.objectContaining({ code: SyntaxErrorCode.INVALID_ARGUMENT })
+		);
+	});
+
+	it('rejects dash argument continuation lines without a previous instruction', () => {
+		expect(() => compileToASTLines(['- 1'])).toThrow(
+			expect.objectContaining({ code: SyntaxErrorCode.INVALID_ARGUMENT })
+		);
+	});
+
 	it('uses callSiteLineNumber from lineMetadata when provided', () => {
 		const code = ['push 10', 'push 20', 'add'];
 		const lineMetadata = [

--- a/packages/compiler/packages/tokenizer/src/parser.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.ts
@@ -105,6 +105,12 @@ type ParsedCompilerSource = {
 	astBuilder?: SourceBlockASTBuilder;
 };
 
+type SourceLine = {
+	line: string;
+	lineNumberBeforeMacroExpansion: number;
+	lineNumberAfterMacroExpansion: number;
+};
+
 const blockStartInstructionSet = new Set<BlockStartInstruction>(blockStartInstructions);
 const sourceBlockStartInstructionSet = new Set(['module', 'function']);
 const sourceBlockEndInstructionSet = new Set(['moduleEnd', 'functionEnd']);
@@ -355,6 +361,93 @@ function tokenizeInstruction(line: string): string[] {
 	return tokens;
 }
 
+function withSyntaxLine(
+	error: SyntaxRulesError,
+	lineNumberBeforeMacroExpansion: number,
+	lineNumberAfterMacroExpansion: number,
+	instruction?: string
+): SyntaxRulesError {
+	return new SyntaxRulesError(error.code, error.message, {
+		lineNumberBeforeMacroExpansion,
+		lineNumberAfterMacroExpansion,
+		instruction,
+	});
+}
+
+function parseInstructionTokens(
+	line: string,
+	lineNumberBeforeMacroExpansion: number,
+	lineNumberAfterMacroExpansion: number
+): string[] {
+	try {
+		return tokenizeInstruction(line);
+	} catch (error) {
+		if (error instanceof SyntaxRulesError) {
+			throw withSyntaxLine(error, lineNumberBeforeMacroExpansion, lineNumberAfterMacroExpansion);
+		}
+		throw error;
+	}
+}
+
+function foldArgumentContinuationLines(code: string[], lineMetadata?: ParsedLineMetadata): SourceLine[] {
+	const sourceLines: SourceLine[] = [];
+	let previousSourceLine: SourceLine | undefined;
+
+	for (const [lineNumberAfterMacroExpansion, line] of code.map((sourceLine, index) => [index, sourceLine] as const)) {
+		if (isComment(line) || !isValidInstruction(line)) {
+			continue;
+		}
+
+		const lineNumberBeforeMacroExpansion =
+			lineMetadata?.[lineNumberAfterMacroExpansion]?.callSiteLineNumber ?? lineNumberAfterMacroExpansion;
+		const tokens = parseInstructionTokens(line, lineNumberBeforeMacroExpansion, lineNumberAfterMacroExpansion);
+		const [instruction] = tokens;
+
+		if (instruction !== '-') {
+			const sourceLine = {
+				line,
+				lineNumberBeforeMacroExpansion,
+				lineNumberAfterMacroExpansion,
+			};
+			sourceLines.push(sourceLine);
+			previousSourceLine = sourceLine;
+			continue;
+		}
+
+		if (!previousSourceLine) {
+			throw new SyntaxRulesError(SyntaxErrorCode.INVALID_ARGUMENT, 'Argument continuation has no instruction.', {
+				lineNumberBeforeMacroExpansion,
+				lineNumberAfterMacroExpansion,
+				instruction,
+			});
+		}
+
+		if (tokens.length < 2) {
+			throw new SyntaxRulesError(SyntaxErrorCode.MISSING_ARGUMENT, 'Missing argument for continuation.', {
+				lineNumberBeforeMacroExpansion,
+				lineNumberAfterMacroExpansion,
+				instruction,
+			});
+		}
+
+		if (tokens.length > 2) {
+			throw new SyntaxRulesError(
+				SyntaxErrorCode.INVALID_ARGUMENT,
+				'Argument continuation accepts exactly one argument.',
+				{
+					lineNumberBeforeMacroExpansion,
+					lineNumberAfterMacroExpansion,
+					instruction,
+				}
+			);
+		}
+
+		previousSourceLine.line = `${previousSourceLine.line} ${tokens[1]}`;
+	}
+
+	return sourceLines;
+}
+
 export function parseLine(
 	line: string,
 	lineNumberBeforeMacroExpansion: number,
@@ -397,12 +490,13 @@ export function parseLine(
 		return parsedLine;
 	} catch (error) {
 		if (error instanceof SyntaxRulesError) {
-			throw new SyntaxRulesError(error.code, error.message, {
+			throw withSyntaxLine(
+				error,
 				lineNumberBeforeMacroExpansion,
 				lineNumberAfterMacroExpansion,
 				// instruction is undefined only if tokenizeInstruction threw before assignment
-				instruction: instruction ?? undefined,
-			});
+				instruction ?? undefined
+			);
 		}
 		throw error;
 	}
@@ -414,14 +508,9 @@ function parseCompilerSource(code: string[], lineMetadata?: ParsedLineMetadata):
 	let onlySemanticLinesBeforeSourceBlock = true;
 	const blockStack: OpenBlock[] = [];
 	const sourceBlockPrologueStack: SourceBlockPrologue[] = [];
+	const sourceLines = foldArgumentContinuationLines(code, lineMetadata);
 
-	for (const [lineNumberAfterMacroExpansion, line] of code.map((sourceLine, index) => [index, sourceLine] as const)) {
-		if (isComment(line) || !isValidInstruction(line)) {
-			continue;
-		}
-
-		const lineNumberBeforeMacroExpansion =
-			lineMetadata?.[lineNumberAfterMacroExpansion]?.callSiteLineNumber ?? lineNumberAfterMacroExpansion;
+	for (const { line, lineNumberBeforeMacroExpansion, lineNumberAfterMacroExpansion } of sourceLines) {
 		const parsedLine = parseLine(line, lineNumberBeforeMacroExpansion, lineNumberAfterMacroExpansion);
 		const astIndex = ast.length;
 		const isFirstASTLine = ast.length === 0;

--- a/packages/compiler/tests/argumentContinuation.test.ts
+++ b/packages/compiler/tests/argumentContinuation.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'vitest';
+
+import compile from '../src';
+
+describe('argument continuation lines', () => {
+	test('compile resolves a split intermodule pointer declaration like the single-line form', () => {
+		const split = compile(
+			[
+				{ code: ['module allpassDiffuser', 'float[] buffer 8 0.0', 'moduleEnd'] },
+				{ code: ['module target', 'float*', '- buffer', '- &allpassDiffuser:buffer', 'moduleEnd'] },
+			],
+			{ startingMemoryWordAddress: 0 }
+		);
+		const singleLine = compile(
+			[
+				{ code: ['module allpassDiffuser', 'float[] buffer 8 0.0', 'moduleEnd'] },
+				{ code: ['module target', 'float* buffer &allpassDiffuser:buffer', 'moduleEnd'] },
+			],
+			{ startingMemoryWordAddress: 0 }
+		);
+
+		const sourceBuffer = split.compiledModules.allpassDiffuser.memoryMap.buffer;
+		const splitPointer = split.compiledModules.target.memoryMap.buffer;
+		const singleLinePointer = singleLine.compiledModules.target.memoryMap.buffer;
+
+		expect(splitPointer.default).toBe(sourceBuffer.byteAddress);
+		expect(splitPointer).toEqual(singleLinePointer);
+	});
+
+	test('compile accepts continuation after a stack instruction', () => {
+		expect(() =>
+			compile([{ code: ['module target', 'push', '- 1', 'drop', 'moduleEnd'] }], {
+				startingMemoryWordAddress: 0,
+			})
+		).not.toThrow();
+	});
+});

--- a/packages/compiler/tests/argumentContinuation.test.ts
+++ b/packages/compiler/tests/argumentContinuation.test.ts
@@ -6,30 +6,42 @@ describe('argument continuation lines', () => {
 	test('compile resolves a split intermodule pointer declaration like the single-line form', () => {
 		const split = compile(
 			[
-				{ code: ['module allpassDiffuser', 'float[] buffer 8 0.0', 'moduleEnd'] },
-				{ code: ['module target', 'float*', '- buffer', '- &allpassDiffuser:buffer', 'moduleEnd'] },
+				{ code: ['module source', 'float[] samples 8 0.0', 'moduleEnd'] },
+				{ code: ['module target', 'float*', '- readHead', '- &source:samples', 'moduleEnd'] },
 			],
 			{ startingMemoryWordAddress: 0 }
 		);
 		const singleLine = compile(
 			[
-				{ code: ['module allpassDiffuser', 'float[] buffer 8 0.0', 'moduleEnd'] },
-				{ code: ['module target', 'float* buffer &allpassDiffuser:buffer', 'moduleEnd'] },
+				{ code: ['module source', 'float[] samples 8 0.0', 'moduleEnd'] },
+				{ code: ['module target', 'float* readHead &source:samples', 'moduleEnd'] },
 			],
 			{ startingMemoryWordAddress: 0 }
 		);
 
-		const sourceBuffer = split.compiledModules.allpassDiffuser.memoryMap.buffer;
-		const splitPointer = split.compiledModules.target.memoryMap.buffer;
-		const singleLinePointer = singleLine.compiledModules.target.memoryMap.buffer;
+		const sourceBuffer = split.compiledModules.source.memoryMap.samples;
+		const splitPointer = split.compiledModules.target.memoryMap.readHead;
+		const singleLinePointer = singleLine.compiledModules.target.memoryMap.readHead;
 
 		expect(splitPointer.default).toBe(sourceBuffer.byteAddress);
 		expect(splitPointer).toEqual(singleLinePointer);
 	});
 
-	test('compile accepts continuation after a stack instruction', () => {
+	test('compile resolves split-byte hex defaults from continuation lines', () => {
+		const split = compile([{ code: ['module target', 'int color', '- 0xA8', '- 0xFF', 'moduleEnd'] }], {
+			startingMemoryWordAddress: 0,
+		});
+		const singleLine = compile([{ code: ['module target', 'int color 0xA8 0xFF', 'moduleEnd'] }], {
+			startingMemoryWordAddress: 0,
+		});
+
+		expect(split.compiledModules.target.memoryMap.color.default).toBe(0xa8ff0000);
+		expect(split.compiledModules.target.memoryMap.color).toEqual(singleLine.compiledModules.target.memoryMap.color);
+	});
+
+	test('compile accepts negative literals from continuation lines after stack instructions', () => {
 		expect(() =>
-			compile([{ code: ['module target', 'push', '- 1', 'drop', 'moduleEnd'] }], {
+			compile([{ code: ['module target', 'push', '- -1', 'drop', 'moduleEnd'] }], {
 				startingMemoryWordAddress: 0,
 			})
 		).not.toThrow();


### PR DESCRIPTION
## Summary
- Fold `- <arg>` continuation lines into the previous source instruction before AST validation
- Add tokenizer coverage for valid folding and invalid bare, multi-argument, and orphaned continuation lines
- Document source syntax and archive TODO 433

## Tests
- `npx nx run @8f4e/tokenizer:test`
- `npx nx run @8f4e/tokenizer:lint`
- `npx nx run @8f4e/tokenizer:build --skip-nx-cache`
- `npx nx run @8f4e/compiler:test`
- pre-commit: `npx nx run-many --target=typecheck --all`
- `git diff --check`