### PR TITLE
fix(compiler): collapse macro line metadata

### DIFF
--- a/packages/cli/src/compile/traceInstructionFlow.ts
+++ b/packages/cli/src/compile/traceInstructionFlow.ts
@@ -111,7 +111,7 @@ function traceAst(
 		}
 
 		entries.push({
-			lineNumber: line.lineNumberBeforeMacroExpansion + 1,
+			lineNumber: line.lineNumber + 1,
 			instruction: line.instruction,
 			arguments: serializeArguments(line),
 			stackBefore,

--- a/packages/compiler-spec/src/ast.ts
+++ b/packages/compiler-spec/src/ast.ts
@@ -21,13 +21,10 @@ import {
 type ClampAddressInstructionName = 'clampAddress' | 'clampModuleAddress' | 'clampGlobalAddress';
 
 export type ASTLineBase<Instruction extends string, Arguments extends Array<Argument>> = {
-	lineNumberBeforeMacroExpansion: number;
-	lineNumberAfterMacroExpansion: number;
+	lineNumber: number;
 	instruction: Instruction;
 	arguments: Arguments;
 };
-
-export type ParsedLineMetadata = Array<{ callSiteLineNumber: number; macroId?: string }>;
 
 export type CompileTimeValueArgument = ArgumentLiteral | ArgumentIdentifier | ArgumentCompileTimeExpression;
 export type PushArgument = ArgumentLiteral | ArgumentIdentifier | ArgumentCompileTimeExpression | ArgumentStringLiteral;

--- a/packages/compiler-spec/src/cache.ts
+++ b/packages/compiler-spec/src/cache.ts
@@ -1,4 +1,4 @@
-import type { AST, ParsedLineMetadata } from './ast';
+import type { AST } from './ast';
 
 /** Hit and miss counters for AST cache lookups. */
 export interface ASTCacheStats {
@@ -12,7 +12,6 @@ export interface ASTCacheEntry<TAst = AST> {
 	hash?: number;
 	hashInput?: {
 		code: string[];
-		lineMetadata?: ParsedLineMetadata;
 	};
 	lineCount: number;
 }

--- a/packages/compiler-spec/src/compiled.ts
+++ b/packages/compiler-spec/src/compiled.ts
@@ -6,8 +6,7 @@ import type { InternalResourceMap, MemoryMap } from './memory';
 import type { StackAnalysisResult } from './semantic';
 
 export type CompiledStackAnalysisLine = {
-	lineNumberBeforeMacroExpansion: number;
-	lineNumberAfterMacroExpansion: number;
+	lineNumber: number;
 	instruction: string;
 	stackAnalysis: StackAnalysisResult;
 };

--- a/packages/compiler-spec/src/diagnostics.ts
+++ b/packages/compiler-spec/src/diagnostics.ts
@@ -19,8 +19,7 @@ export interface CompilerStageError {
  * once serialized. Consumers must not special-case either stage.
  */
 export interface CompilerDiagnosticLine {
-	lineNumberBeforeMacroExpansion: number;
-	lineNumberAfterMacroExpansion: number;
+	lineNumber: number;
 	instruction?: string;
 	arguments?: unknown[];
 }

--- a/packages/compiler-spec/src/macros.ts
+++ b/packages/compiler-spec/src/macros.ts
@@ -1,10 +1,3 @@
-/** Source line produced by macro expansion with its originating call site. */
-export interface ExpandedLine {
-	line: string;
-	callSiteLineNumber: number;
-	macroId?: string;
-}
-
 /** Parsed macro definition body and declaration location. */
 export interface MacroDefinition {
 	name: string;

--- a/packages/compiler-spec/src/semantic.ts
+++ b/packages/compiler-spec/src/semantic.ts
@@ -175,7 +175,6 @@ export interface CompilationContext {
 	currentFunctionExportName?: string;
 	currentFunctionImport?: FunctionImportMetadata;
 	functionTypeRegistry?: FunctionTypeRegistry;
-	currentMacroId?: string;
 	skipExecutionInCycle?: boolean;
 	/** Current default loop cap for subsequent loops. Defaults to 1000 when not set. */
 	loopCap?: number;

--- a/packages/compiler/packages/tokenizer/src/cache/compileToASTCache.test.ts
+++ b/packages/compiler/packages/tokenizer/src/cache/compileToASTCache.test.ts
@@ -5,21 +5,16 @@ import createASTCache from './createASTCache';
 import hashSource from './hashSource';
 
 describe('compileToASTLines cache', () => {
-	it('returns cached AST when source and line metadata are unchanged', () => {
+	it('returns cached AST when source is unchanged', () => {
 		const cache = createASTCache<CompilerASTLines>();
 		const code = ['push 10', 'push 20', 'add'];
-		const lineMetadata = [
-			{ callSiteLineNumber: 4 },
-			{ callSiteLineNumber: 4, macroId: 'sum' },
-			{ callSiteLineNumber: 4, macroId: 'sum' },
-		];
-		const first = compileToASTLines(code, lineMetadata, cache, 'module:0');
-		const second = compileToASTLines(code, lineMetadata, cache, 'module:0');
+		const first = compileToASTLines(code, cache, 'module:0');
+		const second = compileToASTLines(code, cache, 'module:0');
 
 		expect(second).toBe(first);
 		expect(cache.entries.get('module:0')).toMatchObject({
 			ast: first,
-			hash: hashSource(code, lineMetadata),
+			hash: hashSource(code),
 		});
 		expect(cache.entries.get('module:0')?.hashInput).toBeUndefined();
 		expect(cache.stats).toEqual({ hits: 1, misses: 1 });
@@ -28,15 +23,13 @@ describe('compileToASTLines cache', () => {
 	it('stores obvious cache misses without hashing the source', () => {
 		const cache = createASTCache<CompilerASTLines>();
 		const code = ['push 10'];
-		const lineMetadata = [{ callSiteLineNumber: 4, macroId: 'value' }];
-		const ast = compileToASTLines(code, lineMetadata, cache, 'module:0');
+		const ast = compileToASTLines(code, cache, 'module:0');
 		const entry = cache.entries.get('module:0');
 
 		expect(entry).toMatchObject({
 			ast,
 			hashInput: {
 				code,
-				lineMetadata,
 			},
 			lineCount: code.length,
 		});
@@ -45,8 +38,8 @@ describe('compileToASTLines cache', () => {
 
 	it('reparses when source changes for the same cache key', () => {
 		const cache = createASTCache<CompilerASTLines>();
-		const first = compileToASTLines(['push 10'], undefined, cache, 'module:0');
-		const second = compileToASTLines(['push 20'], undefined, cache, 'module:0');
+		const first = compileToASTLines(['push 10'], cache, 'module:0');
+		const second = compileToASTLines(['push 20'], cache, 'module:0');
 
 		expect(second).not.toBe(first);
 		expect(second[0].arguments[0]).toMatchObject({ value: 20 });
@@ -55,8 +48,8 @@ describe('compileToASTLines cache', () => {
 
 	it('reparses when source line count changes for the same cache key', () => {
 		const cache = createASTCache<CompilerASTLines>();
-		const first = compileToASTLines(['push 10'], undefined, cache, 'module:0');
-		const second = compileToASTLines(['push 10', 'push 20'], undefined, cache, 'module:0');
+		const first = compileToASTLines(['push 10'], cache, 'module:0');
+		const second = compileToASTLines(['push 10', 'push 20'], cache, 'module:0');
 
 		expect(second).not.toBe(first);
 		expect(cache.entries.get('module:0')).toMatchObject({
@@ -66,21 +59,10 @@ describe('compileToASTLines cache', () => {
 		expect(cache.stats).toEqual({ hits: 0, misses: 2 });
 	});
 
-	it('reparses when line metadata changes for the same source', () => {
-		const cache = createASTCache<CompilerASTLines>();
-		const code = ['push 10'];
-		const first = compileToASTLines(code, [{ callSiteLineNumber: 1 }], cache, 'module:0');
-		const second = compileToASTLines(code, [{ callSiteLineNumber: 2 }], cache, 'module:0');
-
-		expect(second).not.toBe(first);
-		expect(second[0].lineNumberBeforeMacroExpansion).toBe(2);
-		expect(cache.stats).toEqual({ hits: 0, misses: 2 });
-	});
-
 	it('keeps distinct cache keys independent', () => {
 		const cache = createASTCache<CompilerASTLines>();
-		const moduleAst = compileToASTLines(['push 10'], undefined, cache, 'module:0');
-		const functionAst = compileToASTLines(['push 10'], undefined, cache, 'function:0');
+		const moduleAst = compileToASTLines(['push 10'], cache, 'module:0');
+		const functionAst = compileToASTLines(['push 10'], cache, 'function:0');
 
 		expect(functionAst).not.toBe(moduleAst);
 		expect(cache.entries.get('module:0')?.ast).toBe(moduleAst);

--- a/packages/compiler/packages/tokenizer/src/cache/hashSource.ts
+++ b/packages/compiler/packages/tokenizer/src/cache/hashSource.ts
@@ -1,5 +1,3 @@
-import type { ParsedLineMetadata } from '@8f4e/compiler-spec';
-
 function appendHashInput(hash: number, input: string): number {
 	let nextHash = hash;
 	for (let index = 0; index < input.length; index++) {
@@ -9,18 +7,11 @@ function appendHashInput(hash: number, input: string): number {
 	return nextHash >>> 0;
 }
 
-export default function hashSource(code: string[], lineMetadata: ParsedLineMetadata | undefined): number {
+export default function hashSource(code: string[]): number {
 	let hash = 2166136261;
 	hash = appendHashInput(hash, `${code.length}\0`);
 	for (const line of code) {
 		hash = appendHashInput(hash, `${line.length}\0${line}\0`);
-	}
-
-	hash = appendHashInput(hash, `${lineMetadata?.length ?? 0}\0`);
-	if (lineMetadata) {
-		for (const metadata of lineMetadata) {
-			hash = appendHashInput(hash, `${metadata.callSiteLineNumber}\0${metadata.macroId ?? ''}\0`);
-		}
 	}
 
 	return hash >>> 0;

--- a/packages/compiler/packages/tokenizer/src/parser.test.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.test.ts
@@ -25,8 +25,7 @@ describe('parseLine', () => {
 					},
 				],
 				instruction: 'int',
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				hasExplicitMemoryDefault: true,
 			},
 		],
@@ -43,8 +42,7 @@ describe('parseLine', () => {
 					},
 				],
 				instruction: 'push',
-				lineNumberBeforeMacroExpansion: 100,
-				lineNumberAfterMacroExpansion: 100,
+				lineNumber: 100,
 			},
 		],
 	];
@@ -98,8 +96,7 @@ describe('parseLine', () => {
 	it('parses inline call arguments', () => {
 		const result = parseLine('call foo 2 1.3', 0);
 		expect(result).toEqual({
-			lineNumberBeforeMacroExpansion: 0,
-			lineNumberAfterMacroExpansion: 0,
+			lineNumber: 0,
 			instruction: 'call',
 			arguments: [
 				classifyIdentifier('foo'),
@@ -131,15 +128,14 @@ describe('parseLine', () => {
 
 	it('adds line metadata to parse-time syntax errors', () => {
 		try {
-			parseLine('push 1e309', 7, 12);
+			parseLine('push 1e309', 12);
 			throw new Error('Expected parseLine to throw');
 		} catch (error) {
 			expect(error).toBeInstanceOf(SyntaxRulesError);
 			expect((error as SyntaxRulesError).code).toBe(SyntaxErrorCode.INVALID_NUMERIC_LITERAL);
 			expect((error as SyntaxRulesError).line).toEqual(
 				expect.objectContaining({
-					lineNumberBeforeMacroExpansion: 7,
-					lineNumberAfterMacroExpansion: 12,
+					lineNumber: 12,
 					instruction: 'push',
 				})
 			);
@@ -149,13 +145,12 @@ describe('parseLine', () => {
 	it('exposes instruction in line metadata for argument-level errors', () => {
 		let thrownError: SyntaxRulesError | undefined;
 		try {
-			parseLine('push', 5, 8);
+			parseLine('push', 8);
 		} catch (error) {
 			thrownError = error as SyntaxRulesError;
 		}
 		expect(thrownError).toBeInstanceOf(SyntaxRulesError);
-		expect(thrownError?.line?.lineNumberBeforeMacroExpansion).toBe(5);
-		expect(thrownError?.line?.lineNumberAfterMacroExpansion).toBe(8);
+		expect(thrownError?.line?.lineNumber).toBe(8);
 		expect(thrownError?.line?.instruction).toBe('push');
 	});
 
@@ -342,35 +337,13 @@ describe('compileToASTLines', () => {
 		);
 	});
 
-	it('uses callSiteLineNumber from lineMetadata when provided', () => {
-		const code = ['push 10', 'push 20', 'add'];
-		const lineMetadata = [
-			{ callSiteLineNumber: 5 },
-			{ callSiteLineNumber: 5, macroId: 'double' },
-			{ callSiteLineNumber: 5, macroId: 'double' },
-		];
-
-		const ast = compileToASTLines(code, lineMetadata);
-
-		expect(ast).toHaveLength(3);
-		expect(ast[0].lineNumberBeforeMacroExpansion).toBe(5);
-		expect(ast[1].lineNumberBeforeMacroExpansion).toBe(5);
-		expect(ast[2].lineNumberBeforeMacroExpansion).toBe(5);
-		expect(ast[0].lineNumberAfterMacroExpansion).toBe(0);
-		expect(ast[1].lineNumberAfterMacroExpansion).toBe(1);
-		expect(ast[2].lineNumberAfterMacroExpansion).toBe(2);
-	});
-
-	it('uses actual line numbers when lineMetadata is not provided', () => {
+	it('uses actual line numbers', () => {
 		const ast = compileToASTLines(['push 10', 'push 20', 'add']);
 
 		expect(ast).toHaveLength(3);
-		expect(ast[0].lineNumberBeforeMacroExpansion).toBe(0);
-		expect(ast[1].lineNumberBeforeMacroExpansion).toBe(1);
-		expect(ast[2].lineNumberBeforeMacroExpansion).toBe(2);
-		expect(ast[0].lineNumberAfterMacroExpansion).toBe(0);
-		expect(ast[1].lineNumberAfterMacroExpansion).toBe(1);
-		expect(ast[2].lineNumberAfterMacroExpansion).toBe(2);
+		expect(ast[0].lineNumber).toBe(0);
+		expect(ast[1].lineNumber).toBe(1);
+		expect(ast[2].lineNumber).toBe(2);
 	});
 
 	it('marks directives in module and function prologues', () => {
@@ -553,8 +526,8 @@ describe('compileToASTLines', () => {
 			thrownError = error as SyntaxRulesError;
 		}
 		expect(thrownError).toBeInstanceOf(SyntaxRulesError);
-		expect(thrownError?.line?.lineNumberBeforeMacroExpansion).toBe(1);
-		expect(thrownError?.line?.lineNumberAfterMacroExpansion).toBe(1);
+		expect(thrownError?.line?.lineNumber).toBe(1);
+		expect(thrownError?.line?.lineNumber).toBe(1);
 		expect(thrownError?.line?.instruction).toBe('if');
 	});
 });

--- a/packages/compiler/packages/tokenizer/src/parser.ts
+++ b/packages/compiler/packages/tokenizer/src/parser.ts
@@ -20,7 +20,6 @@ import type {
 	ImportLine,
 	MemoryDeclarationLine,
 	ModuleLine,
-	ParsedLineMetadata,
 	PrototypeLine,
 	RegionLine,
 } from '@8f4e/compiler-spec';
@@ -120,8 +119,7 @@ type ParsedCompilerSource = {
 
 type SourceLine = {
 	line: string;
-	lineNumberBeforeMacroExpansion: number;
-	lineNumberAfterMacroExpansion: number;
+	lineNumber: number;
 };
 
 const blockStartInstructionSet = new Set<BlockStartInstruction>(blockStartInstructions);
@@ -165,17 +163,15 @@ function hasExplicitMemoryDefault(instruction: string, args: Array<Argument>): b
 
 function getASTCacheLookupResult<TAst>(
 	cached: ASTCacheEntry<TAst> | undefined,
-	code: string[],
-	lineMetadata: ParsedLineMetadata | undefined
+	code: string[]
 ): ASTCacheLookupResult<TAst> {
 	// Optimize first compilation and obvious cache misses: only hash when an existing same-line-count entry needs validation.
 	if (!cached || cached.lineCount !== code.length) {
 		return {};
 	}
 
-	const hash = hashSource(code, lineMetadata);
-	const cachedHash =
-		cached.hash ?? (cached.hashInput ? hashSource(cached.hashInput.code, cached.hashInput.lineMetadata) : undefined);
+	const hash = hashSource(code);
+	const cachedHash = cached.hash ?? (cached.hashInput ? hashSource(cached.hashInput.code) : undefined);
 
 	if (cachedHash === undefined) {
 		return { hash };
@@ -307,8 +303,7 @@ function createASTFromBuilder(lines: CompilerASTLines, builder: SourceBlockASTBu
 		case 'function':
 			if (!builder.functionEndLine) {
 				throw new SyntaxRulesError(SyntaxErrorCode.INVALID_BLOCK_STRUCTURE, 'Expected a matching functionEnd.', {
-					lineNumberBeforeMacroExpansion: builder.functionLine.lineNumberBeforeMacroExpansion,
-					lineNumberAfterMacroExpansion: builder.functionLine.lineNumberAfterMacroExpansion,
+					lineNumber: builder.functionLine.lineNumber,
 					instruction: builder.functionLine.instruction,
 				});
 			}
@@ -353,8 +348,7 @@ function toAST(parsedSource: ParsedCompilerSource): AST {
 	}
 
 	throw new SyntaxRulesError(SyntaxErrorCode.INVALID_BLOCK_STRUCTURE, 'Expected a compiler source block.', {
-		lineNumberBeforeMacroExpansion: firstLine?.lineNumberBeforeMacroExpansion ?? 0,
-		lineNumberAfterMacroExpansion: firstLine?.lineNumberAfterMacroExpansion ?? 0,
+		lineNumber: firstLine?.lineNumber ?? 0,
 		instruction: firstLine?.instruction,
 	});
 }
@@ -406,29 +400,19 @@ function tokenizeInstruction(line: string): string[] {
 	return tokens;
 }
 
-function withSyntaxLine(
-	error: SyntaxRulesError,
-	lineNumberBeforeMacroExpansion: number,
-	lineNumberAfterMacroExpansion: number,
-	instruction?: string
-): SyntaxRulesError {
+function withSyntaxLine(error: SyntaxRulesError, lineNumber: number, instruction?: string): SyntaxRulesError {
 	return new SyntaxRulesError(error.code, error.message, {
-		lineNumberBeforeMacroExpansion,
-		lineNumberAfterMacroExpansion,
+		lineNumber,
 		instruction,
 	});
 }
 
-function parseInstructionTokens(
-	line: string,
-	lineNumberBeforeMacroExpansion: number,
-	lineNumberAfterMacroExpansion: number
-): string[] {
+function parseInstructionTokens(line: string, lineNumber: number): string[] {
 	try {
 		return tokenizeInstruction(line);
 	} catch (error) {
 		if (error instanceof SyntaxRulesError) {
-			throw withSyntaxLine(error, lineNumberBeforeMacroExpansion, lineNumberAfterMacroExpansion);
+			throw withSyntaxLine(error, lineNumber);
 		}
 		throw error;
 	}
@@ -438,44 +422,38 @@ function isArgumentContinuationCandidate(line: string): boolean {
 	return /^\s*-(?=\s|;|$)/.test(line);
 }
 
-function foldArgumentContinuationLines(code: string[], lineMetadata?: ParsedLineMetadata): SourceLine[] {
+function foldArgumentContinuationLines(code: string[]): SourceLine[] {
 	const sourceLines: SourceLine[] = [];
 	let previousSourceLine: SourceLine | undefined;
 
-	for (const [lineNumberAfterMacroExpansion, line] of code.map((sourceLine, index) => [index, sourceLine] as const)) {
+	for (const [lineNumber, line] of code.map((sourceLine, index) => [index, sourceLine] as const)) {
 		if (isComment(line) || !isValidInstruction(line)) {
 			continue;
 		}
 
-		const lineNumberBeforeMacroExpansion =
-			lineMetadata?.[lineNumberAfterMacroExpansion]?.callSiteLineNumber ?? lineNumberAfterMacroExpansion;
-
 		if (!isArgumentContinuationCandidate(line)) {
 			const sourceLine = {
 				line,
-				lineNumberBeforeMacroExpansion,
-				lineNumberAfterMacroExpansion,
+				lineNumber,
 			};
 			sourceLines.push(sourceLine);
 			previousSourceLine = sourceLine;
 			continue;
 		}
 
-		const tokens = parseInstructionTokens(line, lineNumberBeforeMacroExpansion, lineNumberAfterMacroExpansion);
+		const tokens = parseInstructionTokens(line, lineNumber);
 		const instruction = '-';
 
 		if (!previousSourceLine) {
 			throw new SyntaxRulesError(SyntaxErrorCode.INVALID_ARGUMENT, 'Argument continuation has no instruction.', {
-				lineNumberBeforeMacroExpansion,
-				lineNumberAfterMacroExpansion,
+				lineNumber,
 				instruction,
 			});
 		}
 
 		if (tokens.length < 2) {
 			throw new SyntaxRulesError(SyntaxErrorCode.MISSING_ARGUMENT, 'Missing argument for continuation.', {
-				lineNumberBeforeMacroExpansion,
-				lineNumberAfterMacroExpansion,
+				lineNumber,
 				instruction,
 			});
 		}
@@ -485,8 +463,7 @@ function foldArgumentContinuationLines(code: string[], lineMetadata?: ParsedLine
 				SyntaxErrorCode.INVALID_ARGUMENT,
 				'Argument continuation accepts exactly one argument.',
 				{
-					lineNumberBeforeMacroExpansion,
-					lineNumberAfterMacroExpansion,
+					lineNumber,
 					instruction,
 				}
 			);
@@ -498,11 +475,7 @@ function foldArgumentContinuationLines(code: string[], lineMetadata?: ParsedLine
 	return sourceLines;
 }
 
-export function parseLine(
-	line: string,
-	lineNumberBeforeMacroExpansion: number,
-	lineNumberAfterMacroExpansion = lineNumberBeforeMacroExpansion
-): CompilerASTLine {
+export function parseLine(line: string, lineNumber: number): CompilerASTLine {
 	let instruction: string | undefined;
 	try {
 		const tokens = tokenizeInstruction(line);
@@ -525,8 +498,7 @@ export function parseLine(
 			referencedNamespaceIds.add(useArgument.value);
 		}
 		const parsedLine = {
-			lineNumberBeforeMacroExpansion,
-			lineNumberAfterMacroExpansion,
+			lineNumber,
 			instruction,
 			arguments: parsedArguments,
 			...(referencedNamespaceIds.size > 0 ? { referencedNamespaceIds: [...referencedNamespaceIds] } : {}),
@@ -542,8 +514,7 @@ export function parseLine(
 		if (error instanceof SyntaxRulesError) {
 			throw withSyntaxLine(
 				error,
-				lineNumberBeforeMacroExpansion,
-				lineNumberAfterMacroExpansion,
+				lineNumber,
 				// instruction is undefined only if tokenizeInstruction threw before assignment
 				instruction ?? undefined
 			);
@@ -552,16 +523,16 @@ export function parseLine(
 	}
 }
 
-function parseCompilerSource(code: string[], lineMetadata?: ParsedLineMetadata): ParsedCompilerSource {
+function parseCompilerSource(code: string[]): ParsedCompilerSource {
 	const ast: CompilerASTLines = [];
 	let astBuilder: SourceBlockASTBuilder | undefined;
 	let onlySemanticLinesBeforeSourceBlock = true;
 	const blockStack: OpenBlock[] = [];
 	const sourceBlockPrologueStack: SourceBlockPrologue[] = [];
-	const sourceLines = foldArgumentContinuationLines(code, lineMetadata);
+	const sourceLines = foldArgumentContinuationLines(code);
 
-	for (const { line, lineNumberBeforeMacroExpansion, lineNumberAfterMacroExpansion } of sourceLines) {
-		const parsedLine = parseLine(line, lineNumberBeforeMacroExpansion, lineNumberAfterMacroExpansion);
+	for (const { line, lineNumber } of sourceLines) {
+		const parsedLine = parseLine(line, lineNumber);
 		const astIndex = ast.length;
 		const isFirstASTLine = ast.length === 0;
 		const currentSourceBlockPrologue = sourceBlockPrologueStack[sourceBlockPrologueStack.length - 1];
@@ -573,8 +544,7 @@ function parseCompilerSource(code: string[], lineMetadata?: ParsedLineMetadata):
 			parsedLine.isBlockPrologue = true;
 		} else if (isCompilerDirective) {
 			throw new SyntaxRulesError(SyntaxErrorCode.COMPILER_DIRECTIVE_MUST_BE_PROLOGUE, undefined, {
-				lineNumberBeforeMacroExpansion,
-				lineNumberAfterMacroExpansion,
+				lineNumber,
 				instruction: parsedLine.instruction,
 			});
 		}
@@ -641,8 +611,7 @@ function parseCompilerSource(code: string[], lineMetadata?: ParsedLineMetadata):
 					SyntaxErrorCode.INVALID_BLOCK_STRUCTURE,
 					'Unexpected else without a matching open if block.',
 					{
-						lineNumberBeforeMacroExpansion,
-						lineNumberAfterMacroExpansion,
+						lineNumber,
 						instruction: parsedLine.instruction,
 					}
 				);
@@ -653,8 +622,7 @@ function parseCompilerSource(code: string[], lineMetadata?: ParsedLineMetadata):
 					SyntaxErrorCode.INVALID_BLOCK_STRUCTURE,
 					'Unexpected else: if blocks may only contain one else branch.',
 					{
-						lineNumberBeforeMacroExpansion,
-						lineNumberAfterMacroExpansion,
+						lineNumber,
 						instruction: parsedLine.instruction,
 					}
 				);
@@ -677,8 +645,7 @@ function parseCompilerSource(code: string[], lineMetadata?: ParsedLineMetadata):
 				SyntaxErrorCode.INVALID_BLOCK_STRUCTURE,
 				`Unexpected ${endInstruction} without a matching open ${expectedStartInstruction} block.`,
 				{
-					lineNumberBeforeMacroExpansion,
-					lineNumberAfterMacroExpansion,
+					lineNumber,
 					instruction: parsedLine.instruction,
 				}
 			);
@@ -689,8 +656,7 @@ function parseCompilerSource(code: string[], lineMetadata?: ParsedLineMetadata):
 				SyntaxErrorCode.INVALID_BLOCK_STRUCTURE,
 				`Unexpected ${endInstruction}: expected ${openBlock.instruction} to be closed before ending ${expectedStartInstruction}.`,
 				{
-					lineNumberBeforeMacroExpansion,
-					lineNumberAfterMacroExpansion,
+					lineNumber,
 					instruction: parsedLine.instruction,
 				}
 			);
@@ -733,8 +699,7 @@ function parseCompilerSource(code: string[], lineMetadata?: ParsedLineMetadata):
 		const openLine = ast[openBlock.astIndex];
 
 		throw new SyntaxRulesError(SyntaxErrorCode.INVALID_BLOCK_STRUCTURE, `Unclosed ${openBlock.instruction} block.`, {
-			lineNumberBeforeMacroExpansion: openLine.lineNumberBeforeMacroExpansion,
-			lineNumberAfterMacroExpansion: openLine.lineNumberAfterMacroExpansion,
+			lineNumber: openLine.lineNumber,
 			instruction: openBlock.instruction,
 		});
 	}
@@ -744,12 +709,11 @@ function parseCompilerSource(code: string[], lineMetadata?: ParsedLineMetadata):
 
 export function compileToASTLines(
 	code: string[],
-	lineMetadata?: ParsedLineMetadata,
 	cache?: ASTCache<CompilerASTLines>,
 	cacheKey?: string
 ): CompilerASTLines {
 	const cached = cacheKey !== undefined ? cache?.entries.get(cacheKey) : undefined;
-	const cachedLookup = getASTCacheLookupResult(cached, code, lineMetadata);
+	const cachedLookup = getASTCacheLookupResult(cached, code);
 	if (cachedLookup.ast) {
 		cache!.stats.hits++;
 		return cachedLookup.ast;
@@ -758,14 +722,13 @@ export function compileToASTLines(
 		cache.stats.misses++;
 	}
 
-	const ast = parseCompilerSource(code, lineMetadata).lines;
+	const ast = parseCompilerSource(code).lines;
 
 	if (cache && cacheKey !== undefined) {
 		const entry: ASTCacheEntry<CompilerASTLines> = {
 			ast,
 			hashInput: {
 				code,
-				lineMetadata,
 			},
 			lineCount: code.length,
 		};
@@ -779,14 +742,9 @@ export function compileToASTLines(
 	return ast;
 }
 
-export function compileToAST(
-	code: string[],
-	lineMetadata?: ParsedLineMetadata,
-	cache?: ASTCache<AST>,
-	cacheKey?: string
-): AST {
+export function compileToAST(code: string[], cache?: ASTCache<AST>, cacheKey?: string): AST {
 	const cached = cacheKey !== undefined ? cache?.entries.get(cacheKey) : undefined;
-	const cachedLookup = getASTCacheLookupResult(cached, code, lineMetadata);
+	const cachedLookup = getASTCacheLookupResult(cached, code);
 	if (cachedLookup.ast) {
 		cache!.stats.hits++;
 		return cachedLookup.ast;
@@ -795,7 +753,7 @@ export function compileToAST(
 		cache.stats.misses++;
 	}
 
-	const parsedSource = parseCompilerSource(code, lineMetadata);
+	const parsedSource = parseCompilerSource(code);
 	const group = toAST(parsedSource);
 
 	if (cache && cacheKey !== undefined) {
@@ -803,7 +761,6 @@ export function compileToAST(
 			ast: group,
 			hashInput: {
 				code,
-				lineMetadata,
 			},
 			lineCount: code.length,
 		};

--- a/packages/compiler/packages/tokenizer/src/syntax/syntaxError.ts
+++ b/packages/compiler/packages/tokenizer/src/syntax/syntaxError.ts
@@ -55,8 +55,7 @@ const SyntaxErrorMessages: Record<SyntaxErrorCodeValue, string> = {
 };
 
 export interface SyntaxErrorLine {
-	lineNumberBeforeMacroExpansion: number;
-	lineNumberAfterMacroExpansion: number;
+	lineNumber: number;
 	instruction?: string;
 	arguments?: unknown[];
 }

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/audio_audioBuffer_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/audio_audioBuffer_8f4e.snap
@@ -1,13 +1,11 @@
 [
   {
-    "lineNumberBeforeMacroExpansion": 0,
-    "lineNumberAfterMacroExpansion": 0,
+    "lineNumber": 0,
     "instruction": "8f4e/v1",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 2,
-    "lineNumberAfterMacroExpansion": 2,
+    "lineNumber": 2,
     "instruction": "entry",
     "arguments": [
       {
@@ -19,8 +17,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 3,
-    "lineNumberAfterMacroExpansion": 3,
+    "lineNumber": 3,
     "instruction": "module",
     "arguments": [
       {
@@ -32,14 +29,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 10,
-    "lineNumberAfterMacroExpansion": 10,
+    "lineNumber": 10,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 11,
-    "lineNumberAfterMacroExpansion": 11,
+    "lineNumber": 11,
     "instruction": "module",
     "arguments": [
       {
@@ -51,8 +46,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 13,
-    "lineNumberAfterMacroExpansion": 13,
+    "lineNumber": 13,
     "instruction": "use",
     "arguments": [
       {
@@ -67,8 +61,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 15,
-    "lineNumberAfterMacroExpansion": 15,
+    "lineNumber": 15,
     "instruction": "float",
     "arguments": [
       {
@@ -86,8 +79,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 16,
-    "lineNumberAfterMacroExpansion": 16,
+    "lineNumber": 16,
     "instruction": "float*",
     "arguments": [
       {
@@ -108,8 +100,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 17,
-    "lineNumberAfterMacroExpansion": 17,
+    "lineNumber": 17,
     "instruction": "float",
     "arguments": [
       {
@@ -122,8 +113,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 18,
-    "lineNumberAfterMacroExpansion": 18,
+    "lineNumber": 18,
     "instruction": "float",
     "arguments": [
       {
@@ -136,8 +126,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 20,
-    "lineNumberAfterMacroExpansion": 20,
+    "lineNumber": 20,
     "instruction": "use",
     "arguments": [
       {
@@ -152,8 +141,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 24,
-    "lineNumberAfterMacroExpansion": 24,
+    "lineNumber": 24,
     "instruction": "push",
     "arguments": [
       {
@@ -167,8 +155,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 25,
-    "lineNumberAfterMacroExpansion": 25,
+    "lineNumber": 25,
     "instruction": "push",
     "arguments": [
       {
@@ -180,8 +167,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 26,
-    "lineNumberAfterMacroExpansion": 26,
+    "lineNumber": 26,
     "instruction": "push",
     "arguments": [
       {
@@ -193,8 +179,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 27,
-    "lineNumberAfterMacroExpansion": 27,
+    "lineNumber": 27,
     "instruction": "push",
     "arguments": [
       {
@@ -208,14 +193,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 28,
-    "lineNumberAfterMacroExpansion": 28,
+    "lineNumber": 28,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 29,
-    "lineNumberAfterMacroExpansion": 29,
+    "lineNumber": 29,
     "instruction": "push",
     "arguments": [
       {
@@ -227,38 +210,32 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 30,
-    "lineNumberAfterMacroExpansion": 30,
+    "lineNumber": 30,
     "instruction": "castToFloat",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 31,
-    "lineNumberAfterMacroExpansion": 31,
+    "lineNumber": 31,
     "instruction": "ensureNonZero",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 32,
-    "lineNumberAfterMacroExpansion": 32,
+    "lineNumber": 32,
     "instruction": "div",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 33,
-    "lineNumberAfterMacroExpansion": 33,
+    "lineNumber": 33,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 34,
-    "lineNumberAfterMacroExpansion": 34,
+    "lineNumber": 34,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 37,
-    "lineNumberAfterMacroExpansion": 37,
+    "lineNumber": 37,
     "instruction": "push",
     "arguments": [
       {
@@ -270,8 +247,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 38,
-    "lineNumberAfterMacroExpansion": 38,
+    "lineNumber": 38,
     "instruction": "push",
     "arguments": [
       {
@@ -283,14 +259,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 39,
-    "lineNumberAfterMacroExpansion": 39,
+    "lineNumber": 39,
     "instruction": "greaterThan",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 40,
-    "lineNumberAfterMacroExpansion": 40,
+    "lineNumber": 40,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -300,8 +274,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 41,
-    "lineNumberAfterMacroExpansion": 41,
+    "lineNumber": 41,
     "instruction": "push",
     "arguments": [
       {
@@ -315,8 +288,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 42,
-    "lineNumberAfterMacroExpansion": 42,
+    "lineNumber": 42,
     "instruction": "push",
     "arguments": [
       {
@@ -328,14 +300,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 43,
-    "lineNumberAfterMacroExpansion": 43,
+    "lineNumber": 43,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 44,
-    "lineNumberAfterMacroExpansion": 44,
+    "lineNumber": 44,
     "instruction": "ifEnd",
     "arguments": [],
     "ifEndBlock": {
@@ -344,8 +314,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 46,
-    "lineNumberAfterMacroExpansion": 46,
+    "lineNumber": 46,
     "instruction": "push",
     "arguments": [
       {
@@ -359,8 +328,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 47,
-    "lineNumberAfterMacroExpansion": 47,
+    "lineNumber": 47,
     "instruction": "push",
     "arguments": [
       {
@@ -372,8 +340,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 50,
-    "lineNumberAfterMacroExpansion": 50,
+    "lineNumber": 50,
     "instruction": "call",
     "arguments": [
       {
@@ -385,20 +352,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 51,
-    "lineNumberAfterMacroExpansion": 51,
+    "lineNumber": 51,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 53,
-    "lineNumberAfterMacroExpansion": 53,
+    "lineNumber": 53,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 54,
-    "lineNumberAfterMacroExpansion": 54,
+    "lineNumber": 54,
     "instruction": "module",
     "arguments": [
       {
@@ -410,8 +374,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 57,
-    "lineNumberAfterMacroExpansion": 57,
+    "lineNumber": 57,
     "instruction": "use",
     "arguments": [
       {
@@ -426,8 +389,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 59,
-    "lineNumberAfterMacroExpansion": 59,
+    "lineNumber": 59,
     "instruction": "float*",
     "arguments": [
       {
@@ -452,8 +414,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 62,
-    "lineNumberAfterMacroExpansion": 62,
+    "lineNumber": 62,
     "instruction": "float[]",
     "arguments": [
       {
@@ -472,8 +433,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 63,
-    "lineNumberAfterMacroExpansion": 63,
+    "lineNumber": 63,
     "instruction": "int",
     "arguments": [
       {
@@ -494,8 +454,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 69,
-    "lineNumberAfterMacroExpansion": 69,
+    "lineNumber": 69,
     "instruction": "push",
     "arguments": [
       {
@@ -507,8 +466,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 70,
-    "lineNumberAfterMacroExpansion": 70,
+    "lineNumber": 70,
     "instruction": "push",
     "arguments": [
       {
@@ -522,14 +480,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 71,
-    "lineNumberAfterMacroExpansion": 71,
+    "lineNumber": 71,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 76,
-    "lineNumberAfterMacroExpansion": 76,
+    "lineNumber": 76,
     "instruction": "push",
     "arguments": [
       {
@@ -543,8 +499,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 77,
-    "lineNumberAfterMacroExpansion": 77,
+    "lineNumber": 77,
     "instruction": "push",
     "arguments": [
       {
@@ -556,8 +511,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 78,
-    "lineNumberAfterMacroExpansion": 78,
+    "lineNumber": 78,
     "instruction": "push",
     "arguments": [
       {
@@ -570,20 +524,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 79,
-    "lineNumberAfterMacroExpansion": 79,
+    "lineNumber": 79,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 80,
-    "lineNumberAfterMacroExpansion": 80,
+    "lineNumber": 80,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 85,
-    "lineNumberAfterMacroExpansion": 85,
+    "lineNumber": 85,
     "instruction": "push",
     "arguments": [
       {
@@ -595,8 +546,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 86,
-    "lineNumberAfterMacroExpansion": 86,
+    "lineNumber": 86,
     "instruction": "push",
     "arguments": [
       {
@@ -610,14 +560,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 87,
-    "lineNumberAfterMacroExpansion": 87,
+    "lineNumber": 87,
     "instruction": "greaterThan",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 88,
-    "lineNumberAfterMacroExpansion": 88,
+    "lineNumber": 88,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -627,8 +575,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 89,
-    "lineNumberAfterMacroExpansion": 89,
+    "lineNumber": 89,
     "instruction": "push",
     "arguments": [
       {
@@ -642,8 +589,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 90,
-    "lineNumberAfterMacroExpansion": 90,
+    "lineNumber": 90,
     "instruction": "push",
     "arguments": [
       {
@@ -657,14 +603,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 91,
-    "lineNumberAfterMacroExpansion": 91,
+    "lineNumber": 91,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 92,
-    "lineNumberAfterMacroExpansion": 92,
+    "lineNumber": 92,
     "instruction": "ifEnd",
     "arguments": [],
     "ifEndBlock": {
@@ -673,14 +617,12 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 94,
-    "lineNumberAfterMacroExpansion": 94,
+    "lineNumber": 94,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 95,
-    "lineNumberAfterMacroExpansion": 95,
+    "lineNumber": 95,
     "instruction": "module",
     "arguments": [
       {
@@ -692,20 +634,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 103,
-    "lineNumberAfterMacroExpansion": 103,
+    "lineNumber": 103,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 104,
-    "lineNumberAfterMacroExpansion": 104,
+    "lineNumber": 104,
     "instruction": "entryEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 105,
-    "lineNumberAfterMacroExpansion": 105,
+    "lineNumber": 105,
     "instruction": "constants",
     "arguments": [
       {
@@ -717,8 +656,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 112,
-    "lineNumberAfterMacroExpansion": 112,
+    "lineNumber": 112,
     "instruction": "const",
     "arguments": [
       {
@@ -735,8 +673,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 113,
-    "lineNumberAfterMacroExpansion": 113,
+    "lineNumber": 113,
     "instruction": "const",
     "arguments": [
       {
@@ -753,14 +690,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 115,
-    "lineNumberAfterMacroExpansion": 115,
+    "lineNumber": 115,
     "instruction": "constantsEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 117,
-    "lineNumberAfterMacroExpansion": 117,
+    "lineNumber": 117,
     "instruction": "function",
     "arguments": [
       {
@@ -772,8 +707,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 119,
-    "lineNumberAfterMacroExpansion": 119,
+    "lineNumber": 119,
     "instruction": "#export",
     "arguments": [
       {
@@ -786,8 +720,7 @@
     "isBlockPrologue": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 120,
-    "lineNumberAfterMacroExpansion": 120,
+    "lineNumber": 120,
     "instruction": "use",
     "arguments": [
       {
@@ -802,8 +735,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 122,
-    "lineNumberAfterMacroExpansion": 122,
+    "lineNumber": 122,
     "instruction": "loop",
     "arguments": [
       {
@@ -815,8 +747,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 123,
-    "lineNumberAfterMacroExpansion": 123,
+    "lineNumber": 123,
     "instruction": "call",
     "arguments": [
       {
@@ -828,20 +759,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 124,
-    "lineNumberAfterMacroExpansion": 124,
+    "lineNumber": 124,
     "instruction": "loopEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 125,
-    "lineNumberAfterMacroExpansion": 125,
+    "lineNumber": 125,
     "instruction": "functionEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 127,
-    "lineNumberAfterMacroExpansion": 127,
+    "lineNumber": 127,
     "instruction": "constants",
     "arguments": [
       {
@@ -853,8 +781,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 130,
-    "lineNumberAfterMacroExpansion": 130,
+    "lineNumber": 130,
     "instruction": "const",
     "arguments": [
       {
@@ -871,8 +798,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 131,
-    "lineNumberAfterMacroExpansion": 131,
+    "lineNumber": 131,
     "instruction": "const",
     "arguments": [
       {
@@ -889,8 +815,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 132,
-    "lineNumberAfterMacroExpansion": 132,
+    "lineNumber": 132,
     "instruction": "const",
     "arguments": [
       {
@@ -907,8 +832,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 133,
-    "lineNumberAfterMacroExpansion": 133,
+    "lineNumber": 133,
     "instruction": "const",
     "arguments": [
       {
@@ -925,8 +849,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 134,
-    "lineNumberAfterMacroExpansion": 134,
+    "lineNumber": 134,
     "instruction": "const",
     "arguments": [
       {
@@ -943,8 +866,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 135,
-    "lineNumberAfterMacroExpansion": 135,
+    "lineNumber": 135,
     "instruction": "const",
     "arguments": [
       {
@@ -961,8 +883,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 136,
-    "lineNumberAfterMacroExpansion": 136,
+    "lineNumber": 136,
     "instruction": "const",
     "arguments": [
       {
@@ -979,8 +900,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 137,
-    "lineNumberAfterMacroExpansion": 137,
+    "lineNumber": 137,
     "instruction": "const",
     "arguments": [
       {
@@ -997,8 +917,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 138,
-    "lineNumberAfterMacroExpansion": 138,
+    "lineNumber": 138,
     "instruction": "const",
     "arguments": [
       {
@@ -1015,8 +934,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 139,
-    "lineNumberAfterMacroExpansion": 139,
+    "lineNumber": 139,
     "instruction": "const",
     "arguments": [
       {
@@ -1033,8 +951,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 140,
-    "lineNumberAfterMacroExpansion": 140,
+    "lineNumber": 140,
     "instruction": "const",
     "arguments": [
       {
@@ -1051,8 +968,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 141,
-    "lineNumberAfterMacroExpansion": 141,
+    "lineNumber": 141,
     "instruction": "const",
     "arguments": [
       {
@@ -1069,8 +985,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 142,
-    "lineNumberAfterMacroExpansion": 142,
+    "lineNumber": 142,
     "instruction": "const",
     "arguments": [
       {
@@ -1087,8 +1002,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 143,
-    "lineNumberAfterMacroExpansion": 143,
+    "lineNumber": 143,
     "instruction": "const",
     "arguments": [
       {
@@ -1105,8 +1019,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 144,
-    "lineNumberAfterMacroExpansion": 144,
+    "lineNumber": 144,
     "instruction": "const",
     "arguments": [
       {
@@ -1123,8 +1036,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 145,
-    "lineNumberAfterMacroExpansion": 145,
+    "lineNumber": 145,
     "instruction": "const",
     "arguments": [
       {
@@ -1141,14 +1053,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 147,
-    "lineNumberAfterMacroExpansion": 147,
+    "lineNumber": 147,
     "instruction": "constantsEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 149,
-    "lineNumberAfterMacroExpansion": 149,
+    "lineNumber": 149,
     "instruction": "function",
     "arguments": [
       {
@@ -1160,8 +1070,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 156,
-    "lineNumberAfterMacroExpansion": 156,
+    "lineNumber": 156,
     "instruction": "param",
     "arguments": [
       {
@@ -1179,8 +1088,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 158,
-    "lineNumberAfterMacroExpansion": 158,
+    "lineNumber": 158,
     "instruction": "use",
     "arguments": [
       {
@@ -1195,8 +1103,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 161,
-    "lineNumberAfterMacroExpansion": 161,
+    "lineNumber": 161,
     "instruction": "push",
     "arguments": [
       {
@@ -1208,8 +1115,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 162,
-    "lineNumberAfterMacroExpansion": 162,
+    "lineNumber": 162,
     "instruction": "push",
     "arguments": [
       {
@@ -1221,14 +1127,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 163,
-    "lineNumberAfterMacroExpansion": 163,
+    "lineNumber": 163,
     "instruction": "greaterThan",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 164,
-    "lineNumberAfterMacroExpansion": 164,
+    "lineNumber": 164,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -1238,8 +1142,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 165,
-    "lineNumberAfterMacroExpansion": 165,
+    "lineNumber": 165,
     "instruction": "push",
     "arguments": [
       {
@@ -1251,8 +1154,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 166,
-    "lineNumberAfterMacroExpansion": 166,
+    "lineNumber": 166,
     "instruction": "push",
     "arguments": [
       {
@@ -1264,14 +1166,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 167,
-    "lineNumberAfterMacroExpansion": 167,
+    "lineNumber": 167,
     "instruction": "sub",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 168,
-    "lineNumberAfterMacroExpansion": 168,
+    "lineNumber": 168,
     "instruction": "localSet",
     "arguments": [
       {
@@ -1283,8 +1183,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 169,
-    "lineNumberAfterMacroExpansion": 169,
+    "lineNumber": 169,
     "instruction": "ifEnd",
     "arguments": [],
     "ifEndBlock": {
@@ -1293,8 +1192,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 171,
-    "lineNumberAfterMacroExpansion": 171,
+    "lineNumber": 171,
     "instruction": "push",
     "arguments": [
       {
@@ -1306,8 +1204,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 172,
-    "lineNumberAfterMacroExpansion": 172,
+    "lineNumber": 172,
     "instruction": "push",
     "arguments": [
       {
@@ -1319,8 +1216,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 173,
-    "lineNumberAfterMacroExpansion": 173,
+    "lineNumber": 173,
     "instruction": "push",
     "arguments": [
       {
@@ -1331,20 +1227,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 174,
-    "lineNumberAfterMacroExpansion": 174,
+    "lineNumber": 174,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 175,
-    "lineNumberAfterMacroExpansion": 175,
+    "lineNumber": 175,
     "instruction": "lessThan",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 176,
-    "lineNumberAfterMacroExpansion": 176,
+    "lineNumber": 176,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -1354,8 +1247,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 177,
-    "lineNumberAfterMacroExpansion": 177,
+    "lineNumber": 177,
     "instruction": "push",
     "arguments": [
       {
@@ -1367,8 +1259,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 178,
-    "lineNumberAfterMacroExpansion": 178,
+    "lineNumber": 178,
     "instruction": "push",
     "arguments": [
       {
@@ -1379,14 +1270,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 179,
-    "lineNumberAfterMacroExpansion": 179,
+    "lineNumber": 179,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 180,
-    "lineNumberAfterMacroExpansion": 180,
+    "lineNumber": 180,
     "instruction": "push",
     "arguments": [
       {
@@ -1398,14 +1287,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 181,
-    "lineNumberAfterMacroExpansion": 181,
+    "lineNumber": 181,
     "instruction": "sub",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 182,
-    "lineNumberAfterMacroExpansion": 182,
+    "lineNumber": 182,
     "instruction": "localSet",
     "arguments": [
       {
@@ -1417,8 +1304,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 183,
-    "lineNumberAfterMacroExpansion": 183,
+    "lineNumber": 183,
     "instruction": "ifEnd",
     "arguments": [],
     "ifEndBlock": {
@@ -1427,8 +1313,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 185,
-    "lineNumberAfterMacroExpansion": 185,
+    "lineNumber": 185,
     "instruction": "local",
     "arguments": [
       {
@@ -1446,8 +1331,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 186,
-    "lineNumberAfterMacroExpansion": 186,
+    "lineNumber": 186,
     "instruction": "push",
     "arguments": [
       {
@@ -1459,8 +1343,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 187,
-    "lineNumberAfterMacroExpansion": 187,
+    "lineNumber": 187,
     "instruction": "push",
     "arguments": [
       {
@@ -1472,14 +1355,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 188,
-    "lineNumberAfterMacroExpansion": 188,
+    "lineNumber": 188,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 189,
-    "lineNumberAfterMacroExpansion": 189,
+    "lineNumber": 189,
     "instruction": "localSet",
     "arguments": [
       {
@@ -1491,8 +1372,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 192,
-    "lineNumberAfterMacroExpansion": 192,
+    "lineNumber": 192,
     "instruction": "const",
     "arguments": [
       {
@@ -1509,8 +1389,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 193,
-    "lineNumberAfterMacroExpansion": 193,
+    "lineNumber": 193,
     "instruction": "const",
     "arguments": [
       {
@@ -1527,8 +1406,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 194,
-    "lineNumberAfterMacroExpansion": 194,
+    "lineNumber": 194,
     "instruction": "const",
     "arguments": [
       {
@@ -1545,8 +1423,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 196,
-    "lineNumberAfterMacroExpansion": 196,
+    "lineNumber": 196,
     "instruction": "push",
     "arguments": [
       {
@@ -1558,8 +1435,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 197,
-    "lineNumberAfterMacroExpansion": 197,
+    "lineNumber": 197,
     "instruction": "push",
     "arguments": [
       {
@@ -1571,14 +1447,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 198,
-    "lineNumberAfterMacroExpansion": 198,
+    "lineNumber": 198,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 199,
-    "lineNumberAfterMacroExpansion": 199,
+    "lineNumber": 199,
     "instruction": "push",
     "arguments": [
       {
@@ -1590,14 +1464,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 200,
-    "lineNumberAfterMacroExpansion": 200,
+    "lineNumber": 200,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 201,
-    "lineNumberAfterMacroExpansion": 201,
+    "lineNumber": 201,
     "instruction": "push",
     "arguments": [
       {
@@ -1609,14 +1481,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 202,
-    "lineNumberAfterMacroExpansion": 202,
+    "lineNumber": 202,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 203,
-    "lineNumberAfterMacroExpansion": 203,
+    "lineNumber": 203,
     "instruction": "push",
     "arguments": [
       {
@@ -1628,14 +1498,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 204,
-    "lineNumberAfterMacroExpansion": 204,
+    "lineNumber": 204,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 205,
-    "lineNumberAfterMacroExpansion": 205,
+    "lineNumber": 205,
     "instruction": "push",
     "arguments": [
       {
@@ -1647,14 +1515,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 206,
-    "lineNumberAfterMacroExpansion": 206,
+    "lineNumber": 206,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 207,
-    "lineNumberAfterMacroExpansion": 207,
+    "lineNumber": 207,
     "instruction": "push",
     "arguments": [
       {
@@ -1665,14 +1531,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 208,
-    "lineNumberAfterMacroExpansion": 208,
+    "lineNumber": 208,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 209,
-    "lineNumberAfterMacroExpansion": 209,
+    "lineNumber": 209,
     "instruction": "push",
     "arguments": [
       {
@@ -1684,14 +1548,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 210,
-    "lineNumberAfterMacroExpansion": 210,
+    "lineNumber": 210,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 212,
-    "lineNumberAfterMacroExpansion": 212,
+    "lineNumber": 212,
     "instruction": "functionEnd",
     "arguments": [
       {

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/digital_bistableMultivibrators_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/digital_bistableMultivibrators_8f4e.snap
@@ -1,13 +1,11 @@
 [
   {
-    "lineNumberBeforeMacroExpansion": 0,
-    "lineNumberAfterMacroExpansion": 0,
+    "lineNumber": 0,
     "instruction": "8f4e/v1",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 2,
-    "lineNumberAfterMacroExpansion": 2,
+    "lineNumber": 2,
     "instruction": "entry",
     "arguments": [
       {
@@ -19,8 +17,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 3,
-    "lineNumberAfterMacroExpansion": 3,
+    "lineNumber": 3,
     "instruction": "module",
     "arguments": [
       {
@@ -32,14 +29,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 9,
-    "lineNumberAfterMacroExpansion": 9,
+    "lineNumber": 9,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 10,
-    "lineNumberAfterMacroExpansion": 10,
+    "lineNumber": 10,
     "instruction": "module",
     "arguments": [
       {
@@ -51,14 +46,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 18,
-    "lineNumberAfterMacroExpansion": 18,
+    "lineNumber": 18,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 19,
-    "lineNumberAfterMacroExpansion": 19,
+    "lineNumber": 19,
     "instruction": "module",
     "arguments": [
       {
@@ -70,8 +63,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 23,
-    "lineNumberAfterMacroExpansion": 23,
+    "lineNumber": 23,
     "instruction": "int",
     "arguments": [
       {
@@ -84,14 +76,12 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 28,
-    "lineNumberAfterMacroExpansion": 28,
+    "lineNumber": 28,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 29,
-    "lineNumberAfterMacroExpansion": 29,
+    "lineNumber": 29,
     "instruction": "module",
     "arguments": [
       {
@@ -103,8 +93,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 32,
-    "lineNumberAfterMacroExpansion": 32,
+    "lineNumber": 32,
     "instruction": "int",
     "arguments": [
       {
@@ -117,14 +106,12 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 37,
-    "lineNumberAfterMacroExpansion": 37,
+    "lineNumber": 37,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 38,
-    "lineNumberAfterMacroExpansion": 38,
+    "lineNumber": 38,
     "instruction": "module",
     "arguments": [
       {
@@ -136,8 +123,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 42,
-    "lineNumberAfterMacroExpansion": 42,
+    "lineNumber": 42,
     "instruction": "int*",
     "arguments": [
       {
@@ -162,8 +148,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 43,
-    "lineNumberAfterMacroExpansion": 43,
+    "lineNumber": 43,
     "instruction": "int",
     "arguments": [
       {
@@ -176,8 +161,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 44,
-    "lineNumberAfterMacroExpansion": 44,
+    "lineNumber": 44,
     "instruction": "int*",
     "arguments": [
       {
@@ -202,8 +186,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 48,
-    "lineNumberAfterMacroExpansion": 48,
+    "lineNumber": 48,
     "instruction": "push",
     "arguments": [
       {
@@ -217,8 +200,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 49,
-    "lineNumberAfterMacroExpansion": 49,
+    "lineNumber": 49,
     "instruction": "push",
     "arguments": [
       {
@@ -232,8 +214,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 50,
-    "lineNumberAfterMacroExpansion": 50,
+    "lineNumber": 50,
     "instruction": "push",
     "arguments": [
       {
@@ -247,14 +228,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 51,
-    "lineNumberAfterMacroExpansion": 51,
+    "lineNumber": 51,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 52,
-    "lineNumberAfterMacroExpansion": 52,
+    "lineNumber": 52,
     "instruction": "push",
     "arguments": [
       {
@@ -265,14 +244,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 53,
-    "lineNumberAfterMacroExpansion": 53,
+    "lineNumber": 53,
     "instruction": "equal",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 54,
-    "lineNumberAfterMacroExpansion": 54,
+    "lineNumber": 54,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -284,8 +261,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 55,
-    "lineNumberAfterMacroExpansion": 55,
+    "lineNumber": 55,
     "instruction": "push",
     "arguments": [
       {
@@ -296,14 +272,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 56,
-    "lineNumberAfterMacroExpansion": 56,
+    "lineNumber": 56,
     "instruction": "else",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 57,
-    "lineNumberAfterMacroExpansion": 57,
+    "lineNumber": 57,
     "instruction": "push",
     "arguments": [
       {
@@ -314,8 +288,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 58,
-    "lineNumberAfterMacroExpansion": 58,
+    "lineNumber": 58,
     "instruction": "ifEnd",
     "arguments": [
       {
@@ -333,20 +306,17 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 59,
-    "lineNumberAfterMacroExpansion": 59,
+    "lineNumber": 59,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 61,
-    "lineNumberAfterMacroExpansion": 61,
+    "lineNumber": 61,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 62,
-    "lineNumberAfterMacroExpansion": 62,
+    "lineNumber": 62,
     "instruction": "module",
     "arguments": [
       {
@@ -358,8 +328,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 66,
-    "lineNumberAfterMacroExpansion": 66,
+    "lineNumber": 66,
     "instruction": "int*",
     "arguments": [
       {
@@ -384,8 +353,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 67,
-    "lineNumberAfterMacroExpansion": 67,
+    "lineNumber": 67,
     "instruction": "int",
     "arguments": [
       {
@@ -398,8 +366,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 68,
-    "lineNumberAfterMacroExpansion": 68,
+    "lineNumber": 68,
     "instruction": "int*",
     "arguments": [
       {
@@ -424,8 +391,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 72,
-    "lineNumberAfterMacroExpansion": 72,
+    "lineNumber": 72,
     "instruction": "push",
     "arguments": [
       {
@@ -439,8 +405,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 73,
-    "lineNumberAfterMacroExpansion": 73,
+    "lineNumber": 73,
     "instruction": "push",
     "arguments": [
       {
@@ -454,8 +419,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 74,
-    "lineNumberAfterMacroExpansion": 74,
+    "lineNumber": 74,
     "instruction": "push",
     "arguments": [
       {
@@ -469,14 +433,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 75,
-    "lineNumberAfterMacroExpansion": 75,
+    "lineNumber": 75,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 76,
-    "lineNumberAfterMacroExpansion": 76,
+    "lineNumber": 76,
     "instruction": "push",
     "arguments": [
       {
@@ -487,14 +449,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 77,
-    "lineNumberAfterMacroExpansion": 77,
+    "lineNumber": 77,
     "instruction": "equal",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 78,
-    "lineNumberAfterMacroExpansion": 78,
+    "lineNumber": 78,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -506,8 +466,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 79,
-    "lineNumberAfterMacroExpansion": 79,
+    "lineNumber": 79,
     "instruction": "push",
     "arguments": [
       {
@@ -518,14 +477,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 80,
-    "lineNumberAfterMacroExpansion": 80,
+    "lineNumber": 80,
     "instruction": "else",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 81,
-    "lineNumberAfterMacroExpansion": 81,
+    "lineNumber": 81,
     "instruction": "push",
     "arguments": [
       {
@@ -536,8 +493,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 82,
-    "lineNumberAfterMacroExpansion": 82,
+    "lineNumber": 82,
     "instruction": "ifEnd",
     "arguments": [
       {
@@ -555,20 +511,17 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 83,
-    "lineNumberAfterMacroExpansion": 83,
+    "lineNumber": 83,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 85,
-    "lineNumberAfterMacroExpansion": 85,
+    "lineNumber": 85,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 86,
-    "lineNumberAfterMacroExpansion": 86,
+    "lineNumber": 86,
     "instruction": "module",
     "arguments": [
       {
@@ -580,8 +533,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 89,
-    "lineNumberAfterMacroExpansion": 89,
+    "lineNumber": 89,
     "instruction": "int*",
     "arguments": [
       {
@@ -606,8 +558,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 90,
-    "lineNumberAfterMacroExpansion": 90,
+    "lineNumber": 90,
     "instruction": "int[]",
     "arguments": [
       {
@@ -625,8 +576,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 91,
-    "lineNumberAfterMacroExpansion": 91,
+    "lineNumber": 91,
     "instruction": "int",
     "arguments": [
       {
@@ -647,8 +597,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 95,
-    "lineNumberAfterMacroExpansion": 95,
+    "lineNumber": 95,
     "instruction": "push",
     "arguments": [
       {
@@ -662,8 +611,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 96,
-    "lineNumberAfterMacroExpansion": 96,
+    "lineNumber": 96,
     "instruction": "push",
     "arguments": [
       {
@@ -675,8 +623,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 97,
-    "lineNumberAfterMacroExpansion": 97,
+    "lineNumber": 97,
     "instruction": "push",
     "arguments": [
       {
@@ -689,20 +636,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 98,
-    "lineNumberAfterMacroExpansion": 98,
+    "lineNumber": 98,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 99,
-    "lineNumberAfterMacroExpansion": 99,
+    "lineNumber": 99,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 101,
-    "lineNumberAfterMacroExpansion": 101,
+    "lineNumber": 101,
     "instruction": "push",
     "arguments": [
       {
@@ -714,8 +658,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 102,
-    "lineNumberAfterMacroExpansion": 102,
+    "lineNumber": 102,
     "instruction": "push",
     "arguments": [
       {
@@ -729,14 +672,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 103,
-    "lineNumberAfterMacroExpansion": 103,
+    "lineNumber": 103,
     "instruction": "greaterThan",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 104,
-    "lineNumberAfterMacroExpansion": 104,
+    "lineNumber": 104,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -746,8 +687,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 105,
-    "lineNumberAfterMacroExpansion": 105,
+    "lineNumber": 105,
     "instruction": "push",
     "arguments": [
       {
@@ -761,8 +701,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 106,
-    "lineNumberAfterMacroExpansion": 106,
+    "lineNumber": 106,
     "instruction": "push",
     "arguments": [
       {
@@ -776,14 +715,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 107,
-    "lineNumberAfterMacroExpansion": 107,
+    "lineNumber": 107,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 108,
-    "lineNumberAfterMacroExpansion": 108,
+    "lineNumber": 108,
     "instruction": "ifEnd",
     "arguments": [],
     "ifEndBlock": {
@@ -792,8 +729,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 110,
-    "lineNumberAfterMacroExpansion": 110,
+    "lineNumber": 110,
     "instruction": "push",
     "arguments": [
       {
@@ -805,8 +741,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 111,
-    "lineNumberAfterMacroExpansion": 111,
+    "lineNumber": 111,
     "instruction": "push",
     "arguments": [
       {
@@ -820,20 +755,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 112,
-    "lineNumberAfterMacroExpansion": 112,
+    "lineNumber": 112,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 114,
-    "lineNumberAfterMacroExpansion": 114,
+    "lineNumber": 114,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 115,
-    "lineNumberAfterMacroExpansion": 115,
+    "lineNumber": 115,
     "instruction": "module",
     "arguments": [
       {
@@ -845,8 +777,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 120,
-    "lineNumberAfterMacroExpansion": 120,
+    "lineNumber": 120,
     "instruction": "int",
     "arguments": [
       {
@@ -859,8 +790,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 121,
-    "lineNumberAfterMacroExpansion": 121,
+    "lineNumber": 121,
     "instruction": "int",
     "arguments": [
       {
@@ -873,14 +803,12 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 129,
-    "lineNumberAfterMacroExpansion": 129,
+    "lineNumber": 129,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 130,
-    "lineNumberAfterMacroExpansion": 130,
+    "lineNumber": 130,
     "instruction": "module",
     "arguments": [
       {
@@ -892,8 +820,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 133,
-    "lineNumberAfterMacroExpansion": 133,
+    "lineNumber": 133,
     "instruction": "int*",
     "arguments": [
       {
@@ -918,8 +845,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 134,
-    "lineNumberAfterMacroExpansion": 134,
+    "lineNumber": 134,
     "instruction": "int",
     "arguments": [
       {
@@ -932,8 +858,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 136,
-    "lineNumberAfterMacroExpansion": 136,
+    "lineNumber": 136,
     "instruction": "push",
     "arguments": [
       {
@@ -947,8 +872,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 137,
-    "lineNumberAfterMacroExpansion": 137,
+    "lineNumber": 137,
     "instruction": "push",
     "arguments": [
       {
@@ -962,8 +886,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 138,
-    "lineNumberAfterMacroExpansion": 138,
+    "lineNumber": 138,
     "instruction": "push",
     "arguments": [
       {
@@ -974,14 +897,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 139,
-    "lineNumberAfterMacroExpansion": 139,
+    "lineNumber": 139,
     "instruction": "equal",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 140,
-    "lineNumberAfterMacroExpansion": 140,
+    "lineNumber": 140,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -993,8 +914,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 141,
-    "lineNumberAfterMacroExpansion": 141,
+    "lineNumber": 141,
     "instruction": "push",
     "arguments": [
       {
@@ -1005,14 +925,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 142,
-    "lineNumberAfterMacroExpansion": 142,
+    "lineNumber": 142,
     "instruction": "else",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 143,
-    "lineNumberAfterMacroExpansion": 143,
+    "lineNumber": 143,
     "instruction": "push",
     "arguments": [
       {
@@ -1023,8 +941,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 144,
-    "lineNumberAfterMacroExpansion": 144,
+    "lineNumber": 144,
     "instruction": "ifEnd",
     "arguments": [
       {
@@ -1042,20 +959,17 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 145,
-    "lineNumberAfterMacroExpansion": 145,
+    "lineNumber": 145,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 147,
-    "lineNumberAfterMacroExpansion": 147,
+    "lineNumber": 147,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 148,
-    "lineNumberAfterMacroExpansion": 148,
+    "lineNumber": 148,
     "instruction": "module",
     "arguments": [
       {
@@ -1067,8 +981,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 152,
-    "lineNumberAfterMacroExpansion": 152,
+    "lineNumber": 152,
     "instruction": "int*",
     "arguments": [
       {
@@ -1093,8 +1006,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 153,
-    "lineNumberAfterMacroExpansion": 153,
+    "lineNumber": 153,
     "instruction": "int",
     "arguments": [
       {
@@ -1107,8 +1019,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 154,
-    "lineNumberAfterMacroExpansion": 154,
+    "lineNumber": 154,
     "instruction": "int*",
     "arguments": [
       {
@@ -1133,8 +1044,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 157,
-    "lineNumberAfterMacroExpansion": 157,
+    "lineNumber": 157,
     "instruction": "push",
     "arguments": [
       {
@@ -1148,8 +1058,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 158,
-    "lineNumberAfterMacroExpansion": 158,
+    "lineNumber": 158,
     "instruction": "push",
     "arguments": [
       {
@@ -1163,8 +1072,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 159,
-    "lineNumberAfterMacroExpansion": 159,
+    "lineNumber": 159,
     "instruction": "push",
     "arguments": [
       {
@@ -1178,14 +1086,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 160,
-    "lineNumberAfterMacroExpansion": 160,
+    "lineNumber": 160,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 161,
-    "lineNumberAfterMacroExpansion": 161,
+    "lineNumber": 161,
     "instruction": "push",
     "arguments": [
       {
@@ -1196,14 +1102,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 162,
-    "lineNumberAfterMacroExpansion": 162,
+    "lineNumber": 162,
     "instruction": "greaterOrEqual",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 163,
-    "lineNumberAfterMacroExpansion": 163,
+    "lineNumber": 163,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -1215,8 +1119,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 164,
-    "lineNumberAfterMacroExpansion": 164,
+    "lineNumber": 164,
     "instruction": "push",
     "arguments": [
       {
@@ -1227,14 +1130,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 165,
-    "lineNumberAfterMacroExpansion": 165,
+    "lineNumber": 165,
     "instruction": "else",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 166,
-    "lineNumberAfterMacroExpansion": 166,
+    "lineNumber": 166,
     "instruction": "push",
     "arguments": [
       {
@@ -1245,8 +1146,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 167,
-    "lineNumberAfterMacroExpansion": 167,
+    "lineNumber": 167,
     "instruction": "ifEnd",
     "arguments": [
       {
@@ -1264,20 +1164,17 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 168,
-    "lineNumberAfterMacroExpansion": 168,
+    "lineNumber": 168,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 170,
-    "lineNumberAfterMacroExpansion": 170,
+    "lineNumber": 170,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 171,
-    "lineNumberAfterMacroExpansion": 171,
+    "lineNumber": 171,
     "instruction": "module",
     "arguments": [
       {
@@ -1289,8 +1186,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 175,
-    "lineNumberAfterMacroExpansion": 175,
+    "lineNumber": 175,
     "instruction": "int*",
     "arguments": [
       {
@@ -1315,8 +1211,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 176,
-    "lineNumberAfterMacroExpansion": 176,
+    "lineNumber": 176,
     "instruction": "int",
     "arguments": [
       {
@@ -1329,8 +1224,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 177,
-    "lineNumberAfterMacroExpansion": 177,
+    "lineNumber": 177,
     "instruction": "int*",
     "arguments": [
       {
@@ -1355,8 +1249,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 180,
-    "lineNumberAfterMacroExpansion": 180,
+    "lineNumber": 180,
     "instruction": "push",
     "arguments": [
       {
@@ -1370,8 +1263,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 181,
-    "lineNumberAfterMacroExpansion": 181,
+    "lineNumber": 181,
     "instruction": "push",
     "arguments": [
       {
@@ -1385,8 +1277,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 182,
-    "lineNumberAfterMacroExpansion": 182,
+    "lineNumber": 182,
     "instruction": "push",
     "arguments": [
       {
@@ -1400,14 +1291,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 183,
-    "lineNumberAfterMacroExpansion": 183,
+    "lineNumber": 183,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 184,
-    "lineNumberAfterMacroExpansion": 184,
+    "lineNumber": 184,
     "instruction": "push",
     "arguments": [
       {
@@ -1418,14 +1307,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 185,
-    "lineNumberAfterMacroExpansion": 185,
+    "lineNumber": 185,
     "instruction": "greaterOrEqual",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 186,
-    "lineNumberAfterMacroExpansion": 186,
+    "lineNumber": 186,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -1437,8 +1324,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 187,
-    "lineNumberAfterMacroExpansion": 187,
+    "lineNumber": 187,
     "instruction": "push",
     "arguments": [
       {
@@ -1449,14 +1335,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 188,
-    "lineNumberAfterMacroExpansion": 188,
+    "lineNumber": 188,
     "instruction": "else",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 189,
-    "lineNumberAfterMacroExpansion": 189,
+    "lineNumber": 189,
     "instruction": "push",
     "arguments": [
       {
@@ -1467,8 +1351,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 190,
-    "lineNumberAfterMacroExpansion": 190,
+    "lineNumber": 190,
     "instruction": "ifEnd",
     "arguments": [
       {
@@ -1486,20 +1369,17 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 191,
-    "lineNumberAfterMacroExpansion": 191,
+    "lineNumber": 191,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 193,
-    "lineNumberAfterMacroExpansion": 193,
+    "lineNumber": 193,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 194,
-    "lineNumberAfterMacroExpansion": 194,
+    "lineNumber": 194,
     "instruction": "module",
     "arguments": [
       {
@@ -1511,8 +1391,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 197,
-    "lineNumberAfterMacroExpansion": 197,
+    "lineNumber": 197,
     "instruction": "int*",
     "arguments": [
       {
@@ -1537,8 +1416,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 198,
-    "lineNumberAfterMacroExpansion": 198,
+    "lineNumber": 198,
     "instruction": "int[]",
     "arguments": [
       {
@@ -1556,8 +1434,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 199,
-    "lineNumberAfterMacroExpansion": 199,
+    "lineNumber": 199,
     "instruction": "int",
     "arguments": [
       {
@@ -1578,8 +1455,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 203,
-    "lineNumberAfterMacroExpansion": 203,
+    "lineNumber": 203,
     "instruction": "push",
     "arguments": [
       {
@@ -1593,8 +1469,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 204,
-    "lineNumberAfterMacroExpansion": 204,
+    "lineNumber": 204,
     "instruction": "push",
     "arguments": [
       {
@@ -1606,8 +1481,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 205,
-    "lineNumberAfterMacroExpansion": 205,
+    "lineNumber": 205,
     "instruction": "push",
     "arguments": [
       {
@@ -1620,20 +1494,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 206,
-    "lineNumberAfterMacroExpansion": 206,
+    "lineNumber": 206,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 207,
-    "lineNumberAfterMacroExpansion": 207,
+    "lineNumber": 207,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 209,
-    "lineNumberAfterMacroExpansion": 209,
+    "lineNumber": 209,
     "instruction": "push",
     "arguments": [
       {
@@ -1645,8 +1516,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 210,
-    "lineNumberAfterMacroExpansion": 210,
+    "lineNumber": 210,
     "instruction": "push",
     "arguments": [
       {
@@ -1660,14 +1530,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 211,
-    "lineNumberAfterMacroExpansion": 211,
+    "lineNumber": 211,
     "instruction": "greaterThan",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 212,
-    "lineNumberAfterMacroExpansion": 212,
+    "lineNumber": 212,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -1677,8 +1545,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 213,
-    "lineNumberAfterMacroExpansion": 213,
+    "lineNumber": 213,
     "instruction": "push",
     "arguments": [
       {
@@ -1692,8 +1559,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 214,
-    "lineNumberAfterMacroExpansion": 214,
+    "lineNumber": 214,
     "instruction": "push",
     "arguments": [
       {
@@ -1707,14 +1573,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 215,
-    "lineNumberAfterMacroExpansion": 215,
+    "lineNumber": 215,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 216,
-    "lineNumberAfterMacroExpansion": 216,
+    "lineNumber": 216,
     "instruction": "ifEnd",
     "arguments": [],
     "ifEndBlock": {
@@ -1723,8 +1587,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 218,
-    "lineNumberAfterMacroExpansion": 218,
+    "lineNumber": 218,
     "instruction": "push",
     "arguments": [
       {
@@ -1736,8 +1599,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 219,
-    "lineNumberAfterMacroExpansion": 219,
+    "lineNumber": 219,
     "instruction": "push",
     "arguments": [
       {
@@ -1751,26 +1613,22 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 220,
-    "lineNumberAfterMacroExpansion": 220,
+    "lineNumber": 220,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 222,
-    "lineNumberAfterMacroExpansion": 222,
+    "lineNumber": 222,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 223,
-    "lineNumberAfterMacroExpansion": 223,
+    "lineNumber": 223,
     "instruction": "entryEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 225,
-    "lineNumberAfterMacroExpansion": 225,
+    "lineNumber": 225,
     "instruction": "constants",
     "arguments": [
       {
@@ -1782,8 +1640,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 231,
-    "lineNumberAfterMacroExpansion": 231,
+    "lineNumber": 231,
     "instruction": "const",
     "arguments": [
       {
@@ -1800,8 +1657,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 233,
-    "lineNumberAfterMacroExpansion": 233,
+    "lineNumber": 233,
     "instruction": "constantsEnd",
     "arguments": []
   }

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/machine-learning_xorProblem_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/machine-learning_xorProblem_8f4e.snap
@@ -1,13 +1,11 @@
 [
   {
-    "lineNumberBeforeMacroExpansion": 0,
-    "lineNumberAfterMacroExpansion": 0,
+    "lineNumber": 0,
     "instruction": "8f4e/v1",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 2,
-    "lineNumberAfterMacroExpansion": 2,
+    "lineNumber": 2,
     "instruction": "entry",
     "arguments": [
       {
@@ -19,8 +17,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 3,
-    "lineNumberAfterMacroExpansion": 3,
+    "lineNumber": 3,
     "instruction": "module",
     "arguments": [
       {
@@ -32,14 +29,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 9,
-    "lineNumberAfterMacroExpansion": 9,
+    "lineNumber": 9,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 10,
-    "lineNumberAfterMacroExpansion": 10,
+    "lineNumber": 10,
     "instruction": "module",
     "arguments": [
       {
@@ -51,8 +46,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 18,
-    "lineNumberAfterMacroExpansion": 18,
+    "lineNumber": 18,
     "instruction": "int*",
     "arguments": [
       {
@@ -77,14 +71,12 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 20,
-    "lineNumberAfterMacroExpansion": 20,
+    "lineNumber": 20,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 21,
-    "lineNumberAfterMacroExpansion": 21,
+    "lineNumber": 21,
     "instruction": "module",
     "arguments": [
       {
@@ -96,14 +88,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 30,
-    "lineNumberAfterMacroExpansion": 30,
+    "lineNumber": 30,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 31,
-    "lineNumberAfterMacroExpansion": 31,
+    "lineNumber": 31,
     "instruction": "module",
     "arguments": [
       {
@@ -115,8 +105,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 37,
-    "lineNumberAfterMacroExpansion": 37,
+    "lineNumber": 37,
     "instruction": "float",
     "arguments": [
       {
@@ -134,8 +123,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 38,
-    "lineNumberAfterMacroExpansion": 38,
+    "lineNumber": 38,
     "instruction": "float",
     "arguments": [
       {
@@ -153,14 +141,12 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 40,
-    "lineNumberAfterMacroExpansion": 40,
+    "lineNumber": 40,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 41,
-    "lineNumberAfterMacroExpansion": 41,
+    "lineNumber": 41,
     "instruction": "module",
     "arguments": [
       {
@@ -172,8 +158,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 45,
-    "lineNumberAfterMacroExpansion": 45,
+    "lineNumber": 45,
     "instruction": "float*",
     "arguments": [
       {
@@ -198,8 +183,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 46,
-    "lineNumberAfterMacroExpansion": 46,
+    "lineNumber": 46,
     "instruction": "float*",
     "arguments": [
       {
@@ -224,8 +208,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 47,
-    "lineNumberAfterMacroExpansion": 47,
+    "lineNumber": 47,
     "instruction": "float",
     "arguments": [
       {
@@ -238,8 +221,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 50,
-    "lineNumberAfterMacroExpansion": 50,
+    "lineNumber": 50,
     "instruction": "const",
     "arguments": [
       {
@@ -256,8 +238,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 51,
-    "lineNumberAfterMacroExpansion": 51,
+    "lineNumber": 51,
     "instruction": "const",
     "arguments": [
       {
@@ -274,8 +255,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 52,
-    "lineNumberAfterMacroExpansion": 52,
+    "lineNumber": 52,
     "instruction": "const",
     "arguments": [
       {
@@ -292,8 +272,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 54,
-    "lineNumberAfterMacroExpansion": 54,
+    "lineNumber": 54,
     "instruction": "push",
     "arguments": [
       {
@@ -307,8 +286,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 55,
-    "lineNumberAfterMacroExpansion": 55,
+    "lineNumber": 55,
     "instruction": "push",
     "arguments": [
       {
@@ -322,8 +300,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 56,
-    "lineNumberAfterMacroExpansion": 56,
+    "lineNumber": 56,
     "instruction": "push",
     "arguments": [
       {
@@ -335,14 +312,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 57,
-    "lineNumberAfterMacroExpansion": 57,
+    "lineNumber": 57,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 58,
-    "lineNumberAfterMacroExpansion": 58,
+    "lineNumber": 58,
     "instruction": "push",
     "arguments": [
       {
@@ -356,8 +331,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 59,
-    "lineNumberAfterMacroExpansion": 59,
+    "lineNumber": 59,
     "instruction": "push",
     "arguments": [
       {
@@ -369,20 +343,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 60,
-    "lineNumberAfterMacroExpansion": 60,
+    "lineNumber": 60,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 61,
-    "lineNumberAfterMacroExpansion": 61,
+    "lineNumber": 61,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 62,
-    "lineNumberAfterMacroExpansion": 62,
+    "lineNumber": 62,
     "instruction": "push",
     "arguments": [
       {
@@ -394,26 +365,22 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 63,
-    "lineNumberAfterMacroExpansion": 63,
+    "lineNumber": 63,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 64,
-    "lineNumberAfterMacroExpansion": 64,
+    "lineNumber": 64,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 65,
-    "lineNumberAfterMacroExpansion": 65,
+    "lineNumber": 65,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 66,
-    "lineNumberAfterMacroExpansion": 66,
+    "lineNumber": 66,
     "instruction": "module",
     "arguments": [
       {
@@ -425,8 +392,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 70,
-    "lineNumberAfterMacroExpansion": 70,
+    "lineNumber": 70,
     "instruction": "float*",
     "arguments": [
       {
@@ -451,8 +417,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 71,
-    "lineNumberAfterMacroExpansion": 71,
+    "lineNumber": 71,
     "instruction": "float*",
     "arguments": [
       {
@@ -477,8 +442,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 72,
-    "lineNumberAfterMacroExpansion": 72,
+    "lineNumber": 72,
     "instruction": "float",
     "arguments": [
       {
@@ -491,8 +455,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 75,
-    "lineNumberAfterMacroExpansion": 75,
+    "lineNumber": 75,
     "instruction": "const",
     "arguments": [
       {
@@ -509,8 +472,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 76,
-    "lineNumberAfterMacroExpansion": 76,
+    "lineNumber": 76,
     "instruction": "const",
     "arguments": [
       {
@@ -527,8 +489,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 77,
-    "lineNumberAfterMacroExpansion": 77,
+    "lineNumber": 77,
     "instruction": "const",
     "arguments": [
       {
@@ -545,8 +506,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 79,
-    "lineNumberAfterMacroExpansion": 79,
+    "lineNumber": 79,
     "instruction": "push",
     "arguments": [
       {
@@ -560,8 +520,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 80,
-    "lineNumberAfterMacroExpansion": 80,
+    "lineNumber": 80,
     "instruction": "push",
     "arguments": [
       {
@@ -575,8 +534,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 81,
-    "lineNumberAfterMacroExpansion": 81,
+    "lineNumber": 81,
     "instruction": "push",
     "arguments": [
       {
@@ -588,14 +546,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 82,
-    "lineNumberAfterMacroExpansion": 82,
+    "lineNumber": 82,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 83,
-    "lineNumberAfterMacroExpansion": 83,
+    "lineNumber": 83,
     "instruction": "push",
     "arguments": [
       {
@@ -609,8 +565,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 84,
-    "lineNumberAfterMacroExpansion": 84,
+    "lineNumber": 84,
     "instruction": "push",
     "arguments": [
       {
@@ -622,20 +577,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 85,
-    "lineNumberAfterMacroExpansion": 85,
+    "lineNumber": 85,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 86,
-    "lineNumberAfterMacroExpansion": 86,
+    "lineNumber": 86,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 87,
-    "lineNumberAfterMacroExpansion": 87,
+    "lineNumber": 87,
     "instruction": "push",
     "arguments": [
       {
@@ -647,26 +599,22 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 88,
-    "lineNumberAfterMacroExpansion": 88,
+    "lineNumber": 88,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 89,
-    "lineNumberAfterMacroExpansion": 89,
+    "lineNumber": 89,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 90,
-    "lineNumberAfterMacroExpansion": 90,
+    "lineNumber": 90,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 91,
-    "lineNumberAfterMacroExpansion": 91,
+    "lineNumber": 91,
     "instruction": "module",
     "arguments": [
       {
@@ -678,8 +626,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 94,
-    "lineNumberAfterMacroExpansion": 94,
+    "lineNumber": 94,
     "instruction": "float*",
     "arguments": [
       {
@@ -704,8 +651,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 95,
-    "lineNumberAfterMacroExpansion": 95,
+    "lineNumber": 95,
     "instruction": "float",
     "arguments": [
       {
@@ -718,8 +664,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 97,
-    "lineNumberAfterMacroExpansion": 97,
+    "lineNumber": 97,
     "instruction": "push",
     "arguments": [
       {
@@ -733,8 +678,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 98,
-    "lineNumberAfterMacroExpansion": 98,
+    "lineNumber": 98,
     "instruction": "push",
     "arguments": [
       {
@@ -748,8 +692,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 99,
-    "lineNumberAfterMacroExpansion": 99,
+    "lineNumber": 99,
     "instruction": "call",
     "arguments": [
       {
@@ -761,20 +704,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 100,
-    "lineNumberAfterMacroExpansion": 100,
+    "lineNumber": 100,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 102,
-    "lineNumberAfterMacroExpansion": 102,
+    "lineNumber": 102,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 103,
-    "lineNumberAfterMacroExpansion": 103,
+    "lineNumber": 103,
     "instruction": "module",
     "arguments": [
       {
@@ -786,8 +726,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 106,
-    "lineNumberAfterMacroExpansion": 106,
+    "lineNumber": 106,
     "instruction": "float*",
     "arguments": [
       {
@@ -812,8 +751,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 107,
-    "lineNumberAfterMacroExpansion": 107,
+    "lineNumber": 107,
     "instruction": "float",
     "arguments": [
       {
@@ -826,8 +764,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 109,
-    "lineNumberAfterMacroExpansion": 109,
+    "lineNumber": 109,
     "instruction": "push",
     "arguments": [
       {
@@ -841,8 +778,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 110,
-    "lineNumberAfterMacroExpansion": 110,
+    "lineNumber": 110,
     "instruction": "push",
     "arguments": [
       {
@@ -856,8 +792,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 111,
-    "lineNumberAfterMacroExpansion": 111,
+    "lineNumber": 111,
     "instruction": "call",
     "arguments": [
       {
@@ -869,20 +804,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 112,
-    "lineNumberAfterMacroExpansion": 112,
+    "lineNumber": 112,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 114,
-    "lineNumberAfterMacroExpansion": 114,
+    "lineNumber": 114,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 115,
-    "lineNumberAfterMacroExpansion": 115,
+    "lineNumber": 115,
     "instruction": "module",
     "arguments": [
       {
@@ -894,8 +826,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 119,
-    "lineNumberAfterMacroExpansion": 119,
+    "lineNumber": 119,
     "instruction": "float*",
     "arguments": [
       {
@@ -920,8 +851,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 120,
-    "lineNumberAfterMacroExpansion": 120,
+    "lineNumber": 120,
     "instruction": "float*",
     "arguments": [
       {
@@ -946,8 +876,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 121,
-    "lineNumberAfterMacroExpansion": 121,
+    "lineNumber": 121,
     "instruction": "float",
     "arguments": [
       {
@@ -960,8 +889,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 124,
-    "lineNumberAfterMacroExpansion": 124,
+    "lineNumber": 124,
     "instruction": "const",
     "arguments": [
       {
@@ -978,8 +906,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 125,
-    "lineNumberAfterMacroExpansion": 125,
+    "lineNumber": 125,
     "instruction": "const",
     "arguments": [
       {
@@ -996,8 +923,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 126,
-    "lineNumberAfterMacroExpansion": 126,
+    "lineNumber": 126,
     "instruction": "const",
     "arguments": [
       {
@@ -1014,8 +940,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 128,
-    "lineNumberAfterMacroExpansion": 128,
+    "lineNumber": 128,
     "instruction": "push",
     "arguments": [
       {
@@ -1029,8 +954,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 129,
-    "lineNumberAfterMacroExpansion": 129,
+    "lineNumber": 129,
     "instruction": "push",
     "arguments": [
       {
@@ -1044,8 +968,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 130,
-    "lineNumberAfterMacroExpansion": 130,
+    "lineNumber": 130,
     "instruction": "push",
     "arguments": [
       {
@@ -1057,14 +980,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 131,
-    "lineNumberAfterMacroExpansion": 131,
+    "lineNumber": 131,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 132,
-    "lineNumberAfterMacroExpansion": 132,
+    "lineNumber": 132,
     "instruction": "push",
     "arguments": [
       {
@@ -1078,8 +999,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 133,
-    "lineNumberAfterMacroExpansion": 133,
+    "lineNumber": 133,
     "instruction": "push",
     "arguments": [
       {
@@ -1091,20 +1011,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 134,
-    "lineNumberAfterMacroExpansion": 134,
+    "lineNumber": 134,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 135,
-    "lineNumberAfterMacroExpansion": 135,
+    "lineNumber": 135,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 136,
-    "lineNumberAfterMacroExpansion": 136,
+    "lineNumber": 136,
     "instruction": "push",
     "arguments": [
       {
@@ -1116,26 +1033,22 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 137,
-    "lineNumberAfterMacroExpansion": 137,
+    "lineNumber": 137,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 138,
-    "lineNumberAfterMacroExpansion": 138,
+    "lineNumber": 138,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 139,
-    "lineNumberAfterMacroExpansion": 139,
+    "lineNumber": 139,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 140,
-    "lineNumberAfterMacroExpansion": 140,
+    "lineNumber": 140,
     "instruction": "module",
     "arguments": [
       {
@@ -1147,8 +1060,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 143,
-    "lineNumberAfterMacroExpansion": 143,
+    "lineNumber": 143,
     "instruction": "float*",
     "arguments": [
       {
@@ -1173,8 +1085,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 144,
-    "lineNumberAfterMacroExpansion": 144,
+    "lineNumber": 144,
     "instruction": "int",
     "arguments": [
       {
@@ -1187,8 +1098,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 146,
-    "lineNumberAfterMacroExpansion": 146,
+    "lineNumber": 146,
     "instruction": "push",
     "arguments": [
       {
@@ -1202,8 +1112,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 148,
-    "lineNumberAfterMacroExpansion": 148,
+    "lineNumber": 148,
     "instruction": "push",
     "arguments": [
       {
@@ -1217,8 +1126,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 149,
-    "lineNumberAfterMacroExpansion": 149,
+    "lineNumber": 149,
     "instruction": "call",
     "arguments": [
       {
@@ -1230,8 +1138,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 151,
-    "lineNumberAfterMacroExpansion": 151,
+    "lineNumber": 151,
     "instruction": "push",
     "arguments": [
       {
@@ -1242,14 +1149,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 152,
-    "lineNumberAfterMacroExpansion": 152,
+    "lineNumber": 152,
     "instruction": "greaterThan",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 153,
-    "lineNumberAfterMacroExpansion": 153,
+    "lineNumber": 153,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -1261,8 +1166,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 154,
-    "lineNumberAfterMacroExpansion": 154,
+    "lineNumber": 154,
     "instruction": "push",
     "arguments": [
       {
@@ -1273,14 +1177,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 155,
-    "lineNumberAfterMacroExpansion": 155,
+    "lineNumber": 155,
     "instruction": "else",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 156,
-    "lineNumberAfterMacroExpansion": 156,
+    "lineNumber": 156,
     "instruction": "push",
     "arguments": [
       {
@@ -1291,8 +1193,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 157,
-    "lineNumberAfterMacroExpansion": 157,
+    "lineNumber": 157,
     "instruction": "ifEnd",
     "arguments": [
       {
@@ -1310,26 +1211,22 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 159,
-    "lineNumberAfterMacroExpansion": 159,
+    "lineNumber": 159,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 161,
-    "lineNumberAfterMacroExpansion": 161,
+    "lineNumber": 161,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 162,
-    "lineNumberAfterMacroExpansion": 162,
+    "lineNumber": 162,
     "instruction": "entryEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 164,
-    "lineNumberAfterMacroExpansion": 164,
+    "lineNumber": 164,
     "instruction": "constants",
     "arguments": [
       {
@@ -1341,8 +1238,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 171,
-    "lineNumberAfterMacroExpansion": 171,
+    "lineNumber": 171,
     "instruction": "const",
     "arguments": [
       {
@@ -1359,8 +1255,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 172,
-    "lineNumberAfterMacroExpansion": 172,
+    "lineNumber": 172,
     "instruction": "const",
     "arguments": [
       {
@@ -1377,14 +1272,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 174,
-    "lineNumberAfterMacroExpansion": 174,
+    "lineNumber": 174,
     "instruction": "constantsEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 176,
-    "lineNumberAfterMacroExpansion": 176,
+    "lineNumber": 176,
     "instruction": "function",
     "arguments": [
       {
@@ -1396,8 +1289,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 178,
-    "lineNumberAfterMacroExpansion": 178,
+    "lineNumber": 178,
     "instruction": "param",
     "arguments": [
       {
@@ -1415,8 +1307,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 182,
-    "lineNumberAfterMacroExpansion": 182,
+    "lineNumber": 182,
     "instruction": "push",
     "arguments": [
       {
@@ -1428,8 +1319,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 183,
-    "lineNumberAfterMacroExpansion": 183,
+    "lineNumber": 183,
     "instruction": "push",
     "arguments": [
       {
@@ -1441,14 +1331,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 184,
-    "lineNumberAfterMacroExpansion": 184,
+    "lineNumber": 184,
     "instruction": "abs",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 185,
-    "lineNumberAfterMacroExpansion": 185,
+    "lineNumber": 185,
     "instruction": "push",
     "arguments": [
       {
@@ -1459,26 +1347,22 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 186,
-    "lineNumberAfterMacroExpansion": 186,
+    "lineNumber": 186,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 187,
-    "lineNumberAfterMacroExpansion": 187,
+    "lineNumber": 187,
     "instruction": "ensureNonZero",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 188,
-    "lineNumberAfterMacroExpansion": 188,
+    "lineNumber": 188,
     "instruction": "div",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 190,
-    "lineNumberAfterMacroExpansion": 190,
+    "lineNumber": 190,
     "instruction": "functionEnd",
     "arguments": [
       {

--- a/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/visuals_dancingWithTheSineLT_8f4e.snap
+++ b/packages/compiler/packages/tokenizer/tests/__snapshots__/exampleProjects/visuals_dancingWithTheSineLT_8f4e.snap
@@ -1,13 +1,11 @@
 [
   {
-    "lineNumberBeforeMacroExpansion": 0,
-    "lineNumberAfterMacroExpansion": 0,
+    "lineNumber": 0,
     "instruction": "8f4e/v1",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 2,
-    "lineNumberAfterMacroExpansion": 2,
+    "lineNumber": 2,
     "instruction": "entry",
     "arguments": [
       {
@@ -19,8 +17,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 3,
-    "lineNumberAfterMacroExpansion": 3,
+    "lineNumber": 3,
     "instruction": "module",
     "arguments": [
       {
@@ -32,14 +29,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 8,
-    "lineNumberAfterMacroExpansion": 8,
+    "lineNumber": 8,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 9,
-    "lineNumberAfterMacroExpansion": 9,
+    "lineNumber": 9,
     "instruction": "module",
     "arguments": [
       {
@@ -51,8 +46,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 12,
-    "lineNumberAfterMacroExpansion": 12,
+    "lineNumber": 12,
     "instruction": "float",
     "arguments": [
       {
@@ -70,8 +64,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 13,
-    "lineNumberAfterMacroExpansion": 13,
+    "lineNumber": 13,
     "instruction": "float",
     "arguments": [
       {
@@ -89,8 +82,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 14,
-    "lineNumberAfterMacroExpansion": 14,
+    "lineNumber": 14,
     "instruction": "float",
     "arguments": [
       {
@@ -108,8 +100,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 15,
-    "lineNumberAfterMacroExpansion": 15,
+    "lineNumber": 15,
     "instruction": "float",
     "arguments": [
       {
@@ -127,8 +118,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 16,
-    "lineNumberAfterMacroExpansion": 16,
+    "lineNumber": 16,
     "instruction": "float",
     "arguments": [
       {
@@ -146,8 +136,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 17,
-    "lineNumberAfterMacroExpansion": 17,
+    "lineNumber": 17,
     "instruction": "float",
     "arguments": [
       {
@@ -165,8 +154,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 18,
-    "lineNumberAfterMacroExpansion": 18,
+    "lineNumber": 18,
     "instruction": "float",
     "arguments": [
       {
@@ -184,8 +172,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 19,
-    "lineNumberAfterMacroExpansion": 19,
+    "lineNumber": 19,
     "instruction": "float",
     "arguments": [
       {
@@ -203,8 +190,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 20,
-    "lineNumberAfterMacroExpansion": 20,
+    "lineNumber": 20,
     "instruction": "float",
     "arguments": [
       {
@@ -222,8 +208,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 21,
-    "lineNumberAfterMacroExpansion": 21,
+    "lineNumber": 21,
     "instruction": "float",
     "arguments": [
       {
@@ -241,8 +226,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 22,
-    "lineNumberAfterMacroExpansion": 22,
+    "lineNumber": 22,
     "instruction": "float",
     "arguments": [
       {
@@ -260,8 +244,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 23,
-    "lineNumberAfterMacroExpansion": 23,
+    "lineNumber": 23,
     "instruction": "float",
     "arguments": [
       {
@@ -279,8 +262,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 24,
-    "lineNumberAfterMacroExpansion": 24,
+    "lineNumber": 24,
     "instruction": "float",
     "arguments": [
       {
@@ -298,8 +280,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 25,
-    "lineNumberAfterMacroExpansion": 25,
+    "lineNumber": 25,
     "instruction": "float",
     "arguments": [
       {
@@ -317,8 +298,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 26,
-    "lineNumberAfterMacroExpansion": 26,
+    "lineNumber": 26,
     "instruction": "float",
     "arguments": [
       {
@@ -336,8 +316,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 27,
-    "lineNumberAfterMacroExpansion": 27,
+    "lineNumber": 27,
     "instruction": "float",
     "arguments": [
       {
@@ -355,8 +334,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 28,
-    "lineNumberAfterMacroExpansion": 28,
+    "lineNumber": 28,
     "instruction": "float",
     "arguments": [
       {
@@ -374,8 +352,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 29,
-    "lineNumberAfterMacroExpansion": 29,
+    "lineNumber": 29,
     "instruction": "float",
     "arguments": [
       {
@@ -393,8 +370,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 30,
-    "lineNumberAfterMacroExpansion": 30,
+    "lineNumber": 30,
     "instruction": "float",
     "arguments": [
       {
@@ -412,8 +388,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 31,
-    "lineNumberAfterMacroExpansion": 31,
+    "lineNumber": 31,
     "instruction": "float",
     "arguments": [
       {
@@ -431,8 +406,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 32,
-    "lineNumberAfterMacroExpansion": 32,
+    "lineNumber": 32,
     "instruction": "float",
     "arguments": [
       {
@@ -450,8 +424,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 33,
-    "lineNumberAfterMacroExpansion": 33,
+    "lineNumber": 33,
     "instruction": "float",
     "arguments": [
       {
@@ -469,8 +442,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 34,
-    "lineNumberAfterMacroExpansion": 34,
+    "lineNumber": 34,
     "instruction": "float",
     "arguments": [
       {
@@ -488,8 +460,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 35,
-    "lineNumberAfterMacroExpansion": 35,
+    "lineNumber": 35,
     "instruction": "float",
     "arguments": [
       {
@@ -507,8 +478,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 36,
-    "lineNumberAfterMacroExpansion": 36,
+    "lineNumber": 36,
     "instruction": "float",
     "arguments": [
       {
@@ -526,8 +496,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 37,
-    "lineNumberAfterMacroExpansion": 37,
+    "lineNumber": 37,
     "instruction": "float",
     "arguments": [
       {
@@ -545,8 +514,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 38,
-    "lineNumberAfterMacroExpansion": 38,
+    "lineNumber": 38,
     "instruction": "float",
     "arguments": [
       {
@@ -564,8 +532,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 39,
-    "lineNumberAfterMacroExpansion": 39,
+    "lineNumber": 39,
     "instruction": "float",
     "arguments": [
       {
@@ -583,8 +550,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 40,
-    "lineNumberAfterMacroExpansion": 40,
+    "lineNumber": 40,
     "instruction": "float",
     "arguments": [
       {
@@ -602,8 +568,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 41,
-    "lineNumberAfterMacroExpansion": 41,
+    "lineNumber": 41,
     "instruction": "float",
     "arguments": [
       {
@@ -621,8 +586,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 42,
-    "lineNumberAfterMacroExpansion": 42,
+    "lineNumber": 42,
     "instruction": "float",
     "arguments": [
       {
@@ -640,8 +604,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 43,
-    "lineNumberAfterMacroExpansion": 43,
+    "lineNumber": 43,
     "instruction": "float",
     "arguments": [
       {
@@ -659,8 +622,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 44,
-    "lineNumberAfterMacroExpansion": 44,
+    "lineNumber": 44,
     "instruction": "float",
     "arguments": [
       {
@@ -678,8 +640,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 45,
-    "lineNumberAfterMacroExpansion": 45,
+    "lineNumber": 45,
     "instruction": "float",
     "arguments": [
       {
@@ -697,8 +658,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 46,
-    "lineNumberAfterMacroExpansion": 46,
+    "lineNumber": 46,
     "instruction": "float",
     "arguments": [
       {
@@ -716,8 +676,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 47,
-    "lineNumberAfterMacroExpansion": 47,
+    "lineNumber": 47,
     "instruction": "float",
     "arguments": [
       {
@@ -735,8 +694,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 48,
-    "lineNumberAfterMacroExpansion": 48,
+    "lineNumber": 48,
     "instruction": "float",
     "arguments": [
       {
@@ -754,8 +712,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 49,
-    "lineNumberAfterMacroExpansion": 49,
+    "lineNumber": 49,
     "instruction": "float",
     "arguments": [
       {
@@ -773,8 +730,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 50,
-    "lineNumberAfterMacroExpansion": 50,
+    "lineNumber": 50,
     "instruction": "float",
     "arguments": [
       {
@@ -792,8 +748,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 51,
-    "lineNumberAfterMacroExpansion": 51,
+    "lineNumber": 51,
     "instruction": "float",
     "arguments": [
       {
@@ -811,8 +766,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 52,
-    "lineNumberAfterMacroExpansion": 52,
+    "lineNumber": 52,
     "instruction": "float",
     "arguments": [
       {
@@ -830,8 +784,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 53,
-    "lineNumberAfterMacroExpansion": 53,
+    "lineNumber": 53,
     "instruction": "float",
     "arguments": [
       {
@@ -849,8 +802,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 54,
-    "lineNumberAfterMacroExpansion": 54,
+    "lineNumber": 54,
     "instruction": "float",
     "arguments": [
       {
@@ -868,8 +820,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 55,
-    "lineNumberAfterMacroExpansion": 55,
+    "lineNumber": 55,
     "instruction": "float",
     "arguments": [
       {
@@ -887,8 +838,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 56,
-    "lineNumberAfterMacroExpansion": 56,
+    "lineNumber": 56,
     "instruction": "float",
     "arguments": [
       {
@@ -906,8 +856,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 57,
-    "lineNumberAfterMacroExpansion": 57,
+    "lineNumber": 57,
     "instruction": "float",
     "arguments": [
       {
@@ -925,8 +874,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 58,
-    "lineNumberAfterMacroExpansion": 58,
+    "lineNumber": 58,
     "instruction": "float",
     "arguments": [
       {
@@ -944,8 +892,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 59,
-    "lineNumberAfterMacroExpansion": 59,
+    "lineNumber": 59,
     "instruction": "float",
     "arguments": [
       {
@@ -963,8 +910,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 60,
-    "lineNumberAfterMacroExpansion": 60,
+    "lineNumber": 60,
     "instruction": "float",
     "arguments": [
       {
@@ -982,8 +928,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 61,
-    "lineNumberAfterMacroExpansion": 61,
+    "lineNumber": 61,
     "instruction": "float",
     "arguments": [
       {
@@ -1001,8 +946,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 62,
-    "lineNumberAfterMacroExpansion": 62,
+    "lineNumber": 62,
     "instruction": "float",
     "arguments": [
       {
@@ -1020,8 +964,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 63,
-    "lineNumberAfterMacroExpansion": 63,
+    "lineNumber": 63,
     "instruction": "float",
     "arguments": [
       {
@@ -1039,8 +982,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 64,
-    "lineNumberAfterMacroExpansion": 64,
+    "lineNumber": 64,
     "instruction": "float",
     "arguments": [
       {
@@ -1058,8 +1000,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 65,
-    "lineNumberAfterMacroExpansion": 65,
+    "lineNumber": 65,
     "instruction": "float",
     "arguments": [
       {
@@ -1077,8 +1018,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 66,
-    "lineNumberAfterMacroExpansion": 66,
+    "lineNumber": 66,
     "instruction": "float",
     "arguments": [
       {
@@ -1096,8 +1036,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 67,
-    "lineNumberAfterMacroExpansion": 67,
+    "lineNumber": 67,
     "instruction": "float",
     "arguments": [
       {
@@ -1115,8 +1054,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 68,
-    "lineNumberAfterMacroExpansion": 68,
+    "lineNumber": 68,
     "instruction": "float",
     "arguments": [
       {
@@ -1134,8 +1072,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 69,
-    "lineNumberAfterMacroExpansion": 69,
+    "lineNumber": 69,
     "instruction": "float",
     "arguments": [
       {
@@ -1153,8 +1090,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 70,
-    "lineNumberAfterMacroExpansion": 70,
+    "lineNumber": 70,
     "instruction": "float",
     "arguments": [
       {
@@ -1172,8 +1108,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 71,
-    "lineNumberAfterMacroExpansion": 71,
+    "lineNumber": 71,
     "instruction": "float",
     "arguments": [
       {
@@ -1191,8 +1126,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 72,
-    "lineNumberAfterMacroExpansion": 72,
+    "lineNumber": 72,
     "instruction": "float",
     "arguments": [
       {
@@ -1210,8 +1144,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 73,
-    "lineNumberAfterMacroExpansion": 73,
+    "lineNumber": 73,
     "instruction": "float",
     "arguments": [
       {
@@ -1229,8 +1162,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 74,
-    "lineNumberAfterMacroExpansion": 74,
+    "lineNumber": 74,
     "instruction": "float",
     "arguments": [
       {
@@ -1248,8 +1180,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 75,
-    "lineNumberAfterMacroExpansion": 75,
+    "lineNumber": 75,
     "instruction": "float",
     "arguments": [
       {
@@ -1267,8 +1198,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 76,
-    "lineNumberAfterMacroExpansion": 76,
+    "lineNumber": 76,
     "instruction": "float",
     "arguments": [
       {
@@ -1286,8 +1216,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 77,
-    "lineNumberAfterMacroExpansion": 77,
+    "lineNumber": 77,
     "instruction": "float",
     "arguments": [
       {
@@ -1305,8 +1234,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 78,
-    "lineNumberAfterMacroExpansion": 78,
+    "lineNumber": 78,
     "instruction": "float",
     "arguments": [
       {
@@ -1324,8 +1252,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 79,
-    "lineNumberAfterMacroExpansion": 79,
+    "lineNumber": 79,
     "instruction": "float",
     "arguments": [
       {
@@ -1343,8 +1270,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 80,
-    "lineNumberAfterMacroExpansion": 80,
+    "lineNumber": 80,
     "instruction": "float",
     "arguments": [
       {
@@ -1362,8 +1288,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 81,
-    "lineNumberAfterMacroExpansion": 81,
+    "lineNumber": 81,
     "instruction": "float",
     "arguments": [
       {
@@ -1381,8 +1306,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 82,
-    "lineNumberAfterMacroExpansion": 82,
+    "lineNumber": 82,
     "instruction": "float",
     "arguments": [
       {
@@ -1400,8 +1324,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 83,
-    "lineNumberAfterMacroExpansion": 83,
+    "lineNumber": 83,
     "instruction": "float",
     "arguments": [
       {
@@ -1419,8 +1342,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 84,
-    "lineNumberAfterMacroExpansion": 84,
+    "lineNumber": 84,
     "instruction": "float",
     "arguments": [
       {
@@ -1438,8 +1360,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 85,
-    "lineNumberAfterMacroExpansion": 85,
+    "lineNumber": 85,
     "instruction": "float",
     "arguments": [
       {
@@ -1457,8 +1378,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 86,
-    "lineNumberAfterMacroExpansion": 86,
+    "lineNumber": 86,
     "instruction": "float",
     "arguments": [
       {
@@ -1476,8 +1396,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 87,
-    "lineNumberAfterMacroExpansion": 87,
+    "lineNumber": 87,
     "instruction": "float",
     "arguments": [
       {
@@ -1495,8 +1414,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 88,
-    "lineNumberAfterMacroExpansion": 88,
+    "lineNumber": 88,
     "instruction": "float",
     "arguments": [
       {
@@ -1514,8 +1432,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 89,
-    "lineNumberAfterMacroExpansion": 89,
+    "lineNumber": 89,
     "instruction": "float",
     "arguments": [
       {
@@ -1533,8 +1450,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 90,
-    "lineNumberAfterMacroExpansion": 90,
+    "lineNumber": 90,
     "instruction": "float",
     "arguments": [
       {
@@ -1552,8 +1468,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 91,
-    "lineNumberAfterMacroExpansion": 91,
+    "lineNumber": 91,
     "instruction": "float",
     "arguments": [
       {
@@ -1571,8 +1486,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 92,
-    "lineNumberAfterMacroExpansion": 92,
+    "lineNumber": 92,
     "instruction": "float",
     "arguments": [
       {
@@ -1590,8 +1504,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 93,
-    "lineNumberAfterMacroExpansion": 93,
+    "lineNumber": 93,
     "instruction": "float",
     "arguments": [
       {
@@ -1609,8 +1522,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 94,
-    "lineNumberAfterMacroExpansion": 94,
+    "lineNumber": 94,
     "instruction": "float",
     "arguments": [
       {
@@ -1628,8 +1540,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 95,
-    "lineNumberAfterMacroExpansion": 95,
+    "lineNumber": 95,
     "instruction": "float",
     "arguments": [
       {
@@ -1647,8 +1558,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 96,
-    "lineNumberAfterMacroExpansion": 96,
+    "lineNumber": 96,
     "instruction": "float",
     "arguments": [
       {
@@ -1666,8 +1576,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 97,
-    "lineNumberAfterMacroExpansion": 97,
+    "lineNumber": 97,
     "instruction": "float",
     "arguments": [
       {
@@ -1685,8 +1594,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 98,
-    "lineNumberAfterMacroExpansion": 98,
+    "lineNumber": 98,
     "instruction": "float",
     "arguments": [
       {
@@ -1704,8 +1612,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 99,
-    "lineNumberAfterMacroExpansion": 99,
+    "lineNumber": 99,
     "instruction": "float",
     "arguments": [
       {
@@ -1723,8 +1630,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 100,
-    "lineNumberAfterMacroExpansion": 100,
+    "lineNumber": 100,
     "instruction": "float",
     "arguments": [
       {
@@ -1742,8 +1648,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 101,
-    "lineNumberAfterMacroExpansion": 101,
+    "lineNumber": 101,
     "instruction": "float",
     "arguments": [
       {
@@ -1761,8 +1666,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 102,
-    "lineNumberAfterMacroExpansion": 102,
+    "lineNumber": 102,
     "instruction": "float",
     "arguments": [
       {
@@ -1780,8 +1684,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 103,
-    "lineNumberAfterMacroExpansion": 103,
+    "lineNumber": 103,
     "instruction": "float",
     "arguments": [
       {
@@ -1799,8 +1702,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 104,
-    "lineNumberAfterMacroExpansion": 104,
+    "lineNumber": 104,
     "instruction": "float",
     "arguments": [
       {
@@ -1818,8 +1720,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 105,
-    "lineNumberAfterMacroExpansion": 105,
+    "lineNumber": 105,
     "instruction": "float",
     "arguments": [
       {
@@ -1837,8 +1738,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 106,
-    "lineNumberAfterMacroExpansion": 106,
+    "lineNumber": 106,
     "instruction": "float",
     "arguments": [
       {
@@ -1856,8 +1756,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 107,
-    "lineNumberAfterMacroExpansion": 107,
+    "lineNumber": 107,
     "instruction": "float",
     "arguments": [
       {
@@ -1875,8 +1774,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 108,
-    "lineNumberAfterMacroExpansion": 108,
+    "lineNumber": 108,
     "instruction": "float",
     "arguments": [
       {
@@ -1894,8 +1792,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 109,
-    "lineNumberAfterMacroExpansion": 109,
+    "lineNumber": 109,
     "instruction": "float",
     "arguments": [
       {
@@ -1913,8 +1810,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 110,
-    "lineNumberAfterMacroExpansion": 110,
+    "lineNumber": 110,
     "instruction": "float",
     "arguments": [
       {
@@ -1932,8 +1828,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 111,
-    "lineNumberAfterMacroExpansion": 111,
+    "lineNumber": 111,
     "instruction": "float",
     "arguments": [
       {
@@ -1951,8 +1846,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 112,
-    "lineNumberAfterMacroExpansion": 112,
+    "lineNumber": 112,
     "instruction": "float",
     "arguments": [
       {
@@ -1970,8 +1864,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 113,
-    "lineNumberAfterMacroExpansion": 113,
+    "lineNumber": 113,
     "instruction": "float",
     "arguments": [
       {
@@ -1989,8 +1882,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 114,
-    "lineNumberAfterMacroExpansion": 114,
+    "lineNumber": 114,
     "instruction": "float",
     "arguments": [
       {
@@ -2008,8 +1900,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 115,
-    "lineNumberAfterMacroExpansion": 115,
+    "lineNumber": 115,
     "instruction": "float",
     "arguments": [
       {
@@ -2027,8 +1918,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 116,
-    "lineNumberAfterMacroExpansion": 116,
+    "lineNumber": 116,
     "instruction": "float",
     "arguments": [
       {
@@ -2046,8 +1936,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 117,
-    "lineNumberAfterMacroExpansion": 117,
+    "lineNumber": 117,
     "instruction": "float",
     "arguments": [
       {
@@ -2065,8 +1954,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 118,
-    "lineNumberAfterMacroExpansion": 118,
+    "lineNumber": 118,
     "instruction": "float",
     "arguments": [
       {
@@ -2084,8 +1972,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 119,
-    "lineNumberAfterMacroExpansion": 119,
+    "lineNumber": 119,
     "instruction": "float",
     "arguments": [
       {
@@ -2103,8 +1990,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 120,
-    "lineNumberAfterMacroExpansion": 120,
+    "lineNumber": 120,
     "instruction": "float",
     "arguments": [
       {
@@ -2122,8 +2008,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 121,
-    "lineNumberAfterMacroExpansion": 121,
+    "lineNumber": 121,
     "instruction": "float",
     "arguments": [
       {
@@ -2141,8 +2026,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 122,
-    "lineNumberAfterMacroExpansion": 122,
+    "lineNumber": 122,
     "instruction": "float",
     "arguments": [
       {
@@ -2160,8 +2044,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 123,
-    "lineNumberAfterMacroExpansion": 123,
+    "lineNumber": 123,
     "instruction": "float",
     "arguments": [
       {
@@ -2179,8 +2062,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 124,
-    "lineNumberAfterMacroExpansion": 124,
+    "lineNumber": 124,
     "instruction": "float",
     "arguments": [
       {
@@ -2198,8 +2080,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 125,
-    "lineNumberAfterMacroExpansion": 125,
+    "lineNumber": 125,
     "instruction": "float",
     "arguments": [
       {
@@ -2217,8 +2098,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 126,
-    "lineNumberAfterMacroExpansion": 126,
+    "lineNumber": 126,
     "instruction": "float",
     "arguments": [
       {
@@ -2236,8 +2116,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 127,
-    "lineNumberAfterMacroExpansion": 127,
+    "lineNumber": 127,
     "instruction": "float",
     "arguments": [
       {
@@ -2255,8 +2134,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 128,
-    "lineNumberAfterMacroExpansion": 128,
+    "lineNumber": 128,
     "instruction": "float",
     "arguments": [
       {
@@ -2274,8 +2152,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 129,
-    "lineNumberAfterMacroExpansion": 129,
+    "lineNumber": 129,
     "instruction": "float",
     "arguments": [
       {
@@ -2293,8 +2170,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 130,
-    "lineNumberAfterMacroExpansion": 130,
+    "lineNumber": 130,
     "instruction": "float",
     "arguments": [
       {
@@ -2312,8 +2188,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 131,
-    "lineNumberAfterMacroExpansion": 131,
+    "lineNumber": 131,
     "instruction": "float",
     "arguments": [
       {
@@ -2331,8 +2206,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 132,
-    "lineNumberAfterMacroExpansion": 132,
+    "lineNumber": 132,
     "instruction": "float",
     "arguments": [
       {
@@ -2350,8 +2224,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 133,
-    "lineNumberAfterMacroExpansion": 133,
+    "lineNumber": 133,
     "instruction": "float",
     "arguments": [
       {
@@ -2369,8 +2242,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 134,
-    "lineNumberAfterMacroExpansion": 134,
+    "lineNumber": 134,
     "instruction": "float",
     "arguments": [
       {
@@ -2388,8 +2260,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 135,
-    "lineNumberAfterMacroExpansion": 135,
+    "lineNumber": 135,
     "instruction": "float",
     "arguments": [
       {
@@ -2407,8 +2278,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 136,
-    "lineNumberAfterMacroExpansion": 136,
+    "lineNumber": 136,
     "instruction": "float",
     "arguments": [
       {
@@ -2426,8 +2296,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 137,
-    "lineNumberAfterMacroExpansion": 137,
+    "lineNumber": 137,
     "instruction": "float",
     "arguments": [
       {
@@ -2445,8 +2314,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 138,
-    "lineNumberAfterMacroExpansion": 138,
+    "lineNumber": 138,
     "instruction": "float",
     "arguments": [
       {
@@ -2464,8 +2332,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 139,
-    "lineNumberAfterMacroExpansion": 139,
+    "lineNumber": 139,
     "instruction": "float",
     "arguments": [
       {
@@ -2483,8 +2350,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 140,
-    "lineNumberAfterMacroExpansion": 140,
+    "lineNumber": 140,
     "instruction": "float",
     "arguments": [
       {
@@ -2502,8 +2368,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 141,
-    "lineNumberAfterMacroExpansion": 141,
+    "lineNumber": 141,
     "instruction": "float",
     "arguments": [
       {
@@ -2521,8 +2386,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 142,
-    "lineNumberAfterMacroExpansion": 142,
+    "lineNumber": 142,
     "instruction": "float",
     "arguments": [
       {
@@ -2540,8 +2404,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 143,
-    "lineNumberAfterMacroExpansion": 143,
+    "lineNumber": 143,
     "instruction": "float",
     "arguments": [
       {
@@ -2559,8 +2422,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 144,
-    "lineNumberAfterMacroExpansion": 144,
+    "lineNumber": 144,
     "instruction": "float",
     "arguments": [
       {
@@ -2578,8 +2440,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 145,
-    "lineNumberAfterMacroExpansion": 145,
+    "lineNumber": 145,
     "instruction": "float",
     "arguments": [
       {
@@ -2597,8 +2458,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 146,
-    "lineNumberAfterMacroExpansion": 146,
+    "lineNumber": 146,
     "instruction": "float",
     "arguments": [
       {
@@ -2616,8 +2476,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 147,
-    "lineNumberAfterMacroExpansion": 147,
+    "lineNumber": 147,
     "instruction": "float",
     "arguments": [
       {
@@ -2635,8 +2494,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 148,
-    "lineNumberAfterMacroExpansion": 148,
+    "lineNumber": 148,
     "instruction": "float",
     "arguments": [
       {
@@ -2654,8 +2512,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 149,
-    "lineNumberAfterMacroExpansion": 149,
+    "lineNumber": 149,
     "instruction": "float",
     "arguments": [
       {
@@ -2673,8 +2530,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 150,
-    "lineNumberAfterMacroExpansion": 150,
+    "lineNumber": 150,
     "instruction": "float",
     "arguments": [
       {
@@ -2692,8 +2548,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 151,
-    "lineNumberAfterMacroExpansion": 151,
+    "lineNumber": 151,
     "instruction": "float",
     "arguments": [
       {
@@ -2711,8 +2566,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 152,
-    "lineNumberAfterMacroExpansion": 152,
+    "lineNumber": 152,
     "instruction": "float",
     "arguments": [
       {
@@ -2730,8 +2584,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 153,
-    "lineNumberAfterMacroExpansion": 153,
+    "lineNumber": 153,
     "instruction": "float",
     "arguments": [
       {
@@ -2749,8 +2602,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 154,
-    "lineNumberAfterMacroExpansion": 154,
+    "lineNumber": 154,
     "instruction": "float",
     "arguments": [
       {
@@ -2768,8 +2620,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 155,
-    "lineNumberAfterMacroExpansion": 155,
+    "lineNumber": 155,
     "instruction": "float",
     "arguments": [
       {
@@ -2787,8 +2638,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 156,
-    "lineNumberAfterMacroExpansion": 156,
+    "lineNumber": 156,
     "instruction": "float",
     "arguments": [
       {
@@ -2806,8 +2656,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 157,
-    "lineNumberAfterMacroExpansion": 157,
+    "lineNumber": 157,
     "instruction": "float",
     "arguments": [
       {
@@ -2825,8 +2674,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 158,
-    "lineNumberAfterMacroExpansion": 158,
+    "lineNumber": 158,
     "instruction": "float",
     "arguments": [
       {
@@ -2844,8 +2692,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 159,
-    "lineNumberAfterMacroExpansion": 159,
+    "lineNumber": 159,
     "instruction": "float",
     "arguments": [
       {
@@ -2863,8 +2710,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 160,
-    "lineNumberAfterMacroExpansion": 160,
+    "lineNumber": 160,
     "instruction": "float",
     "arguments": [
       {
@@ -2882,8 +2728,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 161,
-    "lineNumberAfterMacroExpansion": 161,
+    "lineNumber": 161,
     "instruction": "float",
     "arguments": [
       {
@@ -2901,8 +2746,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 162,
-    "lineNumberAfterMacroExpansion": 162,
+    "lineNumber": 162,
     "instruction": "float",
     "arguments": [
       {
@@ -2920,8 +2764,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 163,
-    "lineNumberAfterMacroExpansion": 163,
+    "lineNumber": 163,
     "instruction": "float",
     "arguments": [
       {
@@ -2939,8 +2782,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 164,
-    "lineNumberAfterMacroExpansion": 164,
+    "lineNumber": 164,
     "instruction": "float",
     "arguments": [
       {
@@ -2958,8 +2800,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 165,
-    "lineNumberAfterMacroExpansion": 165,
+    "lineNumber": 165,
     "instruction": "float",
     "arguments": [
       {
@@ -2977,8 +2818,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 166,
-    "lineNumberAfterMacroExpansion": 166,
+    "lineNumber": 166,
     "instruction": "float",
     "arguments": [
       {
@@ -2996,8 +2836,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 167,
-    "lineNumberAfterMacroExpansion": 167,
+    "lineNumber": 167,
     "instruction": "float",
     "arguments": [
       {
@@ -3015,8 +2854,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 168,
-    "lineNumberAfterMacroExpansion": 168,
+    "lineNumber": 168,
     "instruction": "float",
     "arguments": [
       {
@@ -3034,8 +2872,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 169,
-    "lineNumberAfterMacroExpansion": 169,
+    "lineNumber": 169,
     "instruction": "float",
     "arguments": [
       {
@@ -3053,8 +2890,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 170,
-    "lineNumberAfterMacroExpansion": 170,
+    "lineNumber": 170,
     "instruction": "float",
     "arguments": [
       {
@@ -3072,8 +2908,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 171,
-    "lineNumberAfterMacroExpansion": 171,
+    "lineNumber": 171,
     "instruction": "float",
     "arguments": [
       {
@@ -3091,8 +2926,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 172,
-    "lineNumberAfterMacroExpansion": 172,
+    "lineNumber": 172,
     "instruction": "float",
     "arguments": [
       {
@@ -3110,8 +2944,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 173,
-    "lineNumberAfterMacroExpansion": 173,
+    "lineNumber": 173,
     "instruction": "float",
     "arguments": [
       {
@@ -3129,8 +2962,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 174,
-    "lineNumberAfterMacroExpansion": 174,
+    "lineNumber": 174,
     "instruction": "float",
     "arguments": [
       {
@@ -3148,8 +2980,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 175,
-    "lineNumberAfterMacroExpansion": 175,
+    "lineNumber": 175,
     "instruction": "float",
     "arguments": [
       {
@@ -3167,8 +2998,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 176,
-    "lineNumberAfterMacroExpansion": 176,
+    "lineNumber": 176,
     "instruction": "float",
     "arguments": [
       {
@@ -3186,8 +3016,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 177,
-    "lineNumberAfterMacroExpansion": 177,
+    "lineNumber": 177,
     "instruction": "float",
     "arguments": [
       {
@@ -3205,8 +3034,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 178,
-    "lineNumberAfterMacroExpansion": 178,
+    "lineNumber": 178,
     "instruction": "float",
     "arguments": [
       {
@@ -3224,8 +3052,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 179,
-    "lineNumberAfterMacroExpansion": 179,
+    "lineNumber": 179,
     "instruction": "float",
     "arguments": [
       {
@@ -3243,8 +3070,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 180,
-    "lineNumberAfterMacroExpansion": 180,
+    "lineNumber": 180,
     "instruction": "float",
     "arguments": [
       {
@@ -3262,8 +3088,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 181,
-    "lineNumberAfterMacroExpansion": 181,
+    "lineNumber": 181,
     "instruction": "float",
     "arguments": [
       {
@@ -3281,8 +3106,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 182,
-    "lineNumberAfterMacroExpansion": 182,
+    "lineNumber": 182,
     "instruction": "float",
     "arguments": [
       {
@@ -3300,8 +3124,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 183,
-    "lineNumberAfterMacroExpansion": 183,
+    "lineNumber": 183,
     "instruction": "float",
     "arguments": [
       {
@@ -3319,8 +3142,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 184,
-    "lineNumberAfterMacroExpansion": 184,
+    "lineNumber": 184,
     "instruction": "float",
     "arguments": [
       {
@@ -3338,8 +3160,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 185,
-    "lineNumberAfterMacroExpansion": 185,
+    "lineNumber": 185,
     "instruction": "float",
     "arguments": [
       {
@@ -3357,8 +3178,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 186,
-    "lineNumberAfterMacroExpansion": 186,
+    "lineNumber": 186,
     "instruction": "float",
     "arguments": [
       {
@@ -3376,8 +3196,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 187,
-    "lineNumberAfterMacroExpansion": 187,
+    "lineNumber": 187,
     "instruction": "float",
     "arguments": [
       {
@@ -3395,8 +3214,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 188,
-    "lineNumberAfterMacroExpansion": 188,
+    "lineNumber": 188,
     "instruction": "float",
     "arguments": [
       {
@@ -3414,8 +3232,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 189,
-    "lineNumberAfterMacroExpansion": 189,
+    "lineNumber": 189,
     "instruction": "float",
     "arguments": [
       {
@@ -3433,8 +3250,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 190,
-    "lineNumberAfterMacroExpansion": 190,
+    "lineNumber": 190,
     "instruction": "float",
     "arguments": [
       {
@@ -3452,8 +3268,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 191,
-    "lineNumberAfterMacroExpansion": 191,
+    "lineNumber": 191,
     "instruction": "float",
     "arguments": [
       {
@@ -3471,8 +3286,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 192,
-    "lineNumberAfterMacroExpansion": 192,
+    "lineNumber": 192,
     "instruction": "float",
     "arguments": [
       {
@@ -3490,8 +3304,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 193,
-    "lineNumberAfterMacroExpansion": 193,
+    "lineNumber": 193,
     "instruction": "float",
     "arguments": [
       {
@@ -3509,8 +3322,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 194,
-    "lineNumberAfterMacroExpansion": 194,
+    "lineNumber": 194,
     "instruction": "float",
     "arguments": [
       {
@@ -3528,8 +3340,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 195,
-    "lineNumberAfterMacroExpansion": 195,
+    "lineNumber": 195,
     "instruction": "float",
     "arguments": [
       {
@@ -3547,8 +3358,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 196,
-    "lineNumberAfterMacroExpansion": 196,
+    "lineNumber": 196,
     "instruction": "float",
     "arguments": [
       {
@@ -3566,8 +3376,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 197,
-    "lineNumberAfterMacroExpansion": 197,
+    "lineNumber": 197,
     "instruction": "float",
     "arguments": [
       {
@@ -3585,8 +3394,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 198,
-    "lineNumberAfterMacroExpansion": 198,
+    "lineNumber": 198,
     "instruction": "float",
     "arguments": [
       {
@@ -3604,8 +3412,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 199,
-    "lineNumberAfterMacroExpansion": 199,
+    "lineNumber": 199,
     "instruction": "float",
     "arguments": [
       {
@@ -3623,8 +3430,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 200,
-    "lineNumberAfterMacroExpansion": 200,
+    "lineNumber": 200,
     "instruction": "float",
     "arguments": [
       {
@@ -3642,8 +3448,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 201,
-    "lineNumberAfterMacroExpansion": 201,
+    "lineNumber": 201,
     "instruction": "float",
     "arguments": [
       {
@@ -3661,8 +3466,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 202,
-    "lineNumberAfterMacroExpansion": 202,
+    "lineNumber": 202,
     "instruction": "float",
     "arguments": [
       {
@@ -3680,8 +3484,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 203,
-    "lineNumberAfterMacroExpansion": 203,
+    "lineNumber": 203,
     "instruction": "float",
     "arguments": [
       {
@@ -3699,8 +3502,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 204,
-    "lineNumberAfterMacroExpansion": 204,
+    "lineNumber": 204,
     "instruction": "float",
     "arguments": [
       {
@@ -3718,8 +3520,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 205,
-    "lineNumberAfterMacroExpansion": 205,
+    "lineNumber": 205,
     "instruction": "float",
     "arguments": [
       {
@@ -3737,8 +3538,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 206,
-    "lineNumberAfterMacroExpansion": 206,
+    "lineNumber": 206,
     "instruction": "float",
     "arguments": [
       {
@@ -3756,8 +3556,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 207,
-    "lineNumberAfterMacroExpansion": 207,
+    "lineNumber": 207,
     "instruction": "float",
     "arguments": [
       {
@@ -3775,8 +3574,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 208,
-    "lineNumberAfterMacroExpansion": 208,
+    "lineNumber": 208,
     "instruction": "float",
     "arguments": [
       {
@@ -3794,8 +3592,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 209,
-    "lineNumberAfterMacroExpansion": 209,
+    "lineNumber": 209,
     "instruction": "float",
     "arguments": [
       {
@@ -3813,8 +3610,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 210,
-    "lineNumberAfterMacroExpansion": 210,
+    "lineNumber": 210,
     "instruction": "float",
     "arguments": [
       {
@@ -3832,8 +3628,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 211,
-    "lineNumberAfterMacroExpansion": 211,
+    "lineNumber": 211,
     "instruction": "float",
     "arguments": [
       {
@@ -3851,8 +3646,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 212,
-    "lineNumberAfterMacroExpansion": 212,
+    "lineNumber": 212,
     "instruction": "float",
     "arguments": [
       {
@@ -3870,8 +3664,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 213,
-    "lineNumberAfterMacroExpansion": 213,
+    "lineNumber": 213,
     "instruction": "float",
     "arguments": [
       {
@@ -3889,8 +3682,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 214,
-    "lineNumberAfterMacroExpansion": 214,
+    "lineNumber": 214,
     "instruction": "float",
     "arguments": [
       {
@@ -3908,8 +3700,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 215,
-    "lineNumberAfterMacroExpansion": 215,
+    "lineNumber": 215,
     "instruction": "float",
     "arguments": [
       {
@@ -3927,8 +3718,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 216,
-    "lineNumberAfterMacroExpansion": 216,
+    "lineNumber": 216,
     "instruction": "float",
     "arguments": [
       {
@@ -3946,8 +3736,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 217,
-    "lineNumberAfterMacroExpansion": 217,
+    "lineNumber": 217,
     "instruction": "float",
     "arguments": [
       {
@@ -3965,8 +3754,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 218,
-    "lineNumberAfterMacroExpansion": 218,
+    "lineNumber": 218,
     "instruction": "float",
     "arguments": [
       {
@@ -3984,8 +3772,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 219,
-    "lineNumberAfterMacroExpansion": 219,
+    "lineNumber": 219,
     "instruction": "float",
     "arguments": [
       {
@@ -4003,8 +3790,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 220,
-    "lineNumberAfterMacroExpansion": 220,
+    "lineNumber": 220,
     "instruction": "float",
     "arguments": [
       {
@@ -4022,8 +3808,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 221,
-    "lineNumberAfterMacroExpansion": 221,
+    "lineNumber": 221,
     "instruction": "float",
     "arguments": [
       {
@@ -4041,8 +3826,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 222,
-    "lineNumberAfterMacroExpansion": 222,
+    "lineNumber": 222,
     "instruction": "float",
     "arguments": [
       {
@@ -4060,8 +3844,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 223,
-    "lineNumberAfterMacroExpansion": 223,
+    "lineNumber": 223,
     "instruction": "float",
     "arguments": [
       {
@@ -4079,8 +3862,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 224,
-    "lineNumberAfterMacroExpansion": 224,
+    "lineNumber": 224,
     "instruction": "float",
     "arguments": [
       {
@@ -4098,8 +3880,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 225,
-    "lineNumberAfterMacroExpansion": 225,
+    "lineNumber": 225,
     "instruction": "float",
     "arguments": [
       {
@@ -4117,8 +3898,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 226,
-    "lineNumberAfterMacroExpansion": 226,
+    "lineNumber": 226,
     "instruction": "float",
     "arguments": [
       {
@@ -4136,8 +3916,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 227,
-    "lineNumberAfterMacroExpansion": 227,
+    "lineNumber": 227,
     "instruction": "float",
     "arguments": [
       {
@@ -4155,8 +3934,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 228,
-    "lineNumberAfterMacroExpansion": 228,
+    "lineNumber": 228,
     "instruction": "float",
     "arguments": [
       {
@@ -4174,8 +3952,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 229,
-    "lineNumberAfterMacroExpansion": 229,
+    "lineNumber": 229,
     "instruction": "float",
     "arguments": [
       {
@@ -4193,8 +3970,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 230,
-    "lineNumberAfterMacroExpansion": 230,
+    "lineNumber": 230,
     "instruction": "float",
     "arguments": [
       {
@@ -4212,8 +3988,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 231,
-    "lineNumberAfterMacroExpansion": 231,
+    "lineNumber": 231,
     "instruction": "float",
     "arguments": [
       {
@@ -4231,8 +4006,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 232,
-    "lineNumberAfterMacroExpansion": 232,
+    "lineNumber": 232,
     "instruction": "float",
     "arguments": [
       {
@@ -4250,8 +4024,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 233,
-    "lineNumberAfterMacroExpansion": 233,
+    "lineNumber": 233,
     "instruction": "float",
     "arguments": [
       {
@@ -4269,8 +4042,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 234,
-    "lineNumberAfterMacroExpansion": 234,
+    "lineNumber": 234,
     "instruction": "float",
     "arguments": [
       {
@@ -4288,8 +4060,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 235,
-    "lineNumberAfterMacroExpansion": 235,
+    "lineNumber": 235,
     "instruction": "float",
     "arguments": [
       {
@@ -4307,8 +4078,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 236,
-    "lineNumberAfterMacroExpansion": 236,
+    "lineNumber": 236,
     "instruction": "float",
     "arguments": [
       {
@@ -4326,8 +4096,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 237,
-    "lineNumberAfterMacroExpansion": 237,
+    "lineNumber": 237,
     "instruction": "float",
     "arguments": [
       {
@@ -4345,8 +4114,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 238,
-    "lineNumberAfterMacroExpansion": 238,
+    "lineNumber": 238,
     "instruction": "float",
     "arguments": [
       {
@@ -4364,8 +4132,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 239,
-    "lineNumberAfterMacroExpansion": 239,
+    "lineNumber": 239,
     "instruction": "float",
     "arguments": [
       {
@@ -4383,8 +4150,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 240,
-    "lineNumberAfterMacroExpansion": 240,
+    "lineNumber": 240,
     "instruction": "float",
     "arguments": [
       {
@@ -4402,8 +4168,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 241,
-    "lineNumberAfterMacroExpansion": 241,
+    "lineNumber": 241,
     "instruction": "float",
     "arguments": [
       {
@@ -4421,8 +4186,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 242,
-    "lineNumberAfterMacroExpansion": 242,
+    "lineNumber": 242,
     "instruction": "float",
     "arguments": [
       {
@@ -4440,8 +4204,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 243,
-    "lineNumberAfterMacroExpansion": 243,
+    "lineNumber": 243,
     "instruction": "float",
     "arguments": [
       {
@@ -4459,8 +4222,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 244,
-    "lineNumberAfterMacroExpansion": 244,
+    "lineNumber": 244,
     "instruction": "float",
     "arguments": [
       {
@@ -4478,8 +4240,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 245,
-    "lineNumberAfterMacroExpansion": 245,
+    "lineNumber": 245,
     "instruction": "float",
     "arguments": [
       {
@@ -4497,8 +4258,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 246,
-    "lineNumberAfterMacroExpansion": 246,
+    "lineNumber": 246,
     "instruction": "float",
     "arguments": [
       {
@@ -4516,8 +4276,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 247,
-    "lineNumberAfterMacroExpansion": 247,
+    "lineNumber": 247,
     "instruction": "float",
     "arguments": [
       {
@@ -4535,8 +4294,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 248,
-    "lineNumberAfterMacroExpansion": 248,
+    "lineNumber": 248,
     "instruction": "float",
     "arguments": [
       {
@@ -4554,8 +4312,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 249,
-    "lineNumberAfterMacroExpansion": 249,
+    "lineNumber": 249,
     "instruction": "float",
     "arguments": [
       {
@@ -4573,8 +4330,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 250,
-    "lineNumberAfterMacroExpansion": 250,
+    "lineNumber": 250,
     "instruction": "float",
     "arguments": [
       {
@@ -4592,8 +4348,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 251,
-    "lineNumberAfterMacroExpansion": 251,
+    "lineNumber": 251,
     "instruction": "float",
     "arguments": [
       {
@@ -4611,8 +4366,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 252,
-    "lineNumberAfterMacroExpansion": 252,
+    "lineNumber": 252,
     "instruction": "float",
     "arguments": [
       {
@@ -4630,8 +4384,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 253,
-    "lineNumberAfterMacroExpansion": 253,
+    "lineNumber": 253,
     "instruction": "float",
     "arguments": [
       {
@@ -4649,8 +4402,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 254,
-    "lineNumberAfterMacroExpansion": 254,
+    "lineNumber": 254,
     "instruction": "float",
     "arguments": [
       {
@@ -4668,8 +4420,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 255,
-    "lineNumberAfterMacroExpansion": 255,
+    "lineNumber": 255,
     "instruction": "float",
     "arguments": [
       {
@@ -4687,8 +4438,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 256,
-    "lineNumberAfterMacroExpansion": 256,
+    "lineNumber": 256,
     "instruction": "float",
     "arguments": [
       {
@@ -4706,8 +4456,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 257,
-    "lineNumberAfterMacroExpansion": 257,
+    "lineNumber": 257,
     "instruction": "float",
     "arguments": [
       {
@@ -4725,8 +4474,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 258,
-    "lineNumberAfterMacroExpansion": 258,
+    "lineNumber": 258,
     "instruction": "float",
     "arguments": [
       {
@@ -4744,8 +4492,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 259,
-    "lineNumberAfterMacroExpansion": 259,
+    "lineNumber": 259,
     "instruction": "float",
     "arguments": [
       {
@@ -4763,8 +4510,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 260,
-    "lineNumberAfterMacroExpansion": 260,
+    "lineNumber": 260,
     "instruction": "float",
     "arguments": [
       {
@@ -4782,8 +4528,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 261,
-    "lineNumberAfterMacroExpansion": 261,
+    "lineNumber": 261,
     "instruction": "float",
     "arguments": [
       {
@@ -4801,8 +4546,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 262,
-    "lineNumberAfterMacroExpansion": 262,
+    "lineNumber": 262,
     "instruction": "float",
     "arguments": [
       {
@@ -4820,8 +4564,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 263,
-    "lineNumberAfterMacroExpansion": 263,
+    "lineNumber": 263,
     "instruction": "float",
     "arguments": [
       {
@@ -4839,8 +4582,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 264,
-    "lineNumberAfterMacroExpansion": 264,
+    "lineNumber": 264,
     "instruction": "float",
     "arguments": [
       {
@@ -4858,8 +4600,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 265,
-    "lineNumberAfterMacroExpansion": 265,
+    "lineNumber": 265,
     "instruction": "float",
     "arguments": [
       {
@@ -4877,8 +4618,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 266,
-    "lineNumberAfterMacroExpansion": 266,
+    "lineNumber": 266,
     "instruction": "float",
     "arguments": [
       {
@@ -4896,8 +4636,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 267,
-    "lineNumberAfterMacroExpansion": 267,
+    "lineNumber": 267,
     "instruction": "float",
     "arguments": [
       {
@@ -4915,14 +4654,12 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 269,
-    "lineNumberAfterMacroExpansion": 269,
+    "lineNumber": 269,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 270,
-    "lineNumberAfterMacroExpansion": 270,
+    "lineNumber": 270,
     "instruction": "module",
     "arguments": [
       {
@@ -4934,8 +4671,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 275,
-    "lineNumberAfterMacroExpansion": 275,
+    "lineNumber": 275,
     "instruction": "float*",
     "arguments": [
       {
@@ -4960,8 +4696,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 276,
-    "lineNumberAfterMacroExpansion": 276,
+    "lineNumber": 276,
     "instruction": "float*",
     "arguments": [
       {
@@ -4986,8 +4721,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 277,
-    "lineNumberAfterMacroExpansion": 277,
+    "lineNumber": 277,
     "instruction": "float*",
     "arguments": [
       {
@@ -5012,8 +4746,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 278,
-    "lineNumberAfterMacroExpansion": 278,
+    "lineNumber": 278,
     "instruction": "int",
     "arguments": [
       {
@@ -5026,8 +4759,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 282,
-    "lineNumberAfterMacroExpansion": 282,
+    "lineNumber": 282,
     "instruction": "push",
     "arguments": [
       {
@@ -5041,8 +4773,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 283,
-    "lineNumberAfterMacroExpansion": 283,
+    "lineNumber": 283,
     "instruction": "push",
     "arguments": [
       {
@@ -5054,8 +4785,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 284,
-    "lineNumberAfterMacroExpansion": 284,
+    "lineNumber": 284,
     "instruction": "push",
     "arguments": [
       {
@@ -5066,20 +4796,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 285,
-    "lineNumberAfterMacroExpansion": 285,
+    "lineNumber": 285,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 286,
-    "lineNumberAfterMacroExpansion": 286,
+    "lineNumber": 286,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 288,
-    "lineNumberAfterMacroExpansion": 288,
+    "lineNumber": 288,
     "instruction": "push",
     "arguments": [
       {
@@ -5091,8 +4818,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 289,
-    "lineNumberAfterMacroExpansion": 289,
+    "lineNumber": 289,
     "instruction": "push",
     "arguments": [
       {
@@ -5104,14 +4830,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 290,
-    "lineNumberAfterMacroExpansion": 290,
+    "lineNumber": 290,
     "instruction": "equal",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 291,
-    "lineNumberAfterMacroExpansion": 291,
+    "lineNumber": 291,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -5121,8 +4845,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 292,
-    "lineNumberAfterMacroExpansion": 292,
+    "lineNumber": 292,
     "instruction": "push",
     "arguments": [
       {
@@ -5136,8 +4859,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 293,
-    "lineNumberAfterMacroExpansion": 293,
+    "lineNumber": 293,
     "instruction": "push",
     "arguments": [
       {
@@ -5149,14 +4871,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 294,
-    "lineNumberAfterMacroExpansion": 294,
+    "lineNumber": 294,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 295,
-    "lineNumberAfterMacroExpansion": 295,
+    "lineNumber": 295,
     "instruction": "ifEnd",
     "arguments": [],
     "ifEndBlock": {
@@ -5165,8 +4885,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 297,
-    "lineNumberAfterMacroExpansion": 297,
+    "lineNumber": 297,
     "instruction": "push",
     "arguments": [
       {
@@ -5180,8 +4899,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 298,
-    "lineNumberAfterMacroExpansion": 298,
+    "lineNumber": 298,
     "instruction": "push",
     "arguments": [
       {
@@ -5195,8 +4913,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 299,
-    "lineNumberAfterMacroExpansion": 299,
+    "lineNumber": 299,
     "instruction": "push",
     "arguments": [
       {
@@ -5207,32 +4924,27 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 300,
-    "lineNumberAfterMacroExpansion": 300,
+    "lineNumber": 300,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 301,
-    "lineNumberAfterMacroExpansion": 301,
+    "lineNumber": 301,
     "instruction": "castToInt",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 302,
-    "lineNumberAfterMacroExpansion": 302,
+    "lineNumber": 302,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 304,
-    "lineNumberAfterMacroExpansion": 304,
+    "lineNumber": 304,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 305,
-    "lineNumberAfterMacroExpansion": 305,
+    "lineNumber": 305,
     "instruction": "module",
     "arguments": [
       {
@@ -5244,8 +4956,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 307,
-    "lineNumberAfterMacroExpansion": 307,
+    "lineNumber": 307,
     "instruction": "float*",
     "arguments": [
       {
@@ -5270,8 +4981,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 308,
-    "lineNumberAfterMacroExpansion": 308,
+    "lineNumber": 308,
     "instruction": "float*",
     "arguments": [
       {
@@ -5296,8 +5006,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 309,
-    "lineNumberAfterMacroExpansion": 309,
+    "lineNumber": 309,
     "instruction": "float*",
     "arguments": [
       {
@@ -5322,8 +5031,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 310,
-    "lineNumberAfterMacroExpansion": 310,
+    "lineNumber": 310,
     "instruction": "int",
     "arguments": [
       {
@@ -5336,8 +5044,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 314,
-    "lineNumberAfterMacroExpansion": 314,
+    "lineNumber": 314,
     "instruction": "push",
     "arguments": [
       {
@@ -5351,8 +5058,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 315,
-    "lineNumberAfterMacroExpansion": 315,
+    "lineNumber": 315,
     "instruction": "push",
     "arguments": [
       {
@@ -5364,8 +5070,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 316,
-    "lineNumberAfterMacroExpansion": 316,
+    "lineNumber": 316,
     "instruction": "push",
     "arguments": [
       {
@@ -5376,20 +5081,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 317,
-    "lineNumberAfterMacroExpansion": 317,
+    "lineNumber": 317,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 318,
-    "lineNumberAfterMacroExpansion": 318,
+    "lineNumber": 318,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 320,
-    "lineNumberAfterMacroExpansion": 320,
+    "lineNumber": 320,
     "instruction": "push",
     "arguments": [
       {
@@ -5401,8 +5103,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 321,
-    "lineNumberAfterMacroExpansion": 321,
+    "lineNumber": 321,
     "instruction": "push",
     "arguments": [
       {
@@ -5414,14 +5115,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 322,
-    "lineNumberAfterMacroExpansion": 322,
+    "lineNumber": 322,
     "instruction": "equal",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 323,
-    "lineNumberAfterMacroExpansion": 323,
+    "lineNumber": 323,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -5431,8 +5130,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 324,
-    "lineNumberAfterMacroExpansion": 324,
+    "lineNumber": 324,
     "instruction": "push",
     "arguments": [
       {
@@ -5446,8 +5144,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 325,
-    "lineNumberAfterMacroExpansion": 325,
+    "lineNumber": 325,
     "instruction": "push",
     "arguments": [
       {
@@ -5459,14 +5156,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 326,
-    "lineNumberAfterMacroExpansion": 326,
+    "lineNumber": 326,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 327,
-    "lineNumberAfterMacroExpansion": 327,
+    "lineNumber": 327,
     "instruction": "ifEnd",
     "arguments": [],
     "ifEndBlock": {
@@ -5475,8 +5170,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 329,
-    "lineNumberAfterMacroExpansion": 329,
+    "lineNumber": 329,
     "instruction": "push",
     "arguments": [
       {
@@ -5490,8 +5184,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 330,
-    "lineNumberAfterMacroExpansion": 330,
+    "lineNumber": 330,
     "instruction": "push",
     "arguments": [
       {
@@ -5505,8 +5198,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 331,
-    "lineNumberAfterMacroExpansion": 331,
+    "lineNumber": 331,
     "instruction": "push",
     "arguments": [
       {
@@ -5517,32 +5209,27 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 332,
-    "lineNumberAfterMacroExpansion": 332,
+    "lineNumber": 332,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 333,
-    "lineNumberAfterMacroExpansion": 333,
+    "lineNumber": 333,
     "instruction": "castToInt",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 334,
-    "lineNumberAfterMacroExpansion": 334,
+    "lineNumber": 334,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 336,
-    "lineNumberAfterMacroExpansion": 336,
+    "lineNumber": 336,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 337,
-    "lineNumberAfterMacroExpansion": 337,
+    "lineNumber": 337,
     "instruction": "module",
     "arguments": [
       {
@@ -5554,8 +5241,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 340,
-    "lineNumberAfterMacroExpansion": 340,
+    "lineNumber": 340,
     "instruction": "float*",
     "arguments": [
       {
@@ -5580,8 +5266,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 341,
-    "lineNumberAfterMacroExpansion": 341,
+    "lineNumber": 341,
     "instruction": "float*",
     "arguments": [
       {
@@ -5606,8 +5291,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 342,
-    "lineNumberAfterMacroExpansion": 342,
+    "lineNumber": 342,
     "instruction": "float*",
     "arguments": [
       {
@@ -5632,8 +5316,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 343,
-    "lineNumberAfterMacroExpansion": 343,
+    "lineNumber": 343,
     "instruction": "int",
     "arguments": [
       {
@@ -5646,8 +5329,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 347,
-    "lineNumberAfterMacroExpansion": 347,
+    "lineNumber": 347,
     "instruction": "push",
     "arguments": [
       {
@@ -5661,8 +5343,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 348,
-    "lineNumberAfterMacroExpansion": 348,
+    "lineNumber": 348,
     "instruction": "push",
     "arguments": [
       {
@@ -5674,8 +5355,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 349,
-    "lineNumberAfterMacroExpansion": 349,
+    "lineNumber": 349,
     "instruction": "push",
     "arguments": [
       {
@@ -5686,20 +5366,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 350,
-    "lineNumberAfterMacroExpansion": 350,
+    "lineNumber": 350,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 351,
-    "lineNumberAfterMacroExpansion": 351,
+    "lineNumber": 351,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 353,
-    "lineNumberAfterMacroExpansion": 353,
+    "lineNumber": 353,
     "instruction": "push",
     "arguments": [
       {
@@ -5711,8 +5388,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 354,
-    "lineNumberAfterMacroExpansion": 354,
+    "lineNumber": 354,
     "instruction": "push",
     "arguments": [
       {
@@ -5724,14 +5400,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 355,
-    "lineNumberAfterMacroExpansion": 355,
+    "lineNumber": 355,
     "instruction": "equal",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 356,
-    "lineNumberAfterMacroExpansion": 356,
+    "lineNumber": 356,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -5741,8 +5415,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 357,
-    "lineNumberAfterMacroExpansion": 357,
+    "lineNumber": 357,
     "instruction": "push",
     "arguments": [
       {
@@ -5756,8 +5429,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 358,
-    "lineNumberAfterMacroExpansion": 358,
+    "lineNumber": 358,
     "instruction": "push",
     "arguments": [
       {
@@ -5769,14 +5441,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 359,
-    "lineNumberAfterMacroExpansion": 359,
+    "lineNumber": 359,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 360,
-    "lineNumberAfterMacroExpansion": 360,
+    "lineNumber": 360,
     "instruction": "ifEnd",
     "arguments": [],
     "ifEndBlock": {
@@ -5785,8 +5455,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 362,
-    "lineNumberAfterMacroExpansion": 362,
+    "lineNumber": 362,
     "instruction": "push",
     "arguments": [
       {
@@ -5800,8 +5469,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 363,
-    "lineNumberAfterMacroExpansion": 363,
+    "lineNumber": 363,
     "instruction": "push",
     "arguments": [
       {
@@ -5815,8 +5483,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 364,
-    "lineNumberAfterMacroExpansion": 364,
+    "lineNumber": 364,
     "instruction": "push",
     "arguments": [
       {
@@ -5827,32 +5494,27 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 365,
-    "lineNumberAfterMacroExpansion": 365,
+    "lineNumber": 365,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 366,
-    "lineNumberAfterMacroExpansion": 366,
+    "lineNumber": 366,
     "instruction": "castToInt",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 367,
-    "lineNumberAfterMacroExpansion": 367,
+    "lineNumber": 367,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 369,
-    "lineNumberAfterMacroExpansion": 369,
+    "lineNumber": 369,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 370,
-    "lineNumberAfterMacroExpansion": 370,
+    "lineNumber": 370,
     "instruction": "module",
     "arguments": [
       {
@@ -5864,8 +5526,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 373,
-    "lineNumberAfterMacroExpansion": 373,
+    "lineNumber": 373,
     "instruction": "float*",
     "arguments": [
       {
@@ -5890,8 +5551,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 374,
-    "lineNumberAfterMacroExpansion": 374,
+    "lineNumber": 374,
     "instruction": "float*",
     "arguments": [
       {
@@ -5916,8 +5576,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 375,
-    "lineNumberAfterMacroExpansion": 375,
+    "lineNumber": 375,
     "instruction": "float*",
     "arguments": [
       {
@@ -5942,8 +5601,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 376,
-    "lineNumberAfterMacroExpansion": 376,
+    "lineNumber": 376,
     "instruction": "float*",
     "arguments": [
       {
@@ -5968,8 +5626,7 @@
     "hasExplicitMemoryDefault": true
   },
   {
-    "lineNumberBeforeMacroExpansion": 378,
-    "lineNumberAfterMacroExpansion": 378,
+    "lineNumber": 378,
     "instruction": "int",
     "arguments": [
       {
@@ -5982,8 +5639,7 @@
     "hasExplicitMemoryDefault": false
   },
   {
-    "lineNumberBeforeMacroExpansion": 383,
-    "lineNumberAfterMacroExpansion": 383,
+    "lineNumber": 383,
     "instruction": "push",
     "arguments": [
       {
@@ -5997,8 +5653,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 384,
-    "lineNumberAfterMacroExpansion": 384,
+    "lineNumber": 384,
     "instruction": "push",
     "arguments": [
       {
@@ -6010,8 +5665,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 385,
-    "lineNumberAfterMacroExpansion": 385,
+    "lineNumber": 385,
     "instruction": "push",
     "arguments": [
       {
@@ -6022,20 +5676,17 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 386,
-    "lineNumberAfterMacroExpansion": 386,
+    "lineNumber": 386,
     "instruction": "add",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 387,
-    "lineNumberAfterMacroExpansion": 387,
+    "lineNumber": 387,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 389,
-    "lineNumberAfterMacroExpansion": 389,
+    "lineNumber": 389,
     "instruction": "push",
     "arguments": [
       {
@@ -6047,8 +5698,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 390,
-    "lineNumberAfterMacroExpansion": 390,
+    "lineNumber": 390,
     "instruction": "push",
     "arguments": [
       {
@@ -6060,14 +5710,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 391,
-    "lineNumberAfterMacroExpansion": 391,
+    "lineNumber": 391,
     "instruction": "equal",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 392,
-    "lineNumberAfterMacroExpansion": 392,
+    "lineNumber": 392,
     "instruction": "if",
     "arguments": [],
     "ifBlock": {
@@ -6077,8 +5725,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 393,
-    "lineNumberAfterMacroExpansion": 393,
+    "lineNumber": 393,
     "instruction": "push",
     "arguments": [
       {
@@ -6092,8 +5739,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 394,
-    "lineNumberAfterMacroExpansion": 394,
+    "lineNumber": 394,
     "instruction": "push",
     "arguments": [
       {
@@ -6105,14 +5751,12 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 395,
-    "lineNumberAfterMacroExpansion": 395,
+    "lineNumber": 395,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 396,
-    "lineNumberAfterMacroExpansion": 396,
+    "lineNumber": 396,
     "instruction": "ifEnd",
     "arguments": [],
     "ifEndBlock": {
@@ -6121,8 +5765,7 @@
     }
   },
   {
-    "lineNumberBeforeMacroExpansion": 398,
-    "lineNumberAfterMacroExpansion": 398,
+    "lineNumber": 398,
     "instruction": "push",
     "arguments": [
       {
@@ -6136,8 +5779,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 399,
-    "lineNumberAfterMacroExpansion": 399,
+    "lineNumber": 399,
     "instruction": "push",
     "arguments": [
       {
@@ -6151,8 +5793,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 400,
-    "lineNumberAfterMacroExpansion": 400,
+    "lineNumber": 400,
     "instruction": "push",
     "arguments": [
       {
@@ -6163,38 +5804,32 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 401,
-    "lineNumberAfterMacroExpansion": 401,
+    "lineNumber": 401,
     "instruction": "mul",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 402,
-    "lineNumberAfterMacroExpansion": 402,
+    "lineNumber": 402,
     "instruction": "castToInt",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 403,
-    "lineNumberAfterMacroExpansion": 403,
+    "lineNumber": 403,
     "instruction": "store",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 405,
-    "lineNumberAfterMacroExpansion": 405,
+    "lineNumber": 405,
     "instruction": "moduleEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 406,
-    "lineNumberAfterMacroExpansion": 406,
+    "lineNumber": 406,
     "instruction": "entryEnd",
     "arguments": []
   },
   {
-    "lineNumberBeforeMacroExpansion": 408,
-    "lineNumberAfterMacroExpansion": 408,
+    "lineNumber": 408,
     "instruction": "constants",
     "arguments": [
       {
@@ -6206,8 +5841,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 414,
-    "lineNumberAfterMacroExpansion": 414,
+    "lineNumber": 414,
     "instruction": "const",
     "arguments": [
       {
@@ -6224,8 +5858,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 415,
-    "lineNumberAfterMacroExpansion": 415,
+    "lineNumber": 415,
     "instruction": "const",
     "arguments": [
       {
@@ -6242,8 +5875,7 @@
     ]
   },
   {
-    "lineNumberBeforeMacroExpansion": 417,
-    "lineNumberAfterMacroExpansion": 417,
+    "lineNumber": 417,
     "instruction": "constantsEnd",
     "arguments": []
   }

--- a/packages/compiler/src/compiler.ts
+++ b/packages/compiler/src/compiler.ts
@@ -55,8 +55,7 @@ const importedFunctionAllowedInstructions = new Set([
 function getFallbackErrorLine(ast: { lines: readonly CompilerASTLine[] }): CompilerASTLine {
 	return (
 		ast.lines[0] ?? {
-			lineNumberBeforeMacroExpansion: 0,
-			lineNumberAfterMacroExpansion: 0,
+			lineNumber: 0,
 			instruction: 'block',
 			arguments: [],
 		}
@@ -75,8 +74,7 @@ export function compileCodegenLine(line: AnalyzedLine, context: CompilationConte
 
 function toCompiledStackAnalysisLine(line: AnalyzedLine): CompiledStackAnalysisLine {
 	return {
-		lineNumberBeforeMacroExpansion: line.lineNumberBeforeMacroExpansion,
-		lineNumberAfterMacroExpansion: line.lineNumberAfterMacroExpansion,
+		lineNumber: line.lineNumber,
 		instruction: line.instruction,
 		stackAnalysis: line.stackAnalysis,
 	};

--- a/packages/compiler/src/compilerError.test.ts
+++ b/packages/compiler/src/compilerError.test.ts
@@ -6,8 +6,7 @@ import { getError } from './compilerError';
 
 describe('getError', () => {
 	const line = {
-		lineNumberBeforeMacroExpansion: 1,
-		lineNumberAfterMacroExpansion: 1,
+		lineNumber: 1,
 		instruction: 'push',
 		arguments: [],
 	} as CompilerASTLine;
@@ -54,8 +53,7 @@ describe('getError', () => {
 
 	it('includes the undeclared identifier when provided', () => {
 		const localLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [classifyIdentifier('missingLocal')],
 		} as CompilerASTLine;
@@ -67,8 +65,7 @@ describe('getError', () => {
 
 	it('keeps the generic undeclared identifier message when no identifier is available', () => {
 		const line = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'use',
 			arguments: [],
 		} as CompilerASTLine;
@@ -80,8 +77,7 @@ describe('getError', () => {
 
 	it('includes the duplicate identifier when provided', () => {
 		const line = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'module',
 			arguments: [classifyIdentifier('same')],
 		} as CompilerASTLine;

--- a/packages/compiler/src/compilerError.ts
+++ b/packages/compiler/src/compilerError.ts
@@ -149,7 +149,7 @@ export function getError(
 			return {
 				code,
 				message:
-					line.lineNumberBeforeMacroExpansion +
+					line.lineNumber +
 					': Expected 0 elements on the stack, found ' +
 					stack.length +
 					' [' +

--- a/packages/compiler/src/diagnostic.test.ts
+++ b/packages/compiler/src/diagnostic.test.ts
@@ -6,8 +6,7 @@ import { getError } from './compilerError';
 import { serializeDiagnostic } from './diagnostic';
 
 const stubLine = {
-	lineNumberBeforeMacroExpansion: 3,
-	lineNumberAfterMacroExpansion: 5,
+	lineNumber: 5,
 	instruction: 'push',
 	arguments: [],
 } as CompilerASTLine;
@@ -16,8 +15,7 @@ describe('serializeDiagnostic', () => {
 	describe('syntax errors', () => {
 		it('serializes a SyntaxRulesError with line into CompilerDiagnostic', () => {
 			const err = new SyntaxRulesError(SyntaxErrorCode.MISSING_ARGUMENT, 'Missing arg.', {
-				lineNumberBeforeMacroExpansion: 3,
-				lineNumberAfterMacroExpansion: 5,
+				lineNumber: 5,
 				instruction: 'if',
 			});
 
@@ -27,8 +25,7 @@ describe('serializeDiagnostic', () => {
 				code: SyntaxErrorCode.MISSING_ARGUMENT,
 				message: 'Missing arg.',
 				line: {
-					lineNumberBeforeMacroExpansion: 3,
-					lineNumberAfterMacroExpansion: 5,
+					lineNumber: 5,
 					instruction: 'if',
 				},
 				context: {},
@@ -43,8 +40,7 @@ describe('serializeDiagnostic', () => {
 			expect(result.code).toBe(SyntaxErrorCode.INVALID_IDENTIFIER);
 			expect(result.message).toBe('Invalid identifier.');
 			expect(result.line).toEqual({
-				lineNumberBeforeMacroExpansion: 0,
-				lineNumberAfterMacroExpansion: 0,
+				lineNumber: 0,
 			});
 			expect(result.context).toEqual({});
 		});
@@ -59,8 +55,7 @@ describe('serializeDiagnostic', () => {
 			expect(result.code).toBe(ErrorCode.MEMORY_ACCESS_IN_PURE_FUNCTION);
 			expect(result.message).toContain('Memory declarations are not allowed in functions');
 			expect(result.line).toEqual({
-				lineNumberBeforeMacroExpansion: 3,
-				lineNumberAfterMacroExpansion: 5,
+				lineNumber: 5,
 				instruction: 'push',
 				arguments: [],
 			});
@@ -86,8 +81,7 @@ describe('serializeDiagnostic', () => {
 	describe('unified shape contract', () => {
 		it('syntax and compiler errors both expose code, message, line, context at top level', () => {
 			const syntaxErr = new SyntaxRulesError(SyntaxErrorCode.MISSING_ARGUMENT, 'Missing.', {
-				lineNumberBeforeMacroExpansion: 7,
-				lineNumberAfterMacroExpansion: 7,
+				lineNumber: 7,
 			});
 			const compilerErr = getError(ErrorCode.UNDEFINED_FUNCTION, stubLine);
 
@@ -111,8 +105,7 @@ describe('serializeDiagnostic', () => {
 			expect(result.code).toBe(-1);
 			expect(result.message).toBe('Unexpected crash');
 			expect(result.line).toEqual({
-				lineNumberBeforeMacroExpansion: 0,
-				lineNumberAfterMacroExpansion: 0,
+				lineNumber: 0,
 			});
 			expect(result.context).toEqual({});
 		});
@@ -123,8 +116,7 @@ describe('serializeDiagnostic', () => {
 			expect(result.code).toBe(-1);
 			expect(result.message).toBe('something went wrong');
 			expect(result.line).toEqual({
-				lineNumberBeforeMacroExpansion: 0,
-				lineNumberAfterMacroExpansion: 0,
+				lineNumber: 0,
 			});
 			expect(result.context).toEqual({});
 		});

--- a/packages/compiler/src/diagnostic.ts
+++ b/packages/compiler/src/diagnostic.ts
@@ -10,8 +10,7 @@ import type { CompilerDiagnostic, CompilerStageError } from '@8f4e/compiler-spec
 import { SyntaxRulesError } from '@8f4e/tokenizer';
 
 const FALLBACK_LINE = {
-	lineNumberBeforeMacroExpansion: 0,
-	lineNumberAfterMacroExpansion: 0,
+	lineNumber: 0,
 } as const;
 
 const FALLBACK_CONTEXT = {} as const;
@@ -43,8 +42,7 @@ export function serializeDiagnostic(error: unknown): CompilerDiagnostic {
 			message: error.message,
 			line: error.line
 				? {
-						lineNumberBeforeMacroExpansion: error.line.lineNumberBeforeMacroExpansion,
-						lineNumberAfterMacroExpansion: error.line.lineNumberAfterMacroExpansion,
+						lineNumber: error.line.lineNumber,
 						instruction: error.line.instruction,
 						arguments: error.line.arguments as unknown[],
 					}

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -14,7 +14,6 @@ import type {
 	FunctionTypeRegistry,
 	ModuleAST,
 	Namespaces,
-	ParsedLineMetadata,
 	PrototypeAST,
 	ShapeLine,
 } from '@8f4e/compiler-spec';
@@ -57,11 +56,10 @@ import {
 	collectNamespacesFromASTs,
 } from './semantic/buildNamespace';
 import { getCustomMemoryRegionName, validateMemoryRegionOptions } from './semantic/memoryRegions';
-import { convertExpandedLinesToCode, expandMacros, parseMacroDefinitions } from './utils/macroExpansion';
+import { expandMacros, parseMacroDefinitions } from './utils/macroExpansion';
 
 type ExpandedCompilerSource = {
 	code: string[];
-	lineMetadata: ParsedLineMetadata | undefined;
 	cacheKey: string;
 };
 
@@ -89,7 +87,7 @@ export { createCompilationContext } from './semantic/createCompilationContext';
 export { isMemoryDeclarationInstruction } from './semantic/declarations';
 export { default as normalizeCompileTimeArguments } from './semantic/normalizeCompileTimeArguments';
 export { analyzeInstruction } from './stackAnalysis/analyzeInstruction';
-export { convertExpandedLinesToCode, expandMacros, parseMacroDefinitions } from './utils/macroExpansion';
+export { expandMacros, parseMacroDefinitions } from './utils/macroExpansion';
 export { createInitialMemoryDataSegments };
 
 export function compileModules(
@@ -223,26 +221,16 @@ function getRequiredMemoryBytesByRegion(
 	return result;
 }
 
-function parseModuleAST(
-	code: string[],
-	lineMetadata: ParsedLineMetadata | undefined,
-	cache: CompilerCache,
-	cacheKey: string
-): ModuleAST {
-	const ast = compileToAST(code, lineMetadata, cache.ast, cacheKey);
+function parseModuleAST(code: string[], cache: CompilerCache, cacheKey: string): ModuleAST {
+	const ast = compileToAST(code, cache.ast, cacheKey);
 	if (ast.type !== 'module') {
 		throw getError(ErrorCode.MISSING_MODULE_ID, ast.lines[0], undefined);
 	}
 	return ast;
 }
 
-function parseConstantsAST(
-	code: string[],
-	lineMetadata: ParsedLineMetadata | undefined,
-	cache: CompilerCache,
-	cacheKey: string
-): ConstantsAST {
-	const ast = compileToAST(code, lineMetadata, cache.ast, cacheKey);
+function parseConstantsAST(code: string[], cache: CompilerCache, cacheKey: string): ConstantsAST {
+	const ast = compileToAST(code, cache.ast, cacheKey);
 	if (ast.type !== 'constants') {
 		throw getError(ErrorCode.MISSING_MODULE_ID, ast.lines[0], undefined);
 	}
@@ -259,26 +247,16 @@ function parseConstantsAST(
 	return ast;
 }
 
-function parseFunctionAST(
-	code: string[],
-	lineMetadata: ParsedLineMetadata | undefined,
-	cache: CompilerCache,
-	cacheKey: string
-): FunctionAST {
-	const ast = compileToAST(code, lineMetadata, cache.ast, cacheKey);
+function parseFunctionAST(code: string[], cache: CompilerCache, cacheKey: string): FunctionAST {
+	const ast = compileToAST(code, cache.ast, cacheKey);
 	if (ast.type !== 'function') {
 		throw getError(ErrorCode.MISSING_FUNCTION_ID, ast.lines[0], undefined);
 	}
 	return ast;
 }
 
-function parsePrototypeAST(
-	code: string[],
-	lineMetadata: ParsedLineMetadata | undefined,
-	cache: CompilerCache,
-	cacheKey: string
-): PrototypeAST {
-	const ast = compileToAST(code, lineMetadata, cache.ast, cacheKey);
+function parsePrototypeAST(code: string[], cache: CompilerCache, cacheKey: string): PrototypeAST {
+	const ast = compileToAST(code, cache.ast, cacheKey);
 	if (ast.type !== 'prototype') {
 		throw getError(ErrorCode.MISSING_PROTOTYPE_ID, ast.lines[0], undefined);
 	}
@@ -298,15 +276,8 @@ function startsWithInstruction(line: string, instruction: string): boolean {
 	return line === instruction || (line.startsWith(instruction) && (nextCharacter === ' ' || nextCharacter === '\t'));
 }
 
-function getSourceLineMetadata(
-	source: ExpandedCompilerSource,
-	lineNumberAfterMacroExpansion: number
-): ParsedLineMetadata[number] {
-	return source.lineMetadata?.[lineNumberAfterMacroExpansion] ?? { callSiteLineNumber: lineNumberAfterMacroExpansion };
-}
-
-function getOriginalSourceLine(source: ExpandedCompilerSource, lineNumberAfterMacroExpansion: number): string {
-	return source.code[lineNumberAfterMacroExpansion] ?? '';
+function getOriginalSourceLine(source: ExpandedCompilerSource, lineNumber: number): string {
+	return source.code[lineNumber] ?? '';
 }
 
 function collectPrototypeSources(prototypes: readonly ParsedPrototypeSource[]): Map<string, ParsedPrototypeSource> {
@@ -330,28 +301,20 @@ function expandModuleSourceShapes(
 	prototypeSourcesById: ReadonlyMap<string, ParsedPrototypeSource>
 ): ModuleCompilerSource {
 	const code: string[] = [];
-	const lineMetadata: ParsedLineMetadata = [];
 	let expandedAnyShape = false;
 
-	for (
-		let lineNumberAfterMacroExpansion = 0;
-		lineNumberAfterMacroExpansion < source.code.length;
-		lineNumberAfterMacroExpansion++
-	) {
-		const line = source.code[lineNumberAfterMacroExpansion];
+	for (let lineNumber = 0; lineNumber < source.code.length; lineNumber++) {
+		const line = source.code[lineNumber];
 		const trimmed = line.trim();
 
 		if (!startsWithInstruction(trimmed, 'shape')) {
 			code.push(line);
-			lineMetadata.push(getSourceLineMetadata(source, lineNumberAfterMacroExpansion));
 			continue;
 		}
 
-		const sourceMetadata = getSourceLineMetadata(source, lineNumberAfterMacroExpansion);
-		const shapeLine = parseLine(line, sourceMetadata.callSiteLineNumber, lineNumberAfterMacroExpansion) as ShapeLine;
+		const shapeLine = parseLine(line, lineNumber) as ShapeLine;
 		if (shapeLine.instruction !== 'shape') {
 			code.push(line);
-			lineMetadata.push(sourceMetadata);
 			continue;
 		}
 
@@ -363,9 +326,8 @@ function expandModuleSourceShapes(
 
 		expandedAnyShape = true;
 		for (const declarationLine of prototype.ast.memoryDeclarationLines) {
-			const prototypeLineNumber = declarationLine.lineNumberAfterMacroExpansion;
+			const prototypeLineNumber = declarationLine.lineNumber;
 			code.push(getOriginalSourceLine(prototype.source, prototypeLineNumber));
-			lineMetadata.push(getSourceLineMetadata(prototype.source, prototypeLineNumber));
 		}
 	}
 
@@ -376,7 +338,6 @@ function expandModuleSourceShapes(
 	return {
 		...source,
 		code,
-		lineMetadata,
 	};
 }
 
@@ -394,25 +355,23 @@ export default function compile(
 	const macroDefinitions = parseMacroDefinitions(macros);
 
 	const expandedPrototypes = prototypes.map((prototype, index) => {
-		const expanded = convertExpandedLinesToCode(expandMacros(prototype, macroDefinitions));
 		return {
-			...expanded,
+			code: expandMacros(prototype, macroDefinitions),
 			cacheKey: `prototype:${index}`,
 		};
 	}) satisfies ExpandedCompilerSource[];
 
-	const astPrototypes = expandedPrototypes.map(({ code, lineMetadata, cacheKey }) => ({
-		ast: parsePrototypeAST(code, lineMetadata, cache, cacheKey),
-		source: { code, lineMetadata, cacheKey },
+	const astPrototypes = expandedPrototypes.map(({ code, cacheKey }) => ({
+		ast: parsePrototypeAST(code, cache, cacheKey),
+		source: { code, cacheKey },
 	})) satisfies ParsedPrototypeSource[];
 	const prototypeSourcesById = collectPrototypeSources(astPrototypes);
 
 	// Expand macros and prototype shapes in modules
 	const expandedModules = entryModules.map(({ entryName, module, index }) => {
-		const expanded = convertExpandedLinesToCode(expandMacros(module, macroDefinitions));
 		return expandModuleSourceShapes(
 			{
-				...expanded,
+				code: expandMacros(module, macroDefinitions),
 				cacheKey: `entry:${entryName}:module:${index}`,
 				entryName,
 			},
@@ -421,30 +380,25 @@ export default function compile(
 	}) satisfies ModuleCompilerSource[];
 
 	const expandedConstants = constants.map((constantsBlock, index) => {
-		const expanded = convertExpandedLinesToCode(expandMacros(constantsBlock, macroDefinitions));
 		return {
-			...expanded,
+			code: expandMacros(constantsBlock, macroDefinitions),
 			cacheKey: `constants:${index}`,
 		};
 	}) satisfies ExpandedCompilerSource[];
 
 	// Expand macros in functions
 	const expandedFunctions = functions.map((func, index) => {
-		const expanded = convertExpandedLinesToCode(expandMacros(func, macroDefinitions));
 		return {
-			...expanded,
+			code: expandMacros(func, macroDefinitions),
 			cacheKey: `function:${index}`,
 		};
 	}) satisfies ExpandedCompilerSource[];
 
-	// Compile to AST with line metadata for error mapping.
-	const astModuleEntries = expandedModules.map(({ entryName, code, lineMetadata, cacheKey }) => ({
+	const astModuleEntries = expandedModules.map(({ entryName, code, cacheKey }) => ({
 		entryName,
-		ast: parseModuleAST(code, lineMetadata, cache, cacheKey),
+		ast: parseModuleAST(code, cache, cacheKey),
 	}));
-	const astConstants = expandedConstants.map(({ code, lineMetadata, cacheKey }) =>
-		parseConstantsAST(code, lineMetadata, cache, cacheKey)
-	);
+	const astConstants = expandedConstants.map(({ code, cacheKey }) => parseConstantsAST(code, cache, cacheKey));
 	const entryNames = inputEntryNames;
 	const astModules = astModuleEntries.map(({ ast }) => ast);
 	const moduleEntryNames = astModuleEntries.map(({ entryName }) => entryName);
@@ -460,9 +414,7 @@ export default function compile(
 	);
 
 	// Compile functions first with WASM indices and type registry
-	const astFunctions = expandedFunctions.map(({ code, lineMetadata, cacheKey }) =>
-		parseFunctionAST(code, lineMetadata, cache, cacheKey)
-	);
+	const astFunctions = expandedFunctions.map(({ code, cacheKey }) => parseFunctionAST(code, cache, cacheKey));
 	const importedUserFunctionCount = astFunctions.filter(ast => ast.import).length;
 	const importedFunctionCount = importedUserFunctionCount;
 	const builtInFunctionCount = 1 + entryNames.length;

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -58,18 +58,18 @@ import {
 import { getCustomMemoryRegionName, validateMemoryRegionOptions } from './semantic/memoryRegions';
 import { expandMacros, parseMacroDefinitions } from './utils/macroExpansion';
 
-type ExpandedCompilerSource = {
+type ModuleCompilerSource = {
 	code: string[];
 	cacheKey: string;
-};
-
-type ModuleCompilerSource = ExpandedCompilerSource & {
 	entryName: string;
 };
 
 type ParsedPrototypeSource = {
 	ast: PrototypeAST;
-	source: ExpandedCompilerSource;
+	source: {
+		code: string[];
+		cacheKey: string;
+	};
 };
 
 export { deriveEffectiveMemorySize } from '@8f4e/compiler-wasm-utils';
@@ -276,7 +276,7 @@ function startsWithInstruction(line: string, instruction: string): boolean {
 	return line === instruction || (line.startsWith(instruction) && (nextCharacter === ' ' || nextCharacter === '\t'));
 }
 
-function getOriginalSourceLine(source: ExpandedCompilerSource, lineNumber: number): string {
+function getOriginalSourceLine(source: { code: string[] }, lineNumber: number): string {
 	return source.code[lineNumber] ?? '';
 }
 
@@ -359,7 +359,7 @@ export default function compile(
 			code: expandMacros(prototype, macroDefinitions),
 			cacheKey: `prototype:${index}`,
 		};
-	}) satisfies ExpandedCompilerSource[];
+	});
 
 	const astPrototypes = expandedPrototypes.map(({ code, cacheKey }) => ({
 		ast: parsePrototypeAST(code, cache, cacheKey),
@@ -384,7 +384,7 @@ export default function compile(
 			code: expandMacros(constantsBlock, macroDefinitions),
 			cacheKey: `constants:${index}`,
 		};
-	}) satisfies ExpandedCompilerSource[];
+	});
 
 	// Expand macros in functions
 	const expandedFunctions = functions.map((func, index) => {
@@ -392,7 +392,7 @@ export default function compile(
 			code: expandMacros(func, macroDefinitions),
 			cacheKey: `function:${index}`,
 		};
-	}) satisfies ExpandedCompilerSource[];
+	});
 
 	const astModuleEntries = expandedModules.map(({ entryName, code, cacheKey }) => ({
 		entryName,

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -68,7 +68,6 @@ type ParsedPrototypeSource = {
 	ast: PrototypeAST;
 	source: {
 		code: string[];
-		cacheKey: string;
 	};
 };
 
@@ -276,10 +275,6 @@ function startsWithInstruction(line: string, instruction: string): boolean {
 	return line === instruction || (line.startsWith(instruction) && (nextCharacter === ' ' || nextCharacter === '\t'));
 }
 
-function getOriginalSourceLine(source: { code: string[] }, lineNumber: number): string {
-	return source.code[lineNumber] ?? '';
-}
-
 function collectPrototypeSources(prototypes: readonly ParsedPrototypeSource[]): Map<string, ParsedPrototypeSource> {
 	const prototypeSourcesById = new Map<string, ParsedPrototypeSource>();
 
@@ -327,7 +322,7 @@ function expandModuleSourceShapes(
 		expandedAnyShape = true;
 		for (const declarationLine of prototype.ast.memoryDeclarationLines) {
 			const prototypeLineNumber = declarationLine.lineNumber;
-			code.push(getOriginalSourceLine(prototype.source, prototypeLineNumber));
+			code.push(prototype.source.code[prototypeLineNumber] ?? '');
 		}
 	}
 
@@ -363,7 +358,7 @@ export default function compile(
 
 	const astPrototypes = expandedPrototypes.map(({ code, cacheKey }) => ({
 		ast: parsePrototypeAST(code, cache, cacheKey),
-		source: { code, cacheKey },
+		source: { code },
 	})) satisfies ParsedPrototypeSource[];
 	const prototypeSourcesById = collectPrototypeSources(astPrototypes);
 

--- a/packages/compiler/src/instructionCompilers/abs.test.ts
+++ b/packages/compiler/src/instructionCompilers/abs.test.ts
@@ -12,8 +12,7 @@ describe('abs instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			abs,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'abs',
 				arguments: [],
 			} as CompilerASTLine,
@@ -33,8 +32,7 @@ describe('abs instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			abs,
 			{
-				lineNumberBeforeMacroExpansion: 3,
-				lineNumberAfterMacroExpansion: 3,
+				lineNumber: 3,
 				instruction: 'abs',
 				arguments: [],
 			} as CompilerASTLine,
@@ -55,8 +53,7 @@ describe('abs instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			abs,
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: 'abs',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/abs.ts
+++ b/packages/compiler/src/instructionCompilers/abs.ts
@@ -22,7 +22,7 @@ const abs: InstructionCompiler = (line, context) => {
 	const [operand] = line.stackAnalysis.consumedOperands;
 
 	if (operand.valueType === 'int') {
-		const valueName = '__absify_value' + line.lineNumberAfterMacroExpansion;
+		const valueName = '__absify_value' + line.lineNumber;
 		const valueLocalIndex = Object.keys(context.locals).length;
 
 		context.locals[valueName] = {

--- a/packages/compiler/src/instructionCompilers/add.test.ts
+++ b/packages/compiler/src/instructionCompilers/add.test.ts
@@ -15,8 +15,7 @@ describe('add instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			add,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'add',
 				arguments: [],
 			} as CompilerASTLine,
@@ -39,8 +38,7 @@ describe('add instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			add,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'add',
 				arguments: [],
 			} as CompilerASTLine,
@@ -63,8 +61,7 @@ describe('add instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			add,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'add',
 				arguments: [],
 			} as CompilerASTLine,
@@ -95,8 +92,7 @@ describe('add instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			add,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'add',
 				arguments: [],
 			} as CompilerASTLine,
@@ -136,8 +132,7 @@ describe('add instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			add,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'add',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/and.test.ts
+++ b/packages/compiler/src/instructionCompilers/and.test.ts
@@ -16,8 +16,7 @@ describe('and instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			and,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'and',
 				arguments: [],
 			} as CompilerASTLine,
@@ -37,8 +36,7 @@ describe('and instruction compiler', () => {
 			{ kind: 'value', valueType: 'float', isNonZero: false }
 		);
 		const line = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'and',
 			arguments: [],
 		} as CompilerASTLine;
@@ -58,8 +56,7 @@ describe('and instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			and,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'and',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/block.test.ts
+++ b/packages/compiler/src/instructionCompilers/block.test.ts
@@ -11,8 +11,7 @@ describe('block instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			block,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'block',
 				arguments: [],
 				blockBlock: { matchingBlockEndIndex: 2, resultTypes: ['float'] },
@@ -32,8 +31,7 @@ describe('block instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			block,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'block',
 				arguments: [],
 				blockBlock: { matchingBlockEndIndex: 2, resultTypes: ['int'] },
@@ -53,8 +51,7 @@ describe('block instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			block,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'block',
 				arguments: [],
 				blockBlock: { matchingBlockEndIndex: 2, resultTypes: [] },

--- a/packages/compiler/src/instructionCompilers/blockEnd.test.ts
+++ b/packages/compiler/src/instructionCompilers/blockEnd.test.ts
@@ -11,7 +11,8 @@ describe('blockEnd instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.BLOCK,expectedResultTypes: ['int'],
+					blockType: BlockType.BLOCK,
+					expectedResultTypes: ['int'],
 				},
 			],
 		});
@@ -20,8 +21,7 @@ describe('blockEnd instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			blockEnd,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'blockEnd',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/branch.test.ts
+++ b/packages/compiler/src/instructionCompilers/branch.test.ts
@@ -12,8 +12,7 @@ describe('branch instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			branch,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'branch',
 				arguments: [{ type: ArgumentType.LITERAL, value: 0, isInteger: true }],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/branchIfTrue.test.ts
+++ b/packages/compiler/src/instructionCompilers/branchIfTrue.test.ts
@@ -13,8 +13,7 @@ describe('branchIfTrue instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			branchIfTrue,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'branchIfTrue',
 				arguments: [{ type: ArgumentType.LITERAL, value: 2, isInteger: true }],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/branchIfUnchanged.test.ts
+++ b/packages/compiler/src/instructionCompilers/branchIfUnchanged.test.ts
@@ -13,8 +13,7 @@ describe('branchIfUnchanged instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			branchIfUnchanged,
 			{
-				lineNumberBeforeMacroExpansion: 4,
-				lineNumberAfterMacroExpansion: 4,
+				lineNumber: 4,
 				instruction: 'branchIfUnchanged',
 				arguments: [{ type: ArgumentType.LITERAL, value: 1, isInteger: true }],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/branchIfUnchanged.ts
+++ b/packages/compiler/src/instructionCompilers/branchIfUnchanged.ts
@@ -24,9 +24,9 @@ const branchIfUnchanged: InstructionCompiler<BranchIfUnchangedLine> = (line, con
 	const depth = line.arguments[0].value;
 	const isInteger = operand.valueType === 'int';
 	const type = isInteger ? 'int' : 'float';
-	const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
-	const previousValueMemoryName = '__branchIfUnchanged_previousValue' + lineNumberAfterMacroExpansion;
-	const currentValueMemoryName = '__branchIfUnchanged_currentValue' + lineNumberAfterMacroExpansion;
+	const lineNumber = line.lineNumber;
+	const previousValueMemoryName = '__branchIfUnchanged_previousValue' + lineNumber;
+	const currentValueMemoryName = '__branchIfUnchanged_currentValue' + lineNumber;
 	const previousValue = allocateInternalResource(context, previousValueMemoryName, type);
 	const currentValueLocalIndex = Object.keys(context.locals).length;
 

--- a/packages/compiler/src/instructionCompilers/call.test.ts
+++ b/packages/compiler/src/instructionCompilers/call.test.ts
@@ -26,8 +26,7 @@ describe('call instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			call,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'call',
 				arguments: [classifyIdentifier('foo')],
 				targetFunction,
@@ -56,8 +55,7 @@ describe('call instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			call,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'call',
 				arguments: [classifyIdentifier('foo64')],
 				targetFunction,
@@ -83,8 +81,7 @@ describe('call instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			call,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'call',
 				arguments: [
 					classifyIdentifier('foo'),
@@ -94,14 +91,12 @@ describe('call instruction compiler', () => {
 				targetFunction,
 				inlineArgumentPushes: [
 					{
-						lineNumberBeforeMacroExpansion: 1,
-						lineNumberAfterMacroExpansion: 1,
+						lineNumber: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.LITERAL, value: 2, isInteger: true }],
 					},
 					{
-						lineNumberBeforeMacroExpansion: 1,
-						lineNumberAfterMacroExpansion: 1,
+						lineNumber: 1,
 						instruction: 'push',
 						arguments: [{ type: ArgumentType.LITERAL, value: 1.3, isInteger: false }],
 					},
@@ -132,8 +127,7 @@ describe('call instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				call,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'call',
 					arguments: [classifyIdentifier('foo64')],
 					targetFunction,
@@ -157,8 +151,7 @@ describe('call instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			call,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'call',
 				arguments: [classifyIdentifier('addr')],
 				targetFunction,

--- a/packages/compiler/src/instructionCompilers/castToFloat.test.ts
+++ b/packages/compiler/src/instructionCompilers/castToFloat.test.ts
@@ -12,8 +12,7 @@ describe('castToFloat instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			castToFloat,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'castToFloat',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/castToInt.test.ts
+++ b/packages/compiler/src/instructionCompilers/castToInt.test.ts
@@ -12,8 +12,7 @@ describe('castToInt instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			castToInt,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'castToInt',
 				arguments: [],
 			} as CompilerASTLine,
@@ -33,8 +32,7 @@ describe('castToInt instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			castToInt,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'castToInt',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/clampAddress.test.ts
+++ b/packages/compiler/src/instructionCompilers/clampAddress.test.ts
@@ -20,8 +20,7 @@ function createLine(
 	accessByteWidth?: number
 ) {
 	return {
-		lineNumberBeforeMacroExpansion: 1,
-		lineNumberAfterMacroExpansion: 1,
+		lineNumber: 1,
 		instruction,
 		arguments:
 			accessByteWidth === undefined ? [] : [{ type: ArgumentType.LITERAL, value: accessByteWidth, isInteger: true }],

--- a/packages/compiler/src/instructionCompilers/clearStack.test.ts
+++ b/packages/compiler/src/instructionCompilers/clearStack.test.ts
@@ -15,8 +15,7 @@ describe('clearStack instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			clearStack,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'clearStack',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/createMinMax.ts
+++ b/packages/compiler/src/instructionCompilers/createMinMax.ts
@@ -25,8 +25,8 @@ const createMinMax =
 		const isFloat64 = areAllOperandsFloat64(operand1, operand2);
 
 		if (isInteger) {
-			const leftName = `__${instruction}_left${line.lineNumberAfterMacroExpansion}`;
-			const rightName = `__${instruction}_right${line.lineNumberAfterMacroExpansion}`;
+			const leftName = `__${instruction}_left${line.lineNumber}`;
+			const rightName = `__${instruction}_right${line.lineNumber}`;
 			const leftLocalIndex = Object.keys(context.locals).length;
 			const rightLocalIndex = leftLocalIndex + 1;
 

--- a/packages/compiler/src/instructionCompilers/default.test.ts
+++ b/packages/compiler/src/instructionCompilers/default.test.ts
@@ -10,10 +10,12 @@ describe('default instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,expectedResultTypes: [],
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.MAP,expectedResultTypes: [],
+					blockType: BlockType.MAP,
+					expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,
@@ -27,8 +29,7 @@ describe('default instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			_default,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'default',
 				arguments: [{ type: ArgumentType.LITERAL, value: 99, isInteger: true }],
 			} as CompilerASTLine,
@@ -47,8 +48,7 @@ describe('default instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				_default,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'default',
 					arguments: [{ type: ArgumentType.LITERAL, value: 0, isInteger: true }],
 				} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/div.test.ts
+++ b/packages/compiler/src/instructionCompilers/div.test.ts
@@ -15,8 +15,7 @@ describe('div instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			div,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'div',
 				arguments: [],
 			} as CompilerASTLine,
@@ -39,8 +38,7 @@ describe('div instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			div,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'div',
 				arguments: [],
 			} as CompilerASTLine,
@@ -63,8 +61,7 @@ describe('div instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			div,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'div',
 				arguments: [],
 			} as CompilerASTLine,
@@ -88,8 +85,7 @@ describe('div instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				div,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'div',
 					arguments: [],
 				} as CompilerASTLine,
@@ -108,8 +104,7 @@ describe('div instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			div,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'div',
 				arguments: [],
 			} as CompilerASTLine,
@@ -129,8 +124,7 @@ describe('div instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			div,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'div',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/drop.test.ts
+++ b/packages/compiler/src/instructionCompilers/drop.test.ts
@@ -15,8 +15,7 @@ describe('drop instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			drop,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'drop',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/else.test.ts
+++ b/packages/compiler/src/instructionCompilers/else.test.ts
@@ -11,7 +11,8 @@ describe('else instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.CONDITION,expectedResultTypes: ['int'],
+					blockType: BlockType.CONDITION,
+					expectedResultTypes: ['int'],
 				},
 			],
 		});
@@ -20,8 +21,7 @@ describe('else instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			_else,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'else',
 				arguments: [],
 			} as CompilerASTLine,
@@ -42,8 +42,7 @@ describe('else instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				_else,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'else',
 					arguments: [],
 				} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/ensureNonZero.test.ts
+++ b/packages/compiler/src/instructionCompilers/ensureNonZero.test.ts
@@ -13,8 +13,7 @@ describe('ensureNonZero instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			ensureNonZero,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'ensureNonZero',
 				arguments: [],
 			} as CompilerASTLine,
@@ -35,8 +34,7 @@ describe('ensureNonZero instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			ensureNonZero,
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: 'ensureNonZero',
 				arguments: [{ type: ArgumentType.LITERAL, value: 2.5, isInteger: false }],
 			} as CompilerASTLine,
@@ -57,8 +55,7 @@ describe('ensureNonZero instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			ensureNonZero,
 			{
-				lineNumberBeforeMacroExpansion: 3,
-				lineNumberAfterMacroExpansion: 3,
+				lineNumber: 3,
 				instruction: 'ensureNonZero',
 				arguments: [
 					{

--- a/packages/compiler/src/instructionCompilers/ensureNonZero.ts
+++ b/packages/compiler/src/instructionCompilers/ensureNonZero.ts
@@ -37,7 +37,7 @@ const ensureNonZero: InstructionCompiler = (line, context) => {
 		defaultNonZeroValue = line.arguments[0].value;
 	}
 
-	const tempVariableName = '__ensureNonZero_temp_' + line.lineNumberAfterMacroExpansion;
+	const tempVariableName = '__ensureNonZero_temp_' + line.lineNumber;
 	const tempLocalIndex = Object.keys(context.locals).length;
 
 	if (isInteger) {

--- a/packages/compiler/src/instructionCompilers/equal.test.ts
+++ b/packages/compiler/src/instructionCompilers/equal.test.ts
@@ -16,8 +16,7 @@ describe('equal instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			equal,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'equal',
 				arguments: [],
 			} as CompilerASTLine,
@@ -40,8 +39,7 @@ describe('equal instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			equal,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'equal',
 				arguments: [],
 			} as CompilerASTLine,
@@ -64,8 +62,7 @@ describe('equal instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			equal,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'equal',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/equalToZero.test.ts
+++ b/packages/compiler/src/instructionCompilers/equalToZero.test.ts
@@ -13,8 +13,7 @@ describe('equalToZero instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			equalToZero,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'equalToZero',
 				arguments: [],
 			} as CompilerASTLine,
@@ -32,8 +31,7 @@ describe('equalToZero instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			equalToZero,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'equalToZero',
 				arguments: [],
 			} as CompilerASTLine,
@@ -51,8 +49,7 @@ describe('equalToZero instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			equalToZero,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'equalToZero',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/exitIfTrue.test.ts
+++ b/packages/compiler/src/instructionCompilers/exitIfTrue.test.ts
@@ -15,8 +15,7 @@ describe('exitIfTrue instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			exitIfTrue,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'exitIfTrue',
 				arguments: [],
 			} as CompilerASTLine,
@@ -32,7 +31,8 @@ describe('exitIfTrue instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,expectedResultTypes: [],
+					blockType: BlockType.FUNCTION,
+					expectedResultTypes: [],
 				},
 			],
 		});
@@ -42,8 +42,7 @@ describe('exitIfTrue instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				exitIfTrue,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'exitIfTrue',
 					arguments: [],
 				} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/fallingEdge.test.ts
+++ b/packages/compiler/src/instructionCompilers/fallingEdge.test.ts
@@ -12,8 +12,7 @@ describe('fallingEdge instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			fallingEdge,
 			{
-				lineNumberBeforeMacroExpansion: 5,
-				lineNumberAfterMacroExpansion: 5,
+				lineNumber: 5,
 				instruction: 'fallingEdge',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/fallingEdge.ts
+++ b/packages/compiler/src/instructionCompilers/fallingEdge.ts
@@ -20,9 +20,9 @@ import { saveByteCode } from './utils/saveByteCode';
 const fallingEdge: InstructionCompiler = (line, context) => {
 	const [operand] = line.stackAnalysis.consumedOperands;
 
-	const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
-	const currentValueName = '__fallingEdgeDetector_currentValue' + lineNumberAfterMacroExpansion;
-	const previousValueName = '__fallingEdgeDetector_previousValue' + lineNumberAfterMacroExpansion;
+	const lineNumber = line.lineNumber;
+	const currentValueName = '__fallingEdgeDetector_currentValue' + lineNumber;
+	const previousValueName = '__fallingEdgeDetector_previousValue' + lineNumber;
 	const isInteger = operand.valueType === 'int';
 	const memoryType = isInteger ? 'int' : 'float';
 	const previousValue = allocateInternalResource(context, previousValueName, memoryType);

--- a/packages/compiler/src/instructionCompilers/function.test.ts
+++ b/packages/compiler/src/instructionCompilers/function.test.ts
@@ -13,8 +13,7 @@ describe('function instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			_function,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'function',
 				arguments: [classifyIdentifier('doThing')],
 			} as CompilerASTLine,
@@ -37,8 +36,7 @@ describe('function instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				_function,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'function',
 					arguments: [classifyIdentifier('nested')],
 				} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/functionEnd.test.ts
+++ b/packages/compiler/src/instructionCompilers/functionEnd.test.ts
@@ -13,7 +13,8 @@ describe('functionEnd instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,expectedResultTypes: [],
+					blockType: BlockType.FUNCTION,
+					expectedResultTypes: [],
 				},
 			],
 			currentFunctionSignature: { parameters: ['int'], returns: [] },
@@ -28,8 +29,7 @@ describe('functionEnd instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			functionEnd,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'functionEnd',
 				arguments: [classifyIdentifier('int')],
 			} as CompilerASTLine,
@@ -54,7 +54,8 @@ describe('functionEnd instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,expectedResultTypes: [],
+					blockType: BlockType.FUNCTION,
+					expectedResultTypes: [],
 				},
 			],
 			currentFunctionSignature: { parameters: ['float64'], returns: [] },
@@ -69,8 +70,7 @@ describe('functionEnd instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			functionEnd,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'functionEnd',
 				arguments: [classifyIdentifier('float64')],
 			} as CompilerASTLine,
@@ -101,15 +101,15 @@ describe('functionEnd instruction compiler', () => {
 				blockStack: [
 					...createInstructionCompilerTestContext().blockStack,
 					{
-						blockType: BlockType.FUNCTION,expectedResultTypes: [],
+						blockType: BlockType.FUNCTION,
+						expectedResultTypes: [],
 					},
 				],
 				currentFunctionSignature: { parameters: ['int'], returns: [] },
 				functionTypeRegistry,
 			});
 		const line = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'functionEnd',
 			arguments: [classifyIdentifier('int')],
 		} as CompilerASTLine;
@@ -135,8 +135,7 @@ describe('functionEnd instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				functionEnd,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'functionEnd',
 					arguments: [classifyIdentifier('int')],
 				} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/greaterOrEqual.test.ts
+++ b/packages/compiler/src/instructionCompilers/greaterOrEqual.test.ts
@@ -16,8 +16,7 @@ describe('greaterOrEqual instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			greaterOrEqual,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'greaterOrEqual',
 				arguments: [],
 			} as CompilerASTLine,
@@ -40,8 +39,7 @@ describe('greaterOrEqual instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			greaterOrEqual,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'greaterOrEqual',
 				arguments: [],
 			} as CompilerASTLine,
@@ -64,8 +62,7 @@ describe('greaterOrEqual instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			greaterOrEqual,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'greaterOrEqual',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/greaterOrEqualUnsigned.test.ts
+++ b/packages/compiler/src/instructionCompilers/greaterOrEqualUnsigned.test.ts
@@ -16,8 +16,7 @@ describe('greaterOrEqualUnsigned instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			greaterOrEqualUnsigned,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'greaterOrEqualUnsigned',
 				arguments: [],
 			} as CompilerASTLine,
@@ -40,8 +39,7 @@ describe('greaterOrEqualUnsigned instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			greaterOrEqualUnsigned,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'greaterOrEqualUnsigned',
 				arguments: [],
 			} as CompilerASTLine,
@@ -64,8 +62,7 @@ describe('greaterOrEqualUnsigned instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			greaterOrEqualUnsigned,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'greaterOrEqualUnsigned',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/greaterThan.test.ts
+++ b/packages/compiler/src/instructionCompilers/greaterThan.test.ts
@@ -16,8 +16,7 @@ describe('greaterThan instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			greaterThan,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'greaterThan',
 				arguments: [],
 			} as CompilerASTLine,
@@ -40,8 +39,7 @@ describe('greaterThan instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			greaterThan,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'greaterThan',
 				arguments: [],
 			} as CompilerASTLine,
@@ -64,8 +62,7 @@ describe('greaterThan instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			greaterThan,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'greaterThan',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/hasChanged.test.ts
+++ b/packages/compiler/src/instructionCompilers/hasChanged.test.ts
@@ -12,8 +12,7 @@ describe('hasChanged instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			hasChanged,
 			{
-				lineNumberBeforeMacroExpansion: 3,
-				lineNumberAfterMacroExpansion: 3,
+				lineNumber: 3,
 				instruction: 'hasChanged',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/hasChanged.ts
+++ b/packages/compiler/src/instructionCompilers/hasChanged.ts
@@ -21,9 +21,9 @@ import { saveByteCode } from './utils/saveByteCode';
 const hasChanged: InstructionCompiler = (line, context) => {
 	const [operand] = line.stackAnalysis.consumedOperands;
 
-	const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
-	const currentValueName = '__hasChangedDetector_currentValue' + lineNumberAfterMacroExpansion;
-	const previousValueName = '__hasChangedDetector_previousValue' + lineNumberAfterMacroExpansion;
+	const lineNumber = line.lineNumber;
+	const currentValueName = '__hasChangedDetector_currentValue' + lineNumber;
+	const previousValueName = '__hasChangedDetector_previousValue' + lineNumber;
 	const isInteger = operand.valueType === 'int';
 	const memoryType = isInteger ? 'int' : 'float';
 	const previousValue = allocateInternalResource(context, previousValueName, memoryType);

--- a/packages/compiler/src/instructionCompilers/if.test.ts
+++ b/packages/compiler/src/instructionCompilers/if.test.ts
@@ -12,8 +12,7 @@ describe('if instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			_if,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'if',
 				arguments: [],
 				ifBlock: { matchingIfEndIndex: 2, resultTypes: [], hasElse: false },
@@ -34,8 +33,7 @@ describe('if instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			_if,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'if',
 				arguments: [],
 				ifBlock: { matchingIfEndIndex: 2, resultTypes: [], hasElse: false },
@@ -56,8 +54,7 @@ describe('if instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			_if,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'if',
 				arguments: [],
 				ifBlock: { matchingIfEndIndex: 2, resultTypes: ['float'], hasElse: false },
@@ -78,8 +75,7 @@ describe('if instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			_if,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'if',
 				arguments: [],
 				ifBlock: { matchingIfEndIndex: 2, resultTypes: ['int'], hasElse: false },
@@ -106,8 +102,7 @@ describe('if instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			_if,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'if',
 				arguments: [],
 				ifBlock: { matchingIfEndIndex: 2, resultTypes: ['int', 'float'], hasElse: false },

--- a/packages/compiler/src/instructionCompilers/ifEnd.test.ts
+++ b/packages/compiler/src/instructionCompilers/ifEnd.test.ts
@@ -21,8 +21,7 @@ describe('ifEnd instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			ifEnd,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'ifEnd',
 				arguments: [],
 			} as CompilerASTLine,
@@ -52,8 +51,7 @@ describe('ifEnd instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			ifEnd,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'ifEnd',
 				arguments: [],
 			} as CompilerASTLine,
@@ -74,8 +72,7 @@ describe('ifEnd instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				ifEnd,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'ifEnd',
 					arguments: [],
 				} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/impure.test.ts
+++ b/packages/compiler/src/instructionCompilers/impure.test.ts
@@ -10,7 +10,8 @@ describe('impure instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.FUNCTION,expectedResultTypes: [],
+					blockType: BlockType.FUNCTION,
+					expectedResultTypes: [],
 				},
 			],
 			mode: 'function',
@@ -20,8 +21,7 @@ describe('impure instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			impure,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: '#impure',
 				arguments: [],
 				isBlockPrologue: true,
@@ -39,8 +39,7 @@ describe('impure instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				impure,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: '#impure',
 					arguments: [],
 				} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/lessOrEqual.test.ts
+++ b/packages/compiler/src/instructionCompilers/lessOrEqual.test.ts
@@ -16,8 +16,7 @@ describe('lessOrEqual instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			lessOrEqual,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'lessOrEqual',
 				arguments: [],
 			} as CompilerASTLine,
@@ -40,8 +39,7 @@ describe('lessOrEqual instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			lessOrEqual,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'lessOrEqual',
 				arguments: [],
 			} as CompilerASTLine,
@@ -64,8 +62,7 @@ describe('lessOrEqual instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			lessOrEqual,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'lessOrEqual',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/lessThan.test.ts
+++ b/packages/compiler/src/instructionCompilers/lessThan.test.ts
@@ -16,8 +16,7 @@ describe('lessThan instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			lessThan,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'lessThan',
 				arguments: [],
 			} as CompilerASTLine,
@@ -40,8 +39,7 @@ describe('lessThan instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			lessThan,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'lessThan',
 				arguments: [],
 			} as CompilerASTLine,
@@ -64,8 +62,7 @@ describe('lessThan instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			lessThan,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'lessThan',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/load.test.ts
+++ b/packages/compiler/src/instructionCompilers/load.test.ts
@@ -27,8 +27,7 @@ describe('load instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			load,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'load',
 				arguments: [],
 			} as CompilerASTLine,
@@ -48,8 +47,7 @@ describe('load instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			load,
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: 'load8u',
 				arguments: [],
 			} as CompilerASTLine,
@@ -83,8 +81,7 @@ describe('load instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			load,
 			{
-				lineNumberBeforeMacroExpansion: 3,
-				lineNumberAfterMacroExpansion: 3,
+				lineNumber: 3,
 				instruction: 'load',
 				arguments: [],
 			} as CompilerASTLine,
@@ -109,8 +106,7 @@ describe('load instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			load,
 			{
-				lineNumberBeforeMacroExpansion: 4,
-				lineNumberAfterMacroExpansion: 4,
+				lineNumber: 4,
 				instruction: 'load',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/load.ts
+++ b/packages/compiler/src/instructionCompilers/load.ts
@@ -47,7 +47,7 @@ const load: InstructionCompiler<LoadLine> = (line, context) => {
 		guardedLoad(context, {
 			accessByteWidth,
 			memoryIndex,
-			lineNumberAfterMacroExpansion: line.lineNumberAfterMacroExpansion,
+			lineNumber: line.lineNumber,
 			resultType: WASM_TYPE_I32,
 			loadByteCode: instructions,
 		})

--- a/packages/compiler/src/instructionCompilers/loadFloat.test.ts
+++ b/packages/compiler/src/instructionCompilers/loadFloat.test.ts
@@ -26,8 +26,7 @@ describe('loadFloat instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			loadFloat,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'loadFloat',
 				arguments: [],
 			} as CompilerASTLine,
@@ -47,8 +46,7 @@ describe('loadFloat instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			loadFloat,
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: 'loadFloat',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/loadFloat.ts
+++ b/packages/compiler/src/instructionCompilers/loadFloat.ts
@@ -30,7 +30,7 @@ const loadFloat: InstructionCompiler<LoadFloatLine> = (line, context) => {
 		guardedLoad(context, {
 			accessByteWidth,
 			memoryIndex,
-			lineNumberAfterMacroExpansion: line.lineNumberAfterMacroExpansion,
+			lineNumber: line.lineNumber,
 			resultType: WASM_TYPE_F32,
 			loadByteCode: instructions,
 		})

--- a/packages/compiler/src/instructionCompilers/local.test.ts
+++ b/packages/compiler/src/instructionCompilers/local.test.ts
@@ -14,8 +14,7 @@ describe('local instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			local,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'local',
 				arguments: [classifyIdentifier('int'), classifyIdentifier('count')],
 			} as CompilerASTLine,
@@ -54,8 +53,7 @@ describe('local instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				local,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'local',
 					arguments: [classifyIdentifier('int'), classifyIdentifier('count')],
 				} as CompilerASTLine,
@@ -75,8 +73,7 @@ describe('local instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			local,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'local',
 				arguments: [classifyIdentifier('float64**'), classifyIdentifier('cursor')],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/localSet.test.ts
+++ b/packages/compiler/src/instructionCompilers/localSet.test.ts
@@ -19,8 +19,7 @@ describe('localSet instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			_localSet,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'localSet',
 				arguments: [classifyIdentifier('value')],
 				local,

--- a/packages/compiler/src/instructionCompilers/loop.test.ts
+++ b/packages/compiler/src/instructionCompilers/loop.test.ts
@@ -12,8 +12,7 @@ describe('loop instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			loop,
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: 'loop',
 				arguments: [],
 			} as CompilerASTLine,
@@ -34,8 +33,7 @@ describe('loop instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			loop,
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: 'loop',
 				arguments: [{ type: ArgumentType.LITERAL, value: 32, isInteger: true }],
 			} as CompilerASTLine,
@@ -57,8 +55,7 @@ describe('loop instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			loop,
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: 'loop',
 				arguments: [],
 			} as CompilerASTLine,
@@ -80,8 +77,7 @@ describe('loop instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			loop,
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: 'loop',
 				arguments: [{ type: ArgumentType.LITERAL, value: 10, isInteger: true }],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/loop.ts
+++ b/packages/compiler/src/instructionCompilers/loop.ts
@@ -30,7 +30,7 @@ const loop: InstructionCompiler<NormalizedLoopLine | LoopLine> = (line, context)
 	}
 	const effectiveCap = capArg !== undefined ? (capArg.value as number) : (context.loopCap ?? DEFAULT_LOOP_CAP);
 
-	const infiniteLoopProtectionCounterName = '__infiniteLoopProtectionCounter' + line.lineNumberAfterMacroExpansion;
+	const infiniteLoopProtectionCounterName = '__infiniteLoopProtectionCounter' + line.lineNumber;
 	const counterLocalIndex = Object.keys(context.locals).length;
 	const loopCounterLocal = {
 		isInteger: true,

--- a/packages/compiler/src/instructionCompilers/loopCap.test.ts
+++ b/packages/compiler/src/instructionCompilers/loopCap.test.ts
@@ -11,7 +11,8 @@ describe('#loopCap instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,expectedResultTypes: [],
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
 				},
 			],
 		});
@@ -19,8 +20,7 @@ describe('#loopCap instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			loopCap,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: '#loopCap',
 				arguments: [{ type: ArgumentType.LITERAL, value: 500, isInteger: true }],
 				isBlockPrologue: true,
@@ -35,7 +35,8 @@ describe('#loopCap instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.FUNCTION,expectedResultTypes: [],
+					blockType: BlockType.FUNCTION,
+					expectedResultTypes: [],
 				},
 			],
 		});
@@ -43,8 +44,7 @@ describe('#loopCap instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			loopCap,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: '#loopCap',
 				arguments: [{ type: ArgumentType.LITERAL, value: 2048, isInteger: true }],
 				isBlockPrologue: true,
@@ -59,7 +59,8 @@ describe('#loopCap instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,expectedResultTypes: [],
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
 				},
 			],
 		});
@@ -67,8 +68,7 @@ describe('#loopCap instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			loopCap,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: '#loopCap',
 				arguments: [{ type: ArgumentType.LITERAL, value: 0, isInteger: true }],
 				isBlockPrologue: true,
@@ -83,7 +83,8 @@ describe('#loopCap instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,expectedResultTypes: [],
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
 				},
 			],
 		});
@@ -91,8 +92,7 @@ describe('#loopCap instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			loopCap,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: '#loopCap',
 				arguments: [{ type: ArgumentType.LITERAL, value: 500, isInteger: true }],
 				isBlockPrologue: true,
@@ -105,8 +105,7 @@ describe('#loopCap instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			loopCap,
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: '#loopCap',
 				arguments: [{ type: ArgumentType.LITERAL, value: 100, isInteger: true }],
 				isBlockPrologue: true,
@@ -122,8 +121,7 @@ describe('#loopCap instruction compiler', () => {
 			blockStack: [],
 		});
 		const line = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: '#loopCap',
 			arguments: [{ type: ArgumentType.LITERAL, value: 500, isInteger: true }],
 		} as CompilerASTLine;

--- a/packages/compiler/src/instructionCompilers/loopEnd.test.ts
+++ b/packages/compiler/src/instructionCompilers/loopEnd.test.ts
@@ -11,7 +11,8 @@ describe('loopEnd instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.LOOP,expectedResultTypes: [],
+					blockType: BlockType.LOOP,
+					expectedResultTypes: [],
 					loopCounterLocalName: '__loopCounter1',
 					loopCounterLocal: { kind: 'value', valueType: 'int', index: 0 },
 				},
@@ -21,8 +22,7 @@ describe('loopEnd instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			loopEnd,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'loopEnd',
 				arguments: [],
 			} as CompilerASTLine,
@@ -42,8 +42,7 @@ describe('loopEnd instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				loopEnd,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'loopEnd',
 					arguments: [],
 				} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/loopIndex.test.ts
+++ b/packages/compiler/src/instructionCompilers/loopIndex.test.ts
@@ -15,10 +15,12 @@ describe('loopIndex instruction compiler', () => {
 			},
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,expectedResultTypes: [],
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.LOOP,expectedResultTypes: [],
+					blockType: BlockType.LOOP,
+					expectedResultTypes: [],
 					loopCounterLocalName: '__loopCounter2',
 					loopCounterLocal,
 				},
@@ -28,8 +30,7 @@ describe('loopIndex instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			loopIndex,
 			{
-				lineNumberBeforeMacroExpansion: 10,
-				lineNumberAfterMacroExpansion: 10,
+				lineNumber: 10,
 				instruction: 'loopIndex',
 				arguments: [],
 			} as CompilerASTLine,
@@ -50,15 +51,18 @@ describe('loopIndex instruction compiler', () => {
 			},
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,expectedResultTypes: [],
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.LOOP,expectedResultTypes: [],
+					blockType: BlockType.LOOP,
+					expectedResultTypes: [],
 					loopCounterLocalName: '__outer',
 					loopCounterLocal: outerLoopCounterLocal,
 				},
 				{
-					blockType: BlockType.LOOP,expectedResultTypes: [],
+					blockType: BlockType.LOOP,
+					expectedResultTypes: [],
 					loopCounterLocalName: '__inner',
 					loopCounterLocal: innerLoopCounterLocal,
 				},
@@ -68,8 +72,7 @@ describe('loopIndex instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			loopIndex,
 			{
-				lineNumberBeforeMacroExpansion: 10,
-				lineNumberAfterMacroExpansion: 10,
+				lineNumber: 10,
 				instruction: 'loopIndex',
 				arguments: [],
 			} as CompilerASTLine,
@@ -86,8 +89,7 @@ describe('loopIndex instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				loopIndex,
 				{
-					lineNumberBeforeMacroExpansion: 10,
-					lineNumberAfterMacroExpansion: 10,
+					lineNumber: 10,
 					instruction: 'loopIndex',
 					arguments: [],
 				} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/map.test.ts
+++ b/packages/compiler/src/instructionCompilers/map.test.ts
@@ -20,10 +20,12 @@ describe('map instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,expectedResultTypes: [],
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.MAP,expectedResultTypes: [],
+					blockType: BlockType.MAP,
+					expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,
@@ -37,8 +39,7 @@ describe('map instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			map,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'map',
 				arguments: [
 					{ type: ArgumentType.LITERAL, value: 1, isInteger: true },
@@ -55,10 +56,12 @@ describe('map instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,expectedResultTypes: [],
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.MAP,expectedResultTypes: [],
+					blockType: BlockType.MAP,
+					expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,
@@ -72,8 +75,7 @@ describe('map instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			map,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'map',
 				arguments: [
 					{ type: ArgumentType.STRING_LITERAL, value: 'A' },
@@ -97,10 +99,12 @@ describe('map instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,expectedResultTypes: [],
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.MAP,expectedResultTypes: [],
+					blockType: BlockType.MAP,
+					expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,
@@ -121,8 +125,7 @@ describe('map instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			map,
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: 'map',
 				arguments: [
 					{ type: ArgumentType.LITERAL, value: 1, isInteger: true },
@@ -144,10 +147,12 @@ describe('map instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,expectedResultTypes: [],
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.MAP,expectedResultTypes: [],
+					blockType: BlockType.MAP,
+					expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,
@@ -162,8 +167,7 @@ describe('map instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				map,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'map',
 					arguments: [
 						{ type: ArgumentType.LITERAL, value: 1.5, isInteger: false },
@@ -182,8 +186,7 @@ describe('map instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				map,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'map',
 					arguments: [
 						{ type: ArgumentType.LITERAL, value: 1, isInteger: true },

--- a/packages/compiler/src/instructionCompilers/mapBegin.test.ts
+++ b/packages/compiler/src/instructionCompilers/mapBegin.test.ts
@@ -13,8 +13,7 @@ describe('mapBegin instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			mapBegin,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'mapBegin',
 				arguments: [classifyIdentifier('int')],
 			} as CompilerASTLine,
@@ -32,8 +31,7 @@ describe('mapBegin instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			mapBegin,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'mapBegin',
 				arguments: [classifyIdentifier('float')],
 			} as CompilerASTLine,
@@ -51,8 +49,7 @@ describe('mapBegin instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			mapBegin,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'mapBegin',
 				arguments: [classifyIdentifier('float64')],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/mapEnd.test.ts
+++ b/packages/compiler/src/instructionCompilers/mapEnd.test.ts
@@ -12,10 +12,12 @@ describe('mapEnd instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,expectedResultTypes: [],
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.MAP,expectedResultTypes: [],
+					blockType: BlockType.MAP,
+					expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,
@@ -31,8 +33,7 @@ describe('mapEnd instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				mapEnd,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'mapEnd',
 					arguments: [],
 				} as CompilerASTLine,
@@ -49,8 +50,7 @@ describe('mapEnd instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				mapEnd,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'mapEnd',
 					arguments: [classifyIdentifier('int')],
 				} as CompilerASTLine,
@@ -63,10 +63,12 @@ describe('mapEnd instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,expectedResultTypes: [],
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
 				},
 				{
-					blockType: BlockType.MAP,expectedResultTypes: [],
+					blockType: BlockType.MAP,
+					expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,
@@ -81,8 +83,7 @@ describe('mapEnd instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			mapEnd,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'mapEnd',
 				arguments: [classifyIdentifier('int')],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/memoryCopy.test.ts
+++ b/packages/compiler/src/instructionCompilers/memoryCopy.test.ts
@@ -7,8 +7,7 @@ import createInstructionCompilerTestContext, { analyzeAndCompileInstruction } fr
 import memoryCopy from './memoryCopy';
 
 const line = {
-	lineNumberBeforeMacroExpansion: 1,
-	lineNumberAfterMacroExpansion: 1,
+	lineNumber: 1,
 	instruction: 'memoryCopy',
 	arguments: [{ type: ArgumentType.LITERAL, value: 20, isInteger: true }],
 } as CompilerASTLine;

--- a/packages/compiler/src/instructionCompilers/memoryCopy.ts
+++ b/packages/compiler/src/instructionCompilers/memoryCopy.ts
@@ -35,7 +35,7 @@ const memoryCopy: InstructionCompiler<NormalizedMemoryCopyLine> = (line, context
 			byteLength,
 			destinationMemoryIndex,
 			sourceMemoryIndex,
-			lineNumberAfterMacroExpansion: line.lineNumberAfterMacroExpansion,
+			lineNumber: line.lineNumber,
 			memoryCopyByteCode,
 		})
 	);

--- a/packages/compiler/src/instructionCompilers/mul.test.ts
+++ b/packages/compiler/src/instructionCompilers/mul.test.ts
@@ -15,8 +15,7 @@ describe('mul instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			mul,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'mul',
 				arguments: [],
 			} as CompilerASTLine,
@@ -39,8 +38,7 @@ describe('mul instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			mul,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'mul',
 				arguments: [],
 			} as CompilerASTLine,
@@ -63,8 +61,7 @@ describe('mul instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			mul,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'mul',
 				arguments: [],
 			} as CompilerASTLine,
@@ -87,8 +84,7 @@ describe('mul instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			mul,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'mul',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/notEqual.test.ts
+++ b/packages/compiler/src/instructionCompilers/notEqual.test.ts
@@ -15,8 +15,7 @@ describe('notEqual instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			notEqual,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'notEqual',
 				arguments: [],
 			} as CompilerASTLine,
@@ -39,8 +38,7 @@ describe('notEqual instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			notEqual,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'notEqual',
 				arguments: [],
 			} as CompilerASTLine,
@@ -63,8 +61,7 @@ describe('notEqual instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			notEqual,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'notEqual',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/notZero.test.ts
+++ b/packages/compiler/src/instructionCompilers/notZero.test.ts
@@ -12,8 +12,7 @@ describe('notZero instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			notZero,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'notZero',
 				arguments: [],
 			} as CompilerASTLine,
@@ -33,8 +32,7 @@ describe('notZero instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			notZero,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'notZero',
 				arguments: [],
 			} as CompilerASTLine,
@@ -54,8 +52,7 @@ describe('notZero instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			notZero,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'notZero',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/or.test.ts
+++ b/packages/compiler/src/instructionCompilers/or.test.ts
@@ -15,8 +15,7 @@ describe('or instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			or,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'or',
 				arguments: [],
 			} as CompilerASTLine,
@@ -39,8 +38,7 @@ describe('or instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			or,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'or',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/param.test.ts
+++ b/packages/compiler/src/instructionCompilers/param.test.ts
@@ -13,7 +13,8 @@ describe('param instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,expectedResultTypes: [],
+					blockType: BlockType.FUNCTION,
+					expectedResultTypes: [],
 				},
 			],
 			currentFunctionSignature: { parameters: [], returns: [] },
@@ -23,8 +24,7 @@ describe('param instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			param,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'param',
 				arguments: [classifyIdentifier('int'), classifyIdentifier('value')],
 			} as CompilerASTLine,
@@ -42,7 +42,8 @@ describe('param instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,expectedResultTypes: [],
+					blockType: BlockType.FUNCTION,
+					expectedResultTypes: [],
 				},
 			],
 			currentFunctionSignature: { parameters: [], returns: [] },
@@ -52,8 +53,7 @@ describe('param instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			param,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'param',
 				arguments: [classifyIdentifier('float64'), classifyIdentifier('x')],
 			} as CompilerASTLine,
@@ -71,7 +71,8 @@ describe('param instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,expectedResultTypes: [],
+					blockType: BlockType.FUNCTION,
+					expectedResultTypes: [],
 				},
 			],
 			currentFunctionSignature: { parameters: [], returns: [] },
@@ -81,8 +82,7 @@ describe('param instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			param,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'param',
 				arguments: [classifyIdentifier('float*'), classifyIdentifier('buffer')],
 			} as CompilerASTLine,
@@ -102,7 +102,8 @@ describe('param instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,expectedResultTypes: [],
+					blockType: BlockType.FUNCTION,
+					expectedResultTypes: [],
 				},
 			],
 			currentFunctionSignature: { parameters: [], returns: [] },
@@ -112,8 +113,7 @@ describe('param instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			param,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'param',
 				arguments: [classifyIdentifier('int8u*'), classifyIdentifier('bytes')],
 			} as CompilerASTLine,
@@ -133,7 +133,8 @@ describe('param instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,expectedResultTypes: [],
+					blockType: BlockType.FUNCTION,
+					expectedResultTypes: [],
 				},
 			],
 			currentFunctionSignature: { parameters: [], returns: [] },
@@ -144,8 +145,7 @@ describe('param instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				param,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'param',
 					arguments: [classifyIdentifier('int'), classifyIdentifier('late')],
 				} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/push.test.ts
+++ b/packages/compiler/src/instructionCompilers/push.test.ts
@@ -9,8 +9,7 @@ const { classifyIdentifier } = await import('@8f4e/tokenizer');
 
 function resolvedMemoryPushLine(id: string, memoryItem: MemoryMap[string]): CompilerASTLine {
 	return {
-		lineNumberBeforeMacroExpansion: 1,
-		lineNumberAfterMacroExpansion: 1,
+		lineNumber: 1,
 		instruction: 'push',
 		arguments: [classifyIdentifier(id)],
 		resolvedTarget: { kind: 'memory', memoryItem },
@@ -19,8 +18,7 @@ function resolvedMemoryPushLine(id: string, memoryItem: MemoryMap[string]): Comp
 
 function resolvedMemoryPointerPushLine(id: string, memoryItem: MemoryMap[string]): CompilerASTLine {
 	return {
-		lineNumberBeforeMacroExpansion: 1,
-		lineNumberAfterMacroExpansion: 1,
+		lineNumber: 1,
 		instruction: 'push',
 		arguments: [classifyIdentifier(`*${id}`)],
 		resolvedTarget: { kind: 'memory-pointer', memoryItem },
@@ -34,8 +32,7 @@ describe('push instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			push,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'push',
 				arguments: [{ type: ArgumentType.LITERAL, value: 5, isInteger: true }],
 			} as CompilerASTLine,
@@ -54,8 +51,7 @@ describe('push instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			push,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'push',
 				arguments: [{ type: ArgumentType.LITERAL, value: 42, isInteger: true }],
 			} as CompilerASTLine,
@@ -74,8 +70,7 @@ describe('push instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			push,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'push',
 				arguments: [
 					{
@@ -117,8 +112,7 @@ describe('push instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			push,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'push',
 				arguments: [{ type: ArgumentType.STRING_LITERAL, value: 'hi' }],
 			} as CompilerASTLine,
@@ -137,8 +131,7 @@ describe('push instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			push,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'push',
 				arguments: [
 					{
@@ -164,8 +157,7 @@ describe('push instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			push,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'push',
 				arguments: [
 					{
@@ -188,8 +180,7 @@ describe('push instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			push,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'push',
 				arguments: [
 					{
@@ -215,8 +206,7 @@ describe('push instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			push,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'push',
 				arguments: [
 					{
@@ -239,8 +229,7 @@ describe('push instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			push,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'push',
 				arguments: [{ type: ArgumentType.LITERAL, value: 3.14, isInteger: false }],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushLocal.test.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushLocal.test.ts
@@ -18,8 +18,7 @@ describe('pushLocal', () => {
 
 		pushLocal(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'push',
 				arguments: [classifyIdentifier('temp')],
 				resolvedTarget: { kind: 'local', local },

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushLocalPointer.test.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushLocalPointer.test.ts
@@ -18,8 +18,7 @@ describe('pushLocalPointer', () => {
 
 		pushLocalPointer(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'push',
 				arguments: [classifyIdentifier('*lut')],
 				resolvedTarget: { kind: 'local-pointer', local },
@@ -45,8 +44,7 @@ describe('pushLocalPointer', () => {
 
 		pushLocalPointer(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'push',
 				arguments: [classifyIdentifier('*bytes')],
 				resolvedTarget: { kind: 'local-pointer', local },

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushLocalPointer.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushLocalPointer.ts
@@ -10,7 +10,7 @@ export default function pushLocalPointer(line: ResolvedLocalPointerPushLine, con
 	assertFunctionMemoryIoAllowed(line, context);
 	const dereference = buildPointerDereferenceByteCode(
 		context,
-		line.lineNumberAfterMacroExpansion,
+		line.lineNumber,
 		local,
 		localGet(local.index),
 		'pointer-value',

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryIdentifier.test.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryIdentifier.test.ts
@@ -33,8 +33,7 @@ describe('pushMemoryIdentifier', () => {
 
 		pushMemoryIdentifier(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'push',
 				arguments: [classifyIdentifier('value')],
 				resolvedTarget: { kind: 'memory', memoryItem },

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryPointer.test.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryPointer.test.ts
@@ -13,8 +13,7 @@ function createResolvedMemoryPointerPushLine(
 	dereferenceDepth = 1
 ): ResolvedMemoryPointerPushLine {
 	return {
-		lineNumberBeforeMacroExpansion: 1,
-		lineNumberAfterMacroExpansion: 1,
+		lineNumber: 1,
 		instruction: 'push',
 		arguments: [classifyIdentifier(`${'*'.repeat(dereferenceDepth)}${memoryId}`)],
 		resolvedTarget: { kind: 'memory-pointer', memoryItem },

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryPointer.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryPointer.ts
@@ -13,7 +13,7 @@ export default function pushMemoryPointer(
 	assertFunctionMemoryIoAllowed(line, context);
 	const dereference = buildPointerDereferenceByteCode(
 		context,
-		line.lineNumberAfterMacroExpansion,
+		line.lineNumber,
 		memoryItem,
 		i32const(memoryItem.byteAddress),
 		'pointer-slot',

--- a/packages/compiler/src/instructionCompilers/push/shared.ts
+++ b/packages/compiler/src/instructionCompilers/push/shared.ts
@@ -41,7 +41,7 @@ export const loadOpcode: Record<PushValueKind, (memoryIndex: number) => number[]
 
 function buildGuardedPointerLoadChain(
 	context: CodegenContext,
-	lineNumberAfterMacroExpansion: number,
+	lineNumber: number,
 	kind: PushValueKind,
 	steps: PointerLoadStep[]
 ): number[] {
@@ -52,7 +52,7 @@ function buildGuardedPointerLoadChain(
 			guardedAddressOperation(context, {
 				accessByteWidth: step.accessByteWidth,
 				memoryIndex: step.memoryIndex,
-				lineNumberAfterMacroExpansion,
+				lineNumber,
 				resultType,
 				buildTrueBranch: addressLocalIndex => [...localGet(addressLocalIndex), ...step.loadByteCode, ...continuation],
 			}),
@@ -95,7 +95,7 @@ function getFinalDereferenceLoad(
 
 export function buildPointerDereferenceByteCode(
 	context: CodegenContext,
-	lineNumberAfterMacroExpansion: number,
+	lineNumber: number,
 	pointerMetadata: PointerMetadata,
 	baseAddressByteCode: number[],
 	pointerValueSource: PointerValueSource,
@@ -133,9 +133,6 @@ export function buildPointerDereferenceByteCode(
 
 	return {
 		kind,
-		byteCode: [
-			...baseAddressByteCode,
-			...buildGuardedPointerLoadChain(context, lineNumberAfterMacroExpansion, kind, guardedLoadSteps),
-		],
+		byteCode: [...baseAddressByteCode, ...buildGuardedPointerLoadChain(context, lineNumber, kind, guardedLoadSteps)],
 	};
 }

--- a/packages/compiler/src/instructionCompilers/remainder.test.ts
+++ b/packages/compiler/src/instructionCompilers/remainder.test.ts
@@ -15,8 +15,7 @@ describe('remainder instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			remainder,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'remainder',
 				arguments: [],
 			} as CompilerASTLine,
@@ -40,8 +39,7 @@ describe('remainder instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				remainder,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'remainder',
 					arguments: [],
 				} as CompilerASTLine,
@@ -60,8 +58,7 @@ describe('remainder instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			remainder,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'remainder',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/return.test.ts
+++ b/packages/compiler/src/instructionCompilers/return.test.ts
@@ -12,7 +12,8 @@ describe('return instruction compiler', () => {
 			blockStack: [
 				...createInstructionCompilerTestContext().blockStack,
 				{
-					blockType: BlockType.FUNCTION,expectedResultTypes: [],
+					blockType: BlockType.FUNCTION,
+					expectedResultTypes: [],
 				},
 			],
 		});
@@ -21,8 +22,7 @@ describe('return instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			_return,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'return',
 				arguments: [],
 			} as CompilerASTLine,
@@ -39,8 +39,7 @@ describe('return instruction compiler', () => {
 		const context = createInstructionCompilerTestContext();
 		// default context has MODULE block, not FUNCTION
 		const line = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'return',
 			arguments: [],
 		} as CompilerASTLine;

--- a/packages/compiler/src/instructionCompilers/risingEdge.test.ts
+++ b/packages/compiler/src/instructionCompilers/risingEdge.test.ts
@@ -12,8 +12,7 @@ describe('risingEdge instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			risingEdge,
 			{
-				lineNumberBeforeMacroExpansion: 4,
-				lineNumberAfterMacroExpansion: 4,
+				lineNumber: 4,
 				instruction: 'risingEdge',
 				arguments: [],
 			} as CompilerASTLine,
@@ -35,8 +34,7 @@ describe('risingEdge instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			risingEdge,
 			{
-				lineNumberBeforeMacroExpansion: 4,
-				lineNumberAfterMacroExpansion: 4,
+				lineNumber: 4,
 				instruction: 'risingEdge',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/risingEdge.ts
+++ b/packages/compiler/src/instructionCompilers/risingEdge.ts
@@ -20,9 +20,9 @@ import { saveByteCode } from './utils/saveByteCode';
 const risingEdge: InstructionCompiler = (line, context) => {
 	const [operand] = line.stackAnalysis.consumedOperands;
 
-	const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
-	const currentValueName = '__risingEdgeDetector_currentValue' + lineNumberAfterMacroExpansion;
-	const previousValueName = '__risingEdgeDetector_previousValue' + lineNumberAfterMacroExpansion;
+	const lineNumber = line.lineNumber;
+	const currentValueName = '__risingEdgeDetector_currentValue' + lineNumber;
+	const previousValueName = '__risingEdgeDetector_previousValue' + lineNumber;
 	const isInteger = operand.valueType === 'int';
 	const memoryType = isInteger ? 'int' : 'float';
 	const previousValue = allocateInternalResource(context, previousValueName, memoryType);

--- a/packages/compiler/src/instructionCompilers/round.test.ts
+++ b/packages/compiler/src/instructionCompilers/round.test.ts
@@ -12,8 +12,7 @@ describe('round instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			round,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'round',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/shiftLeft.test.ts
+++ b/packages/compiler/src/instructionCompilers/shiftLeft.test.ts
@@ -15,8 +15,7 @@ describe('shiftLeft instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			shiftLeft,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'shiftLeft',
 				arguments: [],
 			} as CompilerASTLine,
@@ -39,8 +38,7 @@ describe('shiftLeft instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			shiftLeft,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'shiftLeft',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/shiftRight.test.ts
+++ b/packages/compiler/src/instructionCompilers/shiftRight.test.ts
@@ -15,8 +15,7 @@ describe('shiftRight instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			shiftRight,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'shiftRight',
 				arguments: [],
 			} as CompilerASTLine,
@@ -39,8 +38,7 @@ describe('shiftRight instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			shiftRight,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'shiftRight',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/shiftRightUnsigned.test.ts
+++ b/packages/compiler/src/instructionCompilers/shiftRightUnsigned.test.ts
@@ -15,8 +15,7 @@ describe('shiftRightUnsigned instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			shiftRightUnsigned,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'shiftRightUnsigned',
 				arguments: [],
 			} as CompilerASTLine,
@@ -39,8 +38,7 @@ describe('shiftRightUnsigned instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			shiftRightUnsigned,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'shiftRightUnsigned',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/skipExecution.test.ts
+++ b/packages/compiler/src/instructionCompilers/skipExecution.test.ts
@@ -10,7 +10,8 @@ describe('skipExecution instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,expectedResultTypes: [],
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
 				},
 			],
 		});
@@ -18,8 +19,7 @@ describe('skipExecution instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			skipExecution,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: '#skipExecution',
 				arguments: [],
 				isBlockPrologue: true,
@@ -39,8 +39,7 @@ describe('skipExecution instruction compiler', () => {
 			analyzeAndCompileInstruction(
 				skipExecution,
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: '#skipExecution',
 					arguments: [],
 				} as CompilerASTLine,
@@ -53,7 +52,8 @@ describe('skipExecution instruction compiler', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MODULE,expectedResultTypes: [],
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
 				},
 			],
 		});
@@ -61,8 +61,7 @@ describe('skipExecution instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			skipExecution,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: '#skipExecution',
 				arguments: [],
 				isBlockPrologue: true,
@@ -75,8 +74,7 @@ describe('skipExecution instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			skipExecution,
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: '#skipExecution',
 				arguments: [],
 				isBlockPrologue: true,

--- a/packages/compiler/src/instructionCompilers/sqrt.test.ts
+++ b/packages/compiler/src/instructionCompilers/sqrt.test.ts
@@ -13,8 +13,7 @@ describe('sqrt instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			sqrt,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'sqrt',
 				arguments: [],
 			} as CompilerASTLine,
@@ -34,8 +33,7 @@ describe('sqrt instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			sqrt,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'sqrt',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/store.test.ts
+++ b/packages/compiler/src/instructionCompilers/store.test.ts
@@ -30,8 +30,7 @@ describe('store instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			store,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'store',
 				arguments: [],
 			} as CompilerASTLine,
@@ -54,8 +53,7 @@ describe('store instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			store,
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: 'store',
 				arguments: [],
 			} as CompilerASTLine,
@@ -92,8 +90,7 @@ describe('store instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			store,
 			{
-				lineNumberBeforeMacroExpansion: 3,
-				lineNumberAfterMacroExpansion: 3,
+				lineNumber: 3,
 				instruction: 'store',
 				arguments: [],
 			} as CompilerASTLine,
@@ -130,8 +127,7 @@ describe('store instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			store,
 			{
-				lineNumberBeforeMacroExpansion: 4,
-				lineNumberAfterMacroExpansion: 4,
+				lineNumber: 4,
 				instruction: 'store',
 				arguments: [],
 			} as CompilerASTLine,
@@ -152,8 +148,7 @@ describe('store instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			store,
 			{
-				lineNumberBeforeMacroExpansion: 5,
-				lineNumberAfterMacroExpansion: 5,
+				lineNumber: 5,
 				instruction: 'store',
 				arguments: [],
 			} as CompilerASTLine,
@@ -183,8 +178,7 @@ describe('store instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			store,
 			{
-				lineNumberBeforeMacroExpansion: 6,
-				lineNumberAfterMacroExpansion: 6,
+				lineNumber: 6,
 				instruction: 'store',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/store.ts
+++ b/packages/compiler/src/instructionCompilers/store.ts
@@ -40,7 +40,7 @@ const store: InstructionCompiler<StoreLine> = (line, context) => {
 			value: operand1Value,
 			accessByteWidth,
 			memoryIndex,
-			lineNumberAfterMacroExpansion: line.lineNumberAfterMacroExpansion,
+			lineNumber: line.lineNumber,
 			storeByteCode: instructions,
 		})
 	);

--- a/packages/compiler/src/instructionCompilers/storeBytes.test.ts
+++ b/packages/compiler/src/instructionCompilers/storeBytes.test.ts
@@ -16,8 +16,7 @@ describe('storeBytes instruction compiler', () => {
 			{ kind: 'value', valueType: 'int', isNonZero: false }
 		);
 		const line = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'storeBytes',
 			arguments: [{ type: ArgumentType.LITERAL, value: 3, isInteger: true }],
 		} as CompilerASTLine;
@@ -54,8 +53,7 @@ describe('storeBytes instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			storeBytes,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'storeBytes',
 				arguments: [{ type: ArgumentType.LITERAL, value: 3, isInteger: true }],
 			} as CompilerASTLine,
@@ -91,8 +89,7 @@ describe('storeBytes instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			storeBytes,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'storeBytes',
 				arguments: [{ type: ArgumentType.LITERAL, value: 2, isInteger: true }],
 			} as CompilerASTLine,
@@ -127,8 +124,7 @@ describe('storeBytes instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			storeBytes,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'storeBytes',
 				arguments: [{ type: ArgumentType.LITERAL, value: 2, isInteger: true }],
 			} as CompilerASTLine,
@@ -160,8 +156,7 @@ describe('storeBytes instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			storeBytes,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'storeBytes',
 				arguments: [{ type: ArgumentType.LITERAL, value: 0, isInteger: true }],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/storeBytes.ts
+++ b/packages/compiler/src/instructionCompilers/storeBytes.ts
@@ -16,7 +16,7 @@ const storeBytes: InstructionCompiler<StoreBytesLine> = (line, context) => {
 	const operation = getInstructionSpec(line.instruction).effects.memory;
 	const accessByteWidth = operation.accessByteWidth;
 
-	const lineNumberAfterMacroExpansion = line.lineNumberAfterMacroExpansion;
+	const lineNumber = line.lineNumber;
 	const address = requireStackAddress(
 		line.stackAnalysis.consumedOperands[line.stackAnalysis.consumedOperands.length - 1],
 		line,
@@ -25,10 +25,10 @@ const storeBytes: InstructionCompiler<StoreBytesLine> = (line, context) => {
 	const addressIsSafe = isSafeMemoryAccess(address, count);
 	const memoryIndex = address.address.memoryIndex;
 
-	const tempAddrLocal = getOrCreateMemoryGuardLocal(context, `__storeBytesAddr_${lineNumberAfterMacroExpansion}`, {
+	const tempAddrLocal = getOrCreateMemoryGuardLocal(context, `__storeBytesAddr_${lineNumber}`, {
 		valueType: 'int',
 	});
-	const tempByteLocal = getOrCreateMemoryGuardLocal(context, `__storeBytesByte_${lineNumberAfterMacroExpansion}`, {
+	const tempByteLocal = getOrCreateMemoryGuardLocal(context, `__storeBytesByte_${lineNumber}`, {
 		valueType: 'int',
 	});
 

--- a/packages/compiler/src/instructionCompilers/sub.test.ts
+++ b/packages/compiler/src/instructionCompilers/sub.test.ts
@@ -15,8 +15,7 @@ describe('sub instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			sub,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'sub',
 				arguments: [],
 			} as CompilerASTLine,
@@ -39,8 +38,7 @@ describe('sub instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			sub,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'sub',
 				arguments: [],
 			} as CompilerASTLine,
@@ -63,8 +61,7 @@ describe('sub instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			sub,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'sub',
 				arguments: [],
 			} as CompilerASTLine,
@@ -95,8 +92,7 @@ describe('sub instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			sub,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'sub',
 				arguments: [],
 			} as CompilerASTLine,
@@ -136,8 +132,7 @@ describe('sub instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			sub,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'sub',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/instructionCompilers/utils/addressClamp.ts
+++ b/packages/compiler/src/instructionCompilers/utils/addressClamp.ts
@@ -12,7 +12,7 @@ export function clampAddressByteCode(
 	lowerByteAddress: number,
 	upperByteAddressCode: number[]
 ): number[] {
-	const addressLocal = getOrCreateMemoryGuardLocal(context, `__clampAddress_${line.lineNumberAfterMacroExpansion}`, {
+	const addressLocal = getOrCreateMemoryGuardLocal(context, `__clampAddress_${line.lineNumber}`, {
 		valueType: 'int',
 	});
 

--- a/packages/compiler/src/instructionCompilers/utils/memoryAccessGuard.ts
+++ b/packages/compiler/src/instructionCompilers/utils/memoryAccessGuard.ts
@@ -25,7 +25,7 @@ type NumericWasmValueType = typeof WASM_TYPE_I32 | typeof WASM_TYPE_F32 | typeof
 type GuardedLoadOptions = {
 	accessByteWidth: number;
 	memoryIndex: number;
-	lineNumberAfterMacroExpansion: number;
+	lineNumber: number;
 	resultType: NumericWasmValueType;
 	loadByteCode: number[];
 };
@@ -33,7 +33,7 @@ type GuardedLoadOptions = {
 type GuardedAddressOperationOptions = {
 	accessByteWidth: number;
 	memoryIndex: number;
-	lineNumberAfterMacroExpansion: number;
+	lineNumber: number;
 	resultType: NumericWasmValueType;
 	buildTrueBranch: (addressLocalIndex: number) => number[];
 	falseByteCode?: number[];
@@ -43,7 +43,7 @@ type GuardedStoreOptions = {
 	value: StackItem;
 	accessByteWidth: number;
 	memoryIndex: number;
-	lineNumberAfterMacroExpansion: number;
+	lineNumber: number;
 	storeByteCode: number[];
 };
 
@@ -51,7 +51,7 @@ type GuardedMemoryCopyOptions = {
 	byteLength: number;
 	destinationMemoryIndex: number;
 	sourceMemoryIndex: number;
-	lineNumberAfterMacroExpansion: number;
+	lineNumber: number;
 	memoryCopyByteCode: number[];
 };
 
@@ -142,13 +142,9 @@ export function guardedAddressOperation(
 	context: MemoryGuardContext,
 	options: GuardedAddressOperationOptions
 ): number[] {
-	const addressLocal = getOrCreateMemoryGuardLocal(
-		context,
-		`__memoryGuardAddr_${options.lineNumberAfterMacroExpansion}`,
-		{
-			valueType: 'int',
-		}
-	);
+	const addressLocal = getOrCreateMemoryGuardLocal(context, `__memoryGuardAddr_${options.lineNumber}`, {
+		valueType: 'int',
+	});
 
 	return [
 		...localSet(addressLocal.index),
@@ -162,18 +158,10 @@ export function guardedAddressOperation(
 }
 
 export function guardedStore(context: MemoryGuardContext, options: GuardedStoreOptions): number[] {
-	const addressLocal = getOrCreateMemoryGuardLocal(
-		context,
-		`__memoryGuardAddr_${options.lineNumberAfterMacroExpansion}`,
-		{
-			valueType: 'int',
-		}
-	);
-	const valueLocal = getOrCreateMemoryGuardLocal(
-		context,
-		`__memoryGuardValue_${options.lineNumberAfterMacroExpansion}`,
-		options.value
-	);
+	const addressLocal = getOrCreateMemoryGuardLocal(context, `__memoryGuardAddr_${options.lineNumber}`, {
+		valueType: 'int',
+	});
+	const valueLocal = getOrCreateMemoryGuardLocal(context, `__memoryGuardValue_${options.lineNumber}`, options.value);
 
 	return [
 		...localSet(valueLocal.index),
@@ -192,20 +180,12 @@ export function isSafeMemoryCopy(destination: StackItem, source: StackItem, byte
 }
 
 export function guardedMemoryCopy(context: MemoryGuardContext, options: GuardedMemoryCopyOptions): number[] {
-	const destinationLocal = getOrCreateMemoryGuardLocal(
-		context,
-		`__memoryCopyDestination_${options.lineNumberAfterMacroExpansion}`,
-		{
-			valueType: 'int',
-		}
-	);
-	const sourceLocal = getOrCreateMemoryGuardLocal(
-		context,
-		`__memoryCopySource_${options.lineNumberAfterMacroExpansion}`,
-		{
-			valueType: 'int',
-		}
-	);
+	const destinationLocal = getOrCreateMemoryGuardLocal(context, `__memoryCopyDestination_${options.lineNumber}`, {
+		valueType: 'int',
+	});
+	const sourceLocal = getOrCreateMemoryGuardLocal(context, `__memoryCopySource_${options.lineNumber}`, {
+		valueType: 'int',
+	});
 
 	return [
 		...localSet(sourceLocal.index),

--- a/packages/compiler/src/instructionCompilers/xor.test.ts
+++ b/packages/compiler/src/instructionCompilers/xor.test.ts
@@ -15,8 +15,7 @@ describe('xor instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			xor,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'xor',
 				arguments: [],
 			} as CompilerASTLine,
@@ -39,8 +38,7 @@ describe('xor instruction compiler', () => {
 		analyzeAndCompileInstruction(
 			xor,
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'xor',
 				arguments: [],
 			} as CompilerASTLine,

--- a/packages/compiler/src/semantic/declarations/array.test.ts
+++ b/packages/compiler/src/semantic/declarations/array.test.ts
@@ -13,8 +13,7 @@ describe('array declaration compiler', () => {
 
 		array(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int[]',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('values'), { type: ArgumentType.LITERAL, value: 3, isInteger: true }],
@@ -30,8 +29,7 @@ describe('array declaration compiler', () => {
 
 		array(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int[]',
 				hasExplicitMemoryDefault: true,
 				arguments: [
@@ -58,8 +56,7 @@ describe('array declaration compiler', () => {
 
 		array(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int[]',
 				hasExplicitMemoryDefault: false,
 				arguments: [
@@ -83,8 +80,7 @@ describe('array declaration compiler', () => {
 		try {
 			array(
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'int[]',
 					hasExplicitMemoryDefault: false,
 					arguments: [
@@ -109,8 +105,7 @@ describe('array declaration compiler', () => {
 
 		array(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int8[]',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('bytes'), { type: ArgumentType.LITERAL, value: 3, isInteger: true }],
@@ -131,8 +126,7 @@ describe('array declaration compiler', () => {
 
 		array(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int8[]',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('bytes'), { type: ArgumentType.LITERAL, value: 5, isInteger: true }],
@@ -153,8 +147,7 @@ describe('array declaration compiler', () => {
 
 		array(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int16[]',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('shorts'), { type: ArgumentType.LITERAL, value: 3, isInteger: true }],
@@ -175,8 +168,7 @@ describe('array declaration compiler', () => {
 
 		array(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int16[]',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('shorts'), { type: ArgumentType.LITERAL, value: 5, isInteger: true }],
@@ -197,8 +189,7 @@ describe('array declaration compiler', () => {
 
 		array(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int32[]',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('ints'), { type: ArgumentType.LITERAL, value: 3, isInteger: true }],
@@ -219,8 +210,7 @@ describe('array declaration compiler', () => {
 
 		array(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int8u[]',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('unsignedBytes'), { type: ArgumentType.LITERAL, value: 5, isInteger: true }],
@@ -240,8 +230,7 @@ describe('array declaration compiler', () => {
 
 		array(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int16u[]',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('unsignedShorts'), { type: ArgumentType.LITERAL, value: 3, isInteger: true }],
@@ -261,8 +250,7 @@ describe('array declaration compiler', () => {
 
 		array(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int8[]',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('signedBytes'), { type: ArgumentType.LITERAL, value: 5, isInteger: true }],
@@ -279,8 +267,7 @@ describe('array declaration compiler', () => {
 
 		array(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'float64[]',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('doubles'), { type: ArgumentType.LITERAL, value: 3, isInteger: true }],
@@ -302,8 +289,7 @@ describe('array declaration compiler', () => {
 		// Three int32 variables to force an odd word offset
 		array(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int[]',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('ints'), { type: ArgumentType.LITERAL, value: 3, isInteger: true }],
@@ -313,8 +299,7 @@ describe('array declaration compiler', () => {
 
 		array(
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: 'float64[]',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('doubles'), { type: ArgumentType.LITERAL, value: 2, isInteger: true }],

--- a/packages/compiler/src/semantic/declarations/float.test.ts
+++ b/packages/compiler/src/semantic/declarations/float.test.ts
@@ -12,8 +12,7 @@ describe('float instruction compiler', () => {
 
 		float(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'float',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('temperature')],

--- a/packages/compiler/src/semantic/declarations/float64.test.ts
+++ b/packages/compiler/src/semantic/declarations/float64.test.ts
@@ -12,8 +12,7 @@ describe('float64 instruction compiler', () => {
 
 		float64(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'float64',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('value')],
@@ -29,8 +28,7 @@ describe('float64 instruction compiler', () => {
 
 		float64(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'float64',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('value')],
@@ -46,8 +44,7 @@ describe('float64 instruction compiler', () => {
 
 		float64(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'float64',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('value')],
@@ -64,8 +61,7 @@ describe('float64 instruction compiler', () => {
 		// First float64 (starts at word 0, even)
 		float64(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'float64',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('a')],
@@ -76,8 +72,7 @@ describe('float64 instruction compiler', () => {
 		// Three int32 variables (odd count) push the offset to an odd word boundary
 		int(
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: 'int',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('x')],
@@ -86,8 +81,7 @@ describe('float64 instruction compiler', () => {
 		);
 		int(
 			{
-				lineNumberBeforeMacroExpansion: 3,
-				lineNumberAfterMacroExpansion: 3,
+				lineNumber: 3,
 				instruction: 'int',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('y')],
@@ -96,8 +90,7 @@ describe('float64 instruction compiler', () => {
 		);
 		int(
 			{
-				lineNumberBeforeMacroExpansion: 4,
-				lineNumberAfterMacroExpansion: 4,
+				lineNumber: 4,
 				instruction: 'int',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('z')],
@@ -108,8 +101,7 @@ describe('float64 instruction compiler', () => {
 		// Second float64 must still be 8-byte aligned despite odd preceding offset
 		float64(
 			{
-				lineNumberBeforeMacroExpansion: 5,
-				lineNumberAfterMacroExpansion: 5,
+				lineNumber: 5,
 				instruction: 'float64',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('b')],
@@ -127,8 +119,7 @@ describe('float64 instruction compiler', () => {
 
 		float64(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'float64*',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('ptr')],
@@ -148,8 +139,7 @@ describe('float64 instruction compiler', () => {
 
 		float64(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'float64**',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('pptr')],

--- a/packages/compiler/src/semantic/declarations/int.test.ts
+++ b/packages/compiler/src/semantic/declarations/int.test.ts
@@ -12,8 +12,7 @@ describe('int instruction compiler', () => {
 
 		int(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('counter')],

--- a/packages/compiler/src/semantic/declarations/int16.test.ts
+++ b/packages/compiler/src/semantic/declarations/int16.test.ts
@@ -12,8 +12,7 @@ describe('int16 instruction compiler', () => {
 
 		int16(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int16*',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('ptr')],
@@ -34,8 +33,7 @@ describe('int16 instruction compiler', () => {
 
 		int16(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int16**',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('pptr')],
@@ -56,8 +54,7 @@ describe('int16 instruction compiler', () => {
 
 		int16(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int16*',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('p')],

--- a/packages/compiler/src/semantic/declarations/int16u.test.ts
+++ b/packages/compiler/src/semantic/declarations/int16u.test.ts
@@ -12,8 +12,7 @@ describe('int16u instruction compiler', () => {
 
 		int16u(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int16u*',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('ptr')],
@@ -34,8 +33,7 @@ describe('int16u instruction compiler', () => {
 
 		int16u(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int16u**',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('pptr')],

--- a/packages/compiler/src/semantic/declarations/int8.test.ts
+++ b/packages/compiler/src/semantic/declarations/int8.test.ts
@@ -12,8 +12,7 @@ describe('int8 instruction compiler', () => {
 
 		int8(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int8*',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('ptr')],
@@ -34,8 +33,7 @@ describe('int8 instruction compiler', () => {
 
 		int8(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int8**',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('pptr')],
@@ -56,8 +54,7 @@ describe('int8 instruction compiler', () => {
 
 		int8(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int8*',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('p')],

--- a/packages/compiler/src/semantic/declarations/int8u.test.ts
+++ b/packages/compiler/src/semantic/declarations/int8u.test.ts
@@ -12,8 +12,7 @@ describe('int8u instruction compiler', () => {
 
 		int8u(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int8u*',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('ptr')],
@@ -34,8 +33,7 @@ describe('int8u instruction compiler', () => {
 
 		int8u(
 			{
-				lineNumberBeforeMacroExpansion: 1,
-				lineNumberAfterMacroExpansion: 1,
+				lineNumber: 1,
 				instruction: 'int8u**',
 				hasExplicitMemoryDefault: false,
 				arguments: [classifyIdentifier('pptr')],

--- a/packages/compiler/src/semantic/memoryRegions.ts
+++ b/packages/compiler/src/semantic/memoryRegions.ts
@@ -12,8 +12,7 @@ export interface ResolvedMemoryRegion {
 
 function fallbackLine(): CompilerASTLine {
 	return {
-		lineNumberBeforeMacroExpansion: 0,
-		lineNumberAfterMacroExpansion: 0,
+		lineNumber: 0,
 		instruction: 'block',
 		arguments: [],
 	};

--- a/packages/compiler/src/semantic/normalization/call.ts
+++ b/packages/compiler/src/semantic/normalization/call.ts
@@ -13,8 +13,7 @@ import normalizePush from './push';
 
 function createInlinePushLine(line: CallLine, argument: PushArgument): PushLine {
 	return {
-		lineNumberBeforeMacroExpansion: line.lineNumberBeforeMacroExpansion,
-		lineNumberAfterMacroExpansion: line.lineNumberAfterMacroExpansion,
+		lineNumber: line.lineNumber,
 		instruction: 'push',
 		arguments: [argument],
 	};

--- a/packages/compiler/src/semantic/normalizeCompileTimeArguments.test.ts
+++ b/packages/compiler/src/semantic/normalizeCompileTimeArguments.test.ts
@@ -7,8 +7,7 @@ import normalizeCompileTimeArguments from './normalizeCompileTimeArguments';
 describe('normalizeCompileTimeArguments', () => {
 	it('folds compile-time push expressions into literals', () => {
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [parseArgument('2*SIZE')],
 		};
@@ -30,8 +29,7 @@ describe('normalizeCompileTimeArguments', () => {
 
 	it('leaves identifier-definition positions unchanged when not resolvable', () => {
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'int',
 			arguments: [classifyIdentifier('output')],
 		};
@@ -50,8 +48,7 @@ describe('normalizeCompileTimeArguments', () => {
 
 	it('folds compile-time map arguments into literals', () => {
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'map',
 			arguments: [parseArgument('SIZE/2'), parseArgument('2*SIZE')],
 		};
@@ -76,8 +73,7 @@ describe('normalizeCompileTimeArguments', () => {
 
 	it('throws when a targeted compile-time expression cannot be resolved', () => {
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [parseArgument('2*MISSING')],
 		};
@@ -96,8 +92,7 @@ describe('normalizeCompileTimeArguments', () => {
 
 	it('throws UNDECLARED_IDENTIFIER when a map key argument is an unresolved identifier', () => {
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'map',
 			arguments: [classifyIdentifier('MISSING_CONST'), { type: ArgumentType.LITERAL, value: 100, isInteger: true }],
 		};
@@ -116,8 +111,7 @@ describe('normalizeCompileTimeArguments', () => {
 
 	it('throws UNDECLARED_IDENTIFIER when a map value argument is an unresolved identifier', () => {
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'map',
 			arguments: [{ type: ArgumentType.LITERAL, value: 1, isInteger: true }, classifyIdentifier('UNRESOLVED')],
 		};
@@ -136,8 +130,7 @@ describe('normalizeCompileTimeArguments', () => {
 
 	it('throws UNDECLARED_IDENTIFIER when a default argument is an unresolved identifier', () => {
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'default',
 			arguments: [classifyIdentifier('MISSING_CONST')],
 		};
@@ -156,8 +149,7 @@ describe('normalizeCompileTimeArguments', () => {
 
 	it('throws UNDECLARED_IDENTIFIER when a const value remains an unresolved compile-time expression', () => {
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'const',
 			arguments: [classifyIdentifier('SIZE'), parseArgument('2*MISSING')],
 		};
@@ -177,8 +169,7 @@ describe('normalizeCompileTimeArguments', () => {
 	it('resolves push identifier arguments when the identifier is a known local', () => {
 		const local = { kind: 'value', valueType: 'int', index: 0 };
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [classifyIdentifier('localVar')],
 		};
@@ -206,8 +197,7 @@ describe('normalizeCompileTimeArguments', () => {
 			currentModuleWordAlignedSize: 3,
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [classifyIdentifier('unknownVar')],
 		};
@@ -223,8 +213,7 @@ describe('normalizeCompileTimeArguments', () => {
 			currentModuleWordAlignedSize: 3,
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [classifyIdentifier('&this')],
 		};
@@ -259,8 +248,7 @@ describe('normalizeCompileTimeArguments', () => {
 			currentModuleWordAlignedSize: 3,
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [classifyIdentifier('this&')],
 		};
@@ -293,8 +281,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'localSet',
 			arguments: [classifyIdentifier('missing')],
 		};
@@ -313,8 +300,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [classifyIdentifier('&otherModule:missingMemory')],
 		};
@@ -333,8 +319,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'int',
 			arguments: [classifyIdentifier('buffer'), classifyIdentifier('&source:missingBuffer')],
 			hasExplicitMemoryDefault: true,
@@ -365,8 +350,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'int',
 			arguments: [classifyIdentifier('ptr'), classifyIdentifier('&source:buffer')],
 			hasExplicitMemoryDefault: true,
@@ -397,8 +381,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'int[]',
 			arguments: [classifyIdentifier('buffer'), classifyIdentifier('&source:buffer')],
 			hasExplicitMemoryDefault: false,
@@ -413,8 +396,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'int',
 			arguments: [classifyIdentifier('buffer'), parseArgument('2*MISSING')],
 			hasExplicitMemoryDefault: true,
@@ -446,8 +428,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [classifyIdentifier('&source:buffer')],
 		};
@@ -461,8 +442,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [classifyIdentifier('&otherModule:buffer')],
 		};
@@ -496,8 +476,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [classifyIdentifier('&buffer')],
 		};
@@ -550,8 +529,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [classifyIdentifier('buffer&')],
 		};
@@ -584,8 +562,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [classifyIdentifier('&missing')],
 		};
@@ -601,8 +578,7 @@ describe('normalizeCompileTimeArguments', () => {
 			},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [classifyIdentifier('sizeof(*lut)')],
 		};
@@ -621,8 +597,7 @@ describe('normalizeCompileTimeArguments', () => {
 			},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [classifyIdentifier('count(*lut)')],
 		};
@@ -636,8 +611,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'call',
 			arguments: [classifyIdentifier('missingFn')],
 		};
@@ -651,8 +625,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'call',
 			arguments: [classifyIdentifier('anyFn')],
 		};
@@ -675,8 +648,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'call',
 			arguments: [classifyIdentifier('knownFn')],
 		};
@@ -702,8 +674,7 @@ describe('normalizeCompileTimeArguments', () => {
 			locals: {},
 		} as unknown as CompilationContext;
 		const line: CompilerASTLine = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'call',
 			arguments: [classifyIdentifier('knownFn'), classifyIdentifier('SIZE')],
 		};
@@ -714,8 +685,7 @@ describe('normalizeCompileTimeArguments', () => {
 			targetFunction,
 			inlineArgumentPushes: [
 				{
-					lineNumberBeforeMacroExpansion: 1,
-					lineNumberAfterMacroExpansion: 1,
+					lineNumber: 1,
 					instruction: 'push',
 					arguments: [{ type: ArgumentType.LITERAL, value: 8, isInteger: true }],
 				},

--- a/packages/compiler/src/stackAnalysis/analyzeInstruction.test.ts
+++ b/packages/compiler/src/stackAnalysis/analyzeInstruction.test.ts
@@ -14,8 +14,7 @@ describe('analyzeInstruction', () => {
 		);
 
 		const line = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'add',
 			arguments: [],
 		} as CompilerASTLine;
@@ -40,8 +39,7 @@ describe('analyzeInstruction', () => {
 	it('owns stack errors before codegen runs', () => {
 		const context = createInstructionCompilerTestContext();
 		const line = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'add',
 			arguments: [],
 		} as CompilerASTLine;
@@ -52,8 +50,7 @@ describe('analyzeInstruction', () => {
 	it('records push-produced stack metadata', () => {
 		const context = createInstructionCompilerTestContext();
 		const line = {
-			lineNumberBeforeMacroExpansion: 1,
-			lineNumberAfterMacroExpansion: 1,
+			lineNumber: 1,
 			instruction: 'push',
 			arguments: [{ type: ArgumentType.LITERAL, value: 7, isInteger: true }],
 		} as CompilerASTLine;

--- a/packages/compiler/src/stackAnalysis/validateInstruction.test.ts
+++ b/packages/compiler/src/stackAnalysis/validateInstruction.test.ts
@@ -6,15 +6,13 @@ import createInstructionCompilerTestContext from '../utils/testUtils';
 import { validateInstruction } from './validateInstruction';
 
 const pushLine: CompilerASTLine = {
-	lineNumberBeforeMacroExpansion: 1,
-	lineNumberAfterMacroExpansion: 1,
+	lineNumber: 1,
 	instruction: 'push',
 	arguments: [{ type: ArgumentType.LITERAL, value: 1, isInteger: true }],
 };
 
 const mapLine: CompilerASTLine = {
-	lineNumberBeforeMacroExpansion: 1,
-	lineNumberAfterMacroExpansion: 1,
+	lineNumber: 1,
 	instruction: 'map',
 	arguments: [
 		{ type: ArgumentType.LITERAL, value: 1, isInteger: true },
@@ -45,7 +43,8 @@ describe('validateInstruction', () => {
 		const context = createInstructionCompilerTestContext({
 			blockStack: [
 				{
-					blockType: BlockType.MAP,expectedResultTypes: [],
+					blockType: BlockType.MAP,
+					expectedResultTypes: [],
 					mapState: {
 						inputIsInteger: true,
 						inputIsFloat64: false,

--- a/packages/compiler/src/stackAnalysis/validateOperandTypes.test.ts
+++ b/packages/compiler/src/stackAnalysis/validateOperandTypes.test.ts
@@ -4,8 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { validateOperandTypes } from './validateOperandTypes';
 
 const line: Parameters<InstructionCompiler>[0] = {
-	lineNumberBeforeMacroExpansion: 1,
-	lineNumberAfterMacroExpansion: 1,
+	lineNumber: 1,
 	instruction: 'test' as never,
 	arguments: [],
 };

--- a/packages/compiler/src/stackAnalysis/validateScope.test.ts
+++ b/packages/compiler/src/stackAnalysis/validateScope.test.ts
@@ -4,8 +4,7 @@ import createInstructionCompilerTestContext from '../utils/testUtils';
 import { validateScope } from './validateScope';
 
 const line: Parameters<InstructionCompiler>[0] = {
-	lineNumberBeforeMacroExpansion: 1,
-	lineNumberAfterMacroExpansion: 1,
+	lineNumber: 1,
 	instruction: 'test' as never,
 	arguments: [],
 };

--- a/packages/compiler/src/utils/macroExpansion.public.test.ts
+++ b/packages/compiler/src/utils/macroExpansion.public.test.ts
@@ -1,6 +1,6 @@
 import type { Module } from '@8f4e/compiler-spec';
 import { describe, expect, test } from 'vitest';
-import { convertExpandedLinesToCode, expandMacros, parseMacroDefinitions } from './macroExpansion';
+import { expandMacros, parseMacroDefinitions } from './macroExpansion';
 
 describe('parseMacroDefinitions', () => {
 	test('should parse a simple macro definition', () => {
@@ -158,20 +158,20 @@ describe('expandMacros', () => {
 
 		expect(expanded.length).toBe(8);
 		// Line 0: module test
-		expect(expanded[0]).toEqual({ line: 'module test', callSiteLineNumber: 0 });
+		expect(expanded[0]).toBe('module test');
 		// Line 1: int result 0
-		expect(expanded[1]).toEqual({ line: 'int result 0', callSiteLineNumber: 1 });
+		expect(expanded[1]).toBe('int result 0');
 		// Line 2: cycle
-		expect(expanded[2]).toEqual({ line: 'cycle', callSiteLineNumber: 2 });
+		expect(expanded[2]).toBe('cycle');
 		// Line 3: push 5
-		expect(expanded[3]).toEqual({ line: 'push 5', callSiteLineNumber: 3 });
+		expect(expanded[3]).toBe('push 5');
 		// Line 4: macro add10 expands to two lines, both map to line 4
-		expect(expanded[4]).toEqual({ line: 'push 10', callSiteLineNumber: 4, macroId: 'add10' });
-		expect(expanded[5]).toEqual({ line: 'add', callSiteLineNumber: 4, macroId: 'add10' });
+		expect(expanded[4]).toBe('push 10');
+		expect(expanded[5]).toBe('add');
 		// Line 5: store result
-		expect(expanded[6]).toEqual({ line: 'store result', callSiteLineNumber: 5 });
+		expect(expanded[6]).toBe('store result');
 		// Line 6: cycleEnd
-		expect(expanded[7]).toEqual({ line: 'cycleEnd', callSiteLineNumber: 6 });
+		expect(expanded[7]).toBe('cycleEnd');
 	});
 
 	test('should expand multiple macro calls', () => {
@@ -192,15 +192,15 @@ describe('expandMacros', () => {
 
 		expect(expanded.length).toBe(6);
 		// Line 0: module test
-		expect(expanded[0]).toEqual({ line: 'module test', callSiteLineNumber: 0 });
+		expect(expanded[0]).toBe('module test');
 		// Line 1: push 5
-		expect(expanded[1]).toEqual({ line: 'push 5', callSiteLineNumber: 1 });
+		expect(expanded[1]).toBe('push 5');
 		// Line 2: first macro double
-		expect(expanded[2]).toEqual({ line: 'push 2', callSiteLineNumber: 2, macroId: 'double' });
-		expect(expanded[3]).toEqual({ line: 'mul', callSiteLineNumber: 2, macroId: 'double' });
+		expect(expanded[2]).toBe('push 2');
+		expect(expanded[3]).toBe('mul');
 		// Line 3: second macro double
-		expect(expanded[4]).toEqual({ line: 'push 2', callSiteLineNumber: 3, macroId: 'double' });
-		expect(expanded[5]).toEqual({ line: 'mul', callSiteLineNumber: 3, macroId: 'double' });
+		expect(expanded[4]).toBe('push 2');
+		expect(expanded[5]).toBe('mul');
 	});
 
 	test('should throw error on undefined macro', () => {
@@ -234,32 +234,10 @@ describe('expandMacros', () => {
 		const expanded = expandMacros(modules[0], macroMap);
 
 		expect(expanded.length).toBe(5);
-		expect(expanded[0]).toEqual({ line: 'module test', callSiteLineNumber: 0 });
-		expect(expanded[1]).toEqual({ line: '; This is a comment', callSiteLineNumber: 1 });
-		expect(expanded[2]).toEqual({ line: 'push 10', callSiteLineNumber: 2, macroId: 'add10' });
-		expect(expanded[3]).toEqual({ line: 'add', callSiteLineNumber: 2, macroId: 'add10' });
-		expect(expanded[4]).toEqual({ line: '', callSiteLineNumber: 3 });
-	});
-});
-
-describe('convertExpandedLinesToCode', () => {
-	test('should convert expanded lines to code and metadata', () => {
-		const expandedLines = [
-			{ line: 'module test', callSiteLineNumber: 0 },
-			{ line: 'push 10', callSiteLineNumber: 1, macroId: 'add10' },
-			{ line: 'add', callSiteLineNumber: 1, macroId: 'add10' },
-			{ line: 'store result', callSiteLineNumber: 2 },
-		];
-
-		const result = convertExpandedLinesToCode(expandedLines);
-
-		expect(result.code).toEqual(['module test', 'push 10', 'add', 'store result']);
-
-		expect(result.lineMetadata).toEqual([
-			{ callSiteLineNumber: 0 },
-			{ callSiteLineNumber: 1, macroId: 'add10' },
-			{ callSiteLineNumber: 1, macroId: 'add10' },
-			{ callSiteLineNumber: 2 },
-		]);
+		expect(expanded[0]).toBe('module test');
+		expect(expanded[1]).toBe('; This is a comment');
+		expect(expanded[2]).toBe('push 10');
+		expect(expanded[3]).toBe('add');
+		expect(expanded[4]).toBe('');
 	});
 });

--- a/packages/compiler/src/utils/macroExpansion.test.ts
+++ b/packages/compiler/src/utils/macroExpansion.test.ts
@@ -1,6 +1,6 @@
 import type { Module } from '@8f4e/compiler-spec';
 import { describe, expect, test } from 'vitest';
-import { convertExpandedLinesToCode, expandMacros, parseMacroDefinitions } from './macroExpansion';
+import { expandMacros, parseMacroDefinitions } from './macroExpansion';
 
 describe('parseMacroDefinitions', () => {
 	test('should parse a simple macro definition', () => {
@@ -156,36 +156,16 @@ describe('expandMacros', () => {
 		const macroMap = parseMacroDefinitions(macros);
 		const expanded = expandMacros(modules[0], macroMap);
 
-		expect(expanded.length).toBe(8);
-		// Line 0: module test
-		expect(expanded[0]).toEqual({ line: 'module test', callSiteLineNumber: 0 });
-		// Line 1: int result 0
-		expect(expanded[1]).toEqual({
-			line: 'int result 0',
-			callSiteLineNumber: 1,
-		});
-		// Line 2: cycle
-		expect(expanded[2]).toEqual({ line: 'cycle', callSiteLineNumber: 2 });
-		// Line 3: push 5
-		expect(expanded[3]).toEqual({ line: 'push 5', callSiteLineNumber: 3 });
-		// Line 4: macro add10 expands to two lines, both map to line 4
-		expect(expanded[4]).toEqual({
-			line: 'push 10',
-			callSiteLineNumber: 4,
-			macroId: 'add10',
-		});
-		expect(expanded[5]).toEqual({
-			line: 'add',
-			callSiteLineNumber: 4,
-			macroId: 'add10',
-		});
-		// Line 5: store result
-		expect(expanded[6]).toEqual({
-			line: 'store result',
-			callSiteLineNumber: 5,
-		});
-		// Line 6: cycleEnd
-		expect(expanded[7]).toEqual({ line: 'cycleEnd', callSiteLineNumber: 6 });
+		expect(expanded).toEqual([
+			'module test',
+			'int result 0',
+			'cycle',
+			'push 5',
+			'push 10',
+			'add',
+			'store result',
+			'cycleEnd',
+		]);
 	});
 
 	test('should expand multiple macro calls', () => {
@@ -204,33 +184,7 @@ describe('expandMacros', () => {
 		const macroMap = parseMacroDefinitions(macros);
 		const expanded = expandMacros(modules[0], macroMap);
 
-		expect(expanded.length).toBe(6);
-		// Line 0: module test
-		expect(expanded[0]).toEqual({ line: 'module test', callSiteLineNumber: 0 });
-		// Line 1: push 5
-		expect(expanded[1]).toEqual({ line: 'push 5', callSiteLineNumber: 1 });
-		// Line 2: first macro double
-		expect(expanded[2]).toEqual({
-			line: 'push 2',
-			callSiteLineNumber: 2,
-			macroId: 'double',
-		});
-		expect(expanded[3]).toEqual({
-			line: 'mul',
-			callSiteLineNumber: 2,
-			macroId: 'double',
-		});
-		// Line 3: second macro double
-		expect(expanded[4]).toEqual({
-			line: 'push 2',
-			callSiteLineNumber: 3,
-			macroId: 'double',
-		});
-		expect(expanded[5]).toEqual({
-			line: 'mul',
-			callSiteLineNumber: 3,
-			macroId: 'double',
-		});
+		expect(expanded).toEqual(['module test', 'push 5', 'push 2', 'mul', 'push 2', 'mul']);
 	});
 
 	test('should throw error on undefined macro', () => {
@@ -263,44 +217,6 @@ describe('expandMacros', () => {
 		const macroMap = parseMacroDefinitions(macros);
 		const expanded = expandMacros(modules[0], macroMap);
 
-		expect(expanded.length).toBe(5);
-		expect(expanded[0]).toEqual({ line: 'module test', callSiteLineNumber: 0 });
-		expect(expanded[1]).toEqual({
-			line: '; This is a comment',
-			callSiteLineNumber: 1,
-		});
-		expect(expanded[2]).toEqual({
-			line: 'push 10',
-			callSiteLineNumber: 2,
-			macroId: 'add10',
-		});
-		expect(expanded[3]).toEqual({
-			line: 'add',
-			callSiteLineNumber: 2,
-			macroId: 'add10',
-		});
-		expect(expanded[4]).toEqual({ line: '', callSiteLineNumber: 3 });
-	});
-});
-
-describe('convertExpandedLinesToCode', () => {
-	test('should convert expanded lines to code and metadata', () => {
-		const expandedLines = [
-			{ line: 'module test', callSiteLineNumber: 0 },
-			{ line: 'push 10', callSiteLineNumber: 1, macroId: 'add10' },
-			{ line: 'add', callSiteLineNumber: 1, macroId: 'add10' },
-			{ line: 'store result', callSiteLineNumber: 2 },
-		];
-
-		const result = convertExpandedLinesToCode(expandedLines);
-
-		expect(result.code).toEqual(['module test', 'push 10', 'add', 'store result']);
-
-		expect(result.lineMetadata).toEqual([
-			{ callSiteLineNumber: 0 },
-			{ callSiteLineNumber: 1, macroId: 'add10' },
-			{ callSiteLineNumber: 1, macroId: 'add10' },
-			{ callSiteLineNumber: 2 },
-		]);
+		expect(expanded).toEqual(['module test', '; This is a comment', 'push 10', 'add', '']);
 	});
 });

--- a/packages/compiler/src/utils/macroExpansion.ts
+++ b/packages/compiler/src/utils/macroExpansion.ts
@@ -1,4 +1,4 @@
-import type { CompilerASTLine, ExpandedLine, MacroDefinition, Module } from '@8f4e/compiler-spec';
+import type { CompilerASTLine, MacroDefinition, Module } from '@8f4e/compiler-spec';
 import { documentBlockInstructionByType, ErrorCode } from '@8f4e/compiler-spec';
 import { instructionParser, isComment, isValidInstruction } from '@8f4e/tokenizer';
 import { getError } from '../compilerError';
@@ -9,8 +9,7 @@ const macroCallInstruction = documentBlockInstructionByType.macro.type;
 
 function createMacroErrorLine(lineIndex: number): CompilerASTLine {
 	return {
-		lineNumberBeforeMacroExpansion: lineIndex,
-		lineNumberAfterMacroExpansion: lineIndex,
+		lineNumber: lineIndex,
 		instruction: 'block',
 		arguments: [],
 	};
@@ -113,34 +112,27 @@ export function parseMacroDefinitions(macros: Module[]): Map<string, MacroDefini
 
 /**
  * Expand macros in a single source module.
- * Each `macro <name>` instruction is replaced with the macro body,
- * preserving the call-site line number for error mapping.
+ * Each `macro <name>` instruction is replaced with the macro body.
  *
  * @param module Source module to expand
  * @param macroDefinitions Map of macro definitions
- * @returns Array of expanded lines with metadata
+ * @returns Array of expanded source lines
  * @throws Error if an undefined macro is referenced
  */
-export function expandMacros(module: Module, macroDefinitions: Map<string, MacroDefinition>): ExpandedLine[] {
-	const expandedLines: ExpandedLine[] = [];
+export function expandMacros(module: Module, macroDefinitions: Map<string, MacroDefinition>): string[] {
+	const expandedLines: string[] = [];
 	const { code } = module;
 
 	code.forEach((line, lineIndex) => {
 		// For comments and empty lines, preserve as-is
 		if (isComment(line) || !isValidInstruction(line)) {
-			expandedLines.push({
-				line,
-				callSiteLineNumber: lineIndex,
-			});
+			expandedLines.push(line);
 			return;
 		}
 
 		const match = line.match(instructionParser);
 		if (!match) {
-			expandedLines.push({
-				line,
-				callSiteLineNumber: lineIndex,
-			});
+			expandedLines.push(line);
 			return;
 		}
 
@@ -157,42 +149,14 @@ export function expandMacros(module: Module, macroDefinitions: Map<string, Macro
 				throw getError(ErrorCode.UNDEFINED_MACRO, createMacroErrorLine(lineIndex));
 			}
 
-			// Expand macro body, all lines map back to the call site
 			macroDef.body.forEach(macroLine => {
-				expandedLines.push({
-					line: macroLine,
-					callSiteLineNumber: lineIndex,
-					macroId: macroName,
-				});
+				expandedLines.push(macroLine);
 			});
 		} else {
 			// Regular instruction, not a macro call
-			expandedLines.push({
-				line,
-				callSiteLineNumber: lineIndex,
-			});
+			expandedLines.push(line);
 		}
 	});
 
 	return expandedLines;
-}
-
-/**
- * Convert expanded lines back to plain string array and metadata.
- * This is used to integrate with the existing compiler flow.
- *
- * @param expandedLines Array of expanded lines
- * @returns Object containing code array and mapping metadata
- */
-export function convertExpandedLinesToCode(expandedLines: ExpandedLine[]): {
-	code: string[];
-	lineMetadata: Array<{ callSiteLineNumber: number; macroId?: string }>;
-} {
-	return {
-		code: expandedLines.map(el => el.line),
-		lineMetadata: expandedLines.map(el => ({
-			callSiteLineNumber: el.callSiteLineNumber,
-			macroId: el.macroId,
-		})),
-	};
 }

--- a/packages/compiler/src/utils/mapValueKind.test.ts
+++ b/packages/compiler/src/utils/mapValueKind.test.ts
@@ -5,8 +5,7 @@ import { resolveMapKind, validateMapValueKind } from './mapValueKind';
 
 describe('map value kind helpers', () => {
 	const line = {
-		lineNumberBeforeMacroExpansion: 1,
-		lineNumberAfterMacroExpansion: 1,
+		lineNumber: 1,
 		instruction: 'map',
 		arguments: [],
 	} as CompilerASTLine;

--- a/packages/compiler/src/utils/memoryInstructionParser.public.test.ts
+++ b/packages/compiler/src/utils/memoryInstructionParser.public.test.ts
@@ -22,8 +22,7 @@ describe('parseMemoryInstructionArguments', () => {
 		instruction: CompilerASTLine['instruction'],
 		args: CompilerASTLine['arguments']
 	) => ({
-		lineNumberBeforeMacroExpansion: lineNumber,
-		lineNumberAfterMacroExpansion: lineNumber,
+		lineNumber: lineNumber,
 		instruction,
 		arguments: args,
 	});

--- a/packages/compiler/src/utils/memoryInstructionParser.test.ts
+++ b/packages/compiler/src/utils/memoryInstructionParser.test.ts
@@ -28,8 +28,7 @@ describe('parseMemoryInstructionArguments', () => {
 		const args: Argument[] = [{ type: ArgumentType.LITERAL, value: 123, isInteger: true }];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 10,
-				lineNumberAfterMacroExpansion: 10,
+				lineNumber: 10,
 				instruction: 'int',
 				arguments: args,
 			},
@@ -42,8 +41,7 @@ describe('parseMemoryInstructionArguments', () => {
 	it('parses zero arguments as anonymous zero-initialized memory', () => {
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 9,
-				lineNumberAfterMacroExpansion: 9,
+				lineNumber: 9,
 				instruction: 'int',
 				arguments: [],
 			},
@@ -59,8 +57,7 @@ describe('parseMemoryInstructionArguments', () => {
 		const args: Argument[] = [{ type: ArgumentType.STRING_LITERAL, value: 'e' }];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 11,
-				lineNumberAfterMacroExpansion: 11,
+				lineNumber: 11,
 				instruction: 'int',
 				arguments: args,
 			},
@@ -74,8 +71,7 @@ describe('parseMemoryInstructionArguments', () => {
 		const args: Argument[] = [{ type: ArgumentType.STRING_LITERAL, value: 'AB' }];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 12,
-				lineNumberAfterMacroExpansion: 12,
+				lineNumber: 12,
 				instruction: 'int',
 				arguments: args,
 			},
@@ -89,8 +85,7 @@ describe('parseMemoryInstructionArguments', () => {
 		const args: Argument[] = [classifyIdentifier('myId')];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 20,
-				lineNumberAfterMacroExpansion: 20,
+				lineNumber: 20,
 				instruction: 'int',
 				arguments: args,
 			},
@@ -105,8 +100,7 @@ describe('parseMemoryInstructionArguments', () => {
 		expect(() =>
 			parseMemoryInstructionArguments(
 				{
-					lineNumberBeforeMacroExpansion: 30,
-					lineNumberAfterMacroExpansion: 30,
+					lineNumber: 30,
 					instruction: 'int',
 					arguments: args,
 				},
@@ -120,8 +114,7 @@ describe('parseMemoryInstructionArguments', () => {
 		expect(() =>
 			parseMemoryInstructionArguments(
 				{
-					lineNumberBeforeMacroExpansion: 31,
-					lineNumberAfterMacroExpansion: 31,
+					lineNumber: 31,
 					instruction: 'int',
 					arguments: args,
 				},
@@ -134,8 +127,7 @@ describe('parseMemoryInstructionArguments', () => {
 		const args: Argument[] = [classifyIdentifier('myVar'), { type: ArgumentType.LITERAL, value: 99, isInteger: true }];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 40,
-				lineNumberAfterMacroExpansion: 40,
+				lineNumber: 40,
 				instruction: 'int',
 				arguments: args,
 			},
@@ -149,8 +141,7 @@ describe('parseMemoryInstructionArguments', () => {
 		const args: Argument[] = [classifyIdentifier('myVar'), { type: ArgumentType.STRING_LITERAL, value: 'e' }];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 41,
-				lineNumberAfterMacroExpansion: 41,
+				lineNumber: 41,
 				instruction: 'int',
 				arguments: args,
 			},
@@ -164,8 +155,7 @@ describe('parseMemoryInstructionArguments', () => {
 		const args: Argument[] = [classifyIdentifier('myVar'), { type: ArgumentType.STRING_LITERAL, value: 'AB' }];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 42,
-				lineNumberAfterMacroExpansion: 42,
+				lineNumber: 42,
 				instruction: 'int',
 				arguments: args,
 			},
@@ -180,8 +170,7 @@ describe('parseMemoryInstructionArguments', () => {
 		expect(() =>
 			parseMemoryInstructionArguments(
 				{
-					lineNumberBeforeMacroExpansion: 50,
-					lineNumberAfterMacroExpansion: 50,
+					lineNumber: 50,
 					instruction: 'int',
 					arguments: args,
 				},
@@ -198,8 +187,7 @@ describe('parseMemoryInstructionArguments', () => {
 		expect(() =>
 			parseMemoryInstructionArguments(
 				{
-					lineNumberBeforeMacroExpansion: 55,
-					lineNumberAfterMacroExpansion: 55,
+					lineNumber: 55,
 					instruction: 'int',
 					arguments: args,
 				},
@@ -213,8 +201,7 @@ describe('parseMemoryInstructionArguments', () => {
 		expect(() =>
 			parseMemoryInstructionArguments(
 				{
-					lineNumberBeforeMacroExpansion: 56,
-					lineNumberAfterMacroExpansion: 56,
+					lineNumber: 56,
 					instruction: 'int',
 					arguments: args,
 				},
@@ -231,8 +218,7 @@ describe('parseMemoryInstructionArguments', () => {
 		];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 60,
-				lineNumberAfterMacroExpansion: 60,
+				lineNumber: 60,
 				instruction: 'int',
 				arguments: args,
 			},
@@ -252,8 +238,7 @@ describe('parseMemoryInstructionArguments', () => {
 		];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 70,
-				lineNumberAfterMacroExpansion: 70,
+				lineNumber: 70,
 				instruction: 'int',
 				arguments: args,
 			},
@@ -270,8 +255,7 @@ describe('parseMemoryInstructionArguments', () => {
 		];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 80,
-				lineNumberAfterMacroExpansion: 80,
+				lineNumber: 80,
 				instruction: 'int',
 				arguments: args,
 			},
@@ -293,8 +277,7 @@ describe('parseMemoryInstructionArguments', () => {
 		expect(() =>
 			parseMemoryInstructionArguments(
 				{
-					lineNumberBeforeMacroExpansion: 90,
-					lineNumberAfterMacroExpansion: 90,
+					lineNumber: 90,
 					instruction: 'int',
 					arguments: args,
 				},
@@ -307,8 +290,7 @@ describe('parseMemoryInstructionArguments', () => {
 		const args: Argument[] = [classifyIdentifier('myVar'), classifyIdentifier('HI'), classifyIdentifier('LO')];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 100,
-				lineNumberAfterMacroExpansion: 100,
+				lineNumber: 100,
 				instruction: 'int',
 				arguments: args,
 			},
@@ -323,8 +305,7 @@ describe('parseMemoryInstructionArguments', () => {
 		const args: Argument[] = [classifyIdentifier('HI'), classifyIdentifier('LO')];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 110,
-				lineNumberAfterMacroExpansion: 110,
+				lineNumber: 110,
 				instruction: 'int',
 				arguments: args,
 			},
@@ -342,8 +323,7 @@ describe('parseMemoryInstructionArguments', () => {
 		];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 120,
-				lineNumberAfterMacroExpansion: 120,
+				lineNumber: 120,
 				instruction: 'int',
 				arguments: args,
 			},
@@ -359,8 +339,7 @@ describe('parseMemoryInstructionArguments', () => {
 		expect(() =>
 			parseMemoryInstructionArguments(
 				{
-					lineNumberBeforeMacroExpansion: 130,
-					lineNumberAfterMacroExpansion: 130,
+					lineNumber: 130,
 					instruction: 'int',
 					arguments: args,
 				},
@@ -374,8 +353,7 @@ describe('parseMemoryInstructionArguments', () => {
 		expect(() =>
 			parseMemoryInstructionArguments(
 				{
-					lineNumberBeforeMacroExpansion: 140,
-					lineNumberAfterMacroExpansion: 140,
+					lineNumber: 140,
 					instruction: 'int',
 					arguments: args,
 				},
@@ -389,8 +367,7 @@ describe('parseMemoryInstructionArguments', () => {
 		expect(() =>
 			parseMemoryInstructionArguments(
 				{
-					lineNumberBeforeMacroExpansion: 150,
-					lineNumberAfterMacroExpansion: 150,
+					lineNumber: 150,
 					instruction: 'int',
 					arguments: args,
 				},
@@ -403,8 +380,7 @@ describe('parseMemoryInstructionArguments', () => {
 		const args: Argument[] = [classifyIdentifier('ptr'), classifyIdentifier('&myVar')];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 160,
-				lineNumberAfterMacroExpansion: 160,
+				lineNumber: 160,
 				instruction: 'int*',
 				arguments: args,
 			},
@@ -425,8 +401,7 @@ describe('parseMemoryInstructionArguments', () => {
 		expect(
 			parseMemoryInstructionArguments(
 				{
-					lineNumberBeforeMacroExpansion: 161,
-					lineNumberAfterMacroExpansion: 161,
+					lineNumber: 161,
 					instruction: 'int*',
 					arguments: [classifyIdentifier('ptr'), classifyIdentifier('&this')],
 				},
@@ -436,8 +411,7 @@ describe('parseMemoryInstructionArguments', () => {
 		expect(
 			parseMemoryInstructionArguments(
 				{
-					lineNumberBeforeMacroExpansion: 162,
-					lineNumberAfterMacroExpansion: 162,
+					lineNumber: 162,
 					instruction: 'int*',
 					arguments: [classifyIdentifier('ptr'), classifyIdentifier('this&')],
 				},
@@ -455,8 +429,7 @@ describe('parseMemoryInstructionArguments', () => {
 
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 163,
-				lineNumberAfterMacroExpansion: 163,
+				lineNumber: 163,
 				instruction: 'int*',
 				arguments: [classifyIdentifier('ptr'), classifyIdentifier('this&')],
 			},
@@ -470,8 +443,7 @@ describe('parseMemoryInstructionArguments', () => {
 		const args: Argument[] = [classifyIdentifier('ptr'), classifyIdentifier('myVar&')];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 165,
-				lineNumberAfterMacroExpansion: 165,
+				lineNumber: 165,
 				instruction: 'int*',
 				arguments: args,
 			},
@@ -486,8 +458,7 @@ describe('parseMemoryInstructionArguments', () => {
 		const args: Argument[] = [classifyIdentifier('n'), classifyIdentifier('count(myVar)')];
 		const result = parseMemoryInstructionArguments(
 			{
-				lineNumberBeforeMacroExpansion: 170,
-				lineNumberAfterMacroExpansion: 170,
+				lineNumber: 170,
 				instruction: 'int',
 				arguments: args,
 			},
@@ -503,8 +474,7 @@ describe('parseMemoryInstructionArguments', () => {
 		expect(() =>
 			parseMemoryInstructionArguments(
 				{
-					lineNumberBeforeMacroExpansion: 175,
-					lineNumberAfterMacroExpansion: 175,
+					lineNumber: 175,
 					instruction: 'int*',
 					arguments: args,
 				},
@@ -518,8 +488,7 @@ describe('parseMemoryInstructionArguments', () => {
 		expect(() =>
 			parseMemoryInstructionArguments(
 				{
-					lineNumberBeforeMacroExpansion: 180,
-					lineNumberAfterMacroExpansion: 180,
+					lineNumber: 180,
 					instruction: 'int',
 					arguments: args,
 				},

--- a/packages/compiler/src/utils/memoryInstructionParser.ts
+++ b/packages/compiler/src/utils/memoryInstructionParser.ts
@@ -102,14 +102,14 @@ function resolveSplitByteTokens(
  */
 function resolveIdFromShape(
 	firstArg: MemoryArgumentShape,
-	lineNumberAfterMacroExpansion: number,
+	lineNumber: number,
 	lineForError: CompilerASTLine,
 	context: CompilationContext
 ): string {
 	switch (firstArg.type) {
 		case 'literal':
 		case 'split-byte-tokens':
-			return '__anonymous__' + lineNumberAfterMacroExpansion;
+			return '__anonymous__' + lineNumber;
 		case 'constant-identifier':
 			// Bare constant-style names cannot be memory allocation names.
 			throw getError(ErrorCode.CONSTANT_NAME_AS_MEMORY_IDENTIFIER, lineForError, context);
@@ -181,13 +181,13 @@ export default function parseMemoryInstructionArguments(
 	line: CompilerASTLine,
 	context: CompilationContext
 ): { id: string; defaultValue: number; defaultAddress?: AddressMetadata } {
-	const { arguments: args, lineNumberAfterMacroExpansion } = line;
+	const { arguments: args, lineNumber } = line;
 	const lineForError = line;
 
 	// Zero-argument scalar declaration: bare anonymous zero-initialized allocation (e.g. `int`, `float`).
 	if (args.length === 0) {
 		return {
-			id: '__anonymous__' + lineNumberAfterMacroExpansion,
+			id: '__anonymous__' + lineNumber,
 			defaultValue: 0,
 		};
 	}
@@ -206,7 +206,7 @@ export default function parseMemoryInstructionArguments(
 		throw error;
 	}
 
-	const id = resolveIdFromShape(shape.firstArg, lineNumberAfterMacroExpansion, lineForError, context);
+	const id = resolveIdFromShape(shape.firstArg, lineNumber, lineForError, context);
 
 	// Anonymous split-byte sequence (e.g. `int 0xA8 0xFF` or `int HI LO`):
 	if (shape.firstArg.type === 'split-byte-tokens') {

--- a/packages/compiler/tests/errors/__snapshots__/directives/export-after-instruction.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/directives/export-after-instruction.error.8f4e.diagnostic.snap
@@ -3,8 +3,7 @@
   "context": {},
   "line": {
     "instruction": "#export",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Compiler directives must appear in the block prologue, immediately after module or function.",
 }

--- a/packages/compiler/tests/errors/__snapshots__/directives/impure-after-param.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/directives/impure-after-param.error.8f4e.diagnostic.snap
@@ -3,8 +3,7 @@
   "context": {},
   "line": {
     "instruction": "#impure",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Compiler directives must appear in the block prologue, immediately after module or function.",
 }

--- a/packages/compiler/tests/errors/__snapshots__/directives/skip-execution-after-declaration.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/directives/skip-execution-after-declaration.error.8f4e.diagnostic.snap
@@ -3,8 +3,7 @@
   "context": {},
   "line": {
     "instruction": "#skipExecution",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Compiler directives must appear in the block prologue, immediately after module or function.",
 }

--- a/packages/compiler/tests/errors/__snapshots__/directives/skip-execution-in-constants.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/directives/skip-execution-in-constants.error.8f4e.diagnostic.snap
@@ -4,8 +4,7 @@
   "line": {
     "arguments": [],
     "instruction": "#skipExecution",
-    "lineNumberAfterMacroExpansion": 1,
-    "lineNumberBeforeMacroExpansion": 1,
+    "lineNumber": 1,
   },
   "message": "This instruction is not allowed inside this block type. (34)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/directives/skip-execution-in-function.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/directives/skip-execution-in-function.error.8f4e.diagnostic.snap
@@ -7,8 +7,7 @@
   "line": {
     "arguments": [],
     "instruction": "#skipExecution",
-    "lineNumberAfterMacroExpansion": 1,
-    "lineNumberBeforeMacroExpansion": 1,
+    "lineNumber": 1,
   },
   "message": "This compiler directive can only be used within a module block. (31)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/execution-entries/function-entry-name-collision.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/execution-entries/function-entry-name-collision.error.8f4e.diagnostic.snap
@@ -11,8 +11,7 @@
       },
     ],
     "instruction": "function",
-    "lineNumberAfterMacroExpansion": 0,
-    "lineNumberBeforeMacroExpansion": 0,
+    "lineNumber": 0,
   },
   "message": "Duplicate identifier: main. Module and function IDs must be unique. (45)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/array-declaration-in-function.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/array-declaration-in-function.error.8f4e.diagnostic.snap
@@ -19,8 +19,7 @@
       },
     ],
     "instruction": "int[]",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Memory declarations are not allowed in functions. (20)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/call-insufficient-arguments.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/call-insufficient-arguments.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "call",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "Insufficient number of elements in the stack for the operation to proceed. (0)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/call-wrong-argument-types.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/call-wrong-argument-types.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "call",
-    "lineNumberAfterMacroExpansion": 4,
-    "lineNumberBeforeMacroExpansion": 4,
+    "lineNumber": 4,
   },
   "message": "Type mismatch. (19)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/count-pointer-param.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/count-pointer-param.error.8f4e.diagnostic.snap
@@ -16,8 +16,7 @@
       },
     ],
     "instruction": "push",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Pointee element count is unknown: count(*grid). Pass the length explicitly or use count() on a named memory declaration. (58)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/duplicate-export-directive.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/duplicate-export-directive.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "#export",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Duplicate function export name: second. Exported function names must be unique and must not reuse built-in export names. (52)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/duplicate-export-name.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/duplicate-export-name.error.8f4e.diagnostic.snap
@@ -11,8 +11,7 @@
       },
     ],
     "instruction": "#export",
-    "lineNumberAfterMacroExpansion": 1,
-    "lineNumberBeforeMacroExpansion": 1,
+    "lineNumber": 1,
   },
   "message": "Duplicate function export name: same. Exported function names must be unique and must not reuse built-in export names. (52)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/duplicate-function.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/duplicate-function.error.8f4e.diagnostic.snap
@@ -11,8 +11,7 @@
       },
     ],
     "instruction": "function",
-    "lineNumberAfterMacroExpansion": 0,
-    "lineNumberBeforeMacroExpansion": 0,
+    "lineNumber": 0,
   },
   "message": "Duplicate identifier: same. Module and function IDs must be unique. (45)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/duplicate-import-directive.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/duplicate-import-directive.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "#import",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Duplicate function import directive. Imported functions can only declare one #import. (60)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/export-built-in-name.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/export-built-in-name.error.8f4e.diagnostic.snap
@@ -11,8 +11,7 @@
       },
     ],
     "instruction": "#export",
-    "lineNumberAfterMacroExpansion": 1,
-    "lineNumberBeforeMacroExpansion": 1,
+    "lineNumber": 1,
   },
   "message": "Duplicate function export name: initDefaults. Exported function names must be unique and must not reuse built-in export names. (52)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/export-outside-function.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/export-outside-function.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "#export",
-    "lineNumberAfterMacroExpansion": 1,
-    "lineNumberBeforeMacroExpansion": 1,
+    "lineNumber": 1,
   },
   "message": "#export can only be used within a function block. (51)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/function-end-stack-mismatch.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/function-end-stack-mismatch.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "functionEnd",
-    "lineNumberAfterMacroExpansion": 4,
-    "lineNumberBeforeMacroExpansion": 4,
+    "lineNumber": 4,
   },
   "message": "Stack elements do not match function return signature. (18)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/function-end-type-mismatch.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/function-end-type-mismatch.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "functionEnd",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "Stack elements do not match function return signature. (18)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/import-export-conflict.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/import-export-conflict.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "#export",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Imported functions cannot also be exported. (61)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/import-outside-function.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/import-outside-function.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "#import",
-    "lineNumberAfterMacroExpansion": 1,
-    "lineNumberBeforeMacroExpansion": 1,
+    "lineNumber": 1,
   },
   "message": "#import can only be used within a function block. (59)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/imported-function-body.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/imported-function-body.error.8f4e.diagnostic.snap
@@ -13,8 +13,7 @@
       },
     ],
     "instruction": "push",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Imported functions cannot have a function body. Only function directives, param declarations, and functionEnd are allowed. (62)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/invalid-return-type.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/invalid-return-type.error.8f4e.diagnostic.snap
@@ -3,8 +3,7 @@
   "context": {},
   "line": {
     "instruction": "functionEnd",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "Invalid argument for functionEnd: expected function type identifier.",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/load-in-pure-function.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/load-in-pure-function.error.8f4e.diagnostic.snap
@@ -7,8 +7,7 @@
   "line": {
     "arguments": [],
     "instruction": "load",
-    "lineNumberAfterMacroExpansion": 4,
-    "lineNumberBeforeMacroExpansion": 4,
+    "lineNumber": 4,
   },
   "message": "Memory IO in functions requires #impure. (21)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/memory-declaration-in-function.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/memory-declaration-in-function.error.8f4e.diagnostic.snap
@@ -19,8 +19,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Memory declarations are not allowed in functions. (20)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/pointer-dereference-in-pure-function.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/pointer-dereference-in-pure-function.error.8f4e.diagnostic.snap
@@ -16,8 +16,7 @@
       },
     ],
     "instruction": "push",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "Memory IO in functions requires #impure. (21)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/store-in-pure-function.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/store-in-pure-function.error.8f4e.diagnostic.snap
@@ -7,8 +7,7 @@
   "line": {
     "arguments": [],
     "instruction": "store",
-    "lineNumberAfterMacroExpansion": 6,
-    "lineNumberBeforeMacroExpansion": 6,
+    "lineNumber": 6,
   },
   "message": "Memory IO in functions requires #impure. (21)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/too-many-params.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/too-many-params.error.8f4e.diagnostic.snap
@@ -20,8 +20,7 @@
       },
     ],
     "instruction": "param",
-    "lineNumberAfterMacroExpansion": 10,
-    "lineNumberBeforeMacroExpansion": 10,
+    "lineNumber": 10,
   },
   "message": "Function signature overflow. Maximum 8 parameters and 8 return values. (17)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/too-many-returns.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/too-many-returns.error.8f4e.diagnostic.snap
@@ -62,8 +62,7 @@
       },
     ],
     "instruction": "functionEnd",
-    "lineNumberAfterMacroExpansion": 11,
-    "lineNumberBeforeMacroExpansion": 11,
+    "lineNumber": 11,
   },
   "message": "Function signature overflow. Maximum 8 parameters and 8 return values. (17)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/functions/undefined-call.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/functions/undefined-call.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "call",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "Undefined function. (22)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/const/lowercase-name.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/const/lowercase-name.error.8f4e.diagnostic.snap
@@ -3,8 +3,7 @@
   "context": {},
   "line": {
     "instruction": "const",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Invalid argument for const: expected constant identifier.",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/const/starts-with-number.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/const/starts-with-number.error.8f4e.diagnostic.snap
@@ -3,8 +3,7 @@
   "context": {},
   "line": {
     "instruction": "const",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Identifiers cannot start with numbers: 123ABC",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/const/starts-with-underscore.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/const/starts-with-underscore.error.8f4e.diagnostic.snap
@@ -3,8 +3,7 @@
   "context": {},
   "line": {
     "instruction": "const",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Invalid argument for const: expected constant identifier.",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/constants/const-before-use-import.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/constants/const-before-use-import.error.8f4e.diagnostic.snap
@@ -20,8 +20,7 @@
       },
     ],
     "instruction": "const",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: FOO. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/constants/constants-block-inside-function.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/constants/constants-block-inside-function.error.8f4e.diagnostic.snap
@@ -2,8 +2,7 @@
   "code": -1,
   "context": {},
   "line": {
-    "lineNumberAfterMacroExpansion": 0,
-    "lineNumberBeforeMacroExpansion": 0,
+    "lineNumber": 0,
   },
   "message": "Parse error at line 10: mixed block type markers (found opener "constants nested" inside "function" block)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/constants/constants-block-inside-module.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/constants/constants-block-inside-module.error.8f4e.diagnostic.snap
@@ -2,8 +2,7 @@
   "code": -1,
   "context": {},
   "line": {
-    "lineNumberAfterMacroExpansion": 0,
-    "lineNumberBeforeMacroExpansion": 0,
+    "lineNumber": 0,
   },
   "message": "Parse error at line 6: mixed block type markers (found opener "constants nested" inside "module" block)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/constants/constants-block-missing-name.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/constants/constants-block-missing-name.error.8f4e.diagnostic.snap
@@ -3,8 +3,7 @@
   "context": {},
   "line": {
     "instruction": "constants",
-    "lineNumberAfterMacroExpansion": 0,
-    "lineNumberBeforeMacroExpansion": 0,
+    "lineNumber": 0,
   },
   "message": "Missing required argument for constants.",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/constants/constants-end-without-block.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/constants/constants-end-without-block.error.8f4e.diagnostic.snap
@@ -2,8 +2,7 @@
   "code": -1,
   "context": {},
   "line": {
-    "lineNumberAfterMacroExpansion": 0,
-    "lineNumberBeforeMacroExpansion": 0,
+    "lineNumber": 0,
   },
   "message": "Parse error at line 6: closer "constantsEnd" does not match opener "module"",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/constants/forward-const-reference.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/constants/forward-const-reference.error.8f4e.diagnostic.snap
@@ -20,8 +20,7 @@
       },
     ],
     "instruction": "const",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: A. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/constants/module-const-not-visible-without-use.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/constants/module-const-not-visible-without-use.error.8f4e.diagnostic.snap
@@ -20,8 +20,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: SECRET. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/constants/non-const-inside-constants-block.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/constants/non-const-inside-constants-block.error.8f4e.diagnostic.snap
@@ -16,8 +16,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "This instruction is not allowed inside this block type. (34)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/constants/undeclared-const-value.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/constants/undeclared-const-value.error.8f4e.diagnostic.snap
@@ -20,8 +20,7 @@
       },
     ],
     "instruction": "const",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: UNDEFINED_CONST. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/constants/undeclared-expression-operand.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/constants/undeclared-expression-operand.error.8f4e.diagnostic.snap
@@ -30,8 +30,7 @@
       },
     ],
     "instruction": "const",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: UNDEFINED_CONST/2. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/constants/use-undeclared-namespace.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/constants/use-undeclared-namespace.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "use",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: missingNamespace. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/float64-comparison/equal-mixed-width.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/float64-comparison/equal-mixed-width.error.8f4e.diagnostic.snap
@@ -7,8 +7,7 @@
   "line": {
     "arguments": [],
     "instruction": "equal",
-    "lineNumberAfterMacroExpansion": 9,
-    "lineNumberBeforeMacroExpansion": 9,
+    "lineNumber": 9,
   },
   "message": "Mixed float widths: arithmetic operations require all float operands to have the same width (float32 or float64). (33)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/float64-comparison/greater-or-equal-mixed-width.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/float64-comparison/greater-or-equal-mixed-width.error.8f4e.diagnostic.snap
@@ -7,8 +7,7 @@
   "line": {
     "arguments": [],
     "instruction": "greaterOrEqual",
-    "lineNumberAfterMacroExpansion": 9,
-    "lineNumberBeforeMacroExpansion": 9,
+    "lineNumber": 9,
   },
   "message": "Mixed float widths: arithmetic operations require all float operands to have the same width (float32 or float64). (33)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/float64-comparison/greater-or-equal-unsigned-mixed-width.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/float64-comparison/greater-or-equal-unsigned-mixed-width.error.8f4e.diagnostic.snap
@@ -7,8 +7,7 @@
   "line": {
     "arguments": [],
     "instruction": "greaterOrEqualUnsigned",
-    "lineNumberAfterMacroExpansion": 9,
-    "lineNumberBeforeMacroExpansion": 9,
+    "lineNumber": 9,
   },
   "message": "Mixed float widths: arithmetic operations require all float operands to have the same width (float32 or float64). (33)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/float64-comparison/greater-than-mixed-width.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/float64-comparison/greater-than-mixed-width.error.8f4e.diagnostic.snap
@@ -7,8 +7,7 @@
   "line": {
     "arguments": [],
     "instruction": "greaterThan",
-    "lineNumberAfterMacroExpansion": 9,
-    "lineNumberBeforeMacroExpansion": 9,
+    "lineNumber": 9,
   },
   "message": "Mixed float widths: arithmetic operations require all float operands to have the same width (float32 or float64). (33)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/float64-comparison/less-or-equal-mixed-width.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/float64-comparison/less-or-equal-mixed-width.error.8f4e.diagnostic.snap
@@ -7,8 +7,7 @@
   "line": {
     "arguments": [],
     "instruction": "lessOrEqual",
-    "lineNumberAfterMacroExpansion": 9,
-    "lineNumberBeforeMacroExpansion": 9,
+    "lineNumber": 9,
   },
   "message": "Mixed float widths: arithmetic operations require all float operands to have the same width (float32 or float64). (33)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/float64-comparison/less-than-mixed-width.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/float64-comparison/less-than-mixed-width.error.8f4e.diagnostic.snap
@@ -7,8 +7,7 @@
   "line": {
     "arguments": [],
     "instruction": "lessThan",
-    "lineNumberAfterMacroExpansion": 9,
-    "lineNumberBeforeMacroExpansion": 9,
+    "lineNumber": 9,
   },
   "message": "Mixed float widths: arithmetic operations require all float operands to have the same width (float32 or float64). (33)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/function-end/float-returned-as-float64.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/function-end/float-returned-as-float64.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "functionEnd",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "Stack elements do not match function return signature. (18)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/function-end/float64-returned-as-float.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/function-end/float64-returned-as-float.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "functionEnd",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "Stack elements do not match function return signature. (18)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/count-multi-dot.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/count-multi-dot.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: buffer.extra. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/count-unknown-memory.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/count-unknown-memory.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: missing. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/count-unknown-module.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/count-unknown-module.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: missingModule. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/end-address-old-syntax.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/end-address-old-syntax.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int*",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: oldEndAddressSource:buffer&. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/max-multi-dot.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/max-multi-dot.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: buffer.extra. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/max-unknown-memory.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/max-unknown-memory.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: missing. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/max-unknown-module.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/max-unknown-module.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: missingModule. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/min-multi-dot.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/min-multi-dot.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: buffer.extra. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/min-unknown-memory.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/min-unknown-memory.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: missing. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/min-unknown-module.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/min-unknown-module.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: missingModule. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/nth-out-of-order.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/nth-out-of-order.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int*",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: &nthOutOfOrderSource:1. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/sizeof-multi-dot.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/sizeof-multi-dot.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: buffer.extra. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/sizeof-unknown-memory.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/sizeof-unknown-memory.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: missing. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/sizeof-unknown-module.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/sizeof-unknown-module.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: missingModule. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/start-address-multi-dot.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/intermodular-references/start-address-multi-dot.error.8f4e.diagnostic.snap
@@ -22,8 +22,7 @@
       },
     ],
     "instruction": "int*",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: startAddressMultiDotSource:buffer:extra. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/loop-cap/float-cap.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/loop-cap/float-cap.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "loop",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "Type mismatch. (19)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/loop-cap/loop-cap-after-declarations.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/loop-cap/loop-cap-after-declarations.error.8f4e.diagnostic.snap
@@ -3,8 +3,7 @@
   "context": {},
   "line": {
     "instruction": "#loopCap",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "Compiler directives must appear in the block prologue, immediately after module or function.",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/loop-cap/loop-cap-in-constants.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/loop-cap/loop-cap-in-constants.error.8f4e.diagnostic.snap
@@ -10,8 +10,7 @@
       },
     ],
     "instruction": "#loopCap",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "This instruction is not allowed inside this block type. (34)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/loop-cap/negative-cap.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/loop-cap/negative-cap.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "loop",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "Expected value, got an identifier. (8)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/map/default-outside-map-block.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/map/default-outside-map-block.error.8f4e.diagnostic.snap
@@ -13,8 +13,7 @@
       },
     ],
     "instruction": "default",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "This instruction can only be used within a block or a module. (13)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/map/default-unresolved-identifier.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/map/default-unresolved-identifier.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "default",
-    "lineNumberAfterMacroExpansion": 5,
-    "lineNumberBeforeMacroExpansion": 5,
+    "lineNumber": 5,
   },
   "message": "Undeclared identifier: MISSING_CONST. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/map/default-value-type-mismatch.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/map/default-value-type-mismatch.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "mapEnd",
-    "lineNumberAfterMacroExpansion": 6,
-    "lineNumberBeforeMacroExpansion": 6,
+    "lineNumber": 6,
   },
   "message": "The operation only accepts integer values as operands. (2)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/map/instruction-inside-map-block.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/map/instruction-inside-map-block.error.8f4e.diagnostic.snap
@@ -7,8 +7,7 @@
   "line": {
     "arguments": [],
     "instruction": "add",
-    "lineNumberAfterMacroExpansion": 5,
-    "lineNumberBeforeMacroExpansion": 5,
+    "lineNumber": 5,
   },
   "message": "This instruction is not allowed inside this block type. (34)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/map/map-outside-map-block.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/map/map-outside-map-block.error.8f4e.diagnostic.snap
@@ -18,8 +18,7 @@
       },
     ],
     "instruction": "map",
-    "lineNumberAfterMacroExpansion": 4,
-    "lineNumberBeforeMacroExpansion": 4,
+    "lineNumber": 4,
   },
   "message": "This instruction can only be used within a block or a module. (13)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/map/map-value-unresolved-identifier.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/map/map-value-unresolved-identifier.error.8f4e.diagnostic.snap
@@ -19,8 +19,7 @@
       },
     ],
     "instruction": "map",
-    "lineNumberAfterMacroExpansion": 5,
-    "lineNumberBeforeMacroExpansion": 5,
+    "lineNumber": 5,
   },
   "message": "Undeclared identifier: MISSING_CONST. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/map/multi-character-string-key.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/map/multi-character-string-key.error.8f4e.diagnostic.snap
@@ -3,8 +3,7 @@
   "context": {},
   "line": {
     "instruction": "map",
-    "lineNumberAfterMacroExpansion": 5,
-    "lineNumberBeforeMacroExpansion": 5,
+    "lineNumber": 5,
   },
   "message": "Invalid argument for map: string literals must contain exactly one character.",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/map/one-argument-map-outside-map-block.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/map/one-argument-map-outside-map-block.error.8f4e.diagnostic.snap
@@ -13,8 +13,7 @@
       },
     ],
     "instruction": "map",
-    "lineNumberAfterMacroExpansion": 4,
-    "lineNumberBeforeMacroExpansion": 4,
+    "lineNumber": 4,
   },
   "message": "This instruction can only be used within a block or a module. (13)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/map/row-key-type-mismatch.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/map/row-key-type-mismatch.error.8f4e.diagnostic.snap
@@ -18,8 +18,7 @@
       },
     ],
     "instruction": "map",
-    "lineNumberAfterMacroExpansion": 5,
-    "lineNumberBeforeMacroExpansion": 5,
+    "lineNumber": 5,
   },
   "message": "The operation only accepts integer values as operands. (2)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/map/row-value-type-mismatch.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/map/row-value-type-mismatch.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "mapEnd",
-    "lineNumberAfterMacroExpansion": 6,
-    "lineNumberBeforeMacroExpansion": 6,
+    "lineNumber": 6,
   },
   "message": "The operation only accepts integer values as operands. (2)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/param/duplicate-parameter.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/param/duplicate-parameter.error.8f4e.diagnostic.snap
@@ -20,8 +20,7 @@
       },
     ],
     "instruction": "param",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "Duplicate parameter name. Each parameter must have a unique name. (24)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/param/invalid-param-type.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/param/invalid-param-type.error.8f4e.diagnostic.snap
@@ -3,8 +3,7 @@
   "context": {},
   "line": {
     "instruction": "param",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Invalid argument for param: expected function type identifier.",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/param/param-after-body-instruction.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/param/param-after-body-instruction.error.8f4e.diagnostic.snap
@@ -20,8 +20,7 @@
       },
     ],
     "instruction": "param",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "Parameter declarations must come immediately after the function declaration, before any other instructions or local variable declarations. (23)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/param/param-after-local.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/param/param-after-local.error.8f4e.diagnostic.snap
@@ -20,8 +20,7 @@
       },
     ],
     "instruction": "param",
-    "lineNumberAfterMacroExpansion": 3,
-    "lineNumberBeforeMacroExpansion": 3,
+    "lineNumber": 3,
   },
   "message": "Parameter declarations must come immediately after the function declaration, before any other instructions or local variable declarations. (23)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/param/param-missing-arguments.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/param/param-missing-arguments.error.8f4e.diagnostic.snap
@@ -3,8 +3,7 @@
   "context": {},
   "line": {
     "instruction": "param",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Missing required argument for param.",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/param/param-outside-function.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/param/param-outside-function.error.8f4e.diagnostic.snap
@@ -20,8 +20,7 @@
       },
     ],
     "instruction": "param",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "This instruction can only be used within a block or a module. (13)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/push/pointer-dereference-too-deep.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/push/pointer-dereference-too-deep.error.8f4e.diagnostic.snap
@@ -16,8 +16,7 @@
       },
     ],
     "instruction": "push",
-    "lineNumberAfterMacroExpansion": 4,
-    "lineNumberBeforeMacroExpansion": 4,
+    "lineNumber": 4,
   },
   "message": "Pointer dereference depth exceeds the declared pointer depth: **ptr. (57)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/push/unknown-identifier.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/push/unknown-identifier.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "push",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: undeclared. (5)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/instructions/remainder/may-divide-by-zero.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/instructions/remainder/may-divide-by-zero.error.8f4e.diagnostic.snap
@@ -7,8 +7,7 @@
   "line": {
     "arguments": [],
     "instruction": "remainder",
-    "lineNumberAfterMacroExpansion": 9,
-    "lineNumberBeforeMacroExpansion": 9,
+    "lineNumber": 9,
   },
   "message": "Possible division by zero. (14)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/memory-regions/duplicate-region-name.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/memory-regions/duplicate-region-name.error.8f4e.diagnostic.snap
@@ -4,8 +4,7 @@
   "line": {
     "arguments": [],
     "instruction": "block",
-    "lineNumberAfterMacroExpansion": 0,
-    "lineNumberBeforeMacroExpansion": 0,
+    "lineNumber": 0,
   },
   "message": "Duplicate memory region name: sampleMemory. (54)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/memory-regions/invalid-default-region-name.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/memory-regions/invalid-default-region-name.error.8f4e.diagnostic.snap
@@ -4,8 +4,7 @@
   "line": {
     "arguments": [],
     "instruction": "block",
-    "lineNumberAfterMacroExpansion": 0,
-    "lineNumberBeforeMacroExpansion": 0,
+    "lineNumber": 0,
   },
   "message": "Invalid memory region name: default. Custom memory region names must be unique non-numeric identifiers and cannot be "default" or "memory". (53)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/memory-regions/invalid-memory-region-name.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/memory-regions/invalid-memory-region-name.error.8f4e.diagnostic.snap
@@ -4,8 +4,7 @@
   "line": {
     "arguments": [],
     "instruction": "block",
-    "lineNumberAfterMacroExpansion": 0,
-    "lineNumberBeforeMacroExpansion": 0,
+    "lineNumber": 0,
   },
   "message": "Invalid memory region name: memory. Custom memory region names must be unique non-numeric identifiers and cannot be "default" or "memory". (53)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/memory-regions/invalid-numeric-region-name.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/memory-regions/invalid-numeric-region-name.error.8f4e.diagnostic.snap
@@ -4,8 +4,7 @@
   "line": {
     "arguments": [],
     "instruction": "block",
-    "lineNumberAfterMacroExpansion": 0,
-    "lineNumberBeforeMacroExpansion": 0,
+    "lineNumber": 0,
   },
   "message": "Invalid memory region name: 1. Custom memory region names must be unique non-numeric identifiers and cannot be "default" or "memory". (53)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/memory-regions/region-index-out-of-bounds.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/memory-regions/region-index-out-of-bounds.error.8f4e.diagnostic.snap
@@ -13,8 +13,7 @@
       },
     ],
     "instruction": "#region",
-    "lineNumberAfterMacroExpansion": 1,
-    "lineNumberBeforeMacroExpansion": 1,
+    "lineNumber": 1,
   },
   "message": "Memory region index is out of bounds: 2. (56)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/memory-regions/unknown-region.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/memory-regions/unknown-region.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "#region",
-    "lineNumberAfterMacroExpansion": 1,
-    "lineNumberBeforeMacroExpansion": 1,
+    "lineNumber": 1,
   },
   "message": "Unknown memory region: missingMemory. (55)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/modules/duplicate-module.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/modules/duplicate-module.error.8f4e.diagnostic.snap
@@ -11,8 +11,7 @@
       },
     ],
     "instruction": "module",
-    "lineNumberAfterMacroExpansion": 0,
-    "lineNumberBeforeMacroExpansion": 0,
+    "lineNumber": 0,
   },
   "message": "Duplicate identifier: same. Module and function IDs must be unique. (45)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/modules/reserved-this-memory.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/modules/reserved-this-memory.error.8f4e.diagnostic.snap
@@ -14,8 +14,7 @@
       },
     ],
     "instruction": "int",
-    "lineNumberAfterMacroExpansion": 1,
-    "lineNumberBeforeMacroExpansion": 1,
+    "lineNumber": 1,
   },
   "message": "Reserved identifier cannot be used as a memory allocation name: this. (38)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/prototypes/executable-in-prototype.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/prototypes/executable-in-prototype.error.8f4e.diagnostic.snap
@@ -10,8 +10,7 @@
       },
     ],
     "instruction": "push",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "This instruction is not allowed inside this block type. (34)",
 }

--- a/packages/compiler/tests/errors/__snapshots__/prototypes/unknown-shape.error.8f4e.diagnostic.snap
+++ b/packages/compiler/tests/errors/__snapshots__/prototypes/unknown-shape.error.8f4e.diagnostic.snap
@@ -11,8 +11,7 @@
       },
     ],
     "instruction": "shape",
-    "lineNumberAfterMacroExpansion": 2,
-    "lineNumberBeforeMacroExpansion": 2,
+    "lineNumber": 2,
   },
   "message": "Undeclared identifier: missing. (5)",
 }

--- a/packages/compiler/tests/testUtils.ts
+++ b/packages/compiler/tests/testUtils.ts
@@ -217,7 +217,6 @@ function serializeAstLine(line: CompilerASTLine): Record<string, unknown> {
 	const lineSnapshot: Record<string, unknown> = { ...line };
 
 	delete lineSnapshot.lineNumber;
-	delete lineSnapshot.lineNumber;
 	delete lineSnapshot.ifBlock;
 	delete lineSnapshot.ifEndBlock;
 	delete lineSnapshot.blockBlock;

--- a/packages/compiler/tests/testUtils.ts
+++ b/packages/compiler/tests/testUtils.ts
@@ -216,8 +216,8 @@ function serializeInternalResource(resource: InternalResource): Record<string, u
 function serializeAstLine(line: CompilerASTLine): Record<string, unknown> {
 	const lineSnapshot: Record<string, unknown> = { ...line };
 
-	delete lineSnapshot.lineNumberAfterMacroExpansion;
-	delete lineSnapshot.lineNumberBeforeMacroExpansion;
+	delete lineSnapshot.lineNumber;
+	delete lineSnapshot.lineNumber;
 	delete lineSnapshot.ifBlock;
 	delete lineSnapshot.ifEndBlock;
 	delete lineSnapshot.blockBlock;

--- a/packages/editor/packages/editor-state/src/features/program-compiler/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/effect.test.ts
@@ -16,7 +16,7 @@ describe('program compiler effect', () => {
 
 		mockCompileCode = vi.fn().mockRejectedValue({
 			message: 'Memory access is not allowed in pure functions. (19)',
-			line: { lineNumberBeforeMacroExpansion: 2 },
+			line: { lineNumber: 2 },
 			context: {
 				codeBlockId: 'helper',
 				codeBlockType: 'function',
@@ -75,7 +75,7 @@ describe('program compiler effect', () => {
 	it('reads line number from syntax errors that expose line directly (no longer defaults to 0)', async () => {
 		mockCompileCode.mockRejectedValue({
 			message: 'Too many arguments for if.',
-			line: { lineNumberBeforeMacroExpansion: 3, lineNumberAfterMacroExpansion: 3, instruction: 'if' },
+			line: { lineNumber: 3, instruction: 'if' },
 			context: {},
 		});
 

--- a/packages/editor/packages/editor-state/src/features/program-compiler/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/effect.ts
@@ -138,7 +138,7 @@ export default function compiler(store: StateManager<State>) {
 
 			store.set('codeErrors.compilationErrors', [
 				{
-					lineNumber: diagnostic.line.lineNumberBeforeMacroExpansion,
+					lineNumber: diagnostic.line.lineNumber,
 					codeBlockId: diagnostic.context.codeBlockId || '',
 					codeBlockType: diagnostic.context.codeBlockType,
 					message: diagnostic?.message || String(error) || 'Compilation failed',

--- a/packages/editor/packages/editor-state/src/features/tooltip/content.test.ts
+++ b/packages/editor/packages/editor-state/src/features/tooltip/content.test.ts
@@ -32,8 +32,7 @@ describe('selected line tooltip content', () => {
 			'add',
 			TOOLTIP_WRAP_WIDTH,
 			{
-				lineNumberBeforeMacroExpansion: 2,
-				lineNumberAfterMacroExpansion: 2,
+				lineNumber: 2,
 				instruction: 'add',
 				stackAnalysis: {
 					stackBefore: [

--- a/packages/editor/packages/editor-state/src/features/tooltip/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/tooltip/effect.test.ts
@@ -25,8 +25,7 @@ describe('tooltip effect', () => {
 					test: {
 						stackAnalysis: [
 							{
-								lineNumberBeforeMacroExpansion: 2,
-								lineNumberAfterMacroExpansion: 2,
+								lineNumber: 2,
 								instruction: 'add',
 								stackAnalysis: {
 									stackBefore: [
@@ -106,8 +105,7 @@ describe('tooltip effect', () => {
 					helper: {
 						stackAnalysis: [
 							{
-								lineNumberBeforeMacroExpansion: 3,
-								lineNumberAfterMacroExpansion: 3,
+								lineNumber: 3,
 								instruction: 'add',
 								stackAnalysis: {
 									stackBefore: [

--- a/packages/editor/packages/editor-state/src/features/tooltip/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/tooltip/effect.ts
@@ -35,12 +35,12 @@ function getSelectedCodeBlockStackAnalysisLine(
 		}
 
 		return state.compiler.compiledFunctions?.[functionId]?.stackAnalysis?.find(
-			line => line.lineNumberBeforeMacroExpansion === selectedCodeBlock.cursor.row
+			line => line.lineNumber === selectedCodeBlock.cursor.row
 		);
 	}
 
 	return state.compiler.compiledModules[moduleId]?.stackAnalysis?.find(
-		line => line.lineNumberBeforeMacroExpansion === selectedCodeBlock.cursor.row
+		line => line.lineNumber === selectedCodeBlock.cursor.row
 	);
 }
 

--- a/packages/editor/packages/editor-state/src/features/tooltip/sourceLine.ts
+++ b/packages/editor/packages/editor-state/src/features/tooltip/sourceLine.ts
@@ -65,8 +65,7 @@ function getStackSignatureLineFromSourceLine(line: string, instruction: string):
 	}
 
 	return {
-		lineNumberBeforeMacroExpansion: 0,
-		lineNumberAfterMacroExpansion: 0,
+		lineNumber: 0,
 		instruction: 'storeBytes',
 		arguments: [{ type: ArgumentType.LITERAL, value: count, isInteger: true }],
 	};

--- a/packages/editor/packages/editor-state/src/features/tooltip/stackAnalysisTooltip.test.ts
+++ b/packages/editor/packages/editor-state/src/features/tooltip/stackAnalysisTooltip.test.ts
@@ -5,8 +5,7 @@ import { getStackAnalysisTooltipContent, getStackAnalysisTooltipText } from './s
 describe('stack analysis tooltip text', () => {
 	it('formats selected line stack analysis', () => {
 		const stackAnalysisLine = {
-			lineNumberBeforeMacroExpansion: 2,
-			lineNumberAfterMacroExpansion: 2,
+			lineNumber: 2,
 			instruction: 'add',
 			stackAnalysis: {
 				stackBefore: [
@@ -39,8 +38,7 @@ describe('stack analysis tooltip text', () => {
 
 	it('formats long stack analysis as multiline blocks', () => {
 		const stackAnalysisLine = {
-			lineNumberBeforeMacroExpansion: 6,
-			lineNumberAfterMacroExpansion: 6,
+			lineNumber: 6,
 			instruction: 'drop',
 			stackAnalysis: {
 				stackBefore: [


### PR DESCRIPTION
## Summary
- replace before/after macro expansion line fields with a single lineNumber across compiler AST, diagnostics, and stack analysis
- remove macro call-site metadata from tokenizer cache/parser and keep macro expansion as plain source-line expansion
- update editor/CLI consumers and refresh snapshots

## Testing
- npx nx run @8f4e/tokenizer:typecheck
- npx nx run @8f4e/tokenizer:test
- npx nx run compiler:typecheck
- npx nx run compiler:test
- npx nx run @8f4e/editor-state:typecheck
- npx nx run @8f4e/editor-state:test
- npx nx run-many --target=typecheck --projects=@8f4e/cli,@8f4e/compiler-worker
- git diff --check