### PR TITLE
docs(compiler): add missing tsdoc comments

### DIFF
--- a/packages/compiler/src/compileFunction.ts
+++ b/packages/compiler/src/compileFunction.ts
@@ -37,6 +37,7 @@ const importedFunctionAllowedInstructions = new Set([
 	'functionEnd',
 ]);
 
+/** Compiles one validated function AST into a WebAssembly function body or import metadata. */
 export function compileFunction(
 	ast: ValidatedFunctionAST,
 	namespaces: Namespaces,

--- a/packages/compiler/src/compileFunction.ts
+++ b/packages/compiler/src/compileFunction.ts
@@ -37,7 +37,17 @@ const importedFunctionAllowedInstructions = new Set([
 	'functionEnd',
 ]);
 
-/** Compiles one validated function AST into a WebAssembly function body or import metadata. */
+/**
+ * Compiles one validated function AST into a WebAssembly function body or import metadata.
+ *
+ * @param ast - Validated AST being processed.
+ * @param namespaces - Collected namespaces used for symbol and memory resolution.
+ * @param wasmIndex - Assigned WASM function index.
+ * @param typeRegistry - Function type registry used for WASM block signatures.
+ * @param functions - Function metadata lookup available to compilation.
+ * @param options - Compiler options for this compilation pass.
+ * @returns The compiled function artifact.
+ */
 export function compileFunction(
 	ast: ValidatedFunctionAST,
 	namespaces: Namespaces,

--- a/packages/compiler/src/compileLine.ts
+++ b/packages/compiler/src/compileLine.ts
@@ -11,12 +11,14 @@ import instructions from './instructionCompilers';
 import { applySemanticLine } from './semantic/buildNamespace';
 import { analyzeInstruction } from './stackAnalysis/analyzeInstruction';
 
+/** Emits bytecode for one already-analyzed instruction line. */
 export function compileCodegenLine(line: AnalyzedLine, context: CompilationContext) {
 	const instruction = line.instruction as Instruction;
 	const compileInstruction = instructions[instruction] as InstructionCompiler;
 	compileInstruction(line, context);
 }
 
+/** Converts an analyzed instruction into the stack-analysis shape exposed in compile results. */
 export function toCompiledStackAnalysisLine(line: AnalyzedLine): CompiledStackAnalysisLine {
 	return {
 		lineNumber: line.lineNumber,
@@ -25,6 +27,7 @@ export function toCompiledStackAnalysisLine(line: AnalyzedLine): CompiledStackAn
 	};
 }
 
+/** Applies semantic lines or analyzes and emits one codegen line for the active compilation context. */
 export function compileLine(line: CompilerASTLine, context: CompilationContext): AnalyzedLine | undefined {
 	if (isSemanticInstructionLine(line)) {
 		applySemanticLine(line, context);

--- a/packages/compiler/src/compileLine.ts
+++ b/packages/compiler/src/compileLine.ts
@@ -11,14 +11,24 @@ import instructions from './instructionCompilers';
 import { applySemanticLine } from './semantic/buildNamespace';
 import { analyzeInstruction } from './stackAnalysis/analyzeInstruction';
 
-/** Emits bytecode for one already-analyzed instruction line. */
+/**
+ * Emits bytecode for one already-analyzed instruction line.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ */
 export function compileCodegenLine(line: AnalyzedLine, context: CompilationContext) {
 	const instruction = line.instruction as Instruction;
 	const compileInstruction = instructions[instruction] as InstructionCompiler;
 	compileInstruction(line, context);
 }
 
-/** Converts an analyzed instruction into the stack-analysis shape exposed in compile results. */
+/**
+ * Converts an analyzed instruction into the stack-analysis shape exposed in compile results.
+ *
+ * @param line - Compiler line being processed.
+ * @returns The stack items produced or consumed by the operation.
+ */
 export function toCompiledStackAnalysisLine(line: AnalyzedLine): CompiledStackAnalysisLine {
 	return {
 		lineNumber: line.lineNumber,
@@ -27,7 +37,13 @@ export function toCompiledStackAnalysisLine(line: AnalyzedLine): CompiledStackAn
 	};
 }
 
-/** Applies semantic lines or analyzes and emits one codegen line for the active compilation context. */
+/**
+ * Applies semantic lines or analyzes and emits one codegen line for the active compilation context.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export function compileLine(line: CompilerASTLine, context: CompilationContext): AnalyzedLine | undefined {
 	if (isSemanticInstructionLine(line)) {
 		applySemanticLine(line, context);

--- a/packages/compiler/src/compileModule.ts
+++ b/packages/compiler/src/compileModule.ts
@@ -31,6 +31,7 @@ import { getMemoryRegionFields } from './semantic/memoryRegions';
 import normalizeCompileTimeArguments from './semantic/normalizeCompileTimeArguments';
 import { analyzeInstruction } from './stackAnalysis/analyzeInstruction';
 
+/** Compiles one validated module or constants AST into its WebAssembly cycle function and memory metadata. */
 export function compileModule(
 	ast: ValidatedModuleAST | ValidatedConstantsAST,
 	namespaces: Namespaces,

--- a/packages/compiler/src/compileModule.ts
+++ b/packages/compiler/src/compileModule.ts
@@ -31,7 +31,20 @@ import { getMemoryRegionFields } from './semantic/memoryRegions';
 import normalizeCompileTimeArguments from './semantic/normalizeCompileTimeArguments';
 import { analyzeInstruction } from './stackAnalysis/analyzeInstruction';
 
-/** Compiles one validated module or constants AST into its WebAssembly cycle function and memory metadata. */
+/**
+ * Compiles one validated module or constants AST into its WebAssembly cycle function and memory metadata.
+ *
+ * @param ast - Validated AST being processed.
+ * @param namespaces - Collected namespaces used for symbol and memory resolution.
+ * @param startingByteAddress - Absolute byte address where layout should begin.
+ * @param index - WASM index or source index assigned to the compiled item.
+ * @param functions - Function metadata lookup available to compilation.
+ * @param internalAllocator - Allocator state for compiler-generated memory resources.
+ * @param options - Compiler options for this compilation pass.
+ * @param typeRegistry - Function type registry used for WASM block signatures.
+ * @param prototypeShapes - Prototype shape ASTs available during semantic layout.
+ * @returns The compiled module artifact.
+ */
 export function compileModule(
 	ast: ValidatedModuleAST | ValidatedConstantsAST,
 	namespaces: Namespaces,

--- a/packages/compiler/src/compileModules.ts
+++ b/packages/compiler/src/compileModules.ts
@@ -12,6 +12,7 @@ import { GLOBAL_ALIGNMENT_BOUNDARY } from '@8f4e/compiler-spec';
 import { compileModule } from './compileModule';
 import { collectNamespacesFromASTs } from './semantic/buildNamespace';
 
+/** Compiles validated module ASTs using a shared namespace, allocator, and function type registry. */
 export function compileModules(
 	modules: Array<ValidatedModuleAST | ValidatedConstantsAST>,
 	options: CompileOptions,

--- a/packages/compiler/src/compileModules.ts
+++ b/packages/compiler/src/compileModules.ts
@@ -12,7 +12,18 @@ import { GLOBAL_ALIGNMENT_BOUNDARY } from '@8f4e/compiler-spec';
 import { compileModule } from './compileModule';
 import { collectNamespacesFromASTs } from './semantic/buildNamespace';
 
-/** Compiles validated module ASTs using a shared namespace, allocator, and function type registry. */
+/**
+ * Compiles validated module ASTs using a shared namespace, allocator, and function type registry.
+ *
+ * @param modules - modules value used by this operation.
+ * @param options - Compiler options for this compilation pass.
+ * @param namespaces - Collected namespaces used for symbol and memory resolution.
+ * @param compiledFunctions - Compiled function metadata available to module compilation.
+ * @param internalAllocator - Allocator state for compiler-generated memory resources.
+ * @param typeRegistry - Function type registry used for WASM block signatures.
+ * @param prototypeShapes - Prototype shape ASTs available during semantic layout.
+ * @returns The compiled module artifact.
+ */
 export function compileModules(
 	modules: Array<ValidatedModuleAST | ValidatedConstantsAST>,
 	options: CompileOptions,

--- a/packages/compiler/src/compileSubProgram.ts
+++ b/packages/compiler/src/compileSubProgram.ts
@@ -32,27 +32,45 @@ import { expandMacros, parseMacroDefinitions } from './utils/macroExpansion';
 
 /** Expanded module source paired with cache and execution-entry metadata. */
 type ModuleCompilerSource = {
+	/** Source lines after macro expansion. */
 	code: string[];
+	/** Stable cache namespace for the expanded source lines. */
 	cacheKey: string;
+	/** Public entry that should dispatch to the compiled module. */
 	entryName: string;
 };
 
 /** Compiled units and layout metadata for one independently compiled source program. */
 export type CompiledSubProgram = {
+	/** Public entry names generated for this source program. */
 	entryNames: string[];
+	/** Number of imported user functions emitted before built-ins and defined functions. */
 	importedFunctionCount: number;
+	/** Number of built-in helper functions emitted before user-defined functions. */
 	builtInFunctionCount: number;
+	/** Compiled module bodies in source order. */
 	compiledModules: CompiledModule[];
+	/** Compiled module lookup keyed by module id. */
 	compiledModulesMap: CompiledModuleLookup;
+	/** Compiled user functions in source order. */
 	compiledFunctions: CompiledFunction[];
+	/** Compiled function lookup keyed by function id. */
 	compiledFunctionsMap: CompiledFunctionLookup;
+	/** User functions imported from the host environment. */
 	importedUserFunctions: CompiledFunction[];
+	/** User functions defined by the source program. */
 	definedFunctions: CompiledFunction[];
+	/** Function type table accumulated while compiling calls and definitions. */
 	functionTypeRegistry: FunctionTypeRegistry;
+	/** Required linear-memory byte size keyed by WebAssembly memory index. */
 	requiredMemoryBytesByIndex: Record<number, number>;
+	/** Required byte size for default memory. */
 	requiredMemoryBytes: number;
+	/** Required byte size keyed by configured custom memory region name. */
 	requiredMemoryBytesByRegion: Record<string, number>;
+	/** Initial data segments that materialize memory defaults. */
 	initialMemoryDataSegments: InitialMemoryDataSegment[];
+	/** Cache instance carrying validated AST entries for this compilation. */
 	cache: CompilerCache;
 };
 

--- a/packages/compiler/src/compileSubProgram.ts
+++ b/packages/compiler/src/compileSubProgram.ts
@@ -74,7 +74,11 @@ export type CompiledSubProgram = {
 	cache: CompilerCache;
 };
 
-/** Creates the default compiler cache used for validated AST reuse. */
+/**
+ * Creates the default compiler cache used for validated AST reuse.
+ *
+ * @returns A compiler cache ready to store validated ASTs.
+ */
 export function createCompilerCache(): CompilerCache {
 	return {
 		ast: createASTCache<ValidatedAST>(),
@@ -149,7 +153,14 @@ function collectPrototypeShapes(prototypes: readonly ValidatedPrototypeAST[]): R
 	return prototypeShapesById;
 }
 
-/** Compiles one source program into linkable module, function, memory, and data-segment artifacts. */
+/**
+ * Compiles one source program into linkable module, function, memory, and data-segment artifacts.
+ *
+ * @param input - Compiler input program to compile.
+ * @param options - Compiler options for this compilation pass.
+ * @param cache - Compiler cache used for reusable validated ASTs.
+ * @returns The compiled sub-program artifacts.
+ */
 export function compileSubProgram(
 	input: CompileInput,
 	options: CompileOptions,

--- a/packages/compiler/src/compilerError.ts
+++ b/packages/compiler/src/compilerError.ts
@@ -32,6 +32,7 @@ interface ErrorDetails {
 	identifier?: string;
 }
 
+/** Creates a compiler-stage diagnostic for a semantic or code-generation error. */
 export function getError(
 	code: ErrorCodeValue,
 	line: CompilerASTLine,

--- a/packages/compiler/src/compilerError.ts
+++ b/packages/compiler/src/compilerError.ts
@@ -2,19 +2,19 @@
  * Compiler (semantic) errors — raised after syntax is already valid.
  *
  * Use this module for errors that require semantic analysis or compiler state:
- *   - undeclared or duplicate identifiers
- *   - type mismatches
- *   - invalid instruction in the current scope
- *   - stack mismatches or overflows
- *   - function memory declarations or memory IO without the required directive
- *   - constant resolution failures
- *   - any error that cannot be detected from token/argument shape alone
+ *  - undeclared or duplicate identifiers
+ *  - type mismatches
+ *  - invalid instruction in the current scope
+ *  - stack mismatches or overflows
+ *  - function memory declarations or memory IO without the required directive
+ *  - constant resolution failures
+ *  - any error that cannot be detected from token/argument shape alone
  *
  * Boundary rule:
- *   If detecting the error requires symbol resolution, scope validation, stack
- *   state, type checking, or runtime-model knowledge → it belongs here.
- *   If the error can be detected from the raw token or argument structure alone,
- *   before any semantic context is built → use SyntaxRulesError in syntaxError.ts.
+ *  If detecting the error requires symbol resolution, scope validation, stack
+ *  state, type checking, or runtime-model knowledge → it belongs here.
+ *  If the error can be detected from the raw token or argument structure alone,
+ *  before any semantic context is built → use SyntaxRulesError in syntaxError.ts.
  */
 
 import type {
@@ -32,7 +32,15 @@ interface ErrorDetails {
 	identifier?: string;
 }
 
-/** Creates a compiler-stage diagnostic for a semantic or code-generation error. */
+/**
+ * Creates a compiler-stage diagnostic for a semantic or code-generation error.
+ *
+ * @param code - Compiler error code to materialize.
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param details - Optional dynamic details to include in the diagnostic.
+ * @returns The compiler error instance.
+ */
 export function getError(
 	code: ErrorCodeValue,
 	line: CompilerASTLine,

--- a/packages/compiler/src/diagnostic.ts
+++ b/packages/compiler/src/diagnostic.ts
@@ -26,7 +26,12 @@ function isCompilerStageError(value: unknown): value is CompilerStageError {
 	);
 }
 
-/** Serializes thrown compiler or tokenizer errors into the shared diagnostic DTO. */
+/**
+ * Serializes thrown compiler or tokenizer errors into the shared diagnostic DTO.
+ *
+ * @param error - Diagnostic or thrown error to serialize.
+ * @returns The result of the operation.
+ */
 export function serializeDiagnostic(error: unknown): CompilerDiagnostic {
 	if (error instanceof SyntaxRulesError) {
 		return {

--- a/packages/compiler/src/diagnostic.ts
+++ b/packages/compiler/src/diagnostic.ts
@@ -26,6 +26,7 @@ function isCompilerStageError(value: unknown): value is CompilerStageError {
 	);
 }
 
+/** Serializes thrown compiler or tokenizer errors into the shared diagnostic DTO. */
 export function serializeDiagnostic(error: unknown): CompilerDiagnostic {
 	if (error instanceof SyntaxRulesError) {
 		return {

--- a/packages/compiler/src/initialMemoryDataSegments/createInitialMemoryDataSegments.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/createInitialMemoryDataSegments.ts
@@ -4,7 +4,12 @@ import createMemoryDataSegmentCandidate from './createMemoryDataSegmentCandidate
 import mergeAdjacentInitialMemoryDataSegments from './mergeAdjacentInitialMemoryDataSegments';
 import type { InitialMemoryDataSegment } from './types';
 
-/** Creates passive data segments for non-zero and explicitly initialized compiled module memory. */
+/**
+ * Creates passive data segments for non-zero and explicitly initialized compiled module memory.
+ *
+ * @param compiledModules - Compiled modules to inspect for initial memory data.
+ * @returns The materialized initial memory data segment data.
+ */
 export default function createInitialMemoryDataSegments(compiledModules: CompiledModule[]): InitialMemoryDataSegment[] {
 	const segmentCandidates = compiledModules.flatMap(module => [
 		...Object.values(module.memoryMap).flatMap(memory => createMemoryDataSegmentCandidate(memory)),

--- a/packages/compiler/src/initialMemoryDataSegments/createInitialMemoryDataSegments.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/createInitialMemoryDataSegments.ts
@@ -4,6 +4,7 @@ import createMemoryDataSegmentCandidate from './createMemoryDataSegmentCandidate
 import mergeAdjacentInitialMemoryDataSegments from './mergeAdjacentInitialMemoryDataSegments';
 import type { InitialMemoryDataSegment } from './types';
 
+/** Creates passive data segments for non-zero and explicitly initialized compiled module memory. */
 export default function createInitialMemoryDataSegments(compiledModules: CompiledModule[]): InitialMemoryDataSegment[] {
 	const segmentCandidates = compiledModules.flatMap(module => [
 		...Object.values(module.memoryMap).flatMap(memory => createMemoryDataSegmentCandidate(memory)),

--- a/packages/compiler/src/initialMemoryDataSegments/createInternalResourceDataSegmentCandidate.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/createInternalResourceDataSegmentCandidate.ts
@@ -3,6 +3,7 @@ import type { InternalResource } from '@8f4e/compiler-spec';
 import type { InitialMemoryDataSegmentCandidate } from './types';
 import writeInternalResourceDefault from './writeInternalResourceDefault';
 
+/** Creates an initial data segment candidate for a non-zero internal resource default. */
 export default function createInternalResourceDataSegmentCandidate(
 	resource: InternalResource
 ): InitialMemoryDataSegmentCandidate | undefined {

--- a/packages/compiler/src/initialMemoryDataSegments/createInternalResourceDataSegmentCandidate.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/createInternalResourceDataSegmentCandidate.ts
@@ -3,7 +3,12 @@ import type { InternalResource } from '@8f4e/compiler-spec';
 import type { InitialMemoryDataSegmentCandidate } from './types';
 import writeInternalResourceDefault from './writeInternalResourceDefault';
 
-/** Creates an initial data segment candidate for a non-zero internal resource default. */
+/**
+ * Creates an initial data segment candidate for a non-zero internal resource default.
+ *
+ * @param resource - Internal resource declaration to materialize.
+ * @returns The materialized initial memory data segment data.
+ */
 export default function createInternalResourceDataSegmentCandidate(
 	resource: InternalResource
 ): InitialMemoryDataSegmentCandidate | undefined {

--- a/packages/compiler/src/initialMemoryDataSegments/createMemoryDataSegmentCandidate.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/createMemoryDataSegmentCandidate.ts
@@ -4,6 +4,7 @@ import materializeByteChunks from './materializeByteChunks';
 import type { InitialMemoryDataSegmentCandidate } from './types';
 import writeDefaultValue from './writeDefaultValue';
 
+/** Creates initial data segment candidates for explicit or non-zero memory defaults. */
 export default function createMemoryDataSegmentCandidate(memory: DataStructure): InitialMemoryDataSegmentCandidate[] {
 	const isArray = memory.numberOfElements > 1;
 	if (isArray && memory.hasExplicitDefault !== true) {

--- a/packages/compiler/src/initialMemoryDataSegments/createMemoryDataSegmentCandidate.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/createMemoryDataSegmentCandidate.ts
@@ -4,7 +4,12 @@ import materializeByteChunks from './materializeByteChunks';
 import type { InitialMemoryDataSegmentCandidate } from './types';
 import writeDefaultValue from './writeDefaultValue';
 
-/** Creates initial data segment candidates for explicit or non-zero memory defaults. */
+/**
+ * Creates initial data segment candidates for explicit or non-zero memory defaults.
+ *
+ * @param memory - Memory declaration or data structure being materialized.
+ * @returns The materialized initial memory data segment data.
+ */
 export default function createMemoryDataSegmentCandidate(memory: DataStructure): InitialMemoryDataSegmentCandidate[] {
 	const isArray = memory.numberOfElements > 1;
 	if (isArray && memory.hasExplicitDefault !== true) {

--- a/packages/compiler/src/initialMemoryDataSegments/materializeByteChunks.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/materializeByteChunks.ts
@@ -1,7 +1,13 @@
 /** Byte payload or zero-filled gap length used while assembling data segments. */
 export type ByteChunk = Uint8Array | number;
 
-/** Materializes byte chunks and zero-filled gaps into one contiguous byte array. */
+/**
+ * Materializes byte chunks and zero-filled gaps into one contiguous byte array.
+ *
+ * @param chunks - Byte chunks to merge into a contiguous buffer.
+ * @param byteLength - Number of bytes to materialize or validate.
+ * @returns The result of the operation.
+ */
 export default function materializeByteChunks(chunks: ByteChunk[], byteLength: number): Uint8Array {
 	const bytes = new Uint8Array(byteLength);
 	let byteOffset = 0;

--- a/packages/compiler/src/initialMemoryDataSegments/materializeByteChunks.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/materializeByteChunks.ts
@@ -1,5 +1,7 @@
+/** Byte payload or zero-filled gap length used while assembling data segments. */
 export type ByteChunk = Uint8Array | number;
 
+/** Materializes byte chunks and zero-filled gaps into one contiguous byte array. */
 export default function materializeByteChunks(chunks: ByteChunk[], byteLength: number): Uint8Array {
 	const bytes = new Uint8Array(byteLength);
 	let byteOffset = 0;

--- a/packages/compiler/src/initialMemoryDataSegments/mergeAdjacentInitialMemoryDataSegments.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/mergeAdjacentInitialMemoryDataSegments.ts
@@ -2,8 +2,10 @@ import materializeByteChunks from './materializeByteChunks';
 
 import type { InitialMemoryDataSegment } from './types';
 
+/** Maximum zero-filled gap to fold between neighboring passive data segments. */
 export const MAX_ZERO_GAP_BYTES_TO_MERGE = 32;
 
+/** Sorts and merges compatible initial memory data segments, filling small gaps with zeros. */
 export default function mergeAdjacentInitialMemoryDataSegments(
 	segments: InitialMemoryDataSegment[]
 ): InitialMemoryDataSegment[] {

--- a/packages/compiler/src/initialMemoryDataSegments/mergeAdjacentInitialMemoryDataSegments.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/mergeAdjacentInitialMemoryDataSegments.ts
@@ -5,7 +5,12 @@ import type { InitialMemoryDataSegment } from './types';
 /** Maximum zero-filled gap to fold between neighboring passive data segments. */
 export const MAX_ZERO_GAP_BYTES_TO_MERGE = 32;
 
-/** Sorts and merges compatible initial memory data segments, filling small gaps with zeros. */
+/**
+ * Sorts and merges compatible initial memory data segments, filling small gaps with zeros.
+ *
+ * @param segments - Initial memory data segments to merge.
+ * @returns The materialized initial memory data segment data.
+ */
 export default function mergeAdjacentInitialMemoryDataSegments(
 	segments: InitialMemoryDataSegment[]
 ): InitialMemoryDataSegment[] {

--- a/packages/compiler/src/initialMemoryDataSegments/types.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/types.ts
@@ -1,3 +1,4 @@
+/** Passive data segment used to initialize one WebAssembly memory at instantiation time. */
 export interface InitialMemoryDataSegment {
 	memoryIndex: number;
 	memoryRegionName?: string;
@@ -5,6 +6,7 @@ export interface InitialMemoryDataSegment {
 	bytes: Uint8Array;
 }
 
+/** Initial memory data segment candidate tagged with the compiler source that produced it. */
 export interface InitialMemoryDataSegmentCandidate extends InitialMemoryDataSegment {
 	sourceKind: 'scalar' | 'array' | 'internal-resource';
 }

--- a/packages/compiler/src/initialMemoryDataSegments/writeDefaultValue.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/writeDefaultValue.ts
@@ -1,5 +1,6 @@
 import type { DataStructure } from '@8f4e/compiler-spec';
 
+/** Writes one memory declaration default value into a data segment byte view. */
 export default function writeDefaultValue(
 	view: DataView,
 	memory: Pick<DataStructure, 'isInteger' | 'isUnsigned' | 'elementWordSize'>,

--- a/packages/compiler/src/initialMemoryDataSegments/writeDefaultValue.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/writeDefaultValue.ts
@@ -1,6 +1,13 @@
 import type { DataStructure } from '@8f4e/compiler-spec';
 
-/** Writes one memory declaration default value into a data segment byte view. */
+/**
+ * Writes one memory declaration default value into a data segment byte view.
+ *
+ * @param view - DataView receiving the encoded bytes.
+ * @param memory - Memory declaration or data structure being materialized.
+ * @param byteAddress - Byte address where the value should be written.
+ * @param value - Default value to write.
+ */
 export default function writeDefaultValue(
 	view: DataView,
 	memory: Pick<DataStructure, 'isInteger' | 'isUnsigned' | 'elementWordSize'>,

--- a/packages/compiler/src/initialMemoryDataSegments/writeInternalResourceDefault.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/writeInternalResourceDefault.ts
@@ -1,5 +1,6 @@
 import type { InternalResource } from '@8f4e/compiler-spec';
 
+/** Writes one internal resource default value into a data segment byte view. */
 export default function writeInternalResourceDefault(view: DataView, resource: InternalResource) {
 	if (resource.storageType === 'float64') {
 		view.setFloat64(resource.byteAddress, resource.default, true);

--- a/packages/compiler/src/initialMemoryDataSegments/writeInternalResourceDefault.ts
+++ b/packages/compiler/src/initialMemoryDataSegments/writeInternalResourceDefault.ts
@@ -1,6 +1,11 @@
 import type { InternalResource } from '@8f4e/compiler-spec';
 
-/** Writes one internal resource default value into a data segment byte view. */
+/**
+ * Writes one internal resource default value into a data segment byte view.
+ *
+ * @param view - DataView receiving the encoded bytes.
+ * @param resource - Internal resource declaration to materialize.
+ */
 export default function writeInternalResourceDefault(view: DataView, resource: InternalResource) {
 	if (resource.storageType === 'float64') {
 		view.setFloat64(resource.byteAddress, resource.default, true);

--- a/packages/compiler/src/instructionCompilers/assertFunctionMemoryIoAllowed.ts
+++ b/packages/compiler/src/instructionCompilers/assertFunctionMemoryIoAllowed.ts
@@ -2,6 +2,7 @@ import type { CodegenContext, CompilationContext, CompilerASTLine } from '@8f4e/
 import { ErrorCode } from '@8f4e/compiler-spec';
 import { getError } from '../compilerError';
 
+/** Throws when a function attempts memory IO without the `#impure` directive. */
 export default function assertFunctionMemoryIoAllowed(
 	line: CompilerASTLine,
 	context: CodegenContext | CompilationContext

--- a/packages/compiler/src/instructionCompilers/assertFunctionMemoryIoAllowed.ts
+++ b/packages/compiler/src/instructionCompilers/assertFunctionMemoryIoAllowed.ts
@@ -2,7 +2,12 @@ import type { CodegenContext, CompilationContext, CompilerASTLine } from '@8f4e/
 import { ErrorCode } from '@8f4e/compiler-spec';
 import { getError } from '../compilerError';
 
-/** Throws when a function attempts memory IO without the `#impure` directive. */
+/**
+ * Throws when a function attempts memory IO without the `#impure` directive.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ */
 export default function assertFunctionMemoryIoAllowed(
 	line: CompilerASTLine,
 	context: CodegenContext | CompilationContext

--- a/packages/compiler/src/instructionCompilers/clampAddress.ts
+++ b/packages/compiler/src/instructionCompilers/clampAddress.ts
@@ -22,6 +22,7 @@ function clampToRange(
 	);
 }
 
+/** Clamps the top stack address to its inferred safe or explicit clamp range. */
 export const clampAddress: InstructionCompiler = (line, context) => {
 	const [rawOperand] = line.stackAnalysis.consumedOperands;
 	const operand = requireStackAddress(rawOperand, line, context);
@@ -30,12 +31,14 @@ export const clampAddress: InstructionCompiler = (line, context) => {
 	return clampToRange(line, context, operand, range!);
 };
 
+/** Clamps the top stack address to the active module's memory range. */
 export const clampModuleAddress: InstructionCompiler = (line, context) => {
 	const [rawOperand] = line.stackAnalysis.consumedOperands;
 	const operand = requireStackAddress(rawOperand, line, context);
 	return clampToRange(line, context, operand, getModuleAddressRange(context));
 };
 
+/** Clamps the top stack address to the whole linear memory range for its access width. */
 export const clampGlobalAddress: InstructionCompiler = (line, context) => {
 	const [rawOperand] = line.stackAnalysis.consumedOperands;
 	const operand = requireStackAddress(rawOperand, line, context);

--- a/packages/compiler/src/instructionCompilers/index.ts
+++ b/packages/compiler/src/instructionCompilers/index.ts
@@ -148,4 +148,5 @@ const instructions = {
 
 export default instructions;
 
+/** Instruction names with registered codegen handlers. */
 export type Instruction = keyof typeof instructions;

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushLiteral.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushLiteral.ts
@@ -2,6 +2,7 @@ import type { CodegenContext, NormalizedArgumentLiteral } from '@8f4e/compiler-s
 import { saveByteCode } from '../../utils/saveByteCode';
 import { constOpcode, resolveArgumentValueKind } from '../shared';
 
+/** Emits bytecode for pushing a numeric literal onto the stack. */
 export default function pushLiteral(argument: NormalizedArgumentLiteral, context: CodegenContext): CodegenContext {
 	const kind = resolveArgumentValueKind(argument);
 	return saveByteCode(context, constOpcode[kind](argument.value));

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushLiteral.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushLiteral.ts
@@ -2,7 +2,13 @@ import type { CodegenContext, NormalizedArgumentLiteral } from '@8f4e/compiler-s
 import { saveByteCode } from '../../utils/saveByteCode';
 import { constOpcode, resolveArgumentValueKind } from '../shared';
 
-/** Emits bytecode for pushing a numeric literal onto the stack. */
+/**
+ * Emits bytecode for pushing a numeric literal onto the stack.
+ *
+ * @param argument - Argument whose resolved value or metadata should be used.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export default function pushLiteral(argument: NormalizedArgumentLiteral, context: CodegenContext): CodegenContext {
 	const kind = resolveArgumentValueKind(argument);
 	return saveByteCode(context, constOpcode[kind](argument.value));

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushLocal.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushLocal.ts
@@ -2,6 +2,7 @@ import type { CodegenContext, ResolvedLocalPushLine } from '@8f4e/compiler-spec'
 import { localGet } from '@8f4e/compiler-wasm-utils';
 import { saveByteCode } from '../../utils/saveByteCode';
 
+/** Emits bytecode for pushing a local value onto the stack. */
 export default function pushLocal(line: ResolvedLocalPushLine, context: CodegenContext): CodegenContext {
 	const { local } = line.resolvedTarget;
 

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushLocal.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushLocal.ts
@@ -2,7 +2,13 @@ import type { CodegenContext, ResolvedLocalPushLine } from '@8f4e/compiler-spec'
 import { localGet } from '@8f4e/compiler-wasm-utils';
 import { saveByteCode } from '../../utils/saveByteCode';
 
-/** Emits bytecode for pushing a local value onto the stack. */
+/**
+ * Emits bytecode for pushing a local value onto the stack.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export default function pushLocal(line: ResolvedLocalPushLine, context: CodegenContext): CodegenContext {
 	const { local } = line.resolvedTarget;
 

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushLocalPointer.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushLocalPointer.ts
@@ -4,6 +4,7 @@ import assertFunctionMemoryIoAllowed from '../../assertFunctionMemoryIoAllowed';
 import { saveByteCode } from '../../utils/saveByteCode';
 import { buildPointerDereferenceByteCode } from '../shared';
 
+/** Emits bytecode for pushing the value reached by dereferencing a local pointer. */
 export default function pushLocalPointer(line: ResolvedLocalPointerPushLine, context: CodegenContext): CodegenContext {
 	const { local } = line.resolvedTarget;
 	const { dereferenceDepth } = line.arguments[0];

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushLocalPointer.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushLocalPointer.ts
@@ -4,7 +4,13 @@ import assertFunctionMemoryIoAllowed from '../../assertFunctionMemoryIoAllowed';
 import { saveByteCode } from '../../utils/saveByteCode';
 import { buildPointerDereferenceByteCode } from '../shared';
 
-/** Emits bytecode for pushing the value reached by dereferencing a local pointer. */
+/**
+ * Emits bytecode for pushing the value reached by dereferencing a local pointer.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export default function pushLocalPointer(line: ResolvedLocalPointerPushLine, context: CodegenContext): CodegenContext {
 	const { local } = line.resolvedTarget;
 	const { dereferenceDepth } = line.arguments[0];

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryIdentifier.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryIdentifier.ts
@@ -3,7 +3,13 @@ import { i32const } from '@8f4e/compiler-wasm-utils';
 import { saveByteCode } from '../../utils/saveByteCode';
 import { loadOpcode, resolveMemoryValueKind } from '../shared';
 
-/** Emits bytecode for pushing a resolved memory value by identifier. */
+/**
+ * Emits bytecode for pushing a resolved memory value by identifier.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export default function pushMemoryIdentifier(line: ResolvedMemoryPushLine, context: CodegenContext): CodegenContext {
 	const { memoryItem } = line.resolvedTarget;
 	const kind = resolveMemoryValueKind(memoryItem);

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryIdentifier.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryIdentifier.ts
@@ -3,6 +3,7 @@ import { i32const } from '@8f4e/compiler-wasm-utils';
 import { saveByteCode } from '../../utils/saveByteCode';
 import { loadOpcode, resolveMemoryValueKind } from '../shared';
 
+/** Emits bytecode for pushing a resolved memory value by identifier. */
 export default function pushMemoryIdentifier(line: ResolvedMemoryPushLine, context: CodegenContext): CodegenContext {
 	const { memoryItem } = line.resolvedTarget;
 	const kind = resolveMemoryValueKind(memoryItem);

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryPointer.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryPointer.ts
@@ -4,7 +4,13 @@ import assertFunctionMemoryIoAllowed from '../../assertFunctionMemoryIoAllowed';
 import { saveByteCode } from '../../utils/saveByteCode';
 import { buildPointerDereferenceByteCode } from '../shared';
 
-/** Emits bytecode for pushing the value reached by dereferencing a memory pointer. */
+/**
+ * Emits bytecode for pushing the value reached by dereferencing a memory pointer.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export default function pushMemoryPointer(
 	line: ResolvedMemoryPointerPushLine,
 	context: CodegenContext

--- a/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryPointer.ts
+++ b/packages/compiler/src/instructionCompilers/push/handlers/pushMemoryPointer.ts
@@ -4,6 +4,7 @@ import assertFunctionMemoryIoAllowed from '../../assertFunctionMemoryIoAllowed';
 import { saveByteCode } from '../../utils/saveByteCode';
 import { buildPointerDereferenceByteCode } from '../shared';
 
+/** Emits bytecode for pushing the value reached by dereferencing a memory pointer. */
 export default function pushMemoryPointer(
 	line: ResolvedMemoryPointerPushLine,
 	context: CodegenContext

--- a/packages/compiler/src/instructionCompilers/push/shared.ts
+++ b/packages/compiler/src/instructionCompilers/push/shared.ts
@@ -95,7 +95,17 @@ function getFinalDereferenceLoad(
 	return loadOpcode[kind](pointeeMemoryIndex);
 }
 
-/** Builds bytecode for loading through a pointer with optional guarded access checks. */
+/**
+ * Builds bytecode for loading through a pointer with optional guarded access checks.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param lineNumber - Source line number used for generated guard diagnostics.
+ * @param pointerMetadata - Pointer metadata to inspect.
+ * @param baseAddressByteCode - Bytecode that leaves the base pointer address on the stack.
+ * @param pointerValueSource - Source of the pointer value being dereferenced.
+ * @param dereferenceDepth - Pointer dereference depth requested by the instruction.
+ * @returns The result of the operation.
+ */
 export function buildPointerDereferenceByteCode(
 	context: CodegenContext,
 	lineNumber: number,

--- a/packages/compiler/src/instructionCompilers/push/shared.ts
+++ b/packages/compiler/src/instructionCompilers/push/shared.ts
@@ -27,12 +27,14 @@ type PointerLoadStep = { accessByteWidth: number; loadByteCode: number[]; memory
 
 export { kindToStackItem, resolveArgumentValueKind, resolveMemoryValueKind } from '../../utils/pushValueKind';
 
+/** Numeric constant emitters keyed by resolved value kind. */
 export const constOpcode: Record<PushValueKind, (value: number) => number[]> = {
 	int32: i32const,
 	float32: f32const,
 	float64: f64const,
 };
 
+/** Memory load emitters keyed by resolved value kind. */
 export const loadOpcode: Record<PushValueKind, (memoryIndex: number) => number[]> = {
 	int32: memoryIndex => i32load(2, 0, memoryIndex),
 	float32: memoryIndex => f32load(2, 0, memoryIndex),
@@ -93,6 +95,7 @@ function getFinalDereferenceLoad(
 	return loadOpcode[kind](pointeeMemoryIndex);
 }
 
+/** Builds bytecode for loading through a pointer with optional guarded access checks. */
 export function buildPointerDereferenceByteCode(
 	context: CodegenContext,
 	lineNumber: number,

--- a/packages/compiler/src/instructionCompilers/utils/addressClamp.ts
+++ b/packages/compiler/src/instructionCompilers/utils/addressClamp.ts
@@ -6,6 +6,7 @@ export { getClampAccessByteWidth, getClampedAddressStackItem, getModuleAddressRa
 
 import type { CodegenContext, CompilationContext, CompilerASTLine, MemoryAddressRange } from '@8f4e/compiler-spec';
 
+/** Builds bytecode that clamps the top stack address between lower and upper bounds. */
 export function clampAddressByteCode(
 	context: CodegenContext | CompilationContext,
 	line: CompilerASTLine,
@@ -34,6 +35,7 @@ export function clampAddressByteCode(
 	];
 }
 
+/** Builds bytecode for the last valid starting byte address in a memory range. */
 export function rangeUpperByteAddressCode(range: MemoryAddressRange, accessByteWidth: number): number[] {
 	return i32const(range.byteAddress + Math.max(0, range.safeByteLength - accessByteWidth));
 }

--- a/packages/compiler/src/instructionCompilers/utils/addressClamp.ts
+++ b/packages/compiler/src/instructionCompilers/utils/addressClamp.ts
@@ -6,7 +6,15 @@ export { getClampAccessByteWidth, getClampedAddressStackItem, getModuleAddressRa
 
 import type { CodegenContext, CompilationContext, CompilerASTLine, MemoryAddressRange } from '@8f4e/compiler-spec';
 
-/** Builds bytecode that clamps the top stack address between lower and upper bounds. */
+/**
+ * Builds bytecode that clamps the top stack address between lower and upper bounds.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param line - Compiler line being processed.
+ * @param lowerByteAddress - Inclusive lower byte address for the clamp range.
+ * @param upperByteAddressCode - Bytecode that leaves the inclusive upper byte address on the stack.
+ * @returns The result of the operation.
+ */
 export function clampAddressByteCode(
 	context: CodegenContext | CompilationContext,
 	line: CompilerASTLine,
@@ -35,7 +43,13 @@ export function clampAddressByteCode(
 	];
 }
 
-/** Builds bytecode for the last valid starting byte address in a memory range. */
+/**
+ * Builds bytecode for the last valid starting byte address in a memory range.
+ *
+ * @param range - Optional safe memory range to preserve on the produced address.
+ * @param accessByteWidth - Byte width of the memory access being protected.
+ * @returns The result of the operation.
+ */
 export function rangeUpperByteAddressCode(range: MemoryAddressRange, accessByteWidth: number): number[] {
 	return i32const(range.byteAddress + Math.max(0, range.safeByteLength - accessByteWidth));
 }

--- a/packages/compiler/src/instructionCompilers/utils/internalResources.ts
+++ b/packages/compiler/src/instructionCompilers/utils/internalResources.ts
@@ -5,10 +5,12 @@ type InternalResourceType = InternalResource['storageType'];
 
 type InternalResourceContext = CodegenContext | CompilationContext;
 
+/** Creates a stable internal resource id for compiler-generated module state. */
 export function getInternalResourceId(context: InternalResourceContext, baseId: string): string {
 	return `${context.codeBlockId ?? context.namespace.moduleName ?? 'global'}::${baseId}`;
 }
 
+/** Allocates or reuses a compiler-generated internal resource in the current context. */
 export function allocateInternalResource(
 	context: InternalResourceContext,
 	baseId: string,

--- a/packages/compiler/src/instructionCompilers/utils/internalResources.ts
+++ b/packages/compiler/src/instructionCompilers/utils/internalResources.ts
@@ -5,12 +5,26 @@ type InternalResourceType = InternalResource['storageType'];
 
 type InternalResourceContext = CodegenContext | CompilationContext;
 
-/** Creates a stable internal resource id for compiler-generated module state. */
+/**
+ * Creates a stable internal resource id for compiler-generated module state.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param baseId - Stable id prefix for the internal resource.
+ * @returns The resolved string value.
+ */
 export function getInternalResourceId(context: InternalResourceContext, baseId: string): string {
 	return `${context.codeBlockId ?? context.namespace.moduleName ?? 'global'}::${baseId}`;
 }
 
-/** Allocates or reuses a compiler-generated internal resource in the current context. */
+/**
+ * Allocates or reuses a compiler-generated internal resource in the current context.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param baseId - Stable id prefix for the internal resource.
+ * @param type - Function value type to convert.
+ * @param defaultValue - defaultValue value used by this operation.
+ * @returns The result of the operation.
+ */
 export function allocateInternalResource(
 	context: InternalResourceContext,
 	baseId: string,

--- a/packages/compiler/src/instructionCompilers/utils/memoryAccessGuard.ts
+++ b/packages/compiler/src/instructionCompilers/utils/memoryAccessGuard.ts
@@ -57,6 +57,7 @@ type GuardedMemoryCopyOptions = {
 
 type MemoryGuardContext = CodegenContext | CompilationContext;
 
+/** Allocates or reuses a hidden local used by emitted memory guard bytecode. */
 export function getOrCreateMemoryGuardLocal(
 	context: MemoryGuardContext,
 	name: string,
@@ -77,6 +78,7 @@ export function getOrCreateMemoryGuardLocal(
 	return local;
 }
 
+/** Returns whether stack analysis proves an address can safely access the requested byte width. */
 export function isSafeMemoryAccess(address: StackItem, accessByteWidth: number): boolean {
 	if (address.kind !== 'address') {
 		return false;
@@ -88,6 +90,7 @@ export function isSafeMemoryAccess(address: StackItem, accessByteWidth: number):
 	);
 }
 
+/** Builds bytecode for the last valid start address for an access width in a linear memory. */
 export function linearLastValidStartAddress(accessByteWidth: number, memoryIndex = 0): number[] {
 	return [
 		WASM_MEMORY_SIZE,
@@ -131,6 +134,7 @@ function zeroValue(type: NumericWasmValueType): number[] {
 	return type === WASM_TYPE_F32 ? f32const(0) : i32const(0);
 }
 
+/** Builds a guarded load that returns a zero value when the address is out of bounds. */
 export function guardedLoad(context: MemoryGuardContext, options: GuardedLoadOptions): number[] {
 	return guardedAddressOperation(context, {
 		...options,
@@ -138,6 +142,7 @@ export function guardedLoad(context: MemoryGuardContext, options: GuardedLoadOpt
 	});
 }
 
+/** Builds a guarded address operation with caller-provided bytecode for the in-bounds branch. */
 export function guardedAddressOperation(
 	context: MemoryGuardContext,
 	options: GuardedAddressOperationOptions
@@ -157,6 +162,7 @@ export function guardedAddressOperation(
 	];
 }
 
+/** Builds a guarded store that skips writing when the address is out of bounds. */
 export function guardedStore(context: MemoryGuardContext, options: GuardedStoreOptions): number[] {
 	const addressLocal = getOrCreateMemoryGuardLocal(context, `__memoryGuardAddr_${options.lineNumber}`, {
 		valueType: 'int',
@@ -175,10 +181,12 @@ export function guardedStore(context: MemoryGuardContext, options: GuardedStoreO
 	];
 }
 
+/** Returns whether stack analysis proves both memory-copy ranges are in bounds. */
 export function isSafeMemoryCopy(destination: StackItem, source: StackItem, byteLength: number): boolean {
 	return byteLength > 0 && isSafeMemoryAccess(destination, byteLength) && isSafeMemoryAccess(source, byteLength);
 }
 
+/** Builds a guarded memory.copy that skips copying when either range is out of bounds. */
 export function guardedMemoryCopy(context: MemoryGuardContext, options: GuardedMemoryCopyOptions): number[] {
 	const destinationLocal = getOrCreateMemoryGuardLocal(context, `__memoryCopyDestination_${options.lineNumber}`, {
 		valueType: 'int',
@@ -202,6 +210,7 @@ export function guardedMemoryCopy(context: MemoryGuardContext, options: GuardedM
 	];
 }
 
+/** Builds a guarded store using address and value locals already populated by surrounding bytecode. */
 export function guardedStoreFromLocals(
 	addressLocalIndex: number,
 	valueLocalIndex: number,

--- a/packages/compiler/src/instructionCompilers/utils/memoryAccessGuard.ts
+++ b/packages/compiler/src/instructionCompilers/utils/memoryAccessGuard.ts
@@ -57,7 +57,13 @@ type GuardedMemoryCopyOptions = {
 
 type MemoryGuardContext = CodegenContext | CompilationContext;
 
-/** Allocates or reuses a hidden local used by emitted memory guard bytecode. */
+/**
+ * Allocates or reuses a hidden local used by emitted memory guard bytecode.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param name - Local name used for the generated guard slot.
+ * @param item - Memory item that needs a guard local.
+ */
 export function getOrCreateMemoryGuardLocal(
 	context: MemoryGuardContext,
 	name: string,
@@ -78,7 +84,13 @@ export function getOrCreateMemoryGuardLocal(
 	return local;
 }
 
-/** Returns whether stack analysis proves an address can safely access the requested byte width. */
+/**
+ * Returns whether stack analysis proves an address can safely access the requested byte width.
+ *
+ * @param address - Resolved address metadata to inspect.
+ * @param accessByteWidth - Byte width of the memory access being protected.
+ * @returns Whether the check succeeds.
+ */
 export function isSafeMemoryAccess(address: StackItem, accessByteWidth: number): boolean {
 	if (address.kind !== 'address') {
 		return false;
@@ -90,7 +102,13 @@ export function isSafeMemoryAccess(address: StackItem, accessByteWidth: number):
 	);
 }
 
-/** Builds bytecode for the last valid start address for an access width in a linear memory. */
+/**
+ * Builds bytecode for the last valid start address for an access width in a linear memory.
+ *
+ * @param accessByteWidth - Byte width of the memory access being protected.
+ * @param memoryIndex - Memory index to resolve.
+ * @returns The result of the operation.
+ */
 export function linearLastValidStartAddress(accessByteWidth: number, memoryIndex = 0): number[] {
 	return [
 		WASM_MEMORY_SIZE,
@@ -134,7 +152,13 @@ function zeroValue(type: NumericWasmValueType): number[] {
 	return type === WASM_TYPE_F32 ? f32const(0) : i32const(0);
 }
 
-/** Builds a guarded load that returns a zero value when the address is out of bounds. */
+/**
+ * Builds a guarded load that returns a zero value when the address is out of bounds.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param options - Compiler options for this compilation pass.
+ * @returns The result of the operation.
+ */
 export function guardedLoad(context: MemoryGuardContext, options: GuardedLoadOptions): number[] {
 	return guardedAddressOperation(context, {
 		...options,
@@ -142,7 +166,13 @@ export function guardedLoad(context: MemoryGuardContext, options: GuardedLoadOpt
 	});
 }
 
-/** Builds a guarded address operation with caller-provided bytecode for the in-bounds branch. */
+/**
+ * Builds a guarded address operation with caller-provided bytecode for the in-bounds branch.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param options - Compiler options for this compilation pass.
+ * @returns The result of the operation.
+ */
 export function guardedAddressOperation(
 	context: MemoryGuardContext,
 	options: GuardedAddressOperationOptions
@@ -162,7 +192,13 @@ export function guardedAddressOperation(
 	];
 }
 
-/** Builds a guarded store that skips writing when the address is out of bounds. */
+/**
+ * Builds a guarded store that skips writing when the address is out of bounds.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param options - Compiler options for this compilation pass.
+ * @returns The result of the operation.
+ */
 export function guardedStore(context: MemoryGuardContext, options: GuardedStoreOptions): number[] {
 	const addressLocal = getOrCreateMemoryGuardLocal(context, `__memoryGuardAddr_${options.lineNumber}`, {
 		valueType: 'int',
@@ -181,12 +217,25 @@ export function guardedStore(context: MemoryGuardContext, options: GuardedStoreO
 	];
 }
 
-/** Returns whether stack analysis proves both memory-copy ranges are in bounds. */
+/**
+ * Returns whether stack analysis proves both memory-copy ranges are in bounds.
+ *
+ * @param destination - Destination address metadata for the memory copy.
+ * @param source - Source address metadata for the memory copy.
+ * @param byteLength - Number of bytes to materialize or validate.
+ * @returns Whether the check succeeds.
+ */
 export function isSafeMemoryCopy(destination: StackItem, source: StackItem, byteLength: number): boolean {
 	return byteLength > 0 && isSafeMemoryAccess(destination, byteLength) && isSafeMemoryAccess(source, byteLength);
 }
 
-/** Builds a guarded memory.copy that skips copying when either range is out of bounds. */
+/**
+ * Builds a guarded memory.copy that skips copying when either range is out of bounds.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param options - Compiler options for this compilation pass.
+ * @returns The result of the operation.
+ */
 export function guardedMemoryCopy(context: MemoryGuardContext, options: GuardedMemoryCopyOptions): number[] {
 	const destinationLocal = getOrCreateMemoryGuardLocal(context, `__memoryCopyDestination_${options.lineNumber}`, {
 		valueType: 'int',
@@ -210,7 +259,16 @@ export function guardedMemoryCopy(context: MemoryGuardContext, options: GuardedM
 	];
 }
 
-/** Builds a guarded store using address and value locals already populated by surrounding bytecode. */
+/**
+ * Builds a guarded store using address and value locals already populated by surrounding bytecode.
+ *
+ * @param addressLocalIndex - Local index holding the guarded destination address.
+ * @param valueLocalIndex - Local index holding the guarded value to store.
+ * @param accessByteWidth - Byte width of the memory access being protected.
+ * @param storeByteCode - storeByteCode value used by this operation.
+ * @param memoryIndex - Memory index to resolve.
+ * @returns The result of the operation.
+ */
 export function guardedStoreFromLocals(
 	addressLocalIndex: number,
 	valueLocalIndex: number,

--- a/packages/compiler/src/instructionCompilers/utils/saveByteCode.ts
+++ b/packages/compiler/src/instructionCompilers/utils/saveByteCode.ts
@@ -1,5 +1,6 @@
 import type { CodegenContext } from '@8f4e/compiler-spec';
 
+/** Appends one bytecode fragment to the active code generation context. */
 export function saveByteCode(context: CodegenContext, byteCode: number[]): CodegenContext {
 	context.byteCode.push(...byteCode);
 	return context;

--- a/packages/compiler/src/instructionCompilers/utils/saveByteCode.ts
+++ b/packages/compiler/src/instructionCompilers/utils/saveByteCode.ts
@@ -1,6 +1,12 @@
 import type { CodegenContext } from '@8f4e/compiler-spec';
 
-/** Appends one bytecode fragment to the active code generation context. */
+/**
+ * Appends one bytecode fragment to the active code generation context.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param byteCode - Instruction bytes to append to the current output.
+ * @returns The result of the operation.
+ */
 export function saveByteCode(context: CodegenContext, byteCode: number[]): CodegenContext {
 	context.byteCode.push(...byteCode);
 	return context;

--- a/packages/compiler/src/semantic/buildNamespace.ts
+++ b/packages/compiler/src/semantic/buildNamespace.ts
@@ -50,6 +50,10 @@ type FunctionMetadataCollectionOptions = {
  * This allows semantic normalization (e.g. `call` target validation) and
  * function-body codegen to rely on the same registry before full function
  * compilation completes.
+ *
+ * @param asts - Validated ASTs being processed.
+ * @param options - Compiler options for this compilation pass.
+ * @returns The result of the operation.
  */
 export function collectFunctionMetadataFromAsts(
 	asts: readonly ValidatedFunctionAST[],
@@ -93,7 +97,11 @@ export function collectFunctionMetadataFromAsts(
 	return result;
 }
 
-/** Ensures module source blocks declare unique ids before namespace discovery. */
+/**
+ * Ensures module source blocks declare unique ids before namespace discovery.
+ *
+ * @param asts - Validated ASTs being processed.
+ */
 export function assertUniqueModuleIds(asts: readonly (ValidatedModuleAST | ValidatedConstantsAST)[]): void {
 	const seenModuleIds = new Set<string>();
 
@@ -110,7 +118,12 @@ export function assertUniqueModuleIds(asts: readonly (ValidatedModuleAST | Valid
 	}
 }
 
-/** Normalizes and applies one semantic instruction, trusting tokenizer placement validation. */
+/**
+ * Normalizes and applies one semantic instruction, trusting tokenizer placement validation.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ */
 export function applySemanticLine(line: SemanticInstructionLine, context: CompilationContext) {
 	const normalizedLine = normalizeCompileTimeArguments(line, context);
 	applySemanticInstruction(normalizedLine, context);
@@ -218,7 +231,17 @@ function discoverNamespace(
 	return context;
 }
 
-/** Applies semantic declarations and resolves scalar defaults for one namespace AST. */
+/**
+ * Applies semantic declarations and resolves scalar defaults for one namespace AST.
+ *
+ * @param ast - Validated AST being processed.
+ * @param namespaces - Collected namespaces used for symbol and memory resolution.
+ * @param startingByteAddress - Absolute byte address where layout should begin.
+ * @param functions - Function metadata lookup available to compilation.
+ * @param options - Compiler options for this compilation pass.
+ * @param prototypeShapes - Prototype shape ASTs available during semantic layout.
+ * @returns The result of the operation.
+ */
 export function layoutNamespace(
 	ast: ValidatedModuleAST | ValidatedConstantsAST,
 	namespaces: Namespaces,
@@ -287,7 +310,17 @@ function toNamespaceDiscoveryMemoryDeclarationLine(line: MemoryDeclarationLine):
 	};
 }
 
-/** Discovers and lays out namespaces for modules and constants, deferring intermodule dependencies as needed. */
+/**
+ * Discovers and lays out namespaces for modules and constants, deferring intermodule dependencies as needed.
+ *
+ * @param asts - Validated ASTs being processed.
+ * @param startingByteAddress - Absolute byte address where layout should begin.
+ * @param compiledFunctions - Compiled function metadata available to module compilation.
+ * @param layoutAsts - layoutAsts value used by this operation.
+ * @param options - Compiler options for this compilation pass.
+ * @param prototypeShapes - Prototype shape ASTs available during semantic layout.
+ * @returns The result of the operation.
+ */
 export function collectNamespacesFromASTs(
 	asts: readonly (ValidatedModuleAST | ValidatedConstantsAST)[],
 	startingByteAddress = GLOBAL_ALIGNMENT_BOUNDARY,

--- a/packages/compiler/src/semantic/buildNamespace.ts
+++ b/packages/compiler/src/semantic/buildNamespace.ts
@@ -218,6 +218,7 @@ function discoverNamespace(
 	return context;
 }
 
+/** Applies semantic declarations and resolves scalar defaults for one namespace AST. */
 export function layoutNamespace(
 	ast: ValidatedModuleAST | ValidatedConstantsAST,
 	namespaces: Namespaces,
@@ -286,6 +287,7 @@ function toNamespaceDiscoveryMemoryDeclarationLine(line: MemoryDeclarationLine):
 	};
 }
 
+/** Discovers and lays out namespaces for modules and constants, deferring intermodule dependencies as needed. */
 export function collectNamespacesFromASTs(
 	asts: readonly (ValidatedModuleAST | ValidatedConstantsAST)[],
 	startingByteAddress = GLOBAL_ALIGNMENT_BOUNDARY,

--- a/packages/compiler/src/semantic/compilerDirectives.ts
+++ b/packages/compiler/src/semantic/compilerDirectives.ts
@@ -1,2 +1,5 @@
+/** Compiler directives that are valid in module bodies. */
 export const moduleCompilerDirectives = ['#skipExecution', '#loopCap', '#region'] as const;
+
+/** Compiler directives that are valid in function bodies. */
 export const functionCompilerDirectives = ['#impure', '#export', '#import', '#loopCap'] as const;

--- a/packages/compiler/src/semantic/declarations/createDeclarationCompiler.ts
+++ b/packages/compiler/src/semantic/declarations/createDeclarationCompiler.ts
@@ -11,6 +11,7 @@ import { getMemoryRegionFields } from '../memoryRegions';
 import getMemoryFlags from '../utils/memoryFlags';
 import parseMemoryInstructionArguments from '../utils/memoryInstructionParser';
 
+/** Function signature shared by semantic memory declaration compilers. */
 export type MemoryDeclarationCompiler<TLine extends MemoryDeclarationLine = MemoryDeclarationLine> = (
 	line: TLine,
 	context: CompilationContext

--- a/packages/compiler/src/semantic/declarations/createDeclarationCompiler.ts
+++ b/packages/compiler/src/semantic/declarations/createDeclarationCompiler.ts
@@ -75,6 +75,9 @@ function getPointeeElementCount(
  *
  * All declaration compilers share the same five-step pattern; only the base
  * type, truncation behaviour, and non-pointer element word size differ.
+ *
+ * @param options - Compiler options for this compilation pass.
+ * @returns The result of the operation.
  */
 export default function createDeclarationCompiler(options: DeclarationCompilerOptions): MemoryDeclarationCompiler {
 	const { baseType, truncate, nonPointerElementWordSize } = options;

--- a/packages/compiler/src/semantic/declarations/index.ts
+++ b/packages/compiler/src/semantic/declarations/index.ts
@@ -44,12 +44,22 @@ export const declarationCompilers = Object.fromEntries(
 /** Set of instructions handled by semantic memory declaration compilers. */
 export const memoryDeclarationInstructions = new Set<MemoryDeclarationInstruction>(specMemoryDeclarationInstructions);
 
-/** Returns whether an instruction name is a memory declaration instruction. */
+/**
+ * Returns whether an instruction name is a memory declaration instruction.
+ *
+ * @param instruction - instruction value used by this operation.
+ * @returns The result of the operation.
+ */
 export function isMemoryDeclarationInstruction(instruction: string): instruction is MemoryDeclarationInstruction {
 	return memoryDeclarationInstructions.has(instruction as MemoryDeclarationInstruction);
 }
 
-/** Validates and applies one semantic memory declaration line to the namespace context. */
+/**
+ * Validates and applies one semantic memory declaration line to the namespace context.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ */
 export function applyMemoryDeclarationLine(line: MemoryDeclarationLine, context: CompilationContext) {
 	validateInstruction(line, context);
 	const compileDeclaration = declarationCompilers[

--- a/packages/compiler/src/semantic/declarations/index.ts
+++ b/packages/compiler/src/semantic/declarations/index.ts
@@ -36,16 +36,20 @@ function getDeclarationCompiler(instruction: MemoryDeclarationInstruction): Memo
 	return int as MemoryDeclarationCompiler;
 }
 
+/** Semantic declaration compilers keyed by memory declaration instruction. */
 export const declarationCompilers = Object.fromEntries(
 	specMemoryDeclarationInstructions.map(instruction => [instruction, getDeclarationCompiler(instruction)])
 ) as Record<MemoryDeclarationInstruction, MemoryDeclarationCompiler>;
 
+/** Set of instructions handled by semantic memory declaration compilers. */
 export const memoryDeclarationInstructions = new Set<MemoryDeclarationInstruction>(specMemoryDeclarationInstructions);
 
+/** Returns whether an instruction name is a memory declaration instruction. */
 export function isMemoryDeclarationInstruction(instruction: string): instruction is MemoryDeclarationInstruction {
 	return memoryDeclarationInstructions.has(instruction as MemoryDeclarationInstruction);
 }
 
+/** Validates and applies one semantic memory declaration line to the namespace context. */
 export function applyMemoryDeclarationLine(line: MemoryDeclarationLine, context: CompilationContext) {
 	validateInstruction(line, context);
 	const compileDeclaration = declarationCompilers[

--- a/packages/compiler/src/semantic/instructions/module.ts
+++ b/packages/compiler/src/semantic/instructions/module.ts
@@ -9,7 +9,12 @@ import { pushBlock } from '../../utils/blockStack';
 
 const moduleBlockType = compilerSourceBlockInstructionByType.module.type;
 
-/** Applies the `module` semantic instruction to initialize the active namespace context. */
+/**
+ * Applies the `module` semantic instruction to initialize the active namespace context.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ */
 export default function semanticModule(line: ModuleLine, context: CompilationContext) {
 	const moduleId = line.arguments[0].value;
 

--- a/packages/compiler/src/semantic/instructions/module.ts
+++ b/packages/compiler/src/semantic/instructions/module.ts
@@ -9,6 +9,7 @@ import { pushBlock } from '../../utils/blockStack';
 
 const moduleBlockType = compilerSourceBlockInstructionByType.module.type;
 
+/** Applies the `module` semantic instruction to initialize the active namespace context. */
 export default function semanticModule(line: ModuleLine, context: CompilationContext) {
 	const moduleId = line.arguments[0].value;
 

--- a/packages/compiler/src/semantic/instructions/region.ts
+++ b/packages/compiler/src/semantic/instructions/region.ts
@@ -2,7 +2,12 @@ import type { CompilationContext, RegionLine } from '@8f4e/compiler-spec';
 
 import { resolveRegionDirective } from '../memoryRegions';
 
-/** Applies the `#region` directive to switch the active memory region for subsequent declarations. */
+/**
+ * Applies the `#region` directive to switch the active memory region for subsequent declarations.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ */
 export default function semanticRegion(line: RegionLine, context: CompilationContext) {
 	const region = resolveRegionDirective(line, context);
 	context.currentMemoryIndex = region.memoryIndex;

--- a/packages/compiler/src/semantic/instructions/region.ts
+++ b/packages/compiler/src/semantic/instructions/region.ts
@@ -2,6 +2,7 @@ import type { CompilationContext, RegionLine } from '@8f4e/compiler-spec';
 
 import { resolveRegionDirective } from '../memoryRegions';
 
+/** Applies the `#region` directive to switch the active memory region for subsequent declarations. */
 export default function semanticRegion(line: RegionLine, context: CompilationContext) {
 	const region = resolveRegionDirective(line, context);
 	context.currentMemoryIndex = region.memoryIndex;

--- a/packages/compiler/src/semantic/instructions/shape.ts
+++ b/packages/compiler/src/semantic/instructions/shape.ts
@@ -4,6 +4,7 @@ import { getError } from '../../compilerError';
 import { applyMemoryDeclarationLine } from '../declarations';
 import normalizeCompileTimeArguments from '../normalizeCompileTimeArguments';
 
+/** Expands a prototype `shape` instruction into semantic memory declarations. */
 export default function semanticShape(line: ShapeLine, context: CompilationContext) {
 	if (!context.expandPrototypeShapes) {
 		return;

--- a/packages/compiler/src/semantic/instructions/shape.ts
+++ b/packages/compiler/src/semantic/instructions/shape.ts
@@ -4,7 +4,12 @@ import { getError } from '../../compilerError';
 import { applyMemoryDeclarationLine } from '../declarations';
 import normalizeCompileTimeArguments from '../normalizeCompileTimeArguments';
 
-/** Expands a prototype `shape` instruction into semantic memory declarations. */
+/**
+ * Expands a prototype `shape` instruction into semantic memory declarations.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ */
 export default function semanticShape(line: ShapeLine, context: CompilationContext) {
 	if (!context.expandPrototypeShapes) {
 		return;

--- a/packages/compiler/src/semantic/layoutAddresses.ts
+++ b/packages/compiler/src/semantic/layoutAddresses.ts
@@ -1,11 +1,23 @@
 import { GLOBAL_ALIGNMENT_BOUNDARY } from '@8f4e/compiler-spec';
 
-/** Converts a word offset relative to a byte base into an absolute byte address. */
+/**
+ * Converts a word offset relative to a byte base into an absolute byte address.
+ *
+ * @param startingByteAddress - Absolute byte address where layout should begin.
+ * @param wordOffset - wordOffset value used by this operation.
+ * @returns The resolved numeric value.
+ */
 export function getByteAddressFromWordOffset(startingByteAddress: number, wordOffset: number): number {
 	return startingByteAddress + wordOffset * GLOBAL_ALIGNMENT_BOUNDARY;
 }
 
-/** Returns the final byte address occupied by a word-aligned allocation. */
+/**
+ * Returns the final byte address occupied by a word-aligned allocation.
+ *
+ * @param byteAddress - Byte address where the value should be written.
+ * @param wordAlignedSize - wordAlignedSize value used by this operation.
+ * @returns The resolved numeric value.
+ */
 export function getEndByteAddress(byteAddress: number, wordAlignedSize: number): number {
 	if (wordAlignedSize <= 0) {
 		return byteAddress;
@@ -13,12 +25,24 @@ export function getEndByteAddress(byteAddress: number, wordAlignedSize: number):
 	return byteAddress + (wordAlignedSize - 1) * GLOBAL_ALIGNMENT_BOUNDARY;
 }
 
-/** Converts a local word offset into an absolute word offset. */
+/**
+ * Converts a local word offset into an absolute word offset.
+ *
+ * @param startingByteAddress - Absolute byte address where layout should begin.
+ * @param localWordOffset - Word offset relative to the current allocation start.
+ * @returns The resolved numeric value.
+ */
 export function getAbsoluteWordOffset(startingByteAddress: number, localWordOffset: number): number {
 	return startingByteAddress / GLOBAL_ALIGNMENT_BOUNDARY + localWordOffset;
 }
 
-/** Aligns 64-bit allocations to an even absolute word offset. */
+/**
+ * Aligns 64-bit allocations to an even absolute word offset.
+ *
+ * @param absoluteWordOffset - absoluteWordOffset value used by this operation.
+ * @param elementWordSize - Word size used to align the absolute offset.
+ * @returns The resolved numeric value.
+ */
 export function alignAbsoluteWordOffset(absoluteWordOffset: number, elementWordSize: number): number {
 	if (elementWordSize !== 8 || absoluteWordOffset % 2 === 0) {
 		return absoluteWordOffset;

--- a/packages/compiler/src/semantic/layoutAddresses.ts
+++ b/packages/compiler/src/semantic/layoutAddresses.ts
@@ -1,9 +1,11 @@
 import { GLOBAL_ALIGNMENT_BOUNDARY } from '@8f4e/compiler-spec';
 
+/** Converts a word offset relative to a byte base into an absolute byte address. */
 export function getByteAddressFromWordOffset(startingByteAddress: number, wordOffset: number): number {
 	return startingByteAddress + wordOffset * GLOBAL_ALIGNMENT_BOUNDARY;
 }
 
+/** Returns the final byte address occupied by a word-aligned allocation. */
 export function getEndByteAddress(byteAddress: number, wordAlignedSize: number): number {
 	if (wordAlignedSize <= 0) {
 		return byteAddress;
@@ -11,10 +13,12 @@ export function getEndByteAddress(byteAddress: number, wordAlignedSize: number):
 	return byteAddress + (wordAlignedSize - 1) * GLOBAL_ALIGNMENT_BOUNDARY;
 }
 
+/** Converts a local word offset into an absolute word offset. */
 export function getAbsoluteWordOffset(startingByteAddress: number, localWordOffset: number): number {
 	return startingByteAddress / GLOBAL_ALIGNMENT_BOUNDARY + localWordOffset;
 }
 
+/** Aligns 64-bit allocations to an even absolute word offset. */
 export function alignAbsoluteWordOffset(absoluteWordOffset: number, elementWordSize: number): number {
 	if (elementWordSize !== 8 || absoluteWordOffset % 2 === 0) {
 		return absoluteWordOffset;

--- a/packages/compiler/src/semantic/memoryRegions.ts
+++ b/packages/compiler/src/semantic/memoryRegions.ts
@@ -20,12 +20,24 @@ function fallbackLine(): CompilerASTLine {
 	};
 }
 
-/** Returns the configured region name for a non-default memory index. */
+/**
+ * Returns the configured region name for a non-default memory index.
+ *
+ * @param memoryRegions - Configured custom memory region names.
+ * @param memoryIndex - Memory index to resolve.
+ * @returns The resolved string value.
+ */
 export function getCustomMemoryRegionName(memoryRegions: readonly string[], memoryIndex: number): string {
 	return memoryRegions[memoryIndex - 1]!;
 }
 
-/** Builds the optional memory region fields stored on namespaces and memory metadata. */
+/**
+ * Builds the optional memory region fields stored on namespaces and memory metadata.
+ *
+ * @param memoryIndex - Memory index to resolve.
+ * @param memoryRegionName - Configured memory region name to resolve.
+ * @returns The result of the operation.
+ */
 export function getMemoryRegionFields(memoryIndex: number, memoryRegionName?: string): ResolvedMemoryRegion {
 	return {
 		memoryIndex,
@@ -33,7 +45,12 @@ export function getMemoryRegionFields(memoryIndex: number, memoryRegionName?: st
 	};
 }
 
-/** Validates configured memory region names before semantic compilation uses them. */
+/**
+ * Validates configured memory region names before semantic compilation uses them.
+ *
+ * @param options - Compiler options for this compilation pass.
+ * @param line - Compiler line being processed.
+ */
 export function validateMemoryRegionOptions(
 	options?: Pick<CompileOptions, 'memoryRegions'>,
 	line: CompilerASTLine = fallbackLine()
@@ -51,7 +68,15 @@ export function validateMemoryRegionOptions(
 	}
 }
 
-/** Resolves a numeric region directive argument into memory region metadata. */
+/**
+ * Resolves a numeric region directive argument into memory region metadata.
+ *
+ * @param memoryIndex - Memory index to resolve.
+ * @param memoryRegions - Configured custom memory region names.
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export function resolveMemoryRegionByIndex(
 	memoryIndex: number,
 	memoryRegions: readonly string[],
@@ -70,7 +95,15 @@ export function resolveMemoryRegionByIndex(
 	};
 }
 
-/** Resolves a named region directive argument into memory region metadata. */
+/**
+ * Resolves a named region directive argument into memory region metadata.
+ *
+ * @param memoryRegionName - Configured memory region name to resolve.
+ * @param memoryRegions - Configured custom memory region names.
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export function resolveMemoryRegionName(
 	memoryRegionName: string,
 	memoryRegions: readonly string[],
@@ -88,7 +121,13 @@ export function resolveMemoryRegionName(
 	};
 }
 
-/** Resolves the active memory region from a parsed `#region` directive line. */
+/**
+ * Resolves the active memory region from a parsed `#region` directive line.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export function resolveRegionDirective(line: RegionLine, context: CompilationContext): ResolvedMemoryRegion {
 	const [argument] = line.arguments;
 	if (argument.type === ArgumentType.LITERAL) {
@@ -98,7 +137,11 @@ export function resolveRegionDirective(line: RegionLine, context: CompilationCon
 	return resolveMemoryRegionName(argument.value, context.memoryRegions, line, context);
 }
 
-/** Returns metadata for the default WebAssembly memory region. */
+/**
+ * Returns metadata for the default WebAssembly memory region.
+ *
+ * @returns The result of the operation.
+ */
 export function getDefaultMemoryRegion(): ResolvedMemoryRegion {
 	return { memoryIndex: DEFAULT_MEMORY_INDEX };
 }

--- a/packages/compiler/src/semantic/memoryRegions.ts
+++ b/packages/compiler/src/semantic/memoryRegions.ts
@@ -2,9 +2,11 @@ import type { CompilationContext, CompileOptions, CompilerASTLine, RegionLine } 
 import { ArgumentType, ErrorCode } from '@8f4e/compiler-spec';
 import { getError } from '../compilerError';
 
+/** WebAssembly memory index used when no custom region is active. */
 export const DEFAULT_MEMORY_INDEX = 0;
 const RESERVED_REGION_NAMES = new Set(['default', 'memory']);
 
+/** Resolved memory region identity used by semantic layout and codegen. */
 export interface ResolvedMemoryRegion {
 	memoryIndex: number;
 	memoryRegionName?: string;
@@ -18,10 +20,12 @@ function fallbackLine(): CompilerASTLine {
 	};
 }
 
+/** Returns the configured region name for a non-default memory index. */
 export function getCustomMemoryRegionName(memoryRegions: readonly string[], memoryIndex: number): string {
 	return memoryRegions[memoryIndex - 1]!;
 }
 
+/** Builds the optional memory region fields stored on namespaces and memory metadata. */
 export function getMemoryRegionFields(memoryIndex: number, memoryRegionName?: string): ResolvedMemoryRegion {
 	return {
 		memoryIndex,
@@ -29,6 +33,7 @@ export function getMemoryRegionFields(memoryIndex: number, memoryRegionName?: st
 	};
 }
 
+/** Validates configured memory region names before semantic compilation uses them. */
 export function validateMemoryRegionOptions(
 	options?: Pick<CompileOptions, 'memoryRegions'>,
 	line: CompilerASTLine = fallbackLine()
@@ -46,6 +51,7 @@ export function validateMemoryRegionOptions(
 	}
 }
 
+/** Resolves a numeric region directive argument into memory region metadata. */
 export function resolveMemoryRegionByIndex(
 	memoryIndex: number,
 	memoryRegions: readonly string[],
@@ -64,6 +70,7 @@ export function resolveMemoryRegionByIndex(
 	};
 }
 
+/** Resolves a named region directive argument into memory region metadata. */
 export function resolveMemoryRegionName(
 	memoryRegionName: string,
 	memoryRegions: readonly string[],
@@ -81,6 +88,7 @@ export function resolveMemoryRegionName(
 	};
 }
 
+/** Resolves the active memory region from a parsed `#region` directive line. */
 export function resolveRegionDirective(line: RegionLine, context: CompilationContext): ResolvedMemoryRegion {
 	const [argument] = line.arguments;
 	if (argument.type === ArgumentType.LITERAL) {
@@ -90,6 +98,7 @@ export function resolveRegionDirective(line: RegionLine, context: CompilationCon
 	return resolveMemoryRegionName(argument.value, context.memoryRegions, line, context);
 }
 
+/** Returns metadata for the default WebAssembly memory region. */
 export function getDefaultMemoryRegion(): ResolvedMemoryRegion {
 	return { memoryIndex: DEFAULT_MEMORY_INDEX };
 }

--- a/packages/compiler/src/semantic/normalization/clampAddress.ts
+++ b/packages/compiler/src/semantic/normalization/clampAddress.ts
@@ -4,7 +4,13 @@ import { ArgumentType, ErrorCode, SUPPORTED_MEMORY_ACCESS_BYTE_WIDTHS } from '@8
 import { getError } from '../../compilerError';
 import { normalizeAndValidateResolvableArgs } from './helpers';
 
-/** Normalizes and validates optional access-width arguments for clamp-address instructions. */
+/**
+ * Normalizes and validates optional access-width arguments for clamp-address instructions.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export default function normalizeClampAddress(line: CompilerASTLine, context: CompilationContext): CompilerASTLine {
 	const normalized = normalizeAndValidateResolvableArgs(line, context, [0]);
 	const argument = normalized.arguments[0];

--- a/packages/compiler/src/semantic/normalization/clampAddress.ts
+++ b/packages/compiler/src/semantic/normalization/clampAddress.ts
@@ -4,6 +4,7 @@ import { ArgumentType, ErrorCode, SUPPORTED_MEMORY_ACCESS_BYTE_WIDTHS } from '@8
 import { getError } from '../../compilerError';
 import { normalizeAndValidateResolvableArgs } from './helpers';
 
+/** Normalizes and validates optional access-width arguments for clamp-address instructions. */
 export default function normalizeClampAddress(line: CompilerASTLine, context: CompilationContext): CompilerASTLine {
 	const normalized = normalizeAndValidateResolvableArgs(line, context, [0]);
 	const argument = normalized.arguments[0];

--- a/packages/compiler/src/semantic/normalization/const.ts
+++ b/packages/compiler/src/semantic/normalization/const.ts
@@ -11,7 +11,13 @@ import { normalizeArgumentsAtIndexes } from './helpers';
 // Throws UNDECLARED_IDENTIFIER when the value cannot be folded to a literal.
 // During namespace discovery, collectNamespacesFromASTs catches this to defer the AST
 // until the referenced identifiers are available.
-/** Normalizes and requires the value argument for a `const` line to fold to a literal. */
+/**
+ * Normalizes and requires the value argument for a `const` line to fold to a literal.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export default function normalizeConst(line: ConstLine, context: CompilationContext): NormalizedConstLine {
 	const { line: result } = normalizeArgumentsAtIndexes(line, context, [1]);
 

--- a/packages/compiler/src/semantic/normalization/const.ts
+++ b/packages/compiler/src/semantic/normalization/const.ts
@@ -11,6 +11,7 @@ import { normalizeArgumentsAtIndexes } from './helpers';
 // Throws UNDECLARED_IDENTIFIER when the value cannot be folded to a literal.
 // During namespace discovery, collectNamespacesFromASTs catches this to defer the AST
 // until the referenced identifiers are available.
+/** Normalizes and requires the value argument for a `const` line to fold to a literal. */
 export default function normalizeConst(line: ConstLine, context: CompilationContext): NormalizedConstLine {
 	const { line: result } = normalizeArgumentsAtIndexes(line, context, [1]);
 

--- a/packages/compiler/src/semantic/normalization/helpers.ts
+++ b/packages/compiler/src/semantic/normalization/helpers.ts
@@ -11,6 +11,7 @@ import {
 import { getError } from '../../compilerError';
 import { tryResolveCompileTimeArgument } from '../resolveCompileTimeArgument';
 
+/** Returns whether namespace discovery has populated any module or constants namespaces. */
 export function hasCollectedNamespaces(context: CompilationContext): boolean {
 	return Object.keys(context.namespace.namespaces).length > 0;
 }
@@ -20,6 +21,7 @@ function getTargetModuleNamespace(context: CompilationContext, targetModuleId: s
 	return targetNamespace?.kind === 'module' ? targetNamespace : undefined;
 }
 
+/** Returns whether an identifier reference kind targets another namespace. */
 export function isIntermoduleReferenceKind(referenceKind: ReferenceKind): boolean {
 	return (
 		referenceKind === 'intermodular-module-reference' ||
@@ -90,6 +92,7 @@ export function validateIntermoduleAddressReference(
 	}
 }
 
+/** Attempts to fold one argument to a normalized literal, leaving unresolved arguments unchanged. */
 export function normalizeArgument(
 	argument: Argument,
 	context: CompilationContext

--- a/packages/compiler/src/semantic/normalization/helpers.ts
+++ b/packages/compiler/src/semantic/normalization/helpers.ts
@@ -11,7 +11,12 @@ import {
 import { getError } from '../../compilerError';
 import { tryResolveCompileTimeArgument } from '../resolveCompileTimeArgument';
 
-/** Returns whether namespace discovery has populated any module or constants namespaces. */
+/**
+ * Returns whether namespace discovery has populated any module or constants namespaces.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns Whether the check succeeds.
+ */
 export function hasCollectedNamespaces(context: CompilationContext): boolean {
 	return Object.keys(context.namespace.namespaces).length > 0;
 }
@@ -21,7 +26,12 @@ function getTargetModuleNamespace(context: CompilationContext, targetModuleId: s
 	return targetNamespace?.kind === 'module' ? targetNamespace : undefined;
 }
 
-/** Returns whether an identifier reference kind targets another namespace. */
+/**
+ * Returns whether an identifier reference kind targets another namespace.
+ *
+ * @param referenceKind - referenceKind value used by this operation.
+ * @returns Whether the check succeeds.
+ */
 export function isIntermoduleReferenceKind(referenceKind: ReferenceKind): boolean {
 	return (
 		referenceKind === 'intermodular-module-reference' ||
@@ -38,6 +48,10 @@ export function isIntermoduleReferenceKind(referenceKind: ReferenceKind): boolea
  * target existing modules and memory once namespace collection is complete.
  * It does not evaluate the query value itself during namespace discovery; numeric resolution
  * of sizeof/count/max/min forms is handled by tryResolveCompileTimeArgument.
+ *
+ * @param identifier - identifier value used by this operation.
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
  */
 export function validateIntermoduleAddressReference(
 	identifier: ArgumentIdentifier,
@@ -92,7 +106,13 @@ export function validateIntermoduleAddressReference(
 	}
 }
 
-/** Attempts to fold one argument to a normalized literal, leaving unresolved arguments unchanged. */
+/**
+ * Attempts to fold one argument to a normalized literal, leaving unresolved arguments unchanged.
+ *
+ * @param argument - Argument whose resolved value or metadata should be used.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export function normalizeArgument(
 	argument: Argument,
 	context: CompilationContext
@@ -124,6 +144,11 @@ export function normalizeArgument(
  * Validates an unresolved compile-time expression argument, deferring namespace references during discovery.
  * Throws UNDECLARED_IDENTIFIER if the expression cannot be deferred and cannot be resolved.
  * Returns true if the argument was deferred, false if it should continue processing.
+ *
+ * @param argument - Argument whose resolved value or metadata should be used.
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns Whether the check succeeds.
  */
 export function validateOrDeferCompileTimeExpression(
 	argument: Extract<Argument, { type: typeof ArgumentType.COMPILE_TIME_EXPRESSION }>,
@@ -149,6 +174,11 @@ export function validateOrDeferCompileTimeExpression(
  * (e.g. map, default). Throws UNDECLARED_IDENTIFIER unless the identifier is deferred
  * as a namespace reference during discovery.
  * Returns true if the argument was deferred, false if processing should continue.
+ *
+ * @param argument - Argument whose resolved value or metadata should be used.
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns Whether the check succeeds.
  */
 export function validateOrDeferUnresolvedIdentifier(
 	argument: Extract<Argument, { type: typeof ArgumentType.IDENTIFIER }>,
@@ -169,6 +199,11 @@ export function validateOrDeferUnresolvedIdentifier(
  * throw or defer unresolved compile-time expressions or identifiers. Callers
  * are responsible for invoking validateOrDefer* helpers when that behavior
  * is required.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param indexes - Argument indexes that should be normalized.
+ * @returns The result of the operation.
  */
 export function normalizeArgumentsAtIndexes<TLine extends CompilerASTLine>(
 	line: TLine,
@@ -194,6 +229,11 @@ export function normalizeArgumentsAtIndexes<TLine extends CompilerASTLine>(
 /**
  * Normalizes arguments at the given indexes, then validates any remaining unresolved
  * compile-time expressions or identifiers as either deferrable namespace references or errors.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param indexes - Argument indexes that should be normalized.
+ * @returns The result of the operation.
  */
 export function normalizeAndValidateResolvableArgs<TLine extends CompilerASTLine>(
 	line: TLine,

--- a/packages/compiler/src/semantic/normalization/index.ts
+++ b/packages/compiler/src/semantic/normalization/index.ts
@@ -25,7 +25,13 @@ const instructionNormalizers = {
 	push: normalizePush,
 } as const;
 
-/** Dispatches line-specific semantic normalization before analysis and codegen. */
+/**
+ * Dispatches line-specific semantic normalization before analysis and codegen.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export default function dispatchNormalization<TLine extends CompilerASTLine>(
 	line: TLine,
 	context: CompilationContext

--- a/packages/compiler/src/semantic/normalization/index.ts
+++ b/packages/compiler/src/semantic/normalization/index.ts
@@ -25,6 +25,7 @@ const instructionNormalizers = {
 	push: normalizePush,
 } as const;
 
+/** Dispatches line-specific semantic normalization before analysis and codegen. */
 export default function dispatchNormalization<TLine extends CompilerASTLine>(
 	line: TLine,
 	context: CompilationContext

--- a/packages/compiler/src/semantic/normalization/memoryCopy.ts
+++ b/packages/compiler/src/semantic/normalization/memoryCopy.ts
@@ -8,6 +8,7 @@ import {
 import { getError } from '../../compilerError';
 import { normalizeAndValidateResolvableArgs } from './helpers';
 
+/** Normalizes and validates the byte-length argument for `memoryCopy`. */
 export default function normalizeMemoryCopy(
 	line: MemoryCopyLine,
 	context: CompilationContext

--- a/packages/compiler/src/semantic/normalization/memoryCopy.ts
+++ b/packages/compiler/src/semantic/normalization/memoryCopy.ts
@@ -8,7 +8,13 @@ import {
 import { getError } from '../../compilerError';
 import { normalizeAndValidateResolvableArgs } from './helpers';
 
-/** Normalizes and validates the byte-length argument for `memoryCopy`. */
+/**
+ * Normalizes and validates the byte-length argument for `memoryCopy`.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export default function normalizeMemoryCopy(
 	line: MemoryCopyLine,
 	context: CompilationContext

--- a/packages/compiler/src/semantic/normalizeCompileTimeArguments.ts
+++ b/packages/compiler/src/semantic/normalizeCompileTimeArguments.ts
@@ -1,7 +1,13 @@
 import type { CompilationContext, CompilerASTLine, NormalizedLine } from '@8f4e/compiler-spec';
 import dispatchNormalization from './normalization';
 
-/** Dispatches compile-time argument normalization for one AST line. */
+/**
+ * Dispatches compile-time argument normalization for one AST line.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export default function normalizeCompileTimeArguments<TLine extends CompilerASTLine>(
 	line: TLine,
 	context: CompilationContext

--- a/packages/compiler/src/semantic/normalizeCompileTimeArguments.ts
+++ b/packages/compiler/src/semantic/normalizeCompileTimeArguments.ts
@@ -1,6 +1,7 @@
 import type { CompilationContext, CompilerASTLine, NormalizedLine } from '@8f4e/compiler-spec';
 import dispatchNormalization from './normalization';
 
+/** Dispatches compile-time argument normalization for one AST line. */
 export default function normalizeCompileTimeArguments<TLine extends CompilerASTLine>(
 	line: TLine,
 	context: CompilationContext

--- a/packages/compiler/src/semantic/resolveCompileTimeArgument.ts
+++ b/packages/compiler/src/semantic/resolveCompileTimeArgument.ts
@@ -474,6 +474,7 @@ function evaluateConstantExpression(lhsConst: Const, rhsConst: Const, operator: 
 	};
 }
 
+/** Attempts to fold an argument into a compile-time constant using the current semantic context. */
 export function tryResolveCompileTimeArgument(context: CompilationContext, argument: Argument): Const | undefined {
 	if (argument.type === ArgumentType.COMPILE_TIME_EXPRESSION) {
 		const leftConst = resolveCompileTimeOperand(argument.left, context);

--- a/packages/compiler/src/semantic/resolveCompileTimeArgument.ts
+++ b/packages/compiler/src/semantic/resolveCompileTimeArgument.ts
@@ -474,7 +474,13 @@ function evaluateConstantExpression(lhsConst: Const, rhsConst: Const, operator: 
 	};
 }
 
-/** Attempts to fold an argument into a compile-time constant using the current semantic context. */
+/**
+ * Attempts to fold an argument into a compile-time constant using the current semantic context.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param argument - Argument whose resolved value or metadata should be used.
+ * @returns The result of the operation.
+ */
 export function tryResolveCompileTimeArgument(context: CompilationContext, argument: Argument): Const | undefined {
 	if (argument.type === ArgumentType.COMPILE_TIME_EXPRESSION) {
 		const leftConst = resolveCompileTimeOperand(argument.left, context);

--- a/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
+++ b/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
@@ -3,7 +3,13 @@ import { analyzeByInstruction } from './instructionAnalyzers';
 import { cloneStack } from './instructionAnalyzers/stack';
 import { validateInstruction } from './validateInstruction';
 
-/** Validates one AST line, updates stack state, and records the before/after stack analysis metadata. */
+/**
+ * Validates one AST line, updates stack state, and records the before/after stack analysis metadata.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The result of the operation.
+ */
 export function analyzeInstruction(line: CompilerASTLine, context: CompilationContext): AnalyzedLine {
 	validateInstruction(line, context);
 

--- a/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
+++ b/packages/compiler/src/stackAnalysis/analyzeInstruction.ts
@@ -3,6 +3,7 @@ import { analyzeByInstruction } from './instructionAnalyzers';
 import { cloneStack } from './instructionAnalyzers/stack';
 import { validateInstruction } from './validateInstruction';
 
+/** Validates one AST line, updates stack state, and records the before/after stack analysis metadata. */
 export function analyzeInstruction(line: CompilerASTLine, context: CompilationContext): AnalyzedLine {
 	validateInstruction(line, context);
 

--- a/packages/compiler/src/stackAnalysis/inferErrorCodeFromRule.ts
+++ b/packages/compiler/src/stackAnalysis/inferErrorCodeFromRule.ts
@@ -1,7 +1,12 @@
 import type { OperandRule } from '@8f4e/compiler-spec';
 import { ErrorCode, type ErrorCodeValue } from '@8f4e/compiler-spec';
 
-/** Maps an operand rule from the compiler spec to the semantic error emitted when it fails. */
+/**
+ * Maps an operand rule from the compiler spec to the semantic error emitted when it fails.
+ *
+ * @param rule - Operand rule from the compiler spec.
+ * @returns The compiler error instance.
+ */
 export function inferErrorCodeFromRule(rule: OperandRule | OperandRule[]): ErrorCodeValue {
 	if (Array.isArray(rule)) {
 		return ErrorCode.TYPE_MISMATCH;

--- a/packages/compiler/src/stackAnalysis/inferErrorCodeFromRule.ts
+++ b/packages/compiler/src/stackAnalysis/inferErrorCodeFromRule.ts
@@ -1,6 +1,7 @@
 import type { OperandRule } from '@8f4e/compiler-spec';
 import { ErrorCode, type ErrorCodeValue } from '@8f4e/compiler-spec';
 
+/** Maps an operand rule from the compiler spec to the semantic error emitted when it fails. */
 export function inferErrorCodeFromRule(rule: OperandRule | OperandRule[]): ErrorCodeValue {
 	if (Array.isArray(rule)) {
 		return ErrorCode.TYPE_MISMATCH;

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/call.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/call.ts
@@ -5,7 +5,13 @@ import { functionValueTypeToStackItem, stackItemMatchesFunctionValueType } from 
 import { analyzePush } from './push';
 import { consume, produce } from './stack';
 
-/** Applies function-call stack effects after validating arguments against the resolved target signature. */
+/**
+ * Applies function-call stack effects after validating arguments against the resolved target signature.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The stack items produced or consumed by the operation.
+ */
 export function analyzeCall(line: ResolvedCallLine, context: CompilationContext): { consumed: Stack; produced: Stack } {
 	const { parameters, returns } = line.targetFunction.signature;
 

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/call.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/call.ts
@@ -5,6 +5,7 @@ import { functionValueTypeToStackItem, stackItemMatchesFunctionValueType } from 
 import { analyzePush } from './push';
 import { consume, produce } from './stack';
 
+/** Applies function-call stack effects after validating arguments against the resolved target signature. */
 export function analyzeCall(line: ResolvedCallLine, context: CompilationContext): { consumed: Stack; produced: Stack } {
 	const { parameters, returns } = line.targetFunction.signature;
 

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/controlFlow.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/controlFlow.ts
@@ -2,6 +2,7 @@ import type { CompilationContext, CompilerASTLine } from '@8f4e/compiler-spec';
 import { cloneStack, consume } from './stack';
 import type { InstructionAnalysisResult } from './types';
 
+/** Consumes an exit condition and marks the remaining stack as dropped for the conditional branch. */
 export function analyzeExitIfTrue(_line: CompilerASTLine, context: CompilationContext): InstructionAnalysisResult {
 	const consumed = consume(context, 1);
 	return { consumed, produced: [], dropped: cloneStack(context.stack) };

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/controlFlow.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/controlFlow.ts
@@ -2,7 +2,13 @@ import type { CompilationContext, CompilerASTLine } from '@8f4e/compiler-spec';
 import { cloneStack, consume } from './stack';
 import type { InstructionAnalysisResult } from './types';
 
-/** Consumes an exit condition and marks the remaining stack as dropped for the conditional branch. */
+/**
+ * Consumes an exit condition and marks the remaining stack as dropped for the conditional branch.
+ *
+ * @param _line - Compiler line kept for analyzer signature compatibility.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The stack-analysis result for the instruction.
+ */
 export function analyzeExitIfTrue(_line: CompilerASTLine, context: CompilationContext): InstructionAnalysisResult {
 	const consumed = consume(context, 1);
 	return { consumed, produced: [], dropped: cloneStack(context.stack) };

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/index.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/index.ts
@@ -28,7 +28,13 @@ import { analyzePush } from './push';
 import { analyzeFromSpec } from './spec';
 import type { InstructionAnalysisResult } from './types';
 
-/** Dispatches a compiler AST line to the instruction-specific or spec-derived stack analyzer. */
+/**
+ * Dispatches a compiler AST line to the instruction-specific or spec-derived stack analyzer.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The stack-analysis result for the instruction.
+ */
 export function analyzeByInstruction(line: CompilerASTLine, context: CompilationContext): InstructionAnalysisResult {
 	switch (line.instruction) {
 		case 'push': {

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/index.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/index.ts
@@ -28,6 +28,7 @@ import { analyzePush } from './push';
 import { analyzeFromSpec } from './spec';
 import type { InstructionAnalysisResult } from './types';
 
+/** Dispatches a compiler AST line to the instruction-specific or spec-derived stack analyzer. */
 export function analyzeByInstruction(line: CompilerASTLine, context: CompilationContext): InstructionAnalysisResult {
 	switch (line.instruction) {
 		case 'push': {

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/localSet.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/localSet.ts
@@ -3,7 +3,13 @@ import { ErrorCode } from '@8f4e/compiler-spec';
 import { getError } from '../../compilerError';
 import { consume } from './stack';
 
-/** Consumes the assigned value and checks it against the resolved local binding type. */
+/**
+ * Consumes the assigned value and checks it against the resolved local binding type.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The stack items produced or consumed by the operation.
+ */
 export function analyzeLocalSet(
 	line: CompilerASTLine,
 	context: CompilationContext

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/localSet.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/localSet.ts
@@ -3,6 +3,7 @@ import { ErrorCode } from '@8f4e/compiler-spec';
 import { getError } from '../../compilerError';
 import { consume } from './stack';
 
+/** Consumes the assigned value and checks it against the resolved local binding type. */
 export function analyzeLocalSet(
 	line: CompilerASTLine,
 	context: CompilationContext

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/memory.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/memory.ts
@@ -5,6 +5,7 @@ import { getClampAccessByteWidth, getClampedAddressStackItem, getModuleAddressRa
 import { consume, produce } from './stack';
 import type { InstructionAnalysisResult } from './types';
 
+/** Consumes an address-like value and produces the stack item representing the clamped address range. */
 export function analyzeClampAddress(line: CompilerASTLine, context: CompilationContext): InstructionAnalysisResult {
 	const consumed = consume(context, 1);
 	const accessByteWidth = getClampAccessByteWidth(line);

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/memory.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/memory.ts
@@ -5,7 +5,13 @@ import { getClampAccessByteWidth, getClampedAddressStackItem, getModuleAddressRa
 import { consume, produce } from './stack';
 import type { InstructionAnalysisResult } from './types';
 
-/** Consumes an address-like value and produces the stack item representing the clamped address range. */
+/**
+ * Consumes an address-like value and produces the stack item representing the clamped address range.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The stack-analysis result for the instruction.
+ */
 export function analyzeClampAddress(line: CompilerASTLine, context: CompilationContext): InstructionAnalysisResult {
 	const consumed = consume(context, 1);
 	const accessByteWidth = getClampAccessByteWidth(line);

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/push.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/push.ts
@@ -146,6 +146,7 @@ function pushResolvedTargetStackItems(line: ResolvedPushLine): Stack {
 	}
 }
 
+/** Produces stack items for a normalized push line and appends them to the current stack. */
 export function analyzePush(line: NormalizedPushLine, context: CompilationContext): Stack {
 	const produced = 'resolvedTarget' in line ? pushResolvedTargetStackItems(line) : pushLiteralStackItems(line);
 	produce(context, produced);

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/push.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/push.ts
@@ -146,7 +146,13 @@ function pushResolvedTargetStackItems(line: ResolvedPushLine): Stack {
 	}
 }
 
-/** Produces stack items for a normalized push line and appends them to the current stack. */
+/**
+ * Produces stack items for a normalized push line and appends them to the current stack.
+ *
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The stack items produced or consumed by the operation.
+ */
 export function analyzePush(line: NormalizedPushLine, context: CompilationContext): Stack {
 	const produced = 'resolvedTarget' in line ? pushResolvedTargetStackItems(line) : pushLiteralStackItems(line);
 	produce(context, produced);

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/stack.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/stack.ts
@@ -1,5 +1,6 @@
 import type { CompilationContext, Stack, StackItem, StackValueType } from '@8f4e/compiler-spec';
 
+/** Creates a value stack item with optional known-value metadata preserved for later guards. */
 export function createStackValue(
 	valueType: StackValueType,
 	metadata: Pick<StackItem, 'isNonZero' | 'knownIntegerValue'> = {}
@@ -12,6 +13,7 @@ export function createStackValue(
 	};
 }
 
+/** Clones stack items deeply enough to snapshot mutable address metadata safely. */
 export function cloneStack(stack: Stack): Stack {
 	return stack.map(item => ({
 		...item,
@@ -20,6 +22,7 @@ export function cloneStack(stack: Stack): Stack {
 	}));
 }
 
+/** Removes and returns the requested number of items from the top of the semantic stack. */
 export function consume(context: CompilationContext, count: number): Stack {
 	if (count === 0) {
 		return [];
@@ -28,6 +31,7 @@ export function consume(context: CompilationContext, count: number): Stack {
 	return context.stack.splice(context.stack.length - count, count);
 }
 
+/** Appends newly produced items to the semantic stack. */
 export function produce(context: CompilationContext, items: Stack): void {
 	context.stack.push(...items);
 }

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/stack.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/stack.ts
@@ -1,6 +1,12 @@
 import type { CompilationContext, Stack, StackItem, StackValueType } from '@8f4e/compiler-spec';
 
-/** Creates a value stack item with optional known-value metadata preserved for later guards. */
+/**
+ * Creates a value stack item with optional known-value metadata preserved for later guards.
+ *
+ * @param valueType - Stack value type for the item being created.
+ * @param metadata - Optional known-value metadata to copy onto the stack item.
+ * @returns The stack items produced or consumed by the operation.
+ */
 export function createStackValue(
 	valueType: StackValueType,
 	metadata: Pick<StackItem, 'isNonZero' | 'knownIntegerValue'> = {}
@@ -13,7 +19,12 @@ export function createStackValue(
 	};
 }
 
-/** Clones stack items deeply enough to snapshot mutable address metadata safely. */
+/**
+ * Clones stack items deeply enough to snapshot mutable address metadata safely.
+ *
+ * @param stack - Stack to inspect or clone.
+ * @returns The stack items produced or consumed by the operation.
+ */
 export function cloneStack(stack: Stack): Stack {
 	return stack.map(item => ({
 		...item,
@@ -22,7 +33,13 @@ export function cloneStack(stack: Stack): Stack {
 	}));
 }
 
-/** Removes and returns the requested number of items from the top of the semantic stack. */
+/**
+ * Removes and returns the requested number of items from the top of the semantic stack.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param count - Number of stack items to inspect or consume.
+ * @returns The stack items produced or consumed by the operation.
+ */
 export function consume(context: CompilationContext, count: number): Stack {
 	if (count === 0) {
 		return [];
@@ -31,7 +48,12 @@ export function consume(context: CompilationContext, count: number): Stack {
 	return context.stack.splice(context.stack.length - count, count);
 }
 
-/** Appends newly produced items to the semantic stack. */
+/**
+ * Appends newly produced items to the semantic stack.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @param items - items value used by this operation.
+ */
 export function produce(context: CompilationContext, items: Stack): void {
 	context.stack.push(...items);
 }

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/types.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/types.ts
@@ -1,11 +1,13 @@
 import type { CompilationContext, CompilerASTLine, Stack } from '@8f4e/compiler-spec';
 
+/** Stack delta produced by analyzing one compiler instruction. */
 export type InstructionAnalysisResult = {
 	consumed: Stack;
 	produced: Stack;
 	dropped?: Stack;
 };
 
+/** Function shape shared by stack analyzers that handle specific compiler instructions. */
 export type InstructionAnalyzer<TLine extends CompilerASTLine = CompilerASTLine> = (
 	line: TLine,
 	context: CompilationContext

--- a/packages/compiler/src/stackAnalysis/peekStackOperands.ts
+++ b/packages/compiler/src/stackAnalysis/peekStackOperands.ts
@@ -1,5 +1,6 @@
 import type { StackItem } from '@8f4e/compiler-spec';
 
+/** Reads the top stack operands without mutating the stack, returning an empty list when unavailable. */
 export function peekStackOperands(stack: StackItem[], count: number): StackItem[] {
 	if (stack.length < count) {
 		return [];

--- a/packages/compiler/src/stackAnalysis/peekStackOperands.ts
+++ b/packages/compiler/src/stackAnalysis/peekStackOperands.ts
@@ -1,6 +1,12 @@
 import type { StackItem } from '@8f4e/compiler-spec';
 
-/** Reads the top stack operands without mutating the stack, returning an empty list when unavailable. */
+/**
+ * Reads the top stack operands without mutating the stack, returning an empty list when unavailable.
+ *
+ * @param stack - Stack to inspect or clone.
+ * @param count - Number of stack items to inspect or consume.
+ * @returns The stack items produced or consumed by the operation.
+ */
 export function peekStackOperands(stack: StackItem[], count: number): StackItem[] {
 	if (stack.length < count) {
 		return [];

--- a/packages/compiler/src/stackAnalysis/validateOperandTypes.ts
+++ b/packages/compiler/src/stackAnalysis/validateOperandTypes.ts
@@ -5,7 +5,14 @@ import { getError } from '../compilerError';
 import { areAllOperandsFloats, areAllOperandsIntegers, hasMixedFloatWidth } from '../utils/operandTypes';
 import { inferErrorCodeFromRule } from './inferErrorCodeFromRule';
 
-/** Enforces operand type rules from the instruction spec against already-peeked stack operands. */
+/**
+ * Enforces operand type rules from the instruction spec against already-peeked stack operands.
+ *
+ * @param operands - Stack operands to inspect.
+ * @param rule - Operand rule from the compiler spec.
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
+ */
 export function validateOperandTypes(
 	operands: StackItem[],
 	rule: OperandRule | OperandRule[],

--- a/packages/compiler/src/stackAnalysis/validateOperandTypes.ts
+++ b/packages/compiler/src/stackAnalysis/validateOperandTypes.ts
@@ -5,6 +5,7 @@ import { getError } from '../compilerError';
 import { areAllOperandsFloats, areAllOperandsIntegers, hasMixedFloatWidth } from '../utils/operandTypes';
 import { inferErrorCodeFromRule } from './inferErrorCodeFromRule';
 
+/** Enforces operand type rules from the instruction spec against already-peeked stack operands. */
 export function validateOperandTypes(
 	operands: StackItem[],
 	rule: OperandRule | OperandRule[],

--- a/packages/compiler/src/utils/addressClamp.ts
+++ b/packages/compiler/src/utils/addressClamp.ts
@@ -10,11 +10,13 @@ import { getMemoryRegionFields } from '../semantic/memoryRegions';
 
 const DEFAULT_ACCESS_BYTE_WIDTH = WORD_MEMORY_ACCESS_WIDTH;
 
+/** Resolves the byte width protected by a clamp instruction, defaulting to one word. */
 export function getClampAccessByteWidth(line: CompilerASTLine): number {
 	const argument = line.arguments[0];
 	return argument?.type === ArgumentType.LITERAL ? argument.value : DEFAULT_ACCESS_BYTE_WIDTH;
 }
 
+/** Builds the safe address range for the current module memory allocation. */
 export function getModuleAddressRange(context: CodegenContext | CompilationContext): MemoryAddressRange {
 	return {
 		source: 'module-start',
@@ -29,6 +31,7 @@ function clampKnownIntegerValue(value: number | undefined, lower: number, upper:
 	return value === undefined ? undefined : Math.min(Math.max(value, lower), upper);
 }
 
+/** Converts a stack operand into the address item produced after applying an optional clamp range. */
 export function getClampedAddressStackItem(
 	operand: StackItem,
 	range: MemoryAddressRange | undefined,

--- a/packages/compiler/src/utils/addressClamp.ts
+++ b/packages/compiler/src/utils/addressClamp.ts
@@ -10,13 +10,23 @@ import { getMemoryRegionFields } from '../semantic/memoryRegions';
 
 const DEFAULT_ACCESS_BYTE_WIDTH = WORD_MEMORY_ACCESS_WIDTH;
 
-/** Resolves the byte width protected by a clamp instruction, defaulting to one word. */
+/**
+ * Resolves the byte width protected by a clamp instruction, defaulting to one word.
+ *
+ * @param line - Compiler line being processed.
+ * @returns The resolved numeric value.
+ */
 export function getClampAccessByteWidth(line: CompilerASTLine): number {
 	const argument = line.arguments[0];
 	return argument?.type === ArgumentType.LITERAL ? argument.value : DEFAULT_ACCESS_BYTE_WIDTH;
 }
 
-/** Builds the safe address range for the current module memory allocation. */
+/**
+ * Builds the safe address range for the current module memory allocation.
+ *
+ * @param context - Current compiler context consulted or updated by the operation.
+ * @returns The resolved memory address range.
+ */
 export function getModuleAddressRange(context: CodegenContext | CompilationContext): MemoryAddressRange {
 	return {
 		source: 'module-start',
@@ -31,7 +41,14 @@ function clampKnownIntegerValue(value: number | undefined, lower: number, upper:
 	return value === undefined ? undefined : Math.min(Math.max(value, lower), upper);
 }
 
-/** Converts a stack operand into the address item produced after applying an optional clamp range. */
+/**
+ * Converts a stack operand into the address item produced after applying an optional clamp range.
+ *
+ * @param operand - Stack item to convert or clamp.
+ * @param range - Optional safe memory range to preserve on the produced address.
+ * @param accessByteWidth - Byte width of the memory access being protected.
+ * @returns The stack items produced or consumed by the operation.
+ */
 export function getClampedAddressStackItem(
 	operand: StackItem,
 	range: MemoryAddressRange | undefined,

--- a/packages/compiler/src/utils/functionValueType.ts
+++ b/packages/compiler/src/utils/functionValueType.ts
@@ -19,7 +19,13 @@ function getPointerParts(type: PointerFunctionValueType) {
 	return { baseType, pointerDepth };
 }
 
-/** Converts a function signature value type into the local binding shape used during semantic analysis. */
+/**
+ * Converts a function signature value type into the local binding shape used during semantic analysis.
+ *
+ * @param type - Function value type to convert.
+ * @param index - WASM index or source index assigned to the compiled item.
+ * @returns The result of the operation.
+ */
 export function functionValueTypeToLocalBinding(type: FunctionValueType, index: number): LocalBinding {
 	if (type === 'int') {
 		return { isInteger: true, index };
@@ -46,7 +52,12 @@ export function functionValueTypeToLocalBinding(type: FunctionValueType, index: 
 	};
 }
 
-/** Converts a function signature value type into the equivalent stack item shape. */
+/**
+ * Converts a function signature value type into the equivalent stack item shape.
+ *
+ * @param type - Function value type to convert.
+ * @returns The stack items produced or consumed by the operation.
+ */
 export function functionValueTypeToStackItem(type: FunctionValueType): StackItem {
 	return localBindingToStackItem(functionValueTypeToLocalBinding(type, 0));
 }
@@ -75,7 +86,12 @@ function localBindingToStackItem(binding: LocalBinding): StackItem {
 	};
 }
 
-/** Maps a function signature value type to the binary WASM value type emitted for calls and exports. */
+/**
+ * Maps a function signature value type to the binary WASM value type emitted for calls and exports.
+ *
+ * @param type - Function value type to convert.
+ * @returns The matching WASM value type.
+ */
 export function functionValueTypeToWasmType(type: FunctionValueType): WasmTypeValue {
 	if (type === 'float64') {
 		return WASM_TYPE_F64;
@@ -88,7 +104,13 @@ export function functionValueTypeToWasmType(type: FunctionValueType): WasmTypeVa
 	return WASM_TYPE_I32;
 }
 
-/** Checks whether a stack item can satisfy a function parameter or return type. */
+/**
+ * Checks whether a stack item can satisfy a function parameter or return type.
+ *
+ * @param stackItem - Stack item being checked.
+ * @param type - Function value type to convert.
+ * @returns Whether the check succeeds.
+ */
 export function stackItemMatchesFunctionValueType(stackItem: StackItem, type: FunctionValueType): boolean {
 	if (type === 'int') {
 		return stackItem.valueType === 'int';

--- a/packages/compiler/src/utils/functionValueType.ts
+++ b/packages/compiler/src/utils/functionValueType.ts
@@ -19,6 +19,7 @@ function getPointerParts(type: PointerFunctionValueType) {
 	return { baseType, pointerDepth };
 }
 
+/** Converts a function signature value type into the local binding shape used during semantic analysis. */
 export function functionValueTypeToLocalBinding(type: FunctionValueType, index: number): LocalBinding {
 	if (type === 'int') {
 		return { isInteger: true, index };
@@ -45,6 +46,7 @@ export function functionValueTypeToLocalBinding(type: FunctionValueType, index: 
 	};
 }
 
+/** Converts a function signature value type into the equivalent stack item shape. */
 export function functionValueTypeToStackItem(type: FunctionValueType): StackItem {
 	return localBindingToStackItem(functionValueTypeToLocalBinding(type, 0));
 }
@@ -73,6 +75,7 @@ function localBindingToStackItem(binding: LocalBinding): StackItem {
 	};
 }
 
+/** Maps a function signature value type to the binary WASM value type emitted for calls and exports. */
 export function functionValueTypeToWasmType(type: FunctionValueType): WasmTypeValue {
 	if (type === 'float64') {
 		return WASM_TYPE_F64;
@@ -85,6 +88,7 @@ export function functionValueTypeToWasmType(type: FunctionValueType): WasmTypeVa
 	return WASM_TYPE_I32;
 }
 
+/** Checks whether a stack item can satisfy a function parameter or return type. */
 export function stackItemMatchesFunctionValueType(stackItem: StackItem, type: FunctionValueType): boolean {
 	if (type === 'int') {
 		return stackItem.valueType === 'int';

--- a/packages/compiler/src/utils/mapValueKind.ts
+++ b/packages/compiler/src/utils/mapValueKind.ts
@@ -8,6 +8,7 @@ import type {
 import { ErrorCode } from '@8f4e/compiler-spec';
 import { getError } from '../compilerError';
 
+/** Internal scalar kind used to choose typed WASM operations for map rows and values. */
 export type MapKind = 'int32' | 'float32' | 'float64';
 
 interface MapValueKind {

--- a/packages/compiler/src/utils/mapValueKind.ts
+++ b/packages/compiler/src/utils/mapValueKind.ts
@@ -21,6 +21,9 @@ function normalizeMapValueKind(valueKind: MapValueKind | StackItem): MapValueKin
 
 /**
  * Resolves map value metadata to the internal map kind used for typed WASM emission.
+ *
+ * @param valueKind - Map or stack value metadata to resolve.
+ * @returns The result of the operation.
  */
 export function resolveMapKind(valueKind: MapValueKind | StackItem): MapKind {
 	const normalizedValueKind = normalizeMapValueKind(valueKind);
@@ -33,6 +36,11 @@ export function resolveMapKind(valueKind: MapValueKind | StackItem): MapKind {
 
 /**
  * Validates that a map input, row value, or default value matches the expected map kind.
+ *
+ * @param valueKind - Map or stack value metadata to resolve.
+ * @param expectedKind - Map kind that the value must match.
+ * @param line - Compiler line being processed.
+ * @param context - Current compiler context consulted or updated by the operation.
  */
 export function validateMapValueKind(
 	valueKind: MapValueKind | StackItem,

--- a/packages/compiler/src/utils/memoryData.ts
+++ b/packages/compiler/src/utils/memoryData.ts
@@ -2,6 +2,7 @@ import type { DataStructure, MemoryMap, MemoryValueKind, PointerLocalBinding, St
 import { BASE_TYPE_METADATA } from '@8f4e/compiler-spec';
 import { getEndByteAddress } from '../semantic/layoutAddresses';
 
+/** Common pointer metadata shape shared by memory declarations, locals, and stack address items. */
 export type PointerMetadata =
 	| Pick<
 			DataStructure,
@@ -45,62 +46,74 @@ function getPointeeBaseTypeMetadata(pointeeBaseType: NonNullable<PointerMetadata
 	return BASE_TYPE_METADATA[pointeeBaseType];
 }
 
+/** Reads pointer depth from metadata, returning zero when the item is not pointer-like. */
 export function getPointerDepthFromMetadata(pointerMetadata: PointerMetadata | undefined): number {
 	if (!pointerMetadata?.pointeeBaseType) return 0;
 	return pointerMetadata.pointerDepth;
 }
 
+/** Returns a declared memory item's byte address, or zero when the id is absent. */
 export function getDataStructureByteAddress(memoryMap: MemoryMap, id: string): number {
 	const memoryItem = memoryMap[id];
 	return memoryItem ? memoryItem.byteAddress : 0;
 }
 
+/** Returns the inclusive last byte address of a memory item's aligned storage, or zero when absent. */
 export function getMemoryStringLastByteAddress(memoryMap: MemoryMap, id: string): number {
 	const memoryItem = memoryMap[id];
 	return memoryItem ? getEndByteAddress(memoryItem.byteAddress, memoryItem.wordAlignedSize) : 0;
 }
 
+/** Returns the declared element count for a memory item, or zero when absent. */
 export function getElementCount(memoryMap: MemoryMap, id: string): number {
 	const memoryItem = memoryMap[id];
 	return memoryItem ? memoryItem.numberOfElements : 0;
 }
 
+/** Returns the pointer target element count from metadata, defaulting scalar pointees to one. */
 export function getPointeeElementCountFromMetadata(pointerMetadata: PointerMetadata | undefined): number {
 	if (!pointerMetadata?.pointeeBaseType) return 0;
 	return pointerMetadata.pointeeElementCount ?? 1;
 }
 
+/** Returns the pointer target element count for a memory item, or zero when it is not pointer-like. */
 export function getPointeeElementCount(memoryMap: MemoryMap, id: string): number {
 	return getPointeeElementCountFromMetadata(memoryMap[id]);
 }
 
+/** Returns the declared element word size for a memory item, or zero when absent. */
 export function getElementWordSize(memoryMap: MemoryMap, id: string): number {
 	const memoryItem = memoryMap[id];
 	return memoryItem ? memoryItem.elementWordSize : 0;
 }
 
+/** Returns the word size of the value reached by one pointer dereference. */
 export function getPointeeElementWordSizeFromMetadata(pointerMetadata: PointerMetadata | undefined): number {
 	if (!pointerMetadata?.pointeeBaseType) return 0;
 	if (getPointerDepthFromMetadata(pointerMetadata) > 1) return BASE_TYPE_METADATA.pointer.wordSize;
 	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).wordSize;
 }
 
+/** Returns the pointee element word size for a memory item, or zero when it is not pointer-like. */
 export function getPointeeElementWordSize(memoryMap: MemoryMap, id: string): number {
 	return getPointeeElementWordSizeFromMetadata(memoryMap[id]);
 }
 
+/** Returns whether the value reached by one pointer dereference is integer-like. */
 export function getPointeeElementIsIntegerFromMetadata(pointerMetadata: PointerMetadata | undefined): boolean {
 	if (!pointerMetadata?.pointeeBaseType) return false;
 	if (getPointerDepthFromMetadata(pointerMetadata) > 1) return BASE_TYPE_METADATA.pointer.isInteger;
 	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).isInteger;
 }
 
+/** Resolves the memory value kind produced by dereferencing pointer metadata once. */
 export function getPointeeValueKindFromMetadata(pointerMetadata: PointerMetadata | undefined): MemoryValueKind {
 	if (!pointerMetadata?.pointeeBaseType) return 'float32';
 	if (getPointeeElementIsIntegerFromMetadata(pointerMetadata)) return 'int32';
 	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).valueKind;
 }
 
+/** Resolves the word size produced after dereferencing pointer metadata to the requested depth. */
 export function getDereferencedValueWordSizeFromMetadata(
 	pointerMetadata: PointerMetadata | undefined,
 	dereferenceDepth = getPointerDepthFromMetadata(pointerMetadata)
@@ -110,6 +123,7 @@ export function getDereferencedValueWordSizeFromMetadata(
 	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).wordSize;
 }
 
+/** Resolves the memory value kind produced after dereferencing pointer metadata to the requested depth. */
 export function getDereferencedValueKindFromMetadata(
 	pointerMetadata: PointerMetadata | undefined,
 	dereferenceDepth = getPointerDepthFromMetadata(pointerMetadata)
@@ -119,6 +133,7 @@ export function getDereferencedValueKindFromMetadata(
 	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).valueKind;
 }
 
+/** Returns the maximum numeric value allowed by a declared memory item's base type. */
 export function getElementMaxValue(memoryMap: MemoryMap, id: string): number {
 	const memoryItem = memoryMap[id];
 	if (!memoryItem) return 0;
@@ -127,6 +142,7 @@ export function getElementMaxValue(memoryMap: MemoryMap, id: string): number {
 	return memoryItem.isUnsigned ? (metadata.unsignedMax ?? metadata.max) : metadata.max;
 }
 
+/** Returns the maximum numeric value allowed by pointer target metadata. */
 export function getPointeeElementMaxValueFromMetadata(pointerMetadata: PointerMetadata | undefined): number {
 	if (!pointerMetadata?.pointeeBaseType) return 0;
 
@@ -134,10 +150,12 @@ export function getPointeeElementMaxValueFromMetadata(pointerMetadata: PointerMe
 	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).max;
 }
 
+/** Returns the maximum numeric value allowed by a memory item's pointer target. */
 export function getPointeeElementMaxValue(memoryMap: MemoryMap, id: string): number {
 	return getPointeeElementMaxValueFromMetadata(memoryMap[id]);
 }
 
+/** Returns the minimum numeric value allowed by a declared memory item's base type. */
 export function getElementMinValue(memoryMap: MemoryMap, id: string): number {
 	const memoryItem = memoryMap[id];
 	if (!memoryItem) return 0;
@@ -146,6 +164,7 @@ export function getElementMinValue(memoryMap: MemoryMap, id: string): number {
 	return memoryItem.isUnsigned ? (metadata.unsignedMin ?? metadata.min) : metadata.min;
 }
 
+/** Returns the minimum numeric value allowed by pointer target metadata. */
 export function getPointeeElementMinValueFromMetadata(pointerMetadata: PointerMetadata | undefined): number {
 	if (!pointerMetadata?.pointeeBaseType) return 0;
 
@@ -153,6 +172,7 @@ export function getPointeeElementMinValueFromMetadata(pointerMetadata: PointerMe
 	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).min;
 }
 
+/** Returns the minimum numeric value allowed by a memory item's pointer target. */
 export function getPointeeElementMinValue(memoryMap: MemoryMap, id: string): number {
 	return getPointeeElementMinValueFromMetadata(memoryMap[id]);
 }

--- a/packages/compiler/src/utils/memoryData.ts
+++ b/packages/compiler/src/utils/memoryData.ts
@@ -46,74 +46,141 @@ function getPointeeBaseTypeMetadata(pointeeBaseType: NonNullable<PointerMetadata
 	return BASE_TYPE_METADATA[pointeeBaseType];
 }
 
-/** Reads pointer depth from metadata, returning zero when the item is not pointer-like. */
+/**
+ * Reads pointer depth from metadata, returning zero when the item is not pointer-like.
+ *
+ * @param pointerMetadata - Pointer metadata to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getPointerDepthFromMetadata(pointerMetadata: PointerMetadata | undefined): number {
 	if (!pointerMetadata?.pointeeBaseType) return 0;
 	return pointerMetadata.pointerDepth;
 }
 
-/** Returns a declared memory item's byte address, or zero when the id is absent. */
+/**
+ * Returns a declared memory item's byte address, or zero when the id is absent.
+ *
+ * @param memoryMap - Memory lookup that may contain the requested id.
+ * @param id - Identifier of the memory item to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getDataStructureByteAddress(memoryMap: MemoryMap, id: string): number {
 	const memoryItem = memoryMap[id];
 	return memoryItem ? memoryItem.byteAddress : 0;
 }
 
-/** Returns the inclusive last byte address of a memory item's aligned storage, or zero when absent. */
+/**
+ * Returns the inclusive last byte address of a memory item's aligned storage, or zero when absent.
+ *
+ * @param memoryMap - Memory lookup that may contain the requested id.
+ * @param id - Identifier of the memory item to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getMemoryStringLastByteAddress(memoryMap: MemoryMap, id: string): number {
 	const memoryItem = memoryMap[id];
 	return memoryItem ? getEndByteAddress(memoryItem.byteAddress, memoryItem.wordAlignedSize) : 0;
 }
 
-/** Returns the declared element count for a memory item, or zero when absent. */
+/**
+ * Returns the declared element count for a memory item, or zero when absent.
+ *
+ * @param memoryMap - Memory lookup that may contain the requested id.
+ * @param id - Identifier of the memory item to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getElementCount(memoryMap: MemoryMap, id: string): number {
 	const memoryItem = memoryMap[id];
 	return memoryItem ? memoryItem.numberOfElements : 0;
 }
 
-/** Returns the pointer target element count from metadata, defaulting scalar pointees to one. */
+/**
+ * Returns the pointer target element count from metadata, defaulting scalar pointees to one.
+ *
+ * @param pointerMetadata - Pointer metadata to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getPointeeElementCountFromMetadata(pointerMetadata: PointerMetadata | undefined): number {
 	if (!pointerMetadata?.pointeeBaseType) return 0;
 	return pointerMetadata.pointeeElementCount ?? 1;
 }
 
-/** Returns the pointer target element count for a memory item, or zero when it is not pointer-like. */
+/**
+ * Returns the pointer target element count for a memory item, or zero when it is not pointer-like.
+ *
+ * @param memoryMap - Memory lookup that may contain the requested id.
+ * @param id - Identifier of the memory item to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getPointeeElementCount(memoryMap: MemoryMap, id: string): number {
 	return getPointeeElementCountFromMetadata(memoryMap[id]);
 }
 
-/** Returns the declared element word size for a memory item, or zero when absent. */
+/**
+ * Returns the declared element word size for a memory item, or zero when absent.
+ *
+ * @param memoryMap - Memory lookup that may contain the requested id.
+ * @param id - Identifier of the memory item to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getElementWordSize(memoryMap: MemoryMap, id: string): number {
 	const memoryItem = memoryMap[id];
 	return memoryItem ? memoryItem.elementWordSize : 0;
 }
 
-/** Returns the word size of the value reached by one pointer dereference. */
+/**
+ * Returns the word size of the value reached by one pointer dereference.
+ *
+ * @param pointerMetadata - Pointer metadata to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getPointeeElementWordSizeFromMetadata(pointerMetadata: PointerMetadata | undefined): number {
 	if (!pointerMetadata?.pointeeBaseType) return 0;
 	if (getPointerDepthFromMetadata(pointerMetadata) > 1) return BASE_TYPE_METADATA.pointer.wordSize;
 	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).wordSize;
 }
 
-/** Returns the pointee element word size for a memory item, or zero when it is not pointer-like. */
+/**
+ * Returns the pointee element word size for a memory item, or zero when it is not pointer-like.
+ *
+ * @param memoryMap - Memory lookup that may contain the requested id.
+ * @param id - Identifier of the memory item to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getPointeeElementWordSize(memoryMap: MemoryMap, id: string): number {
 	return getPointeeElementWordSizeFromMetadata(memoryMap[id]);
 }
 
-/** Returns whether the value reached by one pointer dereference is integer-like. */
+/**
+ * Returns whether the value reached by one pointer dereference is integer-like.
+ *
+ * @param pointerMetadata - Pointer metadata to inspect.
+ * @returns Whether the check succeeds.
+ */
 export function getPointeeElementIsIntegerFromMetadata(pointerMetadata: PointerMetadata | undefined): boolean {
 	if (!pointerMetadata?.pointeeBaseType) return false;
 	if (getPointerDepthFromMetadata(pointerMetadata) > 1) return BASE_TYPE_METADATA.pointer.isInteger;
 	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).isInteger;
 }
 
-/** Resolves the memory value kind produced by dereferencing pointer metadata once. */
+/**
+ * Resolves the memory value kind produced by dereferencing pointer metadata once.
+ *
+ * @param pointerMetadata - Pointer metadata to inspect.
+ * @returns The result of the operation.
+ */
 export function getPointeeValueKindFromMetadata(pointerMetadata: PointerMetadata | undefined): MemoryValueKind {
 	if (!pointerMetadata?.pointeeBaseType) return 'float32';
 	if (getPointeeElementIsIntegerFromMetadata(pointerMetadata)) return 'int32';
 	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).valueKind;
 }
 
-/** Resolves the word size produced after dereferencing pointer metadata to the requested depth. */
+/**
+ * Resolves the word size produced after dereferencing pointer metadata to the requested depth.
+ *
+ * @param pointerMetadata - Pointer metadata to inspect.
+ * @param dereferenceDepth - Pointer dereference depth requested by the instruction.
+ * @returns The resolved numeric value.
+ */
 export function getDereferencedValueWordSizeFromMetadata(
 	pointerMetadata: PointerMetadata | undefined,
 	dereferenceDepth = getPointerDepthFromMetadata(pointerMetadata)
@@ -123,7 +190,13 @@ export function getDereferencedValueWordSizeFromMetadata(
 	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).wordSize;
 }
 
-/** Resolves the memory value kind produced after dereferencing pointer metadata to the requested depth. */
+/**
+ * Resolves the memory value kind produced after dereferencing pointer metadata to the requested depth.
+ *
+ * @param pointerMetadata - Pointer metadata to inspect.
+ * @param dereferenceDepth - Pointer dereference depth requested by the instruction.
+ * @returns The result of the operation.
+ */
 export function getDereferencedValueKindFromMetadata(
 	pointerMetadata: PointerMetadata | undefined,
 	dereferenceDepth = getPointerDepthFromMetadata(pointerMetadata)
@@ -133,7 +206,13 @@ export function getDereferencedValueKindFromMetadata(
 	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).valueKind;
 }
 
-/** Returns the maximum numeric value allowed by a declared memory item's base type. */
+/**
+ * Returns the maximum numeric value allowed by a declared memory item's base type.
+ *
+ * @param memoryMap - Memory lookup that may contain the requested id.
+ * @param id - Identifier of the memory item to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getElementMaxValue(memoryMap: MemoryMap, id: string): number {
 	const memoryItem = memoryMap[id];
 	if (!memoryItem) return 0;
@@ -142,7 +221,12 @@ export function getElementMaxValue(memoryMap: MemoryMap, id: string): number {
 	return memoryItem.isUnsigned ? (metadata.unsignedMax ?? metadata.max) : metadata.max;
 }
 
-/** Returns the maximum numeric value allowed by pointer target metadata. */
+/**
+ * Returns the maximum numeric value allowed by pointer target metadata.
+ *
+ * @param pointerMetadata - Pointer metadata to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getPointeeElementMaxValueFromMetadata(pointerMetadata: PointerMetadata | undefined): number {
 	if (!pointerMetadata?.pointeeBaseType) return 0;
 
@@ -150,12 +234,24 @@ export function getPointeeElementMaxValueFromMetadata(pointerMetadata: PointerMe
 	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).max;
 }
 
-/** Returns the maximum numeric value allowed by a memory item's pointer target. */
+/**
+ * Returns the maximum numeric value allowed by a memory item's pointer target.
+ *
+ * @param memoryMap - Memory lookup that may contain the requested id.
+ * @param id - Identifier of the memory item to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getPointeeElementMaxValue(memoryMap: MemoryMap, id: string): number {
 	return getPointeeElementMaxValueFromMetadata(memoryMap[id]);
 }
 
-/** Returns the minimum numeric value allowed by a declared memory item's base type. */
+/**
+ * Returns the minimum numeric value allowed by a declared memory item's base type.
+ *
+ * @param memoryMap - Memory lookup that may contain the requested id.
+ * @param id - Identifier of the memory item to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getElementMinValue(memoryMap: MemoryMap, id: string): number {
 	const memoryItem = memoryMap[id];
 	if (!memoryItem) return 0;
@@ -164,7 +260,12 @@ export function getElementMinValue(memoryMap: MemoryMap, id: string): number {
 	return memoryItem.isUnsigned ? (metadata.unsignedMin ?? metadata.min) : metadata.min;
 }
 
-/** Returns the minimum numeric value allowed by pointer target metadata. */
+/**
+ * Returns the minimum numeric value allowed by pointer target metadata.
+ *
+ * @param pointerMetadata - Pointer metadata to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getPointeeElementMinValueFromMetadata(pointerMetadata: PointerMetadata | undefined): number {
 	if (!pointerMetadata?.pointeeBaseType) return 0;
 
@@ -172,7 +273,13 @@ export function getPointeeElementMinValueFromMetadata(pointerMetadata: PointerMe
 	return getPointeeBaseTypeMetadata(pointerMetadata.pointeeBaseType).min;
 }
 
-/** Returns the minimum numeric value allowed by a memory item's pointer target. */
+/**
+ * Returns the minimum numeric value allowed by a memory item's pointer target.
+ *
+ * @param memoryMap - Memory lookup that may contain the requested id.
+ * @param id - Identifier of the memory item to inspect.
+ * @returns The resolved numeric value.
+ */
 export function getPointeeElementMinValue(memoryMap: MemoryMap, id: string): number {
 	return getPointeeElementMinValueFromMetadata(memoryMap[id]);
 }

--- a/packages/compiler/src/utils/operandTypes.ts
+++ b/packages/compiler/src/utils/operandTypes.ts
@@ -1,17 +1,21 @@
 import type { StackItem } from '@8f4e/compiler-spec';
 
+/** Returns whether every operand is an integer stack value. */
 export function areAllOperandsIntegers(...operands: StackItem[]): boolean {
 	return operands.every(operand => operand.valueType === 'int');
 }
 
+/** Returns whether every operand is any supported float stack value. */
 export function areAllOperandsFloats(...operands: StackItem[]): boolean {
 	return operands.every(operand => operand.valueType === 'float' || operand.valueType === 'float64');
 }
 
+/** Returns whether every operand is a float64 stack value and at least one operand exists. */
 export function areAllOperandsFloat64(...operands: StackItem[]): boolean {
 	return operands.length > 0 && operands.every(operand => operand.valueType === 'float64');
 }
 
+/** Returns whether the operands mix float32 and float64 stack values. */
 export function hasMixedFloatWidth(...operands: StackItem[]): boolean {
 	const floats = operands.filter(op => op.valueType === 'float' || op.valueType === 'float64');
 	return floats.some(op => op.valueType === 'float64') && floats.some(op => op.valueType === 'float');

--- a/packages/compiler/src/utils/operandTypes.ts
+++ b/packages/compiler/src/utils/operandTypes.ts
@@ -1,21 +1,41 @@
 import type { StackItem } from '@8f4e/compiler-spec';
 
-/** Returns whether every operand is an integer stack value. */
+/**
+ * Returns whether every operand is an integer stack value.
+ *
+ * @param operands - Stack operands to inspect.
+ * @returns Whether the check succeeds.
+ */
 export function areAllOperandsIntegers(...operands: StackItem[]): boolean {
 	return operands.every(operand => operand.valueType === 'int');
 }
 
-/** Returns whether every operand is any supported float stack value. */
+/**
+ * Returns whether every operand is any supported float stack value.
+ *
+ * @param operands - Stack operands to inspect.
+ * @returns Whether the check succeeds.
+ */
 export function areAllOperandsFloats(...operands: StackItem[]): boolean {
 	return operands.every(operand => operand.valueType === 'float' || operand.valueType === 'float64');
 }
 
-/** Returns whether every operand is a float64 stack value and at least one operand exists. */
+/**
+ * Returns whether every operand is a float64 stack value and at least one operand exists.
+ *
+ * @param operands - Stack operands to inspect.
+ * @returns Whether the check succeeds.
+ */
 export function areAllOperandsFloat64(...operands: StackItem[]): boolean {
 	return operands.length > 0 && operands.every(operand => operand.valueType === 'float64');
 }
 
-/** Returns whether the operands mix float32 and float64 stack values. */
+/**
+ * Returns whether the operands mix float32 and float64 stack values.
+ *
+ * @param operands - Stack operands to inspect.
+ * @returns Whether the check succeeds.
+ */
 export function hasMixedFloatWidth(...operands: StackItem[]): boolean {
 	const floats = operands.filter(op => op.valueType === 'float' || op.valueType === 'float64');
 	return floats.some(op => op.valueType === 'float64') && floats.some(op => op.valueType === 'float');

--- a/packages/compiler/src/utils/pushValueKind.ts
+++ b/packages/compiler/src/utils/pushValueKind.ts
@@ -1,19 +1,23 @@
 import type { DataStructure, StackItem } from '@8f4e/compiler-spec';
 import { WASM_TYPE_F32, WASM_TYPE_F64, WASM_TYPE_I32 } from '@8f4e/compiler-wasm-utils';
 
+/** Scalar kind used by push analysis and code generation before choosing concrete stack or WASM types. */
 export type PushValueKind = 'int32' | 'float32' | 'float64';
 
+/** Resolves the pushed scalar kind for a declared memory item. */
 export function resolveMemoryValueKind(memoryItem: DataStructure): PushValueKind {
 	if (memoryItem.isInteger) return 'int32';
 	if (memoryItem.isFloat64) return 'float64';
 	return 'float32';
 }
 
+/** Resolves the pushed scalar kind for a parsed literal or compile-time argument. */
 export function resolveArgumentValueKind(argument: { isInteger: boolean; isFloat64?: boolean }): PushValueKind {
 	if (argument.isFloat64) return 'float64';
 	return argument.isInteger ? 'int32' : 'float32';
 }
 
+/** Maps a push scalar kind to its emitted WASM value type. */
 export function valueKindToWasmType(
 	kind: PushValueKind
 ): typeof WASM_TYPE_I32 | typeof WASM_TYPE_F32 | typeof WASM_TYPE_F64 {
@@ -27,6 +31,7 @@ export function valueKindToWasmType(
 type StackItemExtras = Pick<StackItem, 'isNonZero' | 'knownIntegerValue'> &
 	Partial<Pick<Extract<StackItem, { kind: 'address' }>, 'address' | 'pointsTo'>>;
 
+/** Creates the stack item represented by a push scalar kind and optional address metadata. */
 export function kindToStackItem(kind: PushValueKind, extras?: StackItemExtras): StackItem {
 	if (kind === 'int32' && extras?.address) {
 		return {

--- a/packages/compiler/src/utils/pushValueKind.ts
+++ b/packages/compiler/src/utils/pushValueKind.ts
@@ -4,20 +4,35 @@ import { WASM_TYPE_F32, WASM_TYPE_F64, WASM_TYPE_I32 } from '@8f4e/compiler-wasm
 /** Scalar kind used by push analysis and code generation before choosing concrete stack or WASM types. */
 export type PushValueKind = 'int32' | 'float32' | 'float64';
 
-/** Resolves the pushed scalar kind for a declared memory item. */
+/**
+ * Resolves the pushed scalar kind for a declared memory item.
+ *
+ * @param memoryItem - Memory item whose scalar kind should be resolved.
+ * @returns The result of the operation.
+ */
 export function resolveMemoryValueKind(memoryItem: DataStructure): PushValueKind {
 	if (memoryItem.isInteger) return 'int32';
 	if (memoryItem.isFloat64) return 'float64';
 	return 'float32';
 }
 
-/** Resolves the pushed scalar kind for a parsed literal or compile-time argument. */
+/**
+ * Resolves the pushed scalar kind for a parsed literal or compile-time argument.
+ *
+ * @param argument - Argument whose resolved value or metadata should be used.
+ * @returns The result of the operation.
+ */
 export function resolveArgumentValueKind(argument: { isInteger: boolean; isFloat64?: boolean }): PushValueKind {
 	if (argument.isFloat64) return 'float64';
 	return argument.isInteger ? 'int32' : 'float32';
 }
 
-/** Maps a push scalar kind to its emitted WASM value type. */
+/**
+ * Maps a push scalar kind to its emitted WASM value type.
+ *
+ * @param kind - Scalar value kind to convert.
+ * @returns The result of the operation.
+ */
 export function valueKindToWasmType(
 	kind: PushValueKind
 ): typeof WASM_TYPE_I32 | typeof WASM_TYPE_F32 | typeof WASM_TYPE_F64 {
@@ -31,7 +46,13 @@ export function valueKindToWasmType(
 type StackItemExtras = Pick<StackItem, 'isNonZero' | 'knownIntegerValue'> &
 	Partial<Pick<Extract<StackItem, { kind: 'address' }>, 'address' | 'pointsTo'>>;
 
-/** Creates the stack item represented by a push scalar kind and optional address metadata. */
+/**
+ * Creates the stack item represented by a push scalar kind and optional address metadata.
+ *
+ * @param kind - Scalar value kind to convert.
+ * @param extras - Optional stack metadata to attach to the produced item.
+ * @returns The stack items produced or consumed by the operation.
+ */
 export function kindToStackItem(kind: PushValueKind, extras?: StackItemExtras): StackItem {
 	if (kind === 'int32' && extras?.address) {
 		return {


### PR DESCRIPTION
## Summary
- scan compiler production source exports for missing TSDoc comments
- add short comments to compiler entry points, semantic helpers, stack analysis helpers, and shared utilities
- include field comments for the compiled sub-program shape

## Tests
- npx biome check --write packages/compiler/src
- npx nx run @8f4e/compiler:typecheck
- npx nx run @8f4e/compiler:test
- pre-commit affected typecheck