### PR TITLE
fix(examples): pass prototypes to coverage logger

### DIFF
--- a/scripts/log-compiler-coverage-counts.mjs
+++ b/scripts/log-compiler-coverage-counts.mjs
@@ -76,8 +76,9 @@ async function main() {
 				{
 					entries: benchmarkCase.entries,
 					constants: benchmarkCase.constantsBlocks,
-					functions: benchmarkCase.functionBlocks.length > 0 ? benchmarkCase.functionBlocks : undefined,
-					macros: benchmarkCase.macroBlocks.length > 0 ? benchmarkCase.macroBlocks : undefined,
+					functions: benchmarkCase.functionBlocks,
+					prototypes: benchmarkCase.prototypeBlocks,
+					macros: benchmarkCase.macroBlocks,
 				},
 				compilerOptions
 			);


### PR DESCRIPTION
## Summary
- pass required `prototypes` and full array inputs into the compiler coverage logger
- keep the logger aligned with the required `CompileInput` shape introduced by prototype memory shapes

## Validation
- `npx biome check --write scripts/log-compiler-coverage-counts.mjs`
- `npx nx run @8f4e/examples:log-compiler-coverage-counts`

Fixes release job failure from https://github.com/andorthehood/8f4e/actions/runs/26772398798/job/78915019880