### PR TITLE
feat(compiler): support multi-result ifEnd blocks

### DIFF
--- a/packages/cli/src/compile/traceInstructionFlow.ts
+++ b/packages/cli/src/compile/traceInstructionFlow.ts
@@ -190,8 +190,7 @@ export default function traceInstructionFlow(
 			stack: [],
 			blockStack: [
 				{
-					hasExpectedResult: false,
-					expectedResultIsInteger: false,
+					expectedResultTypes: [],
 					blockType: kind === constantsBlockType ? BlockType.CONSTANTS : BlockType.MODULE,
 				},
 			],
@@ -230,8 +229,7 @@ export default function traceInstructionFlow(
 			stack: [],
 			blockStack: [
 				{
-					hasExpectedResult: false,
-					expectedResultIsInteger: false,
+					expectedResultTypes: [],
 					blockType: BlockType.FUNCTION,
 				},
 			],

--- a/packages/compiler-spec/src/ast.ts
+++ b/packages/compiler-spec/src/ast.ts
@@ -33,44 +33,49 @@ export type CompileTimeValueArgument = ArgumentLiteral | ArgumentIdentifier | Ar
 export type PushArgument = ArgumentLiteral | ArgumentIdentifier | ArgumentCompileTimeExpression | ArgumentStringLiteral;
 export type PushLine = ASTLineBase<'push', [PushArgument]>;
 
-export type IfBlockResultType = 'int' | 'float' | null;
+export type BlockResultType = 'int' | 'float';
+export type BlockResultTypes = BlockResultType[];
 
 /** Parser metadata linking an `if` line to its closing line and result shape. */
 export interface IfBlockMetadata {
 	matchingIfEndIndex: number;
-	resultType: IfBlockResultType;
+	resultTypes: BlockResultTypes;
 	hasElse: boolean;
 }
 
 /** Parser metadata linking an `ifEnd` line back to its opening `if`. */
 export interface IfEndBlockMetadata {
 	matchingIfIndex: number;
-	resultType: IfBlockResultType;
+	resultTypes: BlockResultTypes;
 }
 
 export type IfLine = ASTLineBase<'if', []> & {
 	ifBlock?: IfBlockMetadata;
 };
-export type IfEndLine = ASTLineBase<'ifEnd', [] | [ArgumentIdentifier]> & {
+export type PairedIfLine = IfLine & {
+	ifBlock: IfBlockMetadata;
+};
+export type IfEndLine = ASTLineBase<'ifEnd', ArgumentIdentifier[]> & {
 	ifEndBlock?: IfEndBlockMetadata;
 };
-
-export type BlockBlockResultType = 'int' | 'float' | null;
 
 /** Parser metadata linking a generic `block` line to its closing line. */
 export interface BlockBlockMetadata {
 	matchingBlockEndIndex: number;
-	resultType: BlockBlockResultType;
+	resultTypes: BlockResultTypes;
 }
 
 /** Parser metadata linking a `blockEnd` line back to its opening `block`. */
 export interface BlockEndBlockMetadata {
 	matchingBlockIndex: number;
-	resultType: BlockBlockResultType;
+	resultTypes: BlockResultTypes;
 }
 
 export type BlockLine = ASTLineBase<'block', []> & {
 	blockBlock?: BlockBlockMetadata;
+};
+export type PairedBlockLine = BlockLine & {
+	blockBlock: BlockBlockMetadata;
 };
 export type BlockEndLine = ASTLineBase<'blockEnd', [] | [ArgumentIdentifier]> & {
 	blockEndBlock?: BlockEndBlockMetadata;

--- a/packages/compiler-spec/src/instructionSpecs.ts
+++ b/packages/compiler-spec/src/instructionSpecs.ts
@@ -614,7 +614,7 @@ export const instructionSpecs = {
 	},
 	// ifEnd ( -- ), ifEnd (T -- T)
 	ifEnd: {
-		sourceArguments: { maxArguments: 1, argumentTypes: 'ifResultType' },
+		sourceArguments: { argumentTypes: 'ifResultType' },
 		scope: 'moduleOrFunction',
 		docs: { shortDescription: 'Ends an if block and validates its optional result value.' },
 		stack: stack({ inputs: ['T?'], outputs: ['T?'] }),

--- a/packages/compiler-spec/src/semantic.ts
+++ b/packages/compiler-spec/src/semantic.ts
@@ -415,8 +415,7 @@ export interface MapBlockState {
 
 /** Common result expectation tracked for every open block frame. */
 interface BlockStackFrameBase {
-	expectedResultIsInteger: boolean;
-	hasExpectedResult: boolean;
+	expectedResultTypes: Array<'int' | 'float'>;
 }
 
 /** Block stack frame for an open module block. */

--- a/packages/compiler/docs/instructions/control-flow.md
+++ b/packages/compiler/docs/instructions/control-flow.md
@@ -114,7 +114,7 @@ ifEnd int
 
 ### ifEnd
 
-The ifEnd instruction ends an if or else block. It accepts an optional result type (`int` or `float`) to declare whether the block must leave a value on the stack. A bare `ifEnd` means the block produces no result.
+The ifEnd instruction ends an if or else block. It accepts zero or more result types (`int` or `float`) to declare the values the block must leave on the stack. A bare `ifEnd` means the block produces no result.
 
 #### Examples
 
@@ -125,6 +125,17 @@ if
 else
  push 2
 ifEnd int
+```
+
+```
+push 1
+if
+ push 10
+ push 20
+else
+ push 30
+ push 40
+ifEnd int int
 ```
 
 ### loop

--- a/packages/compiler/packages/tokenizer/src/parser.test.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.test.ts
@@ -399,7 +399,7 @@ describe('compileToASTLines', () => {
 			arguments: [],
 			ifBlock: {
 				matchingIfEndIndex: 3,
-				resultType: 'int',
+				resultTypes: ['int'],
 				hasElse: false,
 			},
 		});
@@ -407,7 +407,28 @@ describe('compileToASTLines', () => {
 			instruction: 'ifEnd',
 			ifEndBlock: {
 				matchingIfIndex: 1,
-				resultType: 'int',
+				resultTypes: ['int'],
+			},
+		});
+	});
+
+	it('pairs if with multi-result ifEnd metadata', () => {
+		const ast = compileToASTLines(['push 1', 'if', 'push 10', 'push 20', 'ifEnd int float']);
+
+		expect(ast[1]).toMatchObject({
+			instruction: 'if',
+			arguments: [],
+			ifBlock: {
+				matchingIfEndIndex: 4,
+				resultTypes: ['int', 'float'],
+				hasElse: false,
+			},
+		});
+		expect(ast[4]).toMatchObject({
+			instruction: 'ifEnd',
+			ifEndBlock: {
+				matchingIfIndex: 1,
+				resultTypes: ['int', 'float'],
 			},
 		});
 	});
@@ -417,7 +438,7 @@ describe('compileToASTLines', () => {
 
 		expect(ast[1].ifBlock).toMatchObject({
 			matchingIfEndIndex: 5,
-			resultType: null,
+			resultTypes: [],
 			hasElse: true,
 		});
 	});
@@ -438,14 +459,14 @@ describe('compileToASTLines', () => {
 			arguments: [],
 			blockBlock: {
 				matchingBlockEndIndex: 2,
-				resultType: 'int',
+				resultTypes: ['int'],
 			},
 		});
 		expect(ast[2]).toMatchObject({
 			instruction: 'blockEnd',
 			blockEndBlock: {
 				matchingBlockIndex: 0,
-				resultType: 'int',
+				resultTypes: ['int'],
 			},
 		});
 	});
@@ -455,11 +476,11 @@ describe('compileToASTLines', () => {
 
 		expect(ast[0].blockBlock).toMatchObject({
 			matchingBlockEndIndex: 2,
-			resultType: 'float',
+			resultTypes: ['float'],
 		});
 		expect(ast[2].blockEndBlock).toMatchObject({
 			matchingBlockIndex: 0,
-			resultType: 'float',
+			resultTypes: ['float'],
 		});
 	});
 
@@ -468,11 +489,11 @@ describe('compileToASTLines', () => {
 
 		expect(ast[0].blockBlock).toMatchObject({
 			matchingBlockEndIndex: 2,
-			resultType: null,
+			resultTypes: [],
 		});
 		expect(ast[2].blockEndBlock).toMatchObject({
 			matchingBlockIndex: 0,
-			resultType: null,
+			resultTypes: [],
 		});
 	});
 

--- a/packages/compiler/packages/tokenizer/src/parser.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.ts
@@ -3,10 +3,10 @@ import type {
 	AST,
 	ASTCache,
 	ASTCacheEntry,
-	BlockBlockResultType,
 	BlockEndInstruction,
 	BlockEndLine,
 	BlockLine,
+	BlockResultTypes,
 	BlockStartInstruction,
 	CompilerASTLine,
 	CompilerASTLines,
@@ -15,7 +15,6 @@ import type {
 	FunctionEndLine,
 	FunctionLine,
 	FunctionSignature,
-	IfBlockResultType,
 	IfEndLine,
 	IfLine,
 	ImportLine,
@@ -128,8 +127,8 @@ function isBlockEndInstruction(instruction: string): instruction is BlockEndInst
 	return Object.hasOwn(blockEndToStartInstruction, instruction);
 }
 
-function getResultTypeFromFirstArgument(line: IfEndLine | BlockEndLine): IfBlockResultType {
-	return (line.arguments[0]?.value ?? null) as IfBlockResultType;
+function getResultTypesFromArguments(line: IfEndLine | BlockEndLine): BlockResultTypes {
+	return line.arguments.map(argument => argument.value as BlockResultTypes[number]);
 }
 
 function hasExplicitMemoryDefault(instruction: string, args: Array<Argument>): boolean {
@@ -673,25 +672,25 @@ function parseCompilerSource(code: string[], lineMetadata?: ParsedLineMetadata):
 		}
 
 		if (parsedLine.instruction === 'ifEnd' && openBlock.instruction === 'if') {
-			const resultType = getResultTypeFromFirstArgument(parsedLine);
+			const resultTypes = getResultTypesFromArguments(parsedLine);
 			openBlock.line.ifBlock = {
 				matchingIfEndIndex: astIndex,
-				resultType,
+				resultTypes,
 				hasElse: Boolean(openBlock.hasElse),
 			};
 			parsedLine.ifEndBlock = {
 				matchingIfIndex: openBlock.astIndex,
-				resultType,
+				resultTypes,
 			};
 		} else if (parsedLine.instruction === 'blockEnd' && openBlock.instruction === 'block') {
-			const resultType = getResultTypeFromFirstArgument(parsedLine) as BlockBlockResultType;
+			const resultTypes = getResultTypesFromArguments(parsedLine);
 			openBlock.line.blockBlock = {
 				matchingBlockEndIndex: astIndex,
-				resultType,
+				resultTypes,
 			};
 			parsedLine.blockEndBlock = {
 				matchingBlockIndex: openBlock.astIndex,
-				resultType,
+				resultTypes,
 			};
 		}
 	}

--- a/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.test.ts
+++ b/packages/compiler/packages/tokenizer/src/syntax/validateInstructionArguments.test.ts
@@ -146,10 +146,14 @@ describe('validateInstructionArguments', () => {
 		).toThrowError(SyntaxRulesError);
 	});
 
-	it('rejects too many result types for ifEnd', () => {
+	it('accepts multiple result types for ifEnd', () => {
 		expect(() =>
-			validateInstructionArguments('ifEnd', [classifyIdentifier('int'), classifyIdentifier('float')])
-		).toThrowError(SyntaxRulesError);
+			validateInstructionArguments('ifEnd', [
+				classifyIdentifier('int'),
+				classifyIdentifier('float'),
+				classifyIdentifier('int'),
+			])
+		).not.toThrow();
 	});
 
 	it('rejects non-constant identifiers for const declarations', () => {

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/audio_audioBuffer_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/audio_audioBuffer_8f4e.snap
@@ -295,7 +295,7 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 29,
-      "resultType": null,
+      "resultTypes": [],
       "hasElse": false
     }
   },
@@ -340,7 +340,7 @@
     "arguments": [],
     "ifEndBlock": {
       "matchingIfIndex": 25,
-      "resultType": null
+      "resultTypes": []
     }
   },
   {
@@ -622,7 +622,7 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 55,
-      "resultType": null,
+      "resultTypes": [],
       "hasElse": false
     }
   },
@@ -669,7 +669,7 @@
     "arguments": [],
     "ifEndBlock": {
       "matchingIfIndex": 51,
-      "resultType": null
+      "resultTypes": []
     }
   },
   {
@@ -1233,7 +1233,7 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 100,
-      "resultType": null,
+      "resultTypes": [],
       "hasElse": false
     }
   },
@@ -1289,7 +1289,7 @@
     "arguments": [],
     "ifEndBlock": {
       "matchingIfIndex": 95,
-      "resultType": null
+      "resultTypes": []
     }
   },
   {
@@ -1349,7 +1349,7 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 113,
-      "resultType": null,
+      "resultTypes": [],
       "hasElse": false
     }
   },
@@ -1423,7 +1423,7 @@
     "arguments": [],
     "ifEndBlock": {
       "matchingIfIndex": 106,
-      "resultType": null
+      "resultTypes": []
     }
   },
   {

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/digital_bistableMultivibrators_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/digital_bistableMultivibrators_8f4e.snap
@@ -277,7 +277,9 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 26,
-      "resultType": "int",
+      "resultTypes": [
+        "int"
+      ],
       "hasElse": true
     }
   },
@@ -325,7 +327,9 @@
     ],
     "ifEndBlock": {
       "matchingIfIndex": 22,
-      "resultType": "int"
+      "resultTypes": [
+        "int"
+      ]
     }
   },
   {
@@ -495,7 +499,9 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 43,
-      "resultType": "int",
+      "resultTypes": [
+        "int"
+      ],
       "hasElse": true
     }
   },
@@ -543,7 +549,9 @@
     ],
     "ifEndBlock": {
       "matchingIfIndex": 39,
-      "resultType": "int"
+      "resultTypes": [
+        "int"
+      ]
     }
   },
   {
@@ -733,7 +741,7 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 62,
-      "resultType": null,
+      "resultTypes": [],
       "hasElse": false
     }
   },
@@ -780,7 +788,7 @@
     "arguments": [],
     "ifEndBlock": {
       "matchingIfIndex": 58,
-      "resultType": null
+      "resultTypes": []
     }
   },
   {
@@ -978,7 +986,9 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 82,
-      "resultType": "int",
+      "resultTypes": [
+        "int"
+      ],
       "hasElse": true
     }
   },
@@ -1026,7 +1036,9 @@
     ],
     "ifEndBlock": {
       "matchingIfIndex": 78,
-      "resultType": "int"
+      "resultTypes": [
+        "int"
+      ]
     }
   },
   {
@@ -1196,7 +1208,9 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 99,
-      "resultType": "int",
+      "resultTypes": [
+        "int"
+      ],
       "hasElse": true
     }
   },
@@ -1244,7 +1258,9 @@
     ],
     "ifEndBlock": {
       "matchingIfIndex": 95,
-      "resultType": "int"
+      "resultTypes": [
+        "int"
+      ]
     }
   },
   {
@@ -1414,7 +1430,9 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 116,
-      "resultType": "int",
+      "resultTypes": [
+        "int"
+      ],
       "hasElse": true
     }
   },
@@ -1462,7 +1480,9 @@
     ],
     "ifEndBlock": {
       "matchingIfIndex": 112,
-      "resultType": "int"
+      "resultTypes": [
+        "int"
+      ]
     }
   },
   {
@@ -1652,7 +1672,7 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 135,
-      "resultType": null,
+      "resultTypes": [],
       "hasElse": false
     }
   },
@@ -1699,7 +1719,7 @@
     "arguments": [],
     "ifEndBlock": {
       "matchingIfIndex": 131,
-      "resultType": null
+      "resultTypes": []
     }
   },
   {

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/machine-learning_xorProblem_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/machine-learning_xorProblem_8f4e.snap
@@ -1254,7 +1254,9 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 98,
-      "resultType": "int",
+      "resultTypes": [
+        "int"
+      ],
       "hasElse": true
     }
   },
@@ -1302,7 +1304,9 @@
     ],
     "ifEndBlock": {
       "matchingIfIndex": 94,
-      "resultType": "int"
+      "resultTypes": [
+        "int"
+      ]
     }
   },
   {

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/visuals_dancingWithTheSineLT_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/visuals_dancingWithTheSineLT_8f4e.snap
@@ -5116,7 +5116,7 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 279,
-      "resultType": null,
+      "resultTypes": [],
       "hasElse": false
     }
   },
@@ -5161,7 +5161,7 @@
     "arguments": [],
     "ifEndBlock": {
       "matchingIfIndex": 275,
-      "resultType": null
+      "resultTypes": []
     }
   },
   {
@@ -5426,7 +5426,7 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 304,
-      "resultType": null,
+      "resultTypes": [],
       "hasElse": false
     }
   },
@@ -5471,7 +5471,7 @@
     "arguments": [],
     "ifEndBlock": {
       "matchingIfIndex": 300,
-      "resultType": null
+      "resultTypes": []
     }
   },
   {
@@ -5736,7 +5736,7 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 329,
-      "resultType": null,
+      "resultTypes": [],
       "hasElse": false
     }
   },
@@ -5781,7 +5781,7 @@
     "arguments": [],
     "ifEndBlock": {
       "matchingIfIndex": 325,
-      "resultType": null
+      "resultTypes": []
     }
   },
   {
@@ -6072,7 +6072,7 @@
     "arguments": [],
     "ifBlock": {
       "matchingIfEndIndex": 355,
-      "resultType": null,
+      "resultTypes": [],
       "hasElse": false
     }
   },
@@ -6117,7 +6117,7 @@
     "arguments": [],
     "ifEndBlock": {
       "matchingIfIndex": 351,
-      "resultType": null
+      "resultTypes": []
     }
   },
   {

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -104,7 +104,8 @@ export function compileModule(
 	index: number,
 	functions?: FunctionMetadataLookup,
 	internalAllocator = { nextByteAddress: 0 },
-	options: Pick<CompileOptions, 'includeStackAnalysis' | 'memoryRegions'> = {}
+	options: Pick<CompileOptions, 'includeStackAnalysis' | 'memoryRegions'> = {},
+	typeRegistry?: FunctionTypeRegistry
 ): CompiledModule {
 	// Namespace layout establishes memory byte addresses and sizes for this module.
 	// Semantic instructions (const, use, module/moduleEnd) are applied during
@@ -134,6 +135,7 @@ export function compileModule(
 		...(memoryRegionName ? { currentMemoryRegionName: memoryRegionName } : {}),
 		memoryRegions: options.memoryRegions ?? [],
 		mode: 'module',
+		functionTypeRegistry: typeRegistry,
 	});
 
 	const stackAnalysis: CompiledStackAnalysisLine[] = [];

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -89,7 +89,8 @@ export function compileModules(
 	options: CompileOptions,
 	namespaces?: Namespaces,
 	compiledFunctions?: FunctionMetadataLookup,
-	internalAllocator?: { nextByteAddress: number }
+	internalAllocator?: { nextByteAddress: number },
+	typeRegistry?: FunctionTypeRegistry
 ): CompiledModule[] {
 	const startingByteAddress = (options.startingMemoryWordAddress ?? 0) * GLOBAL_ALIGNMENT_BOUNDARY;
 	const ns: Namespaces =
@@ -108,7 +109,16 @@ export function compileModules(
 	return modules.map((ast, index) => {
 		const moduleStartingByteAddress =
 			ns[ast.id]?.byteAddress !== undefined ? ns[ast.id].byteAddress : startingByteAddress;
-		const module = compileModule(ast, ns, moduleStartingByteAddress, index, compiledFunctions, allocator, options);
+		const module = compileModule(
+			ast,
+			ns,
+			moduleStartingByteAddress,
+			index,
+			compiledFunctions,
+			allocator,
+			options,
+			typeRegistry
+		);
 		return module;
 	});
 }
@@ -380,7 +390,8 @@ export default function compile(
 		},
 		namespaces,
 		functionMetadata,
-		internalAllocator
+		internalAllocator,
+		functionTypeRegistry
 	).map((module, index) => ({
 		...module,
 		executionEntryName: moduleEntryNames[index],

--- a/packages/compiler/src/instructionCompilers/__snapshots__/block.test.ts.snap
+++ b/packages/compiler/src/instructionCompilers/__snapshots__/block.test.ts.snap
@@ -5,13 +5,13 @@ exports[`block instruction compiler > emits a typed block for float 1`] = `
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 4,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": true,
+      "expectedResultTypes": [
+        "float",
+      ],
     },
   ],
   "byteCode": [
@@ -26,13 +26,13 @@ exports[`block instruction compiler > emits a typed block for int 1`] = `
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 4,
-      "expectedResultIsInteger": true,
-      "hasExpectedResult": true,
+      "expectedResultTypes": [
+        "int",
+      ],
     },
   ],
   "byteCode": [
@@ -47,13 +47,11 @@ exports[`block instruction compiler > emits a void block when no result type is 
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 4,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
   ],
   "byteCode": [

--- a/packages/compiler/src/instructionCompilers/__snapshots__/else.test.ts.snap
+++ b/packages/compiler/src/instructionCompilers/__snapshots__/else.test.ts.snap
@@ -5,13 +5,13 @@ exports[`else instruction compiler > emits else bytecode and restores block 1`] 
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 2,
-      "expectedResultIsInteger": true,
-      "hasExpectedResult": true,
+      "expectedResultTypes": [
+        "int",
+      ],
     },
   ],
   "byteCode": [

--- a/packages/compiler/src/instructionCompilers/__snapshots__/function.test.ts.snap
+++ b/packages/compiler/src/instructionCompilers/__snapshots__/function.test.ts.snap
@@ -5,8 +5,7 @@ exports[`function instruction compiler > starts a new function block 1`] = `
   "blockStack": [
     {
       "blockType": 3,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
   ],
   "currentFunctionId": "doThing",

--- a/packages/compiler/src/instructionCompilers/__snapshots__/functionEnd.test.ts.snap
+++ b/packages/compiler/src/instructionCompilers/__snapshots__/functionEnd.test.ts.snap
@@ -5,8 +5,7 @@ exports[`functionEnd instruction compiler > accepts float64 return type and emit
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
   ],
   "currentFunctionSignature": {
@@ -31,8 +30,7 @@ exports[`functionEnd instruction compiler > updates function signature and clear
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
   ],
   "currentFunctionSignature": {

--- a/packages/compiler/src/instructionCompilers/__snapshots__/if.test.ts.snap
+++ b/packages/compiler/src/instructionCompilers/__snapshots__/if.test.ts.snap
@@ -5,13 +5,13 @@ exports[`if instruction compiler > emits a float if block 1`] = `
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 2,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": true,
+      "expectedResultTypes": [
+        "float",
+      ],
     },
   ],
   "byteCode": [
@@ -21,18 +21,49 @@ exports[`if instruction compiler > emits a float if block 1`] = `
 }
 `;
 
+exports[`if instruction compiler > emits a multi-result if block type index 1`] = `
+{
+  "blockStack": [
+    {
+      "blockType": 0,
+      "expectedResultTypes": [],
+    },
+    {
+      "blockType": 2,
+      "expectedResultTypes": [
+        "int",
+        "float",
+      ],
+    },
+  ],
+  "byteCode": [
+    4,
+    0,
+  ],
+  "typeCount": 1,
+  "typeSignatures": [
+    {
+      "params": [],
+      "results": [
+        127,
+        125,
+      ],
+      "typeIndex": 0,
+    },
+  ],
+}
+`;
+
 exports[`if instruction compiler > emits a void if block when given no arguments 1`] = `
 {
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 2,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
   ],
   "byteCode": [
@@ -47,13 +78,11 @@ exports[`if instruction compiler > emits a void if block when the matching ifEnd
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 2,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
   ],
   "byteCode": [
@@ -68,13 +97,13 @@ exports[`if instruction compiler > emits an int if block 1`] = `
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 2,
-      "expectedResultIsInteger": true,
-      "hasExpectedResult": true,
+      "expectedResultTypes": [
+        "int",
+      ],
     },
   ],
   "byteCode": [

--- a/packages/compiler/src/instructionCompilers/__snapshots__/ifEnd.test.ts.snap
+++ b/packages/compiler/src/instructionCompilers/__snapshots__/ifEnd.test.ts.snap
@@ -1,12 +1,37 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`ifEnd instruction compiler > ends a conditional block with multiple results 1`] = `
+{
+  "blockStack": [
+    {
+      "blockType": 0,
+      "expectedResultTypes": [],
+    },
+  ],
+  "byteCode": [
+    11,
+  ],
+  "stack": [
+    {
+      "isNonZero": false,
+      "kind": "value",
+      "valueType": "int",
+    },
+    {
+      "isNonZero": false,
+      "kind": "value",
+      "valueType": "float",
+    },
+  ],
+}
+`;
+
 exports[`ifEnd instruction compiler > ends a conditional block with result 1`] = `
 {
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
   ],
   "byteCode": [

--- a/packages/compiler/src/instructionCompilers/__snapshots__/initBlock.ts.snap
+++ b/packages/compiler/src/instructionCompilers/__snapshots__/initBlock.ts.snap
@@ -5,13 +5,11 @@ exports[`initBlock instruction compiler > pushes the init block 1`] = `
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 5,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
   ],
 }

--- a/packages/compiler/src/instructionCompilers/__snapshots__/initBlockEnd.ts.snap
+++ b/packages/compiler/src/instructionCompilers/__snapshots__/initBlockEnd.ts.snap
@@ -5,8 +5,7 @@ exports[`initBlockEnd instruction compiler > pops the init block 1`] = `
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
   ],
 }

--- a/packages/compiler/src/instructionCompilers/__snapshots__/loop.test.ts.snap
+++ b/packages/compiler/src/instructionCompilers/__snapshots__/loop.test.ts.snap
@@ -5,13 +5,11 @@ exports[`loop instruction compiler > compiles the loop segment with default cap 
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 1,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
       "loopCounterLocal": {
         "index": 0,
         "isInteger": true,
@@ -62,13 +60,11 @@ exports[`loop instruction compiler > compiles the loop segment with explicit cap
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 1,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
       "loopCounterLocal": {
         "index": 0,
         "isInteger": true,
@@ -118,13 +114,11 @@ exports[`loop instruction compiler > explicit argument overrides context.loopCap
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 1,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
       "loopCounterLocal": {
         "index": 0,
         "isInteger": true,
@@ -174,13 +168,11 @@ exports[`loop instruction compiler > uses context.loopCap when no argument is pr
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 1,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
       "loopCounterLocal": {
         "index": 0,
         "isInteger": true,

--- a/packages/compiler/src/instructionCompilers/__snapshots__/loopEnd.test.ts.snap
+++ b/packages/compiler/src/instructionCompilers/__snapshots__/loopEnd.test.ts.snap
@@ -5,8 +5,7 @@ exports[`loopEnd instruction compiler > ends a loop block 1`] = `
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
   ],
   "byteCode": [

--- a/packages/compiler/src/instructionCompilers/__snapshots__/mapBegin.test.ts.snap
+++ b/packages/compiler/src/instructionCompilers/__snapshots__/mapBegin.test.ts.snap
@@ -5,13 +5,11 @@ exports[`mapBegin instruction compiler > opens a map block for float input type 
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 6,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
       "mapState": {
         "defaultSet": false,
         "inputIsFloat64": false,
@@ -28,13 +26,11 @@ exports[`mapBegin instruction compiler > opens a map block for float64 input typ
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 6,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
       "mapState": {
         "defaultSet": false,
         "inputIsFloat64": true,
@@ -51,13 +47,11 @@ exports[`mapBegin instruction compiler > opens a map block for int input type 1`
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
     {
       "blockType": 6,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
       "mapState": {
         "defaultSet": false,
         "inputIsFloat64": false,

--- a/packages/compiler/src/instructionCompilers/__snapshots__/mapEnd.test.ts.snap
+++ b/packages/compiler/src/instructionCompilers/__snapshots__/mapEnd.test.ts.snap
@@ -5,8 +5,7 @@ exports[`mapEnd instruction compiler > emits DROP + typed zero for zero rows 1`]
   "blockStack": [
     {
       "blockType": 0,
-      "expectedResultIsInteger": false,
-      "hasExpectedResult": false,
+      "expectedResultTypes": [],
     },
   ],
   "byteCode": [

--- a/packages/compiler/src/instructionCompilers/block.test.ts
+++ b/packages/compiler/src/instructionCompilers/block.test.ts
@@ -15,7 +15,7 @@ describe('block instruction compiler', () => {
 				lineNumberAfterMacroExpansion: 1,
 				instruction: 'block',
 				arguments: [],
-				blockBlock: { matchingBlockEndIndex: 2, resultType: 'float' },
+				blockBlock: { matchingBlockEndIndex: 2, resultTypes: ['float'] },
 			} as CompilerASTLine,
 			context
 		);
@@ -36,7 +36,7 @@ describe('block instruction compiler', () => {
 				lineNumberAfterMacroExpansion: 1,
 				instruction: 'block',
 				arguments: [],
-				blockBlock: { matchingBlockEndIndex: 2, resultType: 'int' },
+				blockBlock: { matchingBlockEndIndex: 2, resultTypes: ['int'] },
 			} as CompilerASTLine,
 			context
 		);
@@ -57,7 +57,7 @@ describe('block instruction compiler', () => {
 				lineNumberAfterMacroExpansion: 1,
 				instruction: 'block',
 				arguments: [],
-				blockBlock: { matchingBlockEndIndex: 2, resultType: null },
+				blockBlock: { matchingBlockEndIndex: 2, resultTypes: [] },
 			} as CompilerASTLine,
 			context
 		);

--- a/packages/compiler/src/instructionCompilers/block.ts
+++ b/packages/compiler/src/instructionCompilers/block.ts
@@ -1,4 +1,4 @@
-import type { BlockLine, InstructionCompiler } from '@8f4e/compiler-spec';
+import type { InstructionCompiler, PairedBlockLine } from '@8f4e/compiler-spec';
 import { BlockType } from '@8f4e/compiler-spec';
 import { WASM_BLOCK } from '@8f4e/compiler-wasm-utils';
 import { pushBlock } from '../utils/blockStack';
@@ -9,11 +9,15 @@ import { saveByteCode } from './utils/saveByteCode';
  * Instruction compiler for `block`.
  * @see [Instruction docs](../../docs/instructions/control-flow.md)
  */
-const block: InstructionCompiler<BlockLine> = (line: BlockLine, context) => {
-	const { blockState, wasmType } = createResultBlockState(line.blockBlock?.resultType, BlockType.BLOCK);
+const block: InstructionCompiler<PairedBlockLine> = (line, context) => {
+	const { blockState, wasmBlockType } = createResultBlockState(
+		line.blockBlock.resultTypes,
+		BlockType.BLOCK,
+		context.functionTypeRegistry
+	);
 
 	pushBlock(context, blockState);
-	return saveByteCode(context, [WASM_BLOCK, wasmType]);
+	return saveByteCode(context, [WASM_BLOCK, ...wasmBlockType]);
 };
 
 export default block;

--- a/packages/compiler/src/instructionCompilers/blockEnd.test.ts
+++ b/packages/compiler/src/instructionCompilers/blockEnd.test.ts
@@ -11,9 +11,7 @@ describe('blockEnd instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.BLOCK,
-					expectedResultIsInteger: true,
-					hasExpectedResult: true,
+					blockType: BlockType.BLOCK,expectedResultTypes: ['int'],
 				},
 			],
 		});

--- a/packages/compiler/src/instructionCompilers/default.test.ts
+++ b/packages/compiler/src/instructionCompilers/default.test.ts
@@ -10,14 +10,10 @@ describe('default instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MODULE,expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.MAP,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MAP,expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,

--- a/packages/compiler/src/instructionCompilers/else.test.ts
+++ b/packages/compiler/src/instructionCompilers/else.test.ts
@@ -11,9 +11,7 @@ describe('else instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.CONDITION,
-					expectedResultIsInteger: true,
-					hasExpectedResult: true,
+					blockType: BlockType.CONDITION,expectedResultTypes: ['int'],
 				},
 			],
 		});

--- a/packages/compiler/src/instructionCompilers/exitIfTrue.test.ts
+++ b/packages/compiler/src/instructionCompilers/exitIfTrue.test.ts
@@ -32,9 +32,7 @@ describe('exitIfTrue instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.FUNCTION,expectedResultTypes: [],
 				},
 			],
 		});

--- a/packages/compiler/src/instructionCompilers/function.ts
+++ b/packages/compiler/src/instructionCompilers/function.ts
@@ -38,8 +38,7 @@ const _function = ((line: FunctionLine, context: CodegenContext) => {
 
 	pushBlock(context, {
 		blockType: BlockType.FUNCTION,
-		expectedResultIsInteger: false,
-		hasExpectedResult: false,
+		expectedResultTypes: [],
 	});
 
 	return context;

--- a/packages/compiler/src/instructionCompilers/functionEnd.test.ts
+++ b/packages/compiler/src/instructionCompilers/functionEnd.test.ts
@@ -13,9 +13,7 @@ describe('functionEnd instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.FUNCTION,expectedResultTypes: [],
 				},
 			],
 			currentFunctionSignature: { parameters: ['int'], returns: [] },
@@ -56,9 +54,7 @@ describe('functionEnd instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.FUNCTION,expectedResultTypes: [],
 				},
 			],
 			currentFunctionSignature: { parameters: ['float64'], returns: [] },
@@ -105,9 +101,7 @@ describe('functionEnd instruction compiler', () => {
 				blockStack: [
 					...createInstructionCompilerTestContext().blockStack,
 					{
-						blockType: BlockType.FUNCTION,
-						expectedResultIsInteger: false,
-						hasExpectedResult: false,
+						blockType: BlockType.FUNCTION,expectedResultTypes: [],
 					},
 				],
 				currentFunctionSignature: { parameters: ['int'], returns: [] },

--- a/packages/compiler/src/instructionCompilers/if.test.ts
+++ b/packages/compiler/src/instructionCompilers/if.test.ts
@@ -16,7 +16,7 @@ describe('if instruction compiler', () => {
 				lineNumberAfterMacroExpansion: 1,
 				instruction: 'if',
 				arguments: [],
-				ifBlock: { matchingIfEndIndex: 2, resultType: null, hasElse: false },
+				ifBlock: { matchingIfEndIndex: 2, resultTypes: [], hasElse: false },
 			} as CompilerASTLine,
 			context
 		);
@@ -38,7 +38,7 @@ describe('if instruction compiler', () => {
 				lineNumberAfterMacroExpansion: 1,
 				instruction: 'if',
 				arguments: [],
-				ifBlock: { matchingIfEndIndex: 2, resultType: null, hasElse: false },
+				ifBlock: { matchingIfEndIndex: 2, resultTypes: [], hasElse: false },
 			} as CompilerASTLine,
 			context
 		);
@@ -60,7 +60,7 @@ describe('if instruction compiler', () => {
 				lineNumberAfterMacroExpansion: 1,
 				instruction: 'if',
 				arguments: [],
-				ifBlock: { matchingIfEndIndex: 2, resultType: 'float', hasElse: false },
+				ifBlock: { matchingIfEndIndex: 2, resultTypes: ['float'], hasElse: false },
 			} as CompilerASTLine,
 			context
 		);
@@ -82,7 +82,7 @@ describe('if instruction compiler', () => {
 				lineNumberAfterMacroExpansion: 1,
 				instruction: 'if',
 				arguments: [],
-				ifBlock: { matchingIfEndIndex: 2, resultType: 'int', hasElse: false },
+				ifBlock: { matchingIfEndIndex: 2, resultTypes: ['int'], hasElse: false },
 			} as CompilerASTLine,
 			context
 		);
@@ -90,6 +90,36 @@ describe('if instruction compiler', () => {
 		expect({
 			blockStack: context.blockStack,
 			byteCode: context.byteCode,
+		}).toMatchSnapshot();
+	});
+
+	it('emits a multi-result if block type index', () => {
+		const context = createInstructionCompilerTestContext({
+			functionTypeRegistry: {
+				baseTypeIndex: 0,
+				signatures: [],
+				types: [],
+			},
+		});
+		context.stack.push({ kind: 'value', valueType: 'int', isNonZero: false });
+
+		analyzeAndCompileInstruction(
+			_if,
+			{
+				lineNumberBeforeMacroExpansion: 1,
+				lineNumberAfterMacroExpansion: 1,
+				instruction: 'if',
+				arguments: [],
+				ifBlock: { matchingIfEndIndex: 2, resultTypes: ['int', 'float'], hasElse: false },
+			} as CompilerASTLine,
+			context
+		);
+
+		expect({
+			blockStack: context.blockStack,
+			byteCode: context.byteCode,
+			typeSignatures: context.functionTypeRegistry?.signatures,
+			typeCount: context.functionTypeRegistry?.types.length,
 		}).toMatchSnapshot();
 	});
 });

--- a/packages/compiler/src/instructionCompilers/if.ts
+++ b/packages/compiler/src/instructionCompilers/if.ts
@@ -1,4 +1,4 @@
-import type { IfLine, InstructionCompiler } from '@8f4e/compiler-spec';
+import type { InstructionCompiler, PairedIfLine } from '@8f4e/compiler-spec';
 import { BlockType } from '@8f4e/compiler-spec';
 import { WASM_IF } from '@8f4e/compiler-wasm-utils';
 import { pushBlock } from '../utils/blockStack';
@@ -9,11 +9,15 @@ import { saveByteCode } from './utils/saveByteCode';
  * Instruction compiler for `if`.
  * @see [Instruction docs](../../docs/instructions/control-flow.md)
  */
-const _if: InstructionCompiler<IfLine> = (line, context) => {
-	const { blockState, wasmType } = createResultBlockState(line.ifBlock?.resultType, BlockType.CONDITION);
+const _if: InstructionCompiler<PairedIfLine> = (line, context) => {
+	const { blockState, wasmBlockType } = createResultBlockState(
+		line.ifBlock.resultTypes,
+		BlockType.CONDITION,
+		context.functionTypeRegistry
+	);
 
 	pushBlock(context, blockState);
-	return saveByteCode(context, [WASM_IF, wasmType]);
+	return saveByteCode(context, [WASM_IF, ...wasmBlockType]);
 };
 
 export default _if;

--- a/packages/compiler/src/instructionCompilers/ifEnd.test.ts
+++ b/packages/compiler/src/instructionCompilers/ifEnd.test.ts
@@ -12,12 +12,42 @@ describe('ifEnd instruction compiler', () => {
 				...createInstructionCompilerTestContext().blockStack,
 				{
 					blockType: BlockType.CONDITION,
-					expectedResultIsInteger: true,
-					hasExpectedResult: true,
+					expectedResultTypes: ['int'],
 				},
 			],
 		});
 		context.stack.push({ kind: 'value', valueType: 'int', isNonZero: false });
+
+		analyzeAndCompileInstruction(
+			ifEnd,
+			{
+				lineNumberBeforeMacroExpansion: 1,
+				lineNumberAfterMacroExpansion: 1,
+				instruction: 'ifEnd',
+				arguments: [],
+			} as CompilerASTLine,
+			context
+		);
+
+		expect({
+			stack: context.stack,
+			blockStack: context.blockStack,
+			byteCode: context.byteCode,
+		}).toMatchSnapshot();
+	});
+
+	it('ends a conditional block with multiple results', () => {
+		const context = createInstructionCompilerTestContext({
+			blockStack: [
+				...createInstructionCompilerTestContext().blockStack,
+				{
+					blockType: BlockType.CONDITION,
+					expectedResultTypes: ['int', 'float'],
+				},
+			],
+		});
+		context.stack.push({ kind: 'value', valueType: 'int', isNonZero: false });
+		context.stack.push({ kind: 'value', valueType: 'float', isNonZero: false });
 
 		analyzeAndCompileInstruction(
 			ifEnd,

--- a/packages/compiler/src/instructionCompilers/impure.test.ts
+++ b/packages/compiler/src/instructionCompilers/impure.test.ts
@@ -10,9 +10,7 @@ describe('impure instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.FUNCTION,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.FUNCTION,expectedResultTypes: [],
 				},
 			],
 			mode: 'function',

--- a/packages/compiler/src/instructionCompilers/loop.ts
+++ b/packages/compiler/src/instructionCompilers/loop.ts
@@ -39,8 +39,7 @@ const loop: InstructionCompiler<NormalizedLoopLine | LoopLine> = (line, context)
 	context.locals[infiniteLoopProtectionCounterName] = loopCounterLocal;
 
 	const loopBlock: LoopBlockStackFrame = {
-		expectedResultIsInteger: false,
-		hasExpectedResult: false,
+		expectedResultTypes: [],
 		blockType: BlockType.LOOP,
 		loopCounterLocalName: infiniteLoopProtectionCounterName,
 		loopCounterLocal,

--- a/packages/compiler/src/instructionCompilers/loopCap.test.ts
+++ b/packages/compiler/src/instructionCompilers/loopCap.test.ts
@@ -11,9 +11,7 @@ describe('#loopCap instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MODULE,expectedResultTypes: [],
 				},
 			],
 		});
@@ -37,9 +35,7 @@ describe('#loopCap instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.FUNCTION,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.FUNCTION,expectedResultTypes: [],
 				},
 			],
 		});
@@ -63,9 +59,7 @@ describe('#loopCap instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MODULE,expectedResultTypes: [],
 				},
 			],
 		});
@@ -89,9 +83,7 @@ describe('#loopCap instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MODULE,expectedResultTypes: [],
 				},
 			],
 		});

--- a/packages/compiler/src/instructionCompilers/loopEnd.test.ts
+++ b/packages/compiler/src/instructionCompilers/loopEnd.test.ts
@@ -11,9 +11,7 @@ describe('loopEnd instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.LOOP,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.LOOP,expectedResultTypes: [],
 					loopCounterLocalName: '__loopCounter1',
 					loopCounterLocal: { kind: 'value', valueType: 'int', index: 0 },
 				},

--- a/packages/compiler/src/instructionCompilers/loopIndex.test.ts
+++ b/packages/compiler/src/instructionCompilers/loopIndex.test.ts
@@ -15,14 +15,10 @@ describe('loopIndex instruction compiler', () => {
 			},
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MODULE,expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.LOOP,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.LOOP,expectedResultTypes: [],
 					loopCounterLocalName: '__loopCounter2',
 					loopCounterLocal,
 				},
@@ -54,21 +50,15 @@ describe('loopIndex instruction compiler', () => {
 			},
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MODULE,expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.LOOP,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.LOOP,expectedResultTypes: [],
 					loopCounterLocalName: '__outer',
 					loopCounterLocal: outerLoopCounterLocal,
 				},
 				{
-					blockType: BlockType.LOOP,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.LOOP,expectedResultTypes: [],
 					loopCounterLocalName: '__inner',
 					loopCounterLocal: innerLoopCounterLocal,
 				},

--- a/packages/compiler/src/instructionCompilers/map.test.ts
+++ b/packages/compiler/src/instructionCompilers/map.test.ts
@@ -20,14 +20,10 @@ describe('map instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MODULE,expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.MAP,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MAP,expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,
@@ -59,14 +55,10 @@ describe('map instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MODULE,expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.MAP,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MAP,expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,
@@ -105,14 +97,10 @@ describe('map instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MODULE,expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.MAP,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MAP,expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,
@@ -156,14 +144,10 @@ describe('map instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MODULE,expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.MAP,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MAP,expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,

--- a/packages/compiler/src/instructionCompilers/mapBegin.ts
+++ b/packages/compiler/src/instructionCompilers/mapBegin.ts
@@ -11,8 +11,7 @@ const mapBegin: InstructionCompiler<MapBeginLine> = (line: MapBeginLine, context
 	const inputType = line.arguments[0].value;
 
 	pushBlock(context, {
-		expectedResultIsInteger: false,
-		hasExpectedResult: false,
+		expectedResultTypes: [],
 		blockType: BlockType.MAP,
 		mapState: {
 			inputIsInteger: inputType === 'int',

--- a/packages/compiler/src/instructionCompilers/mapEnd.test.ts
+++ b/packages/compiler/src/instructionCompilers/mapEnd.test.ts
@@ -12,14 +12,10 @@ describe('mapEnd instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MODULE,expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.MAP,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MAP,expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,
@@ -67,14 +63,10 @@ describe('mapEnd instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MODULE,expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.MAP,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MAP,expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,

--- a/packages/compiler/src/instructionCompilers/param.test.ts
+++ b/packages/compiler/src/instructionCompilers/param.test.ts
@@ -13,9 +13,7 @@ describe('param instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.FUNCTION,expectedResultTypes: [],
 				},
 			],
 			currentFunctionSignature: { parameters: [], returns: [] },
@@ -44,9 +42,7 @@ describe('param instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.FUNCTION,expectedResultTypes: [],
 				},
 			],
 			currentFunctionSignature: { parameters: [], returns: [] },
@@ -75,9 +71,7 @@ describe('param instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.FUNCTION,expectedResultTypes: [],
 				},
 			],
 			currentFunctionSignature: { parameters: [], returns: [] },
@@ -108,9 +102,7 @@ describe('param instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.FUNCTION,expectedResultTypes: [],
 				},
 			],
 			currentFunctionSignature: { parameters: [], returns: [] },
@@ -141,9 +133,7 @@ describe('param instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.FUNCTION,expectedResultTypes: [],
 				},
 			],
 			currentFunctionSignature: { parameters: [], returns: [] },

--- a/packages/compiler/src/instructionCompilers/return.test.ts
+++ b/packages/compiler/src/instructionCompilers/return.test.ts
@@ -12,9 +12,7 @@ describe('return instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.FUNCTION,expectedResultTypes: [],
 				},
 			],
 		});

--- a/packages/compiler/src/instructionCompilers/skipExecution.test.ts
+++ b/packages/compiler/src/instructionCompilers/skipExecution.test.ts
@@ -10,9 +10,7 @@ describe('skipExecution instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MODULE,expectedResultTypes: [],
 				},
 			],
 		});
@@ -55,9 +53,7 @@ describe('skipExecution instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MODULE,expectedResultTypes: [],
 				},
 			],
 		});

--- a/packages/compiler/src/instructionCompilers/utils/createResultBlockState.ts
+++ b/packages/compiler/src/instructionCompilers/utils/createResultBlockState.ts
@@ -1,51 +1,73 @@
-import type { BlockStack, BlockType } from '@8f4e/compiler-spec';
+import type { BlockResultTypes, BlockStack, BlockType, FunctionTypeRegistry } from '@8f4e/compiler-spec';
 
 import type { WasmTypeValue } from '@8f4e/compiler-wasm-utils';
-import { WASM_TYPE_F32, WASM_TYPE_I32, WASM_TYPE_VOID } from '@8f4e/compiler-wasm-utils';
+import { signedLEB128, WASM_TYPE_F32, WASM_TYPE_I32, WASM_TYPE_VOID } from '@8f4e/compiler-wasm-utils';
+import { getOrRegisterFunctionType } from '../../utils/functionTypeRegistry';
 
-type ResultType = 'float' | 'int' | null | undefined;
 type ResultBlockType = typeof BlockType.BLOCK | typeof BlockType.CONDITION;
 
 interface ResultBlockState<TBlockType extends ResultBlockType> {
 	blockState: Extract<BlockStack[number], { blockType: TBlockType }>;
-	wasmType: WasmTypeValue;
+	wasmBlockType: number[];
+}
+
+function resultTypeToWasmType(resultType: BlockResultTypes[number]): WasmTypeValue {
+	return resultType === 'float' ? WASM_TYPE_F32 : WASM_TYPE_I32;
 }
 
 /**
  * Creates the compiler block-stack metadata and matching WASM block result type.
  */
 export default function createResultBlockState<TBlockType extends ResultBlockType>(
-	resultType: ResultType,
-	blockType: TBlockType
+	resultTypes: BlockResultTypes,
+	blockType: TBlockType,
+	typeRegistry?: FunctionTypeRegistry
 ): ResultBlockState<TBlockType> {
-	if (resultType === 'float') {
+	if (resultTypes.length > 1) {
+		if (!typeRegistry) {
+			throw new Error('Missing function type registry for multi-result block.');
+		}
+
+		const resultWasmTypes = resultTypes.map(resultTypeToWasmType);
+		const typeIndex = getOrRegisterFunctionType(typeRegistry, {
+			params: [],
+			results: resultWasmTypes,
+		});
+
 		return {
 			blockState: {
-				expectedResultIsInteger: false,
-				hasExpectedResult: true,
+				expectedResultTypes: resultTypes,
 				blockType,
 			} as Extract<BlockStack[number], { blockType: TBlockType }>,
-			wasmType: WASM_TYPE_F32,
+			wasmBlockType: signedLEB128(typeIndex),
 		};
 	}
 
-	if (resultType === 'int') {
+	if (resultTypes[0] === 'float') {
 		return {
 			blockState: {
-				expectedResultIsInteger: true,
-				hasExpectedResult: true,
+				expectedResultTypes: resultTypes,
 				blockType,
 			} as Extract<BlockStack[number], { blockType: TBlockType }>,
-			wasmType: WASM_TYPE_I32,
+			wasmBlockType: [WASM_TYPE_F32],
+		};
+	}
+
+	if (resultTypes[0] === 'int') {
+		return {
+			blockState: {
+				expectedResultTypes: resultTypes,
+				blockType,
+			} as Extract<BlockStack[number], { blockType: TBlockType }>,
+			wasmBlockType: [WASM_TYPE_I32],
 		};
 	}
 
 	return {
 		blockState: {
-			expectedResultIsInteger: false,
-			hasExpectedResult: false,
+			expectedResultTypes: [],
 			blockType,
 		} as Extract<BlockStack[number], { blockType: TBlockType }>,
-		wasmType: WASM_TYPE_VOID,
+		wasmBlockType: [WASM_TYPE_VOID],
 	};
 }

--- a/packages/compiler/src/semantic/instructions/constants.ts
+++ b/packages/compiler/src/semantic/instructions/constants.ts
@@ -16,11 +16,7 @@ export default function semanticConstants(line: ConstantsLine, context: Compilat
 		throw getError(ErrorCode.INSTRUCTION_MUST_BE_TOP_LEVEL, line, context);
 	}
 
-	pushBlock(context, {
-		hasExpectedResult: false,
-		expectedResultIsInteger: false,
-		blockType: BlockType.CONSTANTS,
-	});
+	pushBlock(context, { expectedResultTypes: [], blockType: BlockType.CONSTANTS });
 
 	const moduleId = line.arguments[0].value;
 	context.namespace.moduleName = moduleId;

--- a/packages/compiler/src/semantic/instructions/module.ts
+++ b/packages/compiler/src/semantic/instructions/module.ts
@@ -12,11 +12,7 @@ const moduleBlockType = compilerSourceBlockInstructionByType.module.type;
 export default function semanticModule(line: ModuleLine, context: CompilationContext) {
 	const moduleId = line.arguments[0].value;
 
-	pushBlock(context, {
-		hasExpectedResult: false,
-		expectedResultIsInteger: false,
-		blockType: BlockType.MODULE,
-	});
+	pushBlock(context, { expectedResultTypes: [], blockType: BlockType.MODULE });
 
 	context.namespace.moduleName = moduleId;
 	context.codeBlockId = moduleId;

--- a/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
+++ b/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
@@ -374,24 +374,29 @@ function analyzeExpectedBlockResult(
 	{ restore = false, validateFloatResult = false } = {}
 ): { consumed: Stack; produced: Stack } {
 	const block = context.blockStack[context.blockStack.length - 1];
+	const expectedResultTypes = block?.expectedResultTypes ?? [];
 
-	if (!block?.hasExpectedResult) {
+	if (expectedResultTypes.length === 0) {
 		return { consumed: [], produced: [] };
 	}
 
-	const consumed = consume(context, 1);
-	const operand = consumed[0];
+	const consumed = consume(context, expectedResultTypes.length);
 
-	if (!operand) {
+	if (consumed.length < expectedResultTypes.length) {
 		throw getError(ErrorCode.INSUFFICIENT_OPERANDS, line, context);
 	}
 
-	if (block.expectedResultIsInteger && operand.valueType !== 'int') {
-		throw getError(ErrorCode.ONLY_INTEGERS, line, context);
-	}
+	for (let index = 0; index < expectedResultTypes.length; index++) {
+		const expectedResultType = expectedResultTypes[index];
+		const operand = consumed[index];
 
-	if (validateFloatResult && !block.expectedResultIsInteger && operand.valueType === 'int') {
-		throw getError(ErrorCode.ONLY_FLOATS, line, context);
+		if (expectedResultType === 'int' && operand.valueType !== 'int') {
+			throw getError(ErrorCode.ONLY_INTEGERS, line, context);
+		}
+
+		if (validateFloatResult && expectedResultType === 'float' && operand.valueType === 'int') {
+			throw getError(ErrorCode.ONLY_FLOATS, line, context);
+		}
 	}
 
 	if (!restore) {

--- a/packages/compiler/src/stackAnalysis/validateInstruction.test.ts
+++ b/packages/compiler/src/stackAnalysis/validateInstruction.test.ts
@@ -45,9 +45,7 @@ describe('validateInstruction', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MAP,
-					expectedResultIsInteger: false,
-					hasExpectedResult: false,
+					blockType: BlockType.MAP,expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,

--- a/packages/compiler/src/utils/blockStack.test.ts
+++ b/packages/compiler/src/utils/blockStack.test.ts
@@ -6,41 +6,27 @@ import createInstructionCompilerTestContext from './testUtils';
 
 describe('blockStack utilities', () => {
 	const mockModuleBlock: BlockStack[number] = {
-		blockType: BlockType.MODULE,
-		expectedResultIsInteger: false,
-		hasExpectedResult: false,
+		blockType: BlockType.MODULE,expectedResultTypes: [],
 	};
 	const mockFunctionBlock: BlockStack[number] = {
-		blockType: BlockType.FUNCTION,
-		expectedResultIsInteger: false,
-		hasExpectedResult: false,
+		blockType: BlockType.FUNCTION,expectedResultTypes: [],
 	};
 	const mockLoopBlock: BlockStack[number] = {
-		blockType: BlockType.LOOP,
-		expectedResultIsInteger: false,
-		hasExpectedResult: false,
+		blockType: BlockType.LOOP,expectedResultTypes: [],
 		loopCounterLocalName: '__loopCounter1',
 		loopCounterLocal: { kind: 'value', valueType: 'int', index: 0 },
 	};
 	const mockGenericBlock: BlockStack[number] = {
-		blockType: BlockType.BLOCK,
-		expectedResultIsInteger: false,
-		hasExpectedResult: false,
+		blockType: BlockType.BLOCK,expectedResultTypes: [],
 	};
 	const mockConditionBlock: BlockStack[number] = {
-		blockType: BlockType.CONDITION,
-		expectedResultIsInteger: false,
-		hasExpectedResult: false,
+		blockType: BlockType.CONDITION,expectedResultTypes: [],
 	};
 	const mockConstantsBlock: BlockStack[number] = {
-		blockType: BlockType.CONSTANTS,
-		expectedResultIsInteger: false,
-		hasExpectedResult: false,
+		blockType: BlockType.CONSTANTS,expectedResultTypes: [],
 	};
 	const mockMapBlock: BlockStack[number] = {
-		blockType: BlockType.MAP,
-		expectedResultIsInteger: false,
-		hasExpectedResult: false,
+		blockType: BlockType.MAP,expectedResultTypes: [],
 		mapState: {
 			inputIsInteger: true,
 			inputIsFloat64: false,

--- a/packages/compiler/src/utils/testUtils.ts
+++ b/packages/compiler/src/utils/testUtils.ts
@@ -17,8 +17,7 @@ export default function createInstructionCompilerTestContext(
 		blockStack: overrides.blockStack ?? [
 			{
 				blockType: BlockType.MODULE,
-				expectedResultIsInteger: false,
-				hasExpectedResult: false,
+				expectedResultTypes: [],
 			},
 		],
 		codeBlockId: overrides.codeBlockId ?? 'test',

--- a/packages/compiler/tests/compilerApiFixtures.test.ts
+++ b/packages/compiler/tests/compilerApiFixtures.test.ts
@@ -177,6 +177,54 @@ entryEnd
 		expect(module.memoryMap.cursor.pointeeBaseType).toBe('int8u');
 	});
 
+	test('supports multi-result ifEnd blocks', async () => {
+		const fixture = await instantiateFixtureProgramSource(`
+8f4e/v1
+
+entry main
+module multiResultIf
+int output
+
+push &output
+push 1
+if
+push 10
+push 20
+push 3
+else
+push 30
+push 40
+push 5
+ifEnd int int int
+call packTriple
+store
+moduleEnd
+entryEnd
+
+function packTriple
+param int left
+param int right
+param int last
+push left
+push 1000
+mul
+push right
+push 10
+mul
+add
+push last
+add
+functionEnd int
+`);
+		const memory = new DataView((fixture.host.memory as WebAssembly.Memory).buffer);
+		const output = fixture.compileResult.compiledModules.multiResultIf.memoryMap.output.byteAddress;
+
+		getExportedFunction(fixture.instance.exports, 'initDefaults')();
+		getExportedFunction(fixture.instance.exports, 'main')();
+
+		expect(memory.getInt32(output, true)).toBe(10203);
+	});
+
 	test('emits memory.fill before loading passive data defaults', async () => {
 		const { compileResult } = compileFixtureProgramSource(`
 8f4e/v1


### PR DESCRIPTION
## Summary
- support multiple result types on `ifEnd`/block metadata and wasm block type emission
- validate all expected block result stack items during stack analysis
- remove compatibility shims around scalar/null block result metadata
- update CLI instruction-flow tracing to use the new block result metadata shape

## Tests
- `git diff --check`
- `npx nx run compiler-spec:typecheck`
- `npx nx run @8f4e/tokenizer:typecheck`
- `npx nx run compiler:typecheck`
- `npx nx run @8f4e/cli:typecheck`
- `npx nx run-many --target=typecheck --all`
- `npx nx run @8f4e/tokenizer:test`
- `npx nx run compiler:test`

Note: Nx reported the existing Nx Cloud free-plan-disabled warning, but local tasks passed.