### PR TITLE
fix(editor-state): rename code block rendering state

### DIFF
--- a/packages/editor/docs/contributing-editor-directives.md
+++ b/packages/editor/docs/contributing-editor-directives.md
@@ -80,7 +80,7 @@ The current directive pipeline is:
 
 1. `deriveDirectiveState(code, options)` scans the block once and parses all registered directives.
 2. Each directive plugin applies its own contributions to a shared draft.
-3. `graphicHelper` consumes the derived result.
+3. `codeBlockRendering` consumes the derived result.
 4. Directive-owned widget contributions optionally run `beforeGraphicDataWidthCalculation(...)` before width calculation.
 5. Directive-owned widget contributions run `afterGraphicDataWidthCalculation(...)` after width calculation.
 
@@ -211,7 +211,7 @@ Use `plugin.ts` to contribute block-level metadata such as:
 - `isHome`
 - display transforms such as `@hide`
 
-If a directive changes how code should be displayed, that should be modeled as a directive-owned contribution to the display model, not as a renderer hack in `graphicHelper`.
+If a directive changes how code should be displayed, that should be modeled as a directive-owned contribution to the display model, not as a renderer hack in `codeBlockRendering`.
 
 ## Layout Contributions
 

--- a/packages/editor/packages/editor-state-testing/src/index.test.ts
+++ b/packages/editor/packages/editor-state-testing/src/index.test.ts
@@ -64,7 +64,7 @@ describe('editor-state testing utilities', () => {
 		expect(state.info.compiler?.compilationTimeMs).toBe(120);
 		expect(state.viewport.width).toBe(400);
 		expect(state.viewport.height).toBe(768);
-		expect(state.graphicHelper.outputsByWordAddress).not.toBe(secondState.graphicHelper.outputsByWordAddress);
+		expect(state.codeBlockRendering.outputsByWordAddress).not.toBe(secondState.codeBlockRendering.outputsByWordAddress);
 	});
 
 	it('creates no-op event dispatchers and viewports', () => {

--- a/packages/editor/packages/editor-state-testing/src/index.ts
+++ b/packages/editor/packages/editor-state-testing/src/index.ts
@@ -142,7 +142,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			},
 		},
 		defaultRuntimeId: 'WebWorkerRuntime',
-		graphicHelper: {
+		codeBlockRendering: {
 			codeBlocks: [],
 			entryOutlines: [],
 			viewportAnchoredCodeBlocks: [],

--- a/packages/editor/packages/editor-state-types/src/features/code-blocks/types.ts
+++ b/packages/editor/packages/editor-state-types/src/features/code-blocks/types.ts
@@ -443,9 +443,9 @@ export interface CodeBlockEntryOutline {
 }
 
 /**
- * Graphic helper state for rendering code blocks and UI elements.
+ * Code block rendering state for rendering code blocks and UI elements.
  */
-export type GraphicHelper = {
+export type CodeBlockRendering = {
 	outputsByWordAddress: Map<number, Output>;
 	codeBlocks: CodeBlockGraphicData[];
 	/**

--- a/packages/editor/packages/editor-state-types/src/index.ts
+++ b/packages/editor/packages/editor-state-types/src/index.ts
@@ -17,10 +17,10 @@ import type {
 	CodeBlock,
 	CodeBlockEntryOutline,
 	CodeBlockGraphicData,
+	CodeBlockRendering,
 	CodeBlockType,
 	Crossfade,
 	Debugger,
-	GraphicHelper,
 	InfoPanel,
 	Input,
 	MemoryIdentifier,
@@ -92,6 +92,7 @@ export type {
 	CodeBlock,
 	CodeBlockEntryOutline,
 	CodeBlockGraphicData,
+	CodeBlockRendering,
 	CodeBlockType,
 	CodeError,
 	CompilationResult,
@@ -106,7 +107,6 @@ export type {
 	DialogContent,
 	DialogState,
 	EventDispatcher,
-	GraphicHelper,
 	GridCoordinates,
 	InfoPanel,
 	Input,
@@ -358,7 +358,7 @@ export interface Options {
 // State interface - complete editor state tree (top-level public API)
 export interface State {
 	compiler: Compiler;
-	graphicHelper: GraphicHelper;
+	codeBlockRendering: CodeBlockRendering;
 	contextMenu: ContextMenu;
 	spriteLookups?: SpriteLookups;
 	/** Post-process effects configuration for custom visual effects */

--- a/packages/editor/packages/editor-state/src/features/browser-local-notes/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/browser-local-notes/effect.test.ts
@@ -50,7 +50,7 @@ describe('browser-local note placement', () => {
 			callbacks: {
 				loadBrowserLocalNotes,
 			},
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [existingTopBlock, existingBottomBlock],
 				nextCodeBlockCreationIndex: 2,
 			},
@@ -63,13 +63,13 @@ describe('browser-local note placement', () => {
 		await getPopulateHandler(events)();
 
 		expect(loadBrowserLocalNotes).toHaveBeenCalledOnce();
-		expect(state.graphicHelper.codeBlocks).toHaveLength(4);
-		expect(state.graphicHelper.codeBlocks[2].gridX).toBe(0);
-		expect(state.graphicHelper.codeBlocks[2].gridY).toBe(13);
-		expect(state.graphicHelper.codeBlocks[2].code).toContain('; @pos 0 13');
-		expect(state.graphicHelper.codeBlocks[3].gridX).toBe(0);
-		expect(state.graphicHelper.codeBlocks[3].gridY).toBe(18);
-		expect(state.graphicHelper.codeBlocks[3].code).toContain('; @pos 0 18');
+		expect(state.codeBlockRendering.codeBlocks).toHaveLength(4);
+		expect(state.codeBlockRendering.codeBlocks[2].gridX).toBe(0);
+		expect(state.codeBlockRendering.codeBlocks[2].gridY).toBe(13);
+		expect(state.codeBlockRendering.codeBlocks[2].code).toContain('; @pos 0 13');
+		expect(state.codeBlockRendering.codeBlocks[3].gridX).toBe(0);
+		expect(state.codeBlockRendering.codeBlocks[3].gridY).toBe(18);
+		expect(state.codeBlockRendering.codeBlocks[3].code).toContain('; @pos 0 18');
 	});
 
 	it('preserves stored coordinates when the preferred slot is already free', async () => {
@@ -84,7 +84,7 @@ describe('browser-local note placement', () => {
 			callbacks: {
 				loadBrowserLocalNotes,
 			},
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [
 					createMockCodeBlock({
 						id: 'existing',
@@ -104,9 +104,9 @@ describe('browser-local note placement', () => {
 
 		await getPopulateHandler(events)();
 
-		expect(state.graphicHelper.codeBlocks[1].gridX).toBe(20);
-		expect(state.graphicHelper.codeBlocks[1].gridY).toBe(7);
-		expect(state.graphicHelper.codeBlocks[1].code).toContain('; @pos 20 7');
+		expect(state.codeBlockRendering.codeBlocks[1].gridX).toBe(20);
+		expect(state.codeBlockRendering.codeBlocks[1].gridY).toBe(7);
+		expect(state.codeBlockRendering.codeBlocks[1].code).toContain('; @pos 20 7');
 	});
 
 	it('does not reposition viewport-anchored browser-local notes', async () => {
@@ -121,7 +121,7 @@ describe('browser-local note placement', () => {
 			callbacks: {
 				loadBrowserLocalNotes,
 			},
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [
 					createMockCodeBlock({
 						id: 'existing',
@@ -141,10 +141,10 @@ describe('browser-local note placement', () => {
 
 		await getPopulateHandler(events)();
 
-		expect(state.graphicHelper.codeBlocks[1].viewportAnchor).toBe('top-right');
-		expect(state.graphicHelper.codeBlocks[1].gridX).toBe(4);
-		expect(state.graphicHelper.codeBlocks[1].gridY).toBe(5);
-		expect(state.graphicHelper.codeBlocks[1].code).toContain('; @pos 4 5');
+		expect(state.codeBlockRendering.codeBlocks[1].viewportAnchor).toBe('top-right');
+		expect(state.codeBlockRendering.codeBlocks[1].gridX).toBe(4);
+		expect(state.codeBlockRendering.codeBlocks[1].gridY).toBe(5);
+		expect(state.codeBlockRendering.codeBlocks[1].code).toContain('; @pos 4 5');
 	});
 
 	it('uses the default local editor config note when storage has no valid local notes', async () => {
@@ -167,8 +167,8 @@ describe('browser-local note placement', () => {
 
 		await getPopulateHandler(events)();
 
-		expect(state.graphicHelper.codeBlocks).toHaveLength(1);
-		expect(state.graphicHelper.codeBlocks[0].code[0]).toBe('note local.editorConfig');
+		expect(state.codeBlockRendering.codeBlocks).toHaveLength(1);
+		expect(state.codeBlockRendering.codeBlocks[0].code[0]).toBe('note local.editorConfig');
 	});
 });
 
@@ -179,7 +179,7 @@ describe('browser-local note persistence', () => {
 			callbacks: {
 				saveBrowserLocalNotes,
 			},
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [],
 			},
 		});
@@ -187,7 +187,7 @@ describe('browser-local note persistence', () => {
 		const events = createMockEventDispatcherWithVitest();
 
 		browserLocalNotes(store, events);
-		store.set('graphicHelper.codeBlocks', [
+		store.set('codeBlockRendering.codeBlocks', [
 			createMockCodeBlock({
 				code: ['module projectBlock', 'moduleEnd'],
 			}),
@@ -222,7 +222,7 @@ describe('browser-local note persistence', () => {
 		await populateBrowserLocalNotes();
 		saveBrowserLocalNotes.mockClear();
 
-		store.set('graphicHelper.codeBlocks', [
+		store.set('codeBlockRendering.codeBlocks', [
 			createMockCodeBlock({
 				code: ['module projectOnly', 'moduleEnd'],
 			}),
@@ -231,7 +231,7 @@ describe('browser-local note persistence', () => {
 
 		await populateBrowserLocalNotes();
 
-		expect(state.graphicHelper.codeBlocks.map(block => block.code[0])).toEqual([
+		expect(state.codeBlockRendering.codeBlocks.map(block => block.code[0])).toEqual([
 			'module projectOnly',
 			'note local.scratchpad',
 		]);
@@ -258,12 +258,12 @@ describe('browser-local note persistence', () => {
 		await getPopulateHandler(events)();
 		saveBrowserLocalNotes.mockClear();
 
-		const codeBlock = state.graphicHelper.codeBlocks[0];
-		state.graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger = codeBlock;
+		const codeBlock = state.codeBlockRendering.codeBlocks[0];
+		state.codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger = codeBlock;
 		codeBlock.code = ['note local.editorConfig', '; @pos 3 4', 'noteEnd'];
 		codeBlock.gridX = 3;
 		codeBlock.gridY = 4;
-		store.set('graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code', codeBlock.code);
+		store.set('codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code', codeBlock.code);
 
 		expect(saveBrowserLocalNotes).toHaveBeenCalledWith([
 			{
@@ -295,8 +295,8 @@ describe('browser-local note persistence', () => {
 		await getPopulateHandler(events)();
 		saveBrowserLocalNotes.mockClear();
 
-		const codeBlock = state.graphicHelper.codeBlocks[0];
-		store.set('graphicHelper.codeBlocks', []);
+		const codeBlock = state.codeBlockRendering.codeBlocks[0];
+		store.set('codeBlockRendering.codeBlocks', []);
 		getEventHandler(events, 'deleteCodeBlock')({ codeBlock });
 
 		expect(saveBrowserLocalNotes).toHaveBeenCalledWith([]);

--- a/packages/editor/packages/editor-state/src/features/browser-local-notes/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/browser-local-notes/effect.ts
@@ -34,11 +34,11 @@ export default function browserLocalNotes(store: StateManager<State>, events: Ev
 			const validBlocks = loadedBlocks.filter(block => isBrowserLocalNoteCode(block.code));
 			const browserLocalNotes = validBlocks.length > 0 ? validBlocks : [DEFAULT_BROWSER_LOCAL_NOTE];
 
-			const nextCodeBlocks = [...state.graphicHelper.codeBlocks];
+			const nextCodeBlocks = [...state.codeBlockRendering.codeBlocks];
 			const occupiedBounds: GridBounds[] = nextCodeBlocks
 				.filter(existingCodeBlock => existingCodeBlock.viewportAnchor === undefined)
 				.map(existingCodeBlock => getCodeBlockGridBounds(existingCodeBlock, state.viewport));
-			let creationIndex = state.graphicHelper.nextCodeBlockCreationIndex;
+			let creationIndex = state.codeBlockRendering.nextCodeBlockCreationIndex;
 
 			for (const rawBlock of browserLocalNotes) {
 				const preferredGridX = rawBlock.gridCoordinates?.x ?? 0;
@@ -97,9 +97,9 @@ export default function browserLocalNotes(store: StateManager<State>, events: Ev
 				creationIndex += 1;
 			}
 
-			state.graphicHelper.nextCodeBlockCreationIndex = creationIndex;
+			state.codeBlockRendering.nextCodeBlockCreationIndex = creationIndex;
 			browserLocalNotesLoaded = true;
-			store.set('graphicHelper.codeBlocks', nextCodeBlocks);
+			store.set('codeBlockRendering.codeBlocks', nextCodeBlocks);
 			saveBrowserLocalNotes();
 		} catch (err) {
 			console.warn('Failed to load browser-local notes from storage:', err);
@@ -111,7 +111,7 @@ export default function browserLocalNotes(store: StateManager<State>, events: Ev
 			return;
 		}
 
-		const serializedBlocks = serializeBrowserLocalNotes(state.graphicHelper.codeBlocks);
+		const serializedBlocks = serializeBrowserLocalNotes(state.codeBlockRendering.codeBlocks);
 		const nextSnapshot = JSON.stringify(serializedBlocks);
 		if (nextSnapshot === lastSavedBrowserLocalNotes) {
 			return;
@@ -122,7 +122,7 @@ export default function browserLocalNotes(store: StateManager<State>, events: Ev
 	}
 
 	function saveSelectedBrowserLocalNote() {
-		if (!isBrowserLocalNoteBlock(state.graphicHelper.selectedCodeBlock)) {
+		if (!isBrowserLocalNoteBlock(state.codeBlockRendering.selectedCodeBlock)) {
 			return;
 		}
 
@@ -130,7 +130,7 @@ export default function browserLocalNotes(store: StateManager<State>, events: Ev
 	}
 
 	function saveProgrammaticallyEditedBrowserLocalNote() {
-		if (!isBrowserLocalNoteBlock(state.graphicHelper.selectedCodeBlockForProgrammaticEdit)) {
+		if (!isBrowserLocalNoteBlock(state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit)) {
 			return;
 		}
 
@@ -138,7 +138,7 @@ export default function browserLocalNotes(store: StateManager<State>, events: Ev
 	}
 
 	function saveProgrammaticallyEditedBrowserLocalNoteWithoutCompilerTrigger() {
-		if (!isBrowserLocalNoteBlock(state.graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger)) {
+		if (!isBrowserLocalNoteBlock(state.codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger)) {
 			return;
 		}
 
@@ -160,13 +160,13 @@ export default function browserLocalNotes(store: StateManager<State>, events: Ev
 	events.on('projectCodeBlocksPopulated', populateBrowserLocalNotes);
 	events.on('deleteCodeBlock', saveAfterLocalNoteDelete);
 	events.on('deleteGroup', saveAfterGroupDelete);
-	store.subscribe('graphicHelper.selectedCodeBlock.code', saveSelectedBrowserLocalNote);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', saveSelectedBrowserLocalNote);
 	store.subscribe(
-		'graphicHelper.selectedCodeBlockForProgrammaticEdit.code',
+		'codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code',
 		saveProgrammaticallyEditedBrowserLocalNote
 	);
 	store.subscribe(
-		'graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code',
+		'codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code',
 		saveProgrammaticallyEditedBrowserLocalNoteWithoutCompilerTrigger
 	);
 }

--- a/packages/editor/packages/editor-state/src/features/code-blocks/README.md
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/README.md
@@ -41,7 +41,7 @@ This feature contains several subfeatures under `features/` that handle specific
 - `codeBlockDragger` - Drag and drop operations
 - `codeBlockNavigation` - Keyboard navigation between blocks
 - `debuggers` - Runtime debugging overlays
-- `graphicHelper` - Visual properties computation
+- `codeBlockRendering` - Visual properties computation
 - `inputs` - Audio input routing
 - `outputs` - Audio output routing
 - `pianoKeyboard` - Piano keyboard interface
@@ -57,8 +57,8 @@ This feature contains several subfeatures under `features/` that handle specific
 
 ### State Touched
 
-- `state.graphicHelper.codeBlocks` - Array of all code blocks with their visual and code data
-- `state.graphicHelper.selectedCodeBlock` - Currently selected block reference
+- `state.codeBlockRendering.codeBlocks` - Array of all code blocks with their visual and code data
+- `state.codeBlockRendering.selectedCodeBlock` - Currently selected block reference
 - Block-specific properties: position, size, color, blockType, code, cursor, widgets (inputs/outputs/buttons/switches)
 
 ## Integration Points

--- a/packages/editor/packages/editor-state/src/features/code-blocks/__tests__/gridCoordinates.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/__tests__/gridCoordinates.test.ts
@@ -4,13 +4,13 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { createMockCodeBlock } from '~/pureHelpers/testingUtils/testUtils';
 
 describe('Grid Coordinates Integration', () => {
-	let mockState: Pick<State, 'graphicHelper' | 'viewport'>;
+	let mockState: Pick<State, 'codeBlockRendering' | 'viewport'>;
 
 	beforeEach(() => {
 		mockState = {
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [],
-			} as State['graphicHelper'],
+			} as State['codeBlockRendering'],
 			viewport: {
 				vGrid: 8, // characterWidth
 				hGrid: 16, // characterHeight
@@ -87,7 +87,7 @@ describe('Grid Coordinates Integration', () => {
 				y: 160,
 			});
 
-			mockState.graphicHelper.codeBlocks.push(codeBlock);
+			mockState.codeBlockRendering.codeBlocks.push(codeBlock);
 
 			// Verify initial state with 8x16 font
 			expect(codeBlock.x).toBe(80);
@@ -100,7 +100,7 @@ describe('Grid Coordinates Integration', () => {
 			mockState.viewport.hGrid = newCharacterHeight;
 
 			// Recompute pixel positions from grid coordinates
-			for (const block of mockState.graphicHelper.codeBlocks) {
+			for (const block of mockState.codeBlockRendering.codeBlocks) {
 				block.x = block.gridX * newCharacterWidth;
 				block.y = block.gridY * newCharacterHeight;
 			}
@@ -131,8 +131,8 @@ describe('Grid Coordinates Integration', () => {
 				y: 240,
 			});
 
-			mockState.graphicHelper.codeBlocks.push(block1);
-			mockState.graphicHelper.codeBlocks.push(block2);
+			mockState.codeBlockRendering.codeBlocks.push(block1);
+			mockState.codeBlockRendering.codeBlocks.push(block2);
 
 			// Calculate initial grid spacing
 			const initialGridSpacingX = block2.gridX - block1.gridX;
@@ -144,7 +144,7 @@ describe('Grid Coordinates Integration', () => {
 			mockState.viewport.vGrid = 6;
 			mockState.viewport.hGrid = 10;
 
-			for (const block of mockState.graphicHelper.codeBlocks) {
+			for (const block of mockState.codeBlockRendering.codeBlocks) {
 				block.x = block.gridX * 6;
 				block.y = block.gridY * 10;
 			}

--- a/packages/editor/packages/editor-state/src/features/code-blocks/creationIndex.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/creationIndex.test.ts
@@ -6,7 +6,7 @@ import projectImport from '~/features/project-import/effect';
 import { EMPTY_DEFAULT_PROJECT } from '~/features/project-import/emptyDefaultProject';
 import { createMockCodeBlock, createMockState } from '~/pureHelpers/testingUtils/testUtils';
 import { createMockEventDispatcherWithVitest } from '~/pureHelpers/testingUtils/vitestTestUtils';
-import graphicHelper from './effect';
+import codeBlockRendering from './effect';
 import codeBlockCreator from './features/codeBlockCreator/effect';
 
 describe('creationIndex', () => {
@@ -33,16 +33,16 @@ describe('creationIndex', () => {
 			const addCodeBlockHandler = addCodeBlockCall![1];
 
 			// Initial state should have nextCodeBlockCreationIndex = 0
-			expect(mockState.graphicHelper.nextCodeBlockCreationIndex).toBe(0);
+			expect(mockState.codeBlockRendering.nextCodeBlockCreationIndex).toBe(0);
 
 			// Add first code block
 			addCodeBlockHandler({ x: 0, y: 0, isNew: true });
 
 			// Verify first code block got creationIndex 0
-			const codeBlocks = mockState.graphicHelper.codeBlocks;
+			const codeBlocks = mockState.codeBlockRendering.codeBlocks;
 			expect(codeBlocks.length).toBe(1);
 			expect(codeBlocks[0].creationIndex).toBe(0);
-			expect(mockState.graphicHelper.nextCodeBlockCreationIndex).toBe(1);
+			expect(mockState.codeBlockRendering.nextCodeBlockCreationIndex).toBe(1);
 		});
 
 		it('should increment creationIndex for each new code block', () => {
@@ -57,13 +57,13 @@ describe('creationIndex', () => {
 			addCodeBlockHandler({ x: 100, y: 0, isNew: true });
 			addCodeBlockHandler({ x: 200, y: 0, isNew: true });
 
-			const codeBlocks = mockState.graphicHelper.codeBlocks;
+			const codeBlocks = mockState.codeBlockRendering.codeBlocks;
 			expect(codeBlocks.length).toBe(3);
 
 			// Verify each block has a unique, incrementing creationIndex
 			const creationIndexes = codeBlocks.map(b => b.creationIndex).sort((a, b) => a - b);
 			expect(creationIndexes).toEqual([0, 1, 2]);
-			expect(mockState.graphicHelper.nextCodeBlockCreationIndex).toBe(3);
+			expect(mockState.codeBlockRendering.nextCodeBlockCreationIndex).toBe(3);
 		});
 
 		it('should leave gaps in creationIndex when blocks are deleted', () => {
@@ -81,7 +81,7 @@ describe('creationIndex', () => {
 			addCodeBlockHandler({ x: 200, y: 0, isNew: true });
 
 			// Delete the middle one (creationIndex 1)
-			const codeBlocks = mockState.graphicHelper.codeBlocks;
+			const codeBlocks = mockState.codeBlockRendering.codeBlocks;
 			const middleBlock = codeBlocks.find(b => b.creationIndex === 1);
 			deleteCodeBlockHandler({ codeBlock: middleBlock });
 
@@ -89,17 +89,17 @@ describe('creationIndex', () => {
 			addCodeBlockHandler({ x: 300, y: 0, isNew: true });
 
 			// Verify the new block gets creationIndex 3 (not 1, leaving a gap)
-			const updatedCodeBlocks = mockState.graphicHelper.codeBlocks;
+			const updatedCodeBlocks = mockState.codeBlockRendering.codeBlocks;
 			const creationIndexes = updatedCodeBlocks.map(b => b.creationIndex).sort((a, b) => a - b);
 			expect(creationIndexes).toEqual([0, 2, 3]);
-			expect(mockState.graphicHelper.nextCodeBlockCreationIndex).toBe(4);
+			expect(mockState.codeBlockRendering.nextCodeBlockCreationIndex).toBe(4);
 		});
 	});
 
 	describe('projectImport', () => {
 		it('should assign creationIndex to code blocks when loading a project', () => {
 			projectImport(store, mockEvents);
-			graphicHelper(store, mockEvents);
+			codeBlockRendering(store, mockEvents);
 
 			const onCalls = (mockEvents.on as unknown as MockInstance).mock.calls;
 			const loadProjectCall = onCalls.find(call => call[0] === 'loadProject');
@@ -116,25 +116,25 @@ describe('creationIndex', () => {
 
 			loadProjectCallback({ project: projectWithBlocks });
 
-			const codeBlocks = mockState.graphicHelper.codeBlocks;
+			const codeBlocks = mockState.codeBlockRendering.codeBlocks;
 			expect(codeBlocks.length).toBe(3);
 
 			// Verify each block has a creationIndex
 			const creationIndexes = codeBlocks.map(b => b.creationIndex).sort((a, b) => a - b);
 			expect(creationIndexes).toEqual([0, 1, 2]);
-			expect(mockState.graphicHelper.nextCodeBlockCreationIndex).toBe(3);
+			expect(mockState.codeBlockRendering.nextCodeBlockCreationIndex).toBe(3);
 		});
 
 		it('should reset creationIndex counter when loading a new project', () => {
 			projectImport(store, mockEvents);
-			graphicHelper(store, mockEvents);
+			codeBlockRendering(store, mockEvents);
 
 			const onCalls = (mockEvents.on as unknown as MockInstance).mock.calls;
 			const loadProjectCall = onCalls.find(call => call[0] === 'loadProject');
 			const loadProjectCallback = loadProjectCall![1];
 
 			// Set a high nextCodeBlockCreationIndex
-			mockState.graphicHelper.nextCodeBlockCreationIndex = 100;
+			mockState.codeBlockRendering.nextCodeBlockCreationIndex = 100;
 
 			const project: Project = {
 				...EMPTY_DEFAULT_PROJECT,
@@ -144,7 +144,7 @@ describe('creationIndex', () => {
 			loadProjectCallback({ project });
 
 			// Counter should be reset to the number of loaded blocks
-			expect(mockState.graphicHelper.nextCodeBlockCreationIndex).toBe(1);
+			expect(mockState.codeBlockRendering.nextCodeBlockCreationIndex).toBe(1);
 		});
 	});
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/effect.test.ts
@@ -4,9 +4,9 @@ import { EMPTY_DEFAULT_PROJECT } from '~/features/project-import/emptyDefaultPro
 import { createMockCodeBlock, createMockState } from '~/pureHelpers/testingUtils/testUtils';
 import { createMockEventDispatcherWithVitest } from '~/pureHelpers/testingUtils/vitestTestUtils';
 import centerViewportOnCodeBlock from '../viewport/centerViewportOnCodeBlock';
-import graphicHelperEffect from './effect';
+import codeBlockRenderingEffect from './effect';
 
-describe('graphic helper error mapping', () => {
+describe('code block rendering error mapping', () => {
 	it('maps typed compiler errors to function blocks', () => {
 		const functionBlock = createMockCodeBlock({
 			id: 'function_helper',
@@ -14,7 +14,7 @@ describe('graphic helper error mapping', () => {
 			blockType: 'function',
 		});
 		const state = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [functionBlock],
 			},
 			codeErrors: {
@@ -31,7 +31,7 @@ describe('graphic helper error mapping', () => {
 		const store = createStateManager(state);
 		const events = createMockEventDispatcherWithVitest();
 
-		graphicHelperEffect(store, events);
+		codeBlockRenderingEffect(store, events);
 
 		expect(functionBlock.widgets.errorMessages).toHaveLength(1);
 		expect(functionBlock.widgets.errorMessages[0].lineNumber).toBe(2);
@@ -39,7 +39,7 @@ describe('graphic helper error mapping', () => {
 	});
 });
 
-describe('graphic helper hidden directive', () => {
+describe('code block rendering hidden directive', () => {
 	it('shows a hidden block only while selected', () => {
 		const hiddenBlock = createMockCodeBlock({
 			code: ['module hidden', '; @hidden', 'moduleEnd'],
@@ -52,7 +52,7 @@ describe('graphic helper hidden directive', () => {
 			code: ['module other', 'moduleEnd'],
 		});
 		const state = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [hiddenBlock, otherBlock],
 			},
 			spriteLookups: {
@@ -67,20 +67,20 @@ describe('graphic helper hidden directive', () => {
 		const store = createStateManager(state);
 		const events = createMockEventDispatcherWithVitest();
 
-		graphicHelperEffect(store, events);
-		store.set('graphicHelper.codeBlocks', state.graphicHelper.codeBlocks);
+		codeBlockRenderingEffect(store, events);
+		store.set('codeBlockRendering.codeBlocks', state.codeBlockRendering.codeBlocks);
 
 		expect(hiddenBlock.hidden).toBe(true);
 
-		store.set('graphicHelper.selectedCodeBlock', hiddenBlock);
+		store.set('codeBlockRendering.selectedCodeBlock', hiddenBlock);
 		expect(hiddenBlock.hidden).toBe(false);
 
-		store.set('graphicHelper.selectedCodeBlock', otherBlock);
+		store.set('codeBlockRendering.selectedCodeBlock', otherBlock);
 		expect(hiddenBlock.hidden).toBe(true);
 	});
 });
 
-describe('graphic helper cursor selection', () => {
+describe('code block rendering cursor selection', () => {
 	it('updates the selected code block cursor through the store when a line is clicked', () => {
 		const selectedBlock = createMockCodeBlock({
 			code: ['zero', 'one', 'two'],
@@ -90,7 +90,7 @@ describe('graphic helper cursor selection', () => {
 			featureFlags: {
 				codeLineSelection: true,
 			},
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [selectedBlock],
 				selectedCodeBlock: selectedBlock,
 			},
@@ -103,8 +103,8 @@ describe('graphic helper cursor selection', () => {
 		const events = createMockEventDispatcherWithVitest();
 		const onSelectedRowChanged = vi.fn();
 
-		store.subscribe('graphicHelper.selectedCodeBlock.cursor.row', onSelectedRowChanged);
-		graphicHelperEffect(store, events);
+		store.subscribe('codeBlockRendering.selectedCodeBlock.cursor.row', onSelectedRowChanged);
+		codeBlockRenderingEffect(store, events);
 
 		const codeBlockClickHandler = (events.on as Mock).mock.calls.find(
 			([eventName]) => eventName === 'codeBlockClick'
@@ -121,13 +121,13 @@ describe('graphic helper cursor selection', () => {
 	});
 });
 
-describe('graphic helper line numbers', () => {
+describe('code block rendering line numbers', () => {
 	it('renders blank line-number gutters for pointer declaration instructions', () => {
 		const pointerBlock = createMockCodeBlock({
 			code: ['module demo', 'int* ptr &buffer', 'float* out &buffer', 'push 1', 'moduleEnd'],
 		});
 		const state = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [pointerBlock],
 			},
 			spriteLookups: {
@@ -142,8 +142,8 @@ describe('graphic helper line numbers', () => {
 		const store = createStateManager(state);
 		const events = createMockEventDispatcherWithVitest();
 
-		graphicHelperEffect(store, events);
-		store.set('graphicHelper.codeBlocks', state.graphicHelper.codeBlocks);
+		codeBlockRenderingEffect(store, events);
+		store.set('codeBlockRendering.codeBlocks', state.codeBlockRendering.codeBlocks);
 
 		const renderedLines = pointerBlock.codeToRender.map(line =>
 			line.map(cell => String.fromCharCode(Number(cell))).join('')
@@ -156,7 +156,7 @@ describe('graphic helper line numbers', () => {
 	});
 });
 
-describe('graphic helper home directive', () => {
+describe('code block rendering home directive', () => {
 	it('centers the initial viewport using the home alignment hint', () => {
 		const state = createMockState({
 			initialProjectState: {
@@ -190,14 +190,14 @@ describe('graphic helper home directive', () => {
 		const store = createStateManager(state);
 		const events = createMockEventDispatcherWithVitest();
 
-		graphicHelperEffect(store, events);
+		codeBlockRenderingEffect(store, events);
 		store.set('initialProjectState', state.initialProjectState);
 
-		expect(state.graphicHelper.codeBlocks).toHaveLength(1);
-		const [homeBlock] = state.graphicHelper.codeBlocks;
+		expect(state.codeBlockRendering.codeBlocks).toHaveLength(1);
+		const [homeBlock] = state.codeBlockRendering.codeBlocks;
 		expect(homeBlock.isHome).toBe(true);
 		expect(homeBlock.homeAlignment).toBe('top');
-		expect(state.graphicHelper.selectedCodeBlock).toBe(homeBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(homeBlock);
 		expect(centerViewportOnCodeBlock(state.viewport, homeBlock, { alignment: 'top' })).toEqual({
 			x: state.viewport.x,
 			y: state.viewport.y,
@@ -237,11 +237,11 @@ describe('graphic helper home directive', () => {
 		const store = createStateManager(state);
 		const events = createMockEventDispatcherWithVitest();
 
-		graphicHelperEffect(store, events);
+		codeBlockRenderingEffect(store, events);
 		store.set('initialProjectState', state.initialProjectState);
 
-		const [homeBlock] = state.graphicHelper.codeBlocks;
-		expect(state.graphicHelper.selectedCodeBlock).toBe(homeBlock);
+		const [homeBlock] = state.codeBlockRendering.codeBlocks;
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(homeBlock);
 
 		state.viewport.vGrid = 6;
 		state.viewport.hGrid = 12;
@@ -270,7 +270,7 @@ describe('graphic helper home directive', () => {
 			y: 320,
 		});
 		const state = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [selectedBlock],
 				selectedCodeBlock: selectedBlock,
 			},
@@ -296,7 +296,7 @@ describe('graphic helper home directive', () => {
 		const store = createStateManager(state);
 		const events = createMockEventDispatcherWithVitest();
 
-		graphicHelperEffect(store, events);
+		codeBlockRenderingEffect(store, events);
 		state.viewport.vGrid = 6;
 		state.viewport.hGrid = 12;
 		const spriteSheetRerenderedHandler = (events.on as Mock).mock.calls.find(

--- a/packages/editor/packages/editor-state/src/features/code-blocks/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/effect.ts
@@ -60,10 +60,10 @@ function getLineNumberPrefix(
 	return `${displayRow}`.padStart(lineNumberColumnWidth, '0') + ' ';
 }
 
-export default function graphicHelper(store: StateManager<State>, events: EventDispatcher) {
+export default function codeBlockRendering(store: StateManager<State>, events: EventDispatcher) {
 	const state = store.getState();
 	const shouldExpandCodeBlockForEditing = (codeBlock: CodeBlockGraphicData): boolean =>
-		codeBlock === state.graphicHelper.selectedCodeBlock;
+		codeBlock === state.codeBlockRendering.selectedCodeBlock;
 
 	const onCodeBlockClick = ({ relativeX = 0, relativeY = 0, codeBlock }: CodeBlockClickEvent) => {
 		if (!state.featureFlags.codeLineSelection) {
@@ -84,11 +84,11 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 			tabStopsByLine[Math.min(row, codeBlock.code.length - 1)] || []
 		);
 		const [boundedRow, boundedCol] = moveCaret(codeBlock.code, row, col, 'jump');
-		if (codeBlock !== state.graphicHelper.selectedCodeBlock) {
+		if (codeBlock !== state.codeBlockRendering.selectedCodeBlock) {
 			return;
 		}
 
-		store.set('graphicHelper.selectedCodeBlock.cursor', {
+		store.set('codeBlockRendering.selectedCodeBlock.cursor', {
 			...codeBlock.cursor,
 			row: boundedRow,
 			col: boundedCol,
@@ -108,7 +108,7 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 		const displayModel = directiveState.displayModel;
 
 		graphicData.disabled = directiveState.blockState.disabled;
-		graphicData.hidden = directiveState.blockState.hidden && state.graphicHelper.selectedCodeBlock !== graphicData;
+		graphicData.hidden = directiveState.blockState.hidden && state.codeBlockRendering.selectedCodeBlock !== graphicData;
 		graphicData.isHome = directiveState.blockState.isHome;
 		graphicData.homeAlignment = directiveState.blockState.homeAlignment;
 		graphicData.isFavorite = directiveState.blockState.isFavorite;
@@ -200,11 +200,11 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 		graphicData.viewportAnchor = directiveState.blockState.viewportAnchor;
 		graphicData.alwaysOnTop = directiveState.blockState.alwaysOnTop ?? false;
 
-		graphicData.textureCacheKey = `codeBlock:${graphicData.creationIndex}:${graphicData.lastUpdated}:${displayModel.isCollapsed ? 'collapsed' : 'expanded'}:${state.graphicHelper.textureCacheEpoch}`;
+		graphicData.textureCacheKey = `codeBlock:${graphicData.creationIndex}:${graphicData.lastUpdated}:${displayModel.isCollapsed ? 'collapsed' : 'expanded'}:${state.codeBlockRendering.textureCacheEpoch}`;
 	};
 
 	const updateGraphicsAll = () => {
-		for (const graphicData of state.graphicHelper.codeBlocks) {
+		for (const graphicData of state.codeBlockRendering.codeBlocks) {
 			updateGraphics(graphicData);
 		}
 	};
@@ -212,7 +212,7 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 	const recomputePixelCoordinatesAndUpdateGraphics = () => {
 		// When viewport grid dimensions change (e.g., font change), recompute pixel positions
 		// from the stable grid coordinates, then update graphics. Combined into single iteration.
-		for (const codeBlock of state.graphicHelper.codeBlocks) {
+		for (const codeBlock of state.codeBlockRendering.codeBlocks) {
 			if (!codeBlock.viewportAnchor) {
 				// World-space blocks: derive pixel position directly from grid coordinates.
 				codeBlock.x = codeBlock.gridX * state.viewport.vGrid;
@@ -226,7 +226,7 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 	};
 
 	const centerViewportOnSelectedCodeBlock = () => {
-		const selectedCodeBlock = state.graphicHelper.selectedCodeBlock;
+		const selectedCodeBlock = state.codeBlockRendering.selectedCodeBlock;
 		if (!selectedCodeBlock) {
 			return;
 		}
@@ -238,14 +238,14 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 	};
 
 	const updateSelectedCodeBlock = () => {
-		if (!state.graphicHelper.selectedCodeBlock) {
+		if (!state.codeBlockRendering.selectedCodeBlock) {
 			return;
 		}
-		updateGraphics(state.graphicHelper.selectedCodeBlock);
+		updateGraphics(state.codeBlockRendering.selectedCodeBlock);
 	};
 
 	const updateProgrammaticSelectedCodeBlock = () => {
-		const block = state.graphicHelper.selectedCodeBlockForProgrammaticEdit;
+		const block = state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit;
 		if (!block) {
 			return;
 		}
@@ -253,7 +253,7 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 	};
 
 	const updateProgrammaticSelectedCodeBlockWithoutCompilerTrigger = () => {
-		const block = state.graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger;
+		const block = state.codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger;
 		if (!block) {
 			return;
 		}
@@ -273,10 +273,10 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 		});
 	};
 
-	let previousSelectedCodeBlock = state.graphicHelper.selectedCodeBlock;
+	let previousSelectedCodeBlock = state.codeBlockRendering.selectedCodeBlock;
 	const onSelectedCodeBlockChanged = () => {
-		updateHideSelectionTransition(previousSelectedCodeBlock, state.graphicHelper.selectedCodeBlock);
-		previousSelectedCodeBlock = state.graphicHelper.selectedCodeBlock;
+		updateHideSelectionTransition(previousSelectedCodeBlock, state.codeBlockRendering.selectedCodeBlock);
+		previousSelectedCodeBlock = state.codeBlockRendering.selectedCodeBlock;
 	};
 
 	const populateCodeBlocks = async () => {
@@ -284,15 +284,15 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 			return;
 		}
 
-		state.graphicHelper.outputsByWordAddress.clear();
-		state.graphicHelper.draggedCodeBlock = undefined;
-		state.graphicHelper.nextCodeBlockCreationIndex = 0;
-		store.set('graphicHelper.selectedCodeBlock', undefined);
-		store.set('graphicHelper.selectedCodeBlockForProgrammaticEdit', undefined);
+		state.codeBlockRendering.outputsByWordAddress.clear();
+		state.codeBlockRendering.draggedCodeBlock = undefined;
+		state.codeBlockRendering.nextCodeBlockCreationIndex = 0;
+		store.set('codeBlockRendering.selectedCodeBlock', undefined);
+		store.set('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', undefined);
 
 		const codeBlocks = state.initialProjectState.codeBlocks.map(codeBlock => {
-			const creationIndex = state.graphicHelper.nextCodeBlockCreationIndex;
-			state.graphicHelper.nextCodeBlockCreationIndex++;
+			const creationIndex = state.codeBlockRendering.nextCodeBlockCreationIndex;
+			state.codeBlockRendering.nextCodeBlockCreationIndex++;
 
 			// Parse @pos directive from code, default to (0,0) if missing or invalid
 			const blockParsedDirectives = parseBlockDirectives(codeBlock.code);
@@ -341,12 +341,12 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 		// Stable-sort to maintain the partition: normal blocks first, always-on-top last.
 		const partitionedCodeBlocks = [...codeBlocks.filter(b => !b.alwaysOnTop), ...codeBlocks.filter(b => b.alwaysOnTop)];
 
-		store.set('graphicHelper.codeBlocks', partitionedCodeBlocks);
+		store.set('codeBlockRendering.codeBlocks', partitionedCodeBlocks);
 
 		// Center viewport on first @home block, or default to (0,0)
 		const homeBlock = codeBlocks.find(block => block.isHome);
 		if (homeBlock) {
-			store.set('graphicHelper.selectedCodeBlock', homeBlock);
+			store.set('codeBlockRendering.selectedCodeBlock', homeBlock);
 			const { x, y } = centerViewportOnCodeBlock(state.viewport, homeBlock, {
 				alignment: homeBlock.homeAlignment,
 			});
@@ -364,7 +364,7 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 			...state.codeErrors.editorDirectiveErrors,
 			...state.codeErrors.shaderErrors,
 		];
-		state.graphicHelper.codeBlocks.forEach(codeBlock => {
+		state.codeBlockRendering.codeBlocks.forEach(codeBlock => {
 			codeBlock.widgets.errorMessages = [];
 			codeErrors.forEach(codeError => {
 				const matchesCodeBlock =
@@ -392,10 +392,10 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 
 	// When user edits code, parse @pos and update runtime position if valid
 	const applyPositionFromCodeEdit = () => {
-		if (!state.graphicHelper.selectedCodeBlock) {
+		if (!state.codeBlockRendering.selectedCodeBlock) {
 			return;
 		}
-		const codeBlock = state.graphicHelper.selectedCodeBlock;
+		const codeBlock = state.codeBlockRendering.selectedCodeBlock;
 		const posResult = parsePos(codeBlock.parsedDirectives);
 
 		// Only update position if @pos is valid
@@ -418,22 +418,25 @@ export default function graphicHelper(store: StateManager<State>, events: EventD
 	events.on<CodeBlockClickEvent>('codeBlockClick', ({ codeBlock }) => updateGraphics(codeBlock));
 	events.on('runtimeInitialized', updateGraphicsAll);
 	events.on('spriteSheetRerendered', () => {
-		state.graphicHelper.textureCacheEpoch += 1;
+		state.codeBlockRendering.textureCacheEpoch += 1;
 		recomputePixelCoordinatesAndUpdateGraphics();
 		centerViewportOnSelectedCodeBlock();
 	});
 	store.subscribe('codeErrors', updateErrorMessages);
 	store.subscribe('initialProjectState', populateCodeBlocks);
-	store.subscribe('graphicHelper.codeBlocks', updateGraphicsAll);
+	store.subscribe('codeBlockRendering.codeBlocks', updateGraphicsAll);
 	store.subscribe('info', updateGraphicsAll);
-	store.subscribe('graphicHelper.selectedCodeBlock', onSelectedCodeBlockChanged);
-	store.subscribe('graphicHelper.selectedCodeBlock.code', updateSelectedCodeBlock);
-	store.subscribe('graphicHelper.selectedCodeBlock.code', applyPositionFromCodeEdit);
-	store.subscribe('graphicHelper.selectedCodeBlock.cursor', updateSelectedCodeBlock);
-	store.subscribe('graphicHelper.selectedCodeBlockForProgrammaticEdit.code', updateProgrammaticSelectedCodeBlock);
-	store.subscribe('graphicHelper.selectedCodeBlockForProgrammaticEdit.cursor', updateProgrammaticSelectedCodeBlock);
+	store.subscribe('codeBlockRendering.selectedCodeBlock', onSelectedCodeBlockChanged);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', updateSelectedCodeBlock);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', applyPositionFromCodeEdit);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.cursor', updateSelectedCodeBlock);
+	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', updateProgrammaticSelectedCodeBlock);
 	store.subscribe(
-		'graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code',
+		'codeBlockRendering.selectedCodeBlockForProgrammaticEdit.cursor',
+		updateProgrammaticSelectedCodeBlock
+	);
+	store.subscribe(
+		'codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code',
 		updateProgrammaticSelectedCodeBlockWithoutCompilerTrigger
 	);
 }

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/auto-env-constants/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/auto-env-constants/effect.test.ts
@@ -146,16 +146,16 @@ describe('autoEnvConstants', () => {
 		autoEnvConstants(store);
 		store.set('initialProjectState', { ...EMPTY_DEFAULT_PROJECT });
 
-		// Simulate graphicHelper populating codeBlocks from initialProjectState
+		// Simulate codeBlockRendering populating codeBlocks from initialProjectState
 		const envCodeBlock = state.initialProjectState?.codeBlocks.find(block => block.code[0]?.includes('constants env'));
 		if (envCodeBlock) {
-			store.set('graphicHelper.codeBlocks', [createGraphicEnvBlock(envCodeBlock.code)]);
+			store.set('codeBlockRendering.codeBlocks', [createGraphicEnvBlock(envCodeBlock.code)]);
 		}
 
-		store.set('graphicHelper.codeBlocks', [createGraphicEnvBlock(envCodeBlock?.code ?? [])]);
+		store.set('codeBlockRendering.codeBlocks', [createGraphicEnvBlock(envCodeBlock?.code ?? [])]);
 		store.set('editorConfig.testRuntime', { magicNumber: 77 });
 
-		const envBlock = state.graphicHelper.codeBlocks.find(block => block.id === AUTO_ENV_BLOCK_ID);
+		const envBlock = state.codeBlockRendering.codeBlocks.find(block => block.id === AUTO_ENV_BLOCK_ID);
 		const magicNumberLine = envBlock?.code.find(line => line.includes('RUNTIME_MAGIC'));
 		expect(magicNumberLine).toBe('const RUNTIME_MAGIC 77');
 		const unusedRuntimeLine = envBlock?.code.find(line => line.includes('UNUSED_RUNTIME_MAGIC'));
@@ -206,10 +206,10 @@ describe('autoEnvConstants', () => {
 		autoEnvConstants(store);
 		store.set('initialProjectState', { ...PROJECT_WITH_CODE_BLOCK });
 
-		// Simulate graphicHelper populating codeBlocks from initialProjectState
+		// Simulate codeBlockRendering populating codeBlocks from initialProjectState
 		const envCodeBlock = state.initialProjectState?.codeBlocks.find(block => block.code[0]?.includes('constants env'));
 		if (envCodeBlock) {
-			store.set('graphicHelper.codeBlocks', [createGraphicEnvBlock(envCodeBlock.code)]);
+			store.set('codeBlockRendering.codeBlocks', [createGraphicEnvBlock(envCodeBlock.code)]);
 		}
 
 		// Add binary asset
@@ -222,7 +222,7 @@ describe('autoEnvConstants', () => {
 			},
 		]);
 
-		const envBlock = state.graphicHelper.codeBlocks.find(block => block.id === AUTO_ENV_BLOCK_ID);
+		const envBlock = state.codeBlockRendering.codeBlocks.find(block => block.id === AUTO_ENV_BLOCK_ID);
 		const assetSizeLine = envBlock?.code.find(line => line.includes('ASSET_0_SIZE'));
 		expect(assetSizeLine).toBe('const ASSET_0_SIZE 88200');
 	});
@@ -236,13 +236,13 @@ describe('autoEnvConstants', () => {
 		if (envCodeBlock) {
 			codeWithCustomPos = [...envCodeBlock.code];
 			codeWithCustomPos[1] = '; @pos 12 -7';
-			store.set('graphicHelper.codeBlocks', [createGraphicEnvBlock(codeWithCustomPos, { gridX: 12, gridY: -7 })]);
+			store.set('codeBlockRendering.codeBlocks', [createGraphicEnvBlock(codeWithCustomPos, { gridX: 12, gridY: -7 })]);
 		}
 
-		store.set('graphicHelper.codeBlocks', [createGraphicEnvBlock(codeWithCustomPos, { gridX: 12, gridY: -7 })]);
+		store.set('codeBlockRendering.codeBlocks', [createGraphicEnvBlock(codeWithCustomPos, { gridX: 12, gridY: -7 })]);
 		store.set('editorConfig.testRuntime', { magicNumber: 77 });
 
-		const envBlock = state.graphicHelper.codeBlocks.find(block => block.id === AUTO_ENV_BLOCK_ID);
+		const envBlock = state.codeBlockRendering.codeBlocks.find(block => block.id === AUTO_ENV_BLOCK_ID);
 		expect(envBlock?.code).toContain('; @pos 12 -7');
 	});
 
@@ -254,13 +254,13 @@ describe('autoEnvConstants', () => {
 		let codeWithoutPos: string[] = [];
 		if (envCodeBlock) {
 			codeWithoutPos = envCodeBlock.code.filter(line => !line.includes('@pos'));
-			store.set('graphicHelper.codeBlocks', [createGraphicEnvBlock(codeWithoutPos)]);
+			store.set('codeBlockRendering.codeBlocks', [createGraphicEnvBlock(codeWithoutPos)]);
 		}
 
-		store.set('graphicHelper.codeBlocks', [createGraphicEnvBlock(codeWithoutPos)]);
+		store.set('codeBlockRendering.codeBlocks', [createGraphicEnvBlock(codeWithoutPos)]);
 		store.set('editorConfig.testRuntime', { magicNumber: 77 });
 
-		const envBlock = state.graphicHelper.codeBlocks.find(block => block.id === AUTO_ENV_BLOCK_ID);
+		const envBlock = state.codeBlockRendering.codeBlocks.find(block => block.id === AUTO_ENV_BLOCK_ID);
 		expect(envBlock?.code).toContain('; @pos 0 0');
 	});
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/auto-env-constants/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/auto-env-constants/effect.ts
@@ -71,7 +71,7 @@ function generateEnvConstantsBlock(state: State, existingPos?: { x: number; y: n
  * This effect automatically maintains a constants block named 'env' that contains
  * environment values like contributed runtime values and binary asset sizes.
  * The env block is added to the project's codeBlocks array when the project is loaded,
- * and its content is updated in graphicHelper.codeBlocks when contributed environment constants or binary assets change.
+ * and its content is updated in codeBlockRendering.codeBlocks when contributed environment constants or binary assets change.
  *
  * @param store - State manager instance
  */
@@ -91,12 +91,12 @@ export default function autoEnvConstants(store: StateManager<State>): void {
 	}
 
 	/**
-	 * Updates the env constants block code in graphicHelper.codeBlocks.
+	 * Updates the env constants block code in codeBlockRendering.codeBlocks.
 	 * This avoids triggering an infinite loop by not modifying initialProjectState.
 	 */
-	function updateEnvConstantsBlockInGraphicHelper(): void {
+	function updateEnvConstantsBlockInCodeBlockRendering(): void {
 		const state = store.getState();
-		const targetBlock = state.graphicHelper.codeBlocks.find(block => isEnvBlock(block));
+		const targetBlock = state.codeBlockRendering.codeBlocks.find(block => isEnvBlock(block));
 
 		if (!targetBlock) {
 			return;
@@ -111,7 +111,7 @@ export default function autoEnvConstants(store: StateManager<State>): void {
 		targetBlock.code = newCode;
 		targetBlock.lastUpdated = performance.now();
 
-		store.set('graphicHelper.selectedCodeBlockForProgrammaticEdit', targetBlock);
+		store.set('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', targetBlock);
 	}
 
 	/**
@@ -146,10 +146,10 @@ export default function autoEnvConstants(store: StateManager<State>): void {
 	// Ensure env block exists when project is loaded
 	store.subscribe('initialProjectState', ensureEnvBlockInProject);
 
-	// Update env block code in graphicHelper.codeBlocks when editor config, runtime registry, or binary assets change.
+	// Update env block code in codeBlockRendering.codeBlocks when editor config, runtime registry, or binary assets change.
 	// This avoids the infinite loop caused by modifying initialProjectState.
-	store.subscribe('graphicHelper.selectedCodeBlock.code', updateEnvConstantsBlockInGraphicHelper);
-	store.subscribe('editorConfig', updateEnvConstantsBlockInGraphicHelper);
-	store.subscribe('runtimeRegistry', updateEnvConstantsBlockInGraphicHelper);
-	store.subscribe('binaryAssets', updateEnvConstantsBlockInGraphicHelper);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', updateEnvConstantsBlockInCodeBlockRendering);
+	store.subscribe('editorConfig', updateEnvConstantsBlockInCodeBlockRendering);
+	store.subscribe('runtimeRegistry', updateEnvConstantsBlockInCodeBlockRendering);
+	store.subscribe('binaryAssets', updateEnvConstantsBlockInCodeBlockRendering);
 }

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/blockTypeUpdater/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/blockTypeUpdater/effect.ts
@@ -20,7 +20,7 @@ export default function blockTypeUpdater(store: StateManager<State>): void {
 	 * Update blockType for all code blocks
 	 */
 	function updateAllBlockTypes(): void {
-		for (const codeBlock of state.graphicHelper.codeBlocks) {
+		for (const codeBlock of state.codeBlockRendering.codeBlocks) {
 			updateBlockType(codeBlock);
 		}
 	}
@@ -29,30 +29,33 @@ export default function blockTypeUpdater(store: StateManager<State>): void {
 	 * Update blockType when the selected code block's code changes
 	 */
 	function onSelectedCodeBlockCodeChange(): void {
-		if (state.graphicHelper.selectedCodeBlock) {
-			updateBlockType(state.graphicHelper.selectedCodeBlock);
+		if (state.codeBlockRendering.selectedCodeBlock) {
+			updateBlockType(state.codeBlockRendering.selectedCodeBlock);
 		}
 	}
 
 	function onProgrammaticSelectedCodeBlockCodeChange(): void {
-		const block = state.graphicHelper.selectedCodeBlockForProgrammaticEdit;
+		const block = state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit;
 		if (block) {
 			updateBlockType(block);
 		}
 	}
 
 	function onProgrammaticSelectedCodeBlockWithoutCompilerTriggerCodeChange(): void {
-		const block = state.graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger;
+		const block = state.codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger;
 		if (block) {
 			updateBlockType(block);
 		}
 	}
 
-	store.subscribe('graphicHelper.codeBlocks', updateAllBlockTypes);
-	store.subscribe('graphicHelper.selectedCodeBlock.code', onSelectedCodeBlockCodeChange);
-	store.subscribe('graphicHelper.selectedCodeBlockForProgrammaticEdit.code', onProgrammaticSelectedCodeBlockCodeChange);
+	store.subscribe('codeBlockRendering.codeBlocks', updateAllBlockTypes);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', onSelectedCodeBlockCodeChange);
 	store.subscribe(
-		'graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code',
+		'codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code',
+		onProgrammaticSelectedCodeBlockCodeChange
+	);
+	store.subscribe(
+		'codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code',
 		onProgrammaticSelectedCodeBlockWithoutCompilerTriggerCodeChange
 	);
 }

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/clearDebugProbes/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/clearDebugProbes/effect.test.ts
@@ -21,7 +21,7 @@ describe('clearDebugProbes', () => {
 			code: ['module test', '; @watch x', '', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		clearDebugProbes(store, mockEvents);
 
@@ -40,7 +40,7 @@ describe('clearDebugProbes', () => {
 			code: ['module test', '; @watch x', '', '; @watch y', '; @watch z', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		clearDebugProbes(store, mockEvents);
 
@@ -58,7 +58,7 @@ describe('clearDebugProbes', () => {
 			code: ['module test', '', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		clearDebugProbes(store, mockEvents);
 
@@ -76,7 +76,7 @@ describe('clearDebugProbes', () => {
 			code: ['module test', '; @group mygroup', '; @watch x', '; @favorite', '; @watch y', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		clearDebugProbes(store, mockEvents);
 
@@ -94,7 +94,7 @@ describe('clearDebugProbes', () => {
 			code: ['module test', '; @watch x  ', '', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		clearDebugProbes(store, mockEvents);
 
@@ -112,7 +112,7 @@ describe('clearDebugProbes', () => {
 			code: ['module test', '  ; @watch x', '', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		clearDebugProbes(store, mockEvents);
 
@@ -131,7 +131,7 @@ describe('clearDebugProbes', () => {
 			blockType: 'module',
 			lastUpdated: 1000,
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		clearDebugProbes(store, mockEvents);
 
@@ -149,7 +149,7 @@ describe('clearDebugProbes', () => {
 			code: ['module test', '; @watch x', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		clearDebugProbes(store, mockEvents);
 
@@ -161,7 +161,7 @@ describe('clearDebugProbes', () => {
 
 		clearCallback({ codeBlock });
 
-		expect(setSpy).toHaveBeenCalledWith('graphicHelper.selectedCodeBlockForProgrammaticEdit', codeBlock);
+		expect(setSpy).toHaveBeenCalledWith('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', codeBlock);
 	});
 
 	it('should not clear when editing is disabled', () => {
@@ -169,7 +169,7 @@ describe('clearDebugProbes', () => {
 			code: ['module test', '; @watch x', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 		mockState.featureFlags.editing = false;
 
 		clearDebugProbes(store, mockEvents);
@@ -188,7 +188,7 @@ describe('clearDebugProbes', () => {
 			code: ['module test', '; @watch', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		clearDebugProbes(store, mockEvents);
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/clearDebugProbes/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/clearDebugProbes/effect.ts
@@ -16,7 +16,7 @@ export default function clearDebugProbes(store: StateManager<State>, events: Eve
 		}
 
 		// Set target code block for programmatic edit to avoid re-rendering all code blocks
-		state.graphicHelper.selectedCodeBlockForProgrammaticEdit = codeBlock;
+		state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit = codeBlock;
 
 		// Remove all @watch directive lines
 		codeBlock.code = removeDirective(codeBlock.code, 'watch');
@@ -25,7 +25,7 @@ export default function clearDebugProbes(store: StateManager<State>, events: Eve
 		codeBlock.lastUpdated = Date.now();
 
 		// Trigger store update to re-render only the specific code block
-		store.set('graphicHelper.selectedCodeBlockForProgrammaticEdit', codeBlock);
+		store.set('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', codeBlock);
 	}
 
 	events.on('clearDebugProbes', onClearDebugProbes);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/checkIfCodeBlockIdIsTaken.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/checkIfCodeBlockIdIsTaken.ts
@@ -6,5 +6,5 @@ export function checkIfCodeBlockIdIsTaken(
 	id: string
 ): boolean {
 	const typedId = `${blockType}_${id}`;
-	return state.graphicHelper.codeBlocks.some(codeBlock => codeBlock.id === typedId);
+	return state.codeBlockRendering.codeBlocks.some(codeBlock => codeBlock.id === typedId);
 }

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/copyPaste.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/copyPaste.test.ts
@@ -36,7 +36,7 @@ describe('codeBlockCreator - group copy/paste', () => {
 				groupName: 'audio',
 			});
 
-			mockState.graphicHelper.codeBlocks = [block1, block2];
+			mockState.codeBlockRendering.codeBlocks = [block1, block2];
 
 			groupCopier(store, mockEvents);
 
@@ -78,7 +78,7 @@ describe('codeBlockCreator - group copy/paste', () => {
 				disabled: true,
 			});
 
-			mockState.graphicHelper.codeBlocks = [block1];
+			mockState.codeBlockRendering.codeBlocks = [block1];
 
 			groupCopier(store, mockEvents);
 
@@ -105,7 +105,7 @@ describe('codeBlockCreator - group copy/paste', () => {
 				groupName: undefined,
 			});
 
-			mockState.graphicHelper.codeBlocks = [block1];
+			mockState.codeBlockRendering.codeBlocks = [block1];
 
 			groupCopier(store, mockEvents);
 
@@ -143,7 +143,7 @@ describe('codeBlockCreator - group copy/paste', () => {
 				creationIndex: 3,
 			});
 
-			mockState.graphicHelper.codeBlocks = [block1, block2, block3];
+			mockState.codeBlockRendering.codeBlocks = [block1, block2, block3];
 
 			groupCopier(store, mockEvents);
 
@@ -186,17 +186,17 @@ describe('codeBlockCreator - group copy/paste', () => {
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: false, code: [''] });
 
 			// Verify two blocks were created
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(2);
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(2);
 
 			// Verify first block is at paste anchor position
 			const anchorGridX = Math.round(100 / 8);
 			const anchorGridY = Math.round(100 / 8);
-			expect(mockState.graphicHelper.codeBlocks[0].gridX).toBe(anchorGridX);
-			expect(mockState.graphicHelper.codeBlocks[0].gridY).toBe(anchorGridY);
+			expect(mockState.codeBlockRendering.codeBlocks[0].gridX).toBe(anchorGridX);
+			expect(mockState.codeBlockRendering.codeBlocks[0].gridY).toBe(anchorGridY);
 
 			// Verify second block has relative offset
-			expect(mockState.graphicHelper.codeBlocks[1].gridX).toBe(anchorGridX + 5);
-			expect(mockState.graphicHelper.codeBlocks[1].gridY).toBe(anchorGridY + 3);
+			expect(mockState.codeBlockRendering.codeBlocks[1].gridX).toBe(anchorGridX + 5);
+			expect(mockState.codeBlockRendering.codeBlocks[1].gridY).toBe(anchorGridY + 3);
 		});
 
 		it('should parse disabled state from @disabled directive on pasted blocks', async () => {
@@ -216,8 +216,8 @@ describe('codeBlockCreator - group copy/paste', () => {
 
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: false, code: [''] });
 
-			expect(mockState.graphicHelper.codeBlocks[0].disabled).toBe(true);
-			expect(mockState.graphicHelper.codeBlocks[1].disabled).toBe(false);
+			expect(mockState.codeBlockRendering.codeBlocks[0].disabled).toBe(true);
+			expect(mockState.codeBlockRendering.codeBlocks[1].disabled).toBe(false);
 		});
 
 		it('should rename colliding group names on paste', async () => {
@@ -226,7 +226,7 @@ describe('codeBlockCreator - group copy/paste', () => {
 				code: ['module existing', '; @group audio', 'moduleEnd'],
 				groupName: 'audio',
 			});
-			mockState.graphicHelper.codeBlocks = [existingBlock];
+			mockState.codeBlockRendering.codeBlocks = [existingBlock];
 
 			// Paste blocks with same group name
 			const clipboardData = JSON.stringify([
@@ -246,11 +246,11 @@ describe('codeBlockCreator - group copy/paste', () => {
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: false, code: [''] });
 
 			// Original block should still have "audio" at line 1
-			expect(mockState.graphicHelper.codeBlocks[0].code[1]).toBe('; @group audio');
+			expect(mockState.codeBlockRendering.codeBlocks[0].code[1]).toBe('; @group audio');
 
 			// Pasted blocks should have renamed group "audio1" at line 2 (after @pos)
-			expect(mockState.graphicHelper.codeBlocks[1].code[2]).toBe('; @group audio1');
-			expect(mockState.graphicHelper.codeBlocks[2].code[2]).toBe('; @group audio1');
+			expect(mockState.codeBlockRendering.codeBlocks[1].code[2]).toBe('; @group audio1');
+			expect(mockState.codeBlockRendering.codeBlocks[2].code[2]).toBe('; @group audio1');
 		});
 
 		it('should handle multiple different group names in paste', async () => {
@@ -262,7 +262,7 @@ describe('codeBlockCreator - group copy/paste', () => {
 				code: ['module existing2', '; @group video', 'moduleEnd'],
 				groupName: 'video',
 			});
-			mockState.graphicHelper.codeBlocks = [existingBlock1, existingBlock2];
+			mockState.codeBlockRendering.codeBlocks = [existingBlock1, existingBlock2];
 
 			const clipboardData = JSON.stringify([
 				{ code: ['module foo', '; @group audio', 'moduleEnd'], gridCoordinates: { x: 0, y: 0 } },
@@ -282,9 +282,9 @@ describe('codeBlockCreator - group copy/paste', () => {
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: false, code: [''] });
 
 			// audio -> audio1, video -> video1 (now at line 2 after @pos)
-			expect(mockState.graphicHelper.codeBlocks[2].code[2]).toBe('; @group audio1');
-			expect(mockState.graphicHelper.codeBlocks[3].code[2]).toBe('; @group video1');
-			expect(mockState.graphicHelper.codeBlocks[4].code[2]).toBe('; @group audio1'); // Same as first
+			expect(mockState.codeBlockRendering.codeBlocks[2].code[2]).toBe('; @group audio1');
+			expect(mockState.codeBlockRendering.codeBlocks[3].code[2]).toBe('; @group video1');
+			expect(mockState.codeBlockRendering.codeBlocks[4].code[2]).toBe('; @group audio1'); // Same as first
 		});
 
 		it('should fallback to single-block paste for invalid JSON', async () => {
@@ -302,11 +302,11 @@ describe('codeBlockCreator - group copy/paste', () => {
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: false, code: [''] });
 
 			// Should create one block with plain text (now includes @pos)
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(1);
-			expect(mockState.graphicHelper.codeBlocks[0].code[0]).toBe('module test');
-			expect(mockState.graphicHelper.codeBlocks[0].code[1]).toMatch(/^; @pos \d+ \d+$/);
-			expect(mockState.graphicHelper.codeBlocks[0].code[2]).toBe('');
-			expect(mockState.graphicHelper.codeBlocks[0].code[3]).toBe('moduleEnd');
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(1);
+			expect(mockState.codeBlockRendering.codeBlocks[0].code[0]).toBe('module test');
+			expect(mockState.codeBlockRendering.codeBlocks[0].code[1]).toMatch(/^; @pos \d+ \d+$/);
+			expect(mockState.codeBlockRendering.codeBlocks[0].code[2]).toBe('');
+			expect(mockState.codeBlockRendering.codeBlocks[0].code[3]).toBe('moduleEnd');
 		});
 
 		it('should fallback to single-block paste for array with only 1 item', async () => {
@@ -324,7 +324,7 @@ describe('codeBlockCreator - group copy/paste', () => {
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: false, code: [''] });
 
 			// Should fallback to single paste
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(1);
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(1);
 		});
 
 		it('should update module IDs to avoid collisions', async () => {
@@ -332,7 +332,7 @@ describe('codeBlockCreator - group copy/paste', () => {
 				id: 'foo',
 				code: ['module foo', 'moduleEnd'],
 			});
-			mockState.graphicHelper.codeBlocks = [existingBlock];
+			mockState.codeBlockRendering.codeBlocks = [existingBlock];
 
 			const clipboardData = JSON.stringify([
 				{ code: ['module foo', 'moduleEnd'], gridCoordinates: { x: 0, y: 0 } },
@@ -351,9 +351,9 @@ describe('codeBlockCreator - group copy/paste', () => {
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: false, code: [''] });
 
 			// Pasted blocks should have unique IDs
-			expect(mockState.graphicHelper.codeBlocks[1].id).not.toBe('foo');
-			expect(mockState.graphicHelper.codeBlocks[2].id).not.toBe('foo');
-			expect(mockState.graphicHelper.codeBlocks[1].id).not.toBe(mockState.graphicHelper.codeBlocks[2].id);
+			expect(mockState.codeBlockRendering.codeBlocks[1].id).not.toBe('foo');
+			expect(mockState.codeBlockRendering.codeBlocks[2].id).not.toBe('foo');
+			expect(mockState.codeBlockRendering.codeBlocks[1].id).not.toBe(mockState.codeBlockRendering.codeBlocks[2].id);
 		});
 
 		it('should update inter-module references when pasted module ids are renamed', async () => {
@@ -361,7 +361,7 @@ describe('codeBlockCreator - group copy/paste', () => {
 				id: 'module_foo',
 				code: ['module foo', 'moduleEnd'],
 			});
-			mockState.graphicHelper.codeBlocks = [existingBlock];
+			mockState.codeBlockRendering.codeBlocks = [existingBlock];
 
 			const clipboardData = JSON.stringify([
 				{ code: ['module foo', 'moduleEnd'], gridCoordinates: { x: 0, y: 0 } },
@@ -382,9 +382,9 @@ describe('codeBlockCreator - group copy/paste', () => {
 
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: false, code: [''] });
 
-			expect(mockState.graphicHelper.codeBlocks[1].code[0]).toBe('module foo2');
-			expect(mockState.graphicHelper.codeBlocks[2].code[2]).toBe('int* source &foo2:memoryItem');
-			expect(mockState.graphicHelper.codeBlocks[2].code[3]).toBe('push count(foo2:buffer)');
+			expect(mockState.codeBlockRendering.codeBlocks[1].code[0]).toBe('module foo2');
+			expect(mockState.codeBlockRendering.codeBlocks[2].code[2]).toBe('int* source &foo2:memoryItem');
+			expect(mockState.codeBlockRendering.codeBlocks[2].code[3]).toBe('push count(foo2:buffer)');
 		});
 
 		it('should preserve nonstick flag in group directive', async () => {
@@ -405,8 +405,8 @@ describe('codeBlockCreator - group copy/paste', () => {
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: false, code: [''] });
 
 			// Nonstick flag should be preserved (now at index 2 after @pos)
-			expect(mockState.graphicHelper.codeBlocks[0].code[2]).toContain('nonstick');
-			expect(mockState.graphicHelper.codeBlocks[1].code[2]).toContain('nonstick');
+			expect(mockState.codeBlockRendering.codeBlocks[0].code[2]).toContain('nonstick');
+			expect(mockState.codeBlockRendering.codeBlocks[1].code[2]).toContain('nonstick');
 		});
 	});
 });

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.test.ts
@@ -37,11 +37,11 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 			expect(mockReadClipboard).toHaveBeenCalled();
 
 			// Verify code block was added with clipboard content (now includes @pos)
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(1);
-			expect(mockState.graphicHelper.codeBlocks[0].code[0]).toBe('module test');
-			expect(mockState.graphicHelper.codeBlocks[0].code[1]).toMatch(/^; @pos \d+ \d+$/);
-			expect(mockState.graphicHelper.codeBlocks[0].code[2]).toBe('');
-			expect(mockState.graphicHelper.codeBlocks[0].code[3]).toBe('moduleEnd');
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(1);
+			expect(mockState.codeBlockRendering.codeBlocks[0].code[0]).toBe('module test');
+			expect(mockState.codeBlockRendering.codeBlocks[0].code[1]).toMatch(/^; @pos \d+ \d+$/);
+			expect(mockState.codeBlockRendering.codeBlocks[0].code[2]).toBe('');
+			expect(mockState.codeBlockRendering.codeBlocks[0].code[3]).toBe('moduleEnd');
 		});
 
 		it('should fail silently when readClipboardText is not provided', async () => {
@@ -57,7 +57,7 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: false, code: [''] });
 
 			// Verify no code block was added
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(0);
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(0);
 		});
 
 		it('should fail silently when clipboard read fails', async () => {
@@ -77,7 +77,7 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 			expect(mockReadClipboard).toHaveBeenCalled();
 
 			// Verify no code block was added (silent failure)
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(0);
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(0);
 		});
 	});
 
@@ -91,15 +91,15 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: true, blockType: 'module' });
 
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(1);
-			expect(mockState.graphicHelper.codeBlocks[0].entry).toBe('entry');
-			expect(mockState.graphicHelper.codeBlocks[0].code[0]).toMatch(/^module \w+$/);
-			expect(mockState.graphicHelper.codeBlocks[0].code[1]).toMatch(/^; @pos \d+ \d+$/);
-			expect(mockState.graphicHelper.codeBlocks[0].code.at(-1)).toBe('moduleEnd');
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(1);
+			expect(mockState.codeBlockRendering.codeBlocks[0].entry).toBe('entry');
+			expect(mockState.codeBlockRendering.codeBlocks[0].code[0]).toMatch(/^module \w+$/);
+			expect(mockState.codeBlockRendering.codeBlocks[0].code[1]).toMatch(/^; @pos \d+ \d+$/);
+			expect(mockState.codeBlockRendering.codeBlocks[0].code.at(-1)).toBe('moduleEnd');
 		});
 
 		it('increments the entry name when creating outside entries and the default new entry name is already used', async () => {
-			mockState.graphicHelper.codeBlocks = [
+			mockState.codeBlockRendering.codeBlocks = [
 				createMockCodeBlock({
 					code: ['module existing', 'moduleEnd'],
 					blockType: 'module',
@@ -115,12 +115,12 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: true, blockType: 'module' });
 
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(2);
-			expect(mockState.graphicHelper.codeBlocks[1].entry).toBe('entry2');
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(2);
+			expect(mockState.codeBlockRendering.codeBlocks[1].entry).toBe('entry2');
 		});
 
 		it('assigns a regular new module to the containing non-main entry', async () => {
-			mockState.graphicHelper.entryOutlines = [
+			mockState.codeBlockRendering.entryOutlines = [
 				{
 					entryName: 'fx',
 					topLeft: { x: 0, y: 0 },
@@ -138,12 +138,12 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: true, blockType: 'module' });
 
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(1);
-			expect(mockState.graphicHelper.codeBlocks[0].entry).toBe('fx');
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(1);
+			expect(mockState.codeBlockRendering.codeBlocks[0].entry).toBe('fx');
 		});
 
 		it('uses the first overlapping entry outline at the new module position', async () => {
-			mockState.graphicHelper.entryOutlines = [
+			mockState.codeBlockRendering.entryOutlines = [
 				{
 					entryName: 'first',
 					topLeft: { x: 0, y: 0 },
@@ -168,12 +168,12 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: true, blockType: 'module' });
 
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(1);
-			expect(mockState.graphicHelper.codeBlocks[0].entry).toBe('first');
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(1);
+			expect(mockState.codeBlockRendering.codeBlocks[0].entry).toBe('first');
 		});
 
 		it('stores the main entry explicitly', async () => {
-			mockState.graphicHelper.entryOutlines = [
+			mockState.codeBlockRendering.entryOutlines = [
 				{
 					entryName: 'main',
 					topLeft: { x: 0, y: 0 },
@@ -191,8 +191,8 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: true, blockType: 'module' });
 
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(1);
-			expect(mockState.graphicHelper.codeBlocks[0].entry).toBe('main');
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(1);
+			expect(mockState.codeBlockRendering.codeBlocks[0].entry).toBe('main');
 		});
 	});
 
@@ -207,7 +207,7 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 				code: ['module test', '', 'moduleEnd'],
 				blockType: 'module',
 			});
-			mockState.graphicHelper.codeBlocks = [testCodeBlock];
+			mockState.codeBlockRendering.codeBlocks = [testCodeBlock];
 
 			codeBlockCreator(store, mockEvents);
 
@@ -219,7 +219,7 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 			const copyCodeBlockCallback = copyCodeBlockCall![1];
 
 			// Trigger copy
-			copyCodeBlockCallback({ codeBlock: mockState.graphicHelper.codeBlocks[0] });
+			copyCodeBlockCallback({ codeBlock: mockState.codeBlockRendering.codeBlocks[0] });
 
 			// Wait for async operation
 			await new Promise(resolve => setTimeout(resolve, 0));
@@ -237,7 +237,7 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 				code: ['module test', '', 'moduleEnd'],
 				blockType: 'module',
 			});
-			mockState.graphicHelper.codeBlocks = [testCodeBlock];
+			mockState.codeBlockRendering.codeBlocks = [testCodeBlock];
 
 			codeBlockCreator(store, mockEvents);
 
@@ -247,7 +247,7 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 
 			// Trigger copy - should not throw
 			expect(() => {
-				copyCodeBlockCallback({ codeBlock: mockState.graphicHelper.codeBlocks[0] });
+				copyCodeBlockCallback({ codeBlock: mockState.codeBlockRendering.codeBlocks[0] });
 			}).not.toThrow();
 		});
 
@@ -261,7 +261,7 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 				code: ['module test', '', 'moduleEnd'],
 				blockType: 'module',
 			});
-			mockState.graphicHelper.codeBlocks = [testCodeBlock];
+			mockState.codeBlockRendering.codeBlocks = [testCodeBlock];
 
 			codeBlockCreator(store, mockEvents);
 
@@ -270,7 +270,7 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 			const copyCodeBlockCallback = copyCodeBlockCall![1];
 
 			// Trigger copy
-			copyCodeBlockCallback({ codeBlock: mockState.graphicHelper.codeBlocks[0] });
+			copyCodeBlockCallback({ codeBlock: mockState.codeBlockRendering.codeBlocks[0] });
 
 			// Wait for async operation
 			await new Promise(resolve => setTimeout(resolve, 0));
@@ -308,15 +308,19 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 			await addCodeBlockBySlugCallback({ codeBlockSlug: 'main', x: 100, y: 100 });
 
 			// Verify all modules were added
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(3);
-			expect(mockState.graphicHelper.codeBlocks[0].id).toBe('module_main');
-			expect(mockState.graphicHelper.codeBlocks[1].id).toBe('module_dep1');
-			expect(mockState.graphicHelper.codeBlocks[2].id).toBe('module_dep2');
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(3);
+			expect(mockState.codeBlockRendering.codeBlocks[0].id).toBe('module_main');
+			expect(mockState.codeBlockRendering.codeBlocks[1].id).toBe('module_dep1');
+			expect(mockState.codeBlockRendering.codeBlocks[2].id).toBe('module_dep2');
 
 			// Verify positions - dep1 should be to the right of main
-			expect(mockState.graphicHelper.codeBlocks[1].gridX).toBeGreaterThan(mockState.graphicHelper.codeBlocks[0].gridX);
+			expect(mockState.codeBlockRendering.codeBlocks[1].gridX).toBeGreaterThan(
+				mockState.codeBlockRendering.codeBlocks[0].gridX
+			);
 			// Verify positions - dep2 should be to the right of dep1
-			expect(mockState.graphicHelper.codeBlocks[2].gridX).toBeGreaterThan(mockState.graphicHelper.codeBlocks[1].gridX);
+			expect(mockState.codeBlockRendering.codeBlocks[2].gridX).toBeGreaterThan(
+				mockState.codeBlockRendering.codeBlocks[1].gridX
+			);
 		});
 
 		it('should skip dependencies that already exist', async () => {
@@ -341,7 +345,7 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 				code: ['module dep1', '', 'moduleEnd'],
 				blockType: 'module',
 			});
-			mockState.graphicHelper.codeBlocks = [existingDep1];
+			mockState.codeBlockRendering.codeBlocks = [existingDep1];
 
 			codeBlockCreator(store, mockEvents);
 
@@ -353,10 +357,10 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 			await addCodeBlockBySlugCallback({ codeBlockSlug: 'main', x: 100, y: 100 });
 
 			// Verify only main and dep2 were added (dep1 already existed)
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(3);
-			expect(mockState.graphicHelper.codeBlocks[0].id).toBe('module_dep1'); // Existing
-			expect(mockState.graphicHelper.codeBlocks[1].id).toBe('module_main'); // New
-			expect(mockState.graphicHelper.codeBlocks[2].id).toBe('module_dep2'); // New
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(3);
+			expect(mockState.codeBlockRendering.codeBlocks[0].id).toBe('module_dep1'); // Existing
+			expect(mockState.codeBlockRendering.codeBlocks[1].id).toBe('module_main'); // New
+			expect(mockState.codeBlockRendering.codeBlocks[2].id).toBe('module_dep2'); // New
 		});
 
 		it('should work without dependencies field', async () => {
@@ -375,8 +379,8 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 			await addCodeBlockBySlugCallback({ codeBlockSlug: 'simple', x: 100, y: 100 });
 
 			// Verify only the main module was added
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(1);
-			expect(mockState.graphicHelper.codeBlocks[0].id).toBe('module_simple');
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(1);
+			expect(mockState.codeBlockRendering.codeBlocks[0].id).toBe('module_simple');
 		});
 
 		it('should handle dependency loading errors gracefully', async () => {
@@ -406,9 +410,9 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 			await addCodeBlockBySlugCallback({ codeBlockSlug: 'main', x: 100, y: 100 });
 
 			// Verify main and dep1 were added, but missing was skipped
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(2);
-			expect(mockState.graphicHelper.codeBlocks[0].id).toBe('module_main');
-			expect(mockState.graphicHelper.codeBlocks[1].id).toBe('module_dep1');
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(2);
+			expect(mockState.codeBlockRendering.codeBlocks[0].id).toBe('module_main');
+			expect(mockState.codeBlockRendering.codeBlocks[1].id).toBe('module_dep1');
 
 			// Verify warning was logged
 			expect(consoleWarnSpy).toHaveBeenCalledWith('Failed to load dependency: missing', expect.any(Error));
@@ -441,11 +445,11 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 			await addCodeBlockBySlugCallback({ codeBlockSlug: 'main', x: 100, y: 100 });
 
 			// Verify both modules were added
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(2);
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(2);
 
 			// Calculate expected positions
-			const mainModule = mockState.graphicHelper.codeBlocks[0];
-			const dep1Module = mockState.graphicHelper.codeBlocks[1];
+			const mainModule = mockState.codeBlockRendering.codeBlocks[0];
+			const dep1Module = mockState.codeBlockRendering.codeBlocks[1];
 
 			// Main module should be at the clicked grid position
 			expect(mainModule.gridX).toBeCloseTo(Math.round((mockState.viewport.x + 100) / mockState.viewport.vGrid), 0);
@@ -475,7 +479,7 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 				code: ['module sine', '', 'moduleEnd'],
 				blockType: 'module',
 			});
-			mockState.graphicHelper.codeBlocks = [existingSineModule];
+			mockState.codeBlockRendering.codeBlocks = [existingSineModule];
 
 			codeBlockCreator(store, mockEvents);
 
@@ -490,13 +494,13 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 			// because the existing 'sine' is a module, not a function
 			// Note: IDs are now type-scoped, so existing `module_sine` does not force
 			// incrementing `function_sine`.
-			expect(mockState.graphicHelper.codeBlocks).toHaveLength(3);
-			expect(mockState.graphicHelper.codeBlocks[0].id).toBe('module_sine'); // Existing module
-			expect(mockState.graphicHelper.codeBlocks[0].blockType).toBe('module');
-			expect(mockState.graphicHelper.codeBlocks[1].id).toBe('module_main'); // New module
-			expect(mockState.graphicHelper.codeBlocks[2].id).toBe('function_sine'); // New function
+			expect(mockState.codeBlockRendering.codeBlocks).toHaveLength(3);
+			expect(mockState.codeBlockRendering.codeBlocks[0].id).toBe('module_sine'); // Existing module
+			expect(mockState.codeBlockRendering.codeBlocks[0].blockType).toBe('module');
+			expect(mockState.codeBlockRendering.codeBlocks[1].id).toBe('module_main'); // New module
+			expect(mockState.codeBlockRendering.codeBlocks[2].id).toBe('function_sine'); // New function
 			// Check the code contains function markers
-			expect(mockState.graphicHelper.codeBlocks[2].code.join('\n')).toContain('function sine');
+			expect(mockState.codeBlockRendering.codeBlocks[2].code.join('\n')).toContain('function sine');
 		});
 	});
 });
@@ -514,7 +518,7 @@ describe('codeBlockCreator - toggleCodeBlockDisabled', () => {
 
 	it('should toggle disabled state from false to true', () => {
 		const codeBlock = createMockCodeBlock({ disabled: false });
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		codeBlockCreator(store, mockEvents);
 
@@ -530,7 +534,7 @@ describe('codeBlockCreator - toggleCodeBlockDisabled', () => {
 
 	it('should toggle disabled state from true to false', () => {
 		const codeBlock = createMockCodeBlock({ disabled: true });
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		codeBlockCreator(store, mockEvents);
 
@@ -545,7 +549,7 @@ describe('codeBlockCreator - toggleCodeBlockDisabled', () => {
 
 	it('should update lastUpdated for cache invalidation', () => {
 		const codeBlock = createMockCodeBlock({ disabled: false, lastUpdated: 1000 });
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		codeBlockCreator(store, mockEvents);
 
@@ -560,7 +564,7 @@ describe('codeBlockCreator - toggleCodeBlockDisabled', () => {
 
 	it('should trigger store update', () => {
 		const codeBlock = createMockCodeBlock({ disabled: false });
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		codeBlockCreator(store, mockEvents);
 
@@ -572,12 +576,12 @@ describe('codeBlockCreator - toggleCodeBlockDisabled', () => {
 
 		toggleCallback({ codeBlock });
 
-		expect(setSpy).toHaveBeenCalledWith('graphicHelper.selectedCodeBlockForProgrammaticEdit', codeBlock);
+		expect(setSpy).toHaveBeenCalledWith('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', codeBlock);
 	});
 
 	it('should not toggle when editing is disabled', () => {
 		const codeBlock = createMockCodeBlock({ disabled: false });
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 		mockState.featureFlags.editing = false;
 
 		codeBlockCreator(store, mockEvents);
@@ -593,7 +597,7 @@ describe('codeBlockCreator - toggleCodeBlockDisabled', () => {
 
 	it('should add @disabled directive when enabling disabled', () => {
 		const codeBlock = createMockCodeBlock({ code: ['module test', 'moduleEnd'], disabled: false });
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		codeBlockCreator(store, mockEvents);
 
@@ -609,7 +613,7 @@ describe('codeBlockCreator - toggleCodeBlockDisabled', () => {
 
 	it('should remove @disabled directive when disabling disabled', () => {
 		const codeBlock = createMockCodeBlock({ code: ['module test', '; @disabled', 'moduleEnd'], disabled: true });
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		codeBlockCreator(store, mockEvents);
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.ts
@@ -101,7 +101,7 @@ function incrementCodeBlockIdUntilUnique(state: State, blockType: RenameableCode
 
 function getUniqueEntryName(state: State): string {
 	const usedEntryNames = new Set(
-		state.graphicHelper.codeBlocks
+		state.codeBlockRendering.codeBlocks
 			.filter(block => block.blockType === moduleBlock.type || getModuleId(block.code))
 			.map(block => block.entry)
 	);
@@ -117,7 +117,7 @@ function getUniqueEntryName(state: State): string {
 function getEntryNameForNewModule(state: State, x: number, y: number, newEntry?: boolean): string {
 	return newEntry
 		? getUniqueEntryName(state)
-		: (findEntryNameAtPosition(state.graphicHelper.entryOutlines, x, y) ?? getUniqueEntryName(state));
+		: (findEntryNameAtPosition(state.codeBlockRendering.entryOutlines, x, y) ?? getUniqueEntryName(state));
 }
 
 export default function codeBlockCreator(store: StateManager<State>, events: EventDispatcher): void {
@@ -202,8 +202,8 @@ export default function codeBlockCreator(store: StateManager<State>, events: Eve
 			);
 		}
 
-		const creationIndex = state.graphicHelper.nextCodeBlockCreationIndex;
-		state.graphicHelper.nextCodeBlockCreationIndex++;
+		const creationIndex = state.codeBlockRendering.nextCodeBlockCreationIndex;
+		state.codeBlockRendering.nextCodeBlockCreationIndex++;
 
 		// Calculate grid position
 		const gridX = Math.round((state.viewport.x + x) / state.viewport.vGrid);
@@ -238,10 +238,10 @@ export default function codeBlockCreator(store: StateManager<State>, events: Eve
 		});
 
 		// Insert new block before any always-on-top blocks to maintain z-order partition.
-		const existingBlocks = state.graphicHelper.codeBlocks;
+		const existingBlocks = state.codeBlockRendering.codeBlocks;
 		const normalBlocks = existingBlocks.filter(b => !b.alwaysOnTop);
 		const topBlocks = existingBlocks.filter(b => b.alwaysOnTop);
-		store.set('graphicHelper.codeBlocks', [...normalBlocks, codeBlock, ...topBlocks]);
+		store.set('codeBlockRendering.codeBlocks', [...normalBlocks, codeBlock, ...topBlocks]);
 	}
 
 	function onDeleteCodeBlock({ codeBlock }: { codeBlock: CodeBlockGraphicData }): void {
@@ -250,8 +250,8 @@ export default function codeBlockCreator(store: StateManager<State>, events: Eve
 		}
 
 		store.set(
-			'graphicHelper.codeBlocks',
-			state.graphicHelper.codeBlocks.filter(block => block !== codeBlock)
+			'codeBlockRendering.codeBlocks',
+			state.codeBlockRendering.codeBlocks.filter(block => block !== codeBlock)
 		);
 	}
 
@@ -277,7 +277,7 @@ export default function codeBlockCreator(store: StateManager<State>, events: Eve
 		// Update lastUpdated to invalidate cache
 		codeBlock.lastUpdated = Date.now();
 		// Use selectedCodeBlockForProgrammaticEdit to trigger graphics update
-		store.set('graphicHelper.selectedCodeBlockForProgrammaticEdit', codeBlock);
+		store.set('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', codeBlock);
 	}
 
 	async function onAddCodeBlockBySlug({

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/insertDependencies.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/insertDependencies.ts
@@ -49,7 +49,7 @@ export async function insertDependencies({
 			// Skip if a code block with this moduleId and type already exists
 			// Filter by block type first, then check IDs of matching type
 			// Use getBlockType to parse the type from code rather than relying on stored blockType
-			const existsAlready = state.graphicHelper.codeBlocks.some(block => {
+			const existsAlready = state.codeBlockRendering.codeBlocks.some(block => {
 				const blockType = getBlockType(block.code);
 				if (blockType !== dependencyBlockType) {
 					return false;

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/pasteMultipleBlocks.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/pasteMultipleBlocks.ts
@@ -104,7 +104,7 @@ export function pasteMultipleBlocks(
 	}
 
 	// Create group name mapping to avoid collisions
-	const groupNameMapping = createGroupNameMapping(pastedGroupNames, state.graphicHelper.codeBlocks);
+	const groupNameMapping = createGroupNameMapping(pastedGroupNames, state.codeBlockRendering.codeBlocks);
 
 	// First pass: determine ID mappings for all pasted blocks
 	// We need to handle cases where multiple pasted blocks have the same original ID
@@ -198,8 +198,8 @@ export function pasteMultipleBlocks(
 		// Parse disabled state from @disabled directive in code
 		const disabled = hasDirective(code, 'disabled');
 
-		const creationIndex = state.graphicHelper.nextCodeBlockCreationIndex;
-		state.graphicHelper.nextCodeBlockCreationIndex++;
+		const creationIndex = state.codeBlockRendering.nextCodeBlockCreationIndex;
+		state.codeBlockRendering.nextCodeBlockCreationIndex++;
 
 		const codeBlock = createCodeBlockGraphicData({
 			code,
@@ -214,16 +214,16 @@ export function pasteMultipleBlocks(
 		});
 
 		// Add block immediately so next iteration's ID uniqueness check sees it
-		state.graphicHelper.codeBlocks.push(codeBlock);
+		state.codeBlockRendering.codeBlocks.push(codeBlock);
 		newBlocks.push(codeBlock);
 	}
 
 	// Stable-sort to maintain the partition: normal blocks first, always-on-top last.
 	const sorted = [
-		...state.graphicHelper.codeBlocks.filter(b => !b.alwaysOnTop),
-		...state.graphicHelper.codeBlocks.filter(b => b.alwaysOnTop),
+		...state.codeBlockRendering.codeBlocks.filter(b => !b.alwaysOnTop),
+		...state.codeBlockRendering.codeBlocks.filter(b => b.alwaysOnTop),
 	];
 
 	// Trigger single store update with all new blocks
-	store.set('graphicHelper.codeBlocks', sorted);
+	store.set('codeBlockRendering.codeBlocks', sorted);
 }

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockDragger/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockDragger/effect.test.ts
@@ -19,7 +19,7 @@ describe('codeBlockDragger', () => {
 			featureFlags: {
 				moduleDragging: true,
 			},
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [],
 				viewportAnchoredCodeBlocks: [],
 				draggedCodeBlock: undefined,
@@ -78,7 +78,7 @@ describe('codeBlockDragger', () => {
 				blockType: 'module',
 			});
 
-			state.graphicHelper.codeBlocks = [block1];
+			state.codeBlockRendering.codeBlocks = [block1];
 
 			codeBlockDragger(store, events);
 
@@ -95,7 +95,7 @@ describe('codeBlockDragger', () => {
 				altKey: false,
 			});
 
-			expect(state.graphicHelper.draggedCodeBlock).toBe(block1);
+			expect(state.codeBlockRendering.draggedCodeBlock).toBe(block1);
 
 			// Mousemove
 			mousemoveHandlers[0]({
@@ -120,7 +120,7 @@ describe('codeBlockDragger', () => {
 			expect(block1.gridY).toBe(6); // Math.round(110 / 20)
 			expect(block1.x).toBe(60); // 6 * 10
 			expect(block1.y).toBe(120); // 6 * 20
-			expect(state.graphicHelper.draggedCodeBlock).toBeUndefined();
+			expect(state.codeBlockRendering.draggedCodeBlock).toBeUndefined();
 		});
 	});
 
@@ -148,7 +148,7 @@ describe('codeBlockDragger', () => {
 				groupName: 'audio',
 			});
 
-			state.graphicHelper.codeBlocks = [block1, block2];
+			state.codeBlockRendering.codeBlocks = [block1, block2];
 
 			codeBlockDragger(store, events);
 
@@ -218,7 +218,7 @@ describe('codeBlockDragger', () => {
 				blockType: 'module',
 			});
 
-			state.graphicHelper.codeBlocks = [block1, block2, block3];
+			state.codeBlockRendering.codeBlocks = [block1, block2, block3];
 
 			codeBlockDragger(store, events);
 
@@ -235,7 +235,7 @@ describe('codeBlockDragger', () => {
 				altKey: false,
 			});
 
-			expect(state.graphicHelper.draggedCodeBlock).toBe(block1);
+			expect(state.codeBlockRendering.draggedCodeBlock).toBe(block1);
 
 			// Mousemove
 			mousemoveHandlers[0]({
@@ -277,7 +277,7 @@ describe('codeBlockDragger', () => {
 			expect(block3.gridX).toBe(15);
 			expect(block3.gridY).toBe(15);
 
-			expect(state.graphicHelper.draggedCodeBlock).toBeUndefined();
+			expect(state.codeBlockRendering.draggedCodeBlock).toBeUndefined();
 		});
 
 		it('should not group drag if block has no group name even without Alt key', () => {
@@ -301,7 +301,7 @@ describe('codeBlockDragger', () => {
 				blockType: 'module',
 			});
 
-			state.graphicHelper.codeBlocks = [block1, block2];
+			state.codeBlockRendering.codeBlocks = [block1, block2];
 
 			codeBlockDragger(store, events);
 
@@ -361,7 +361,7 @@ describe('codeBlockDragger', () => {
 				groupName: 'visual',
 			});
 
-			state.graphicHelper.codeBlocks = [block1, block2];
+			state.codeBlockRendering.codeBlocks = [block1, block2];
 
 			codeBlockDragger(store, events);
 
@@ -423,7 +423,7 @@ describe('codeBlockDragger', () => {
 				groupName: 'audio',
 			});
 
-			state.graphicHelper.codeBlocks = [block1, block2];
+			state.codeBlockRendering.codeBlocks = [block1, block2];
 
 			codeBlockDragger(store, events);
 
@@ -440,7 +440,7 @@ describe('codeBlockDragger', () => {
 				altKey: true,
 			});
 
-			expect(state.graphicHelper.draggedCodeBlock).toBe(block1);
+			expect(state.codeBlockRendering.draggedCodeBlock).toBe(block1);
 
 			// Mousemove
 			mousemoveHandlers[0]({
@@ -477,7 +477,7 @@ describe('codeBlockDragger', () => {
 			expect(block2.x).toBe(100);
 			expect(block2.y).toBe(200);
 
-			expect(state.graphicHelper.draggedCodeBlock).toBeUndefined();
+			expect(state.codeBlockRendering.draggedCodeBlock).toBeUndefined();
 		});
 
 		it('should drag single block by default for nonstick groups (Alt reverses to group drag)', () => {
@@ -505,7 +505,7 @@ describe('codeBlockDragger', () => {
 				groupNonstick: true,
 			});
 
-			state.graphicHelper.codeBlocks = [block1, block2];
+			state.codeBlockRendering.codeBlocks = [block1, block2];
 
 			codeBlockDragger(store, events);
 
@@ -568,7 +568,7 @@ describe('codeBlockDragger', () => {
 				groupNonstick: true,
 			});
 
-			state.graphicHelper.codeBlocks = [block1, block2];
+			state.codeBlockRendering.codeBlocks = [block1, block2];
 
 			codeBlockDragger(store, events);
 
@@ -618,7 +618,7 @@ describe('codeBlockDragger', () => {
 				blockType: 'module',
 			});
 
-			state.graphicHelper.codeBlocks = [block1];
+			state.codeBlockRendering.codeBlocks = [block1];
 
 			codeBlockDragger(store, events);
 
@@ -667,7 +667,7 @@ describe('codeBlockDragger', () => {
 				blockType: 'module',
 			});
 
-			state.graphicHelper.codeBlocks = [block1];
+			state.codeBlockRendering.codeBlocks = [block1];
 
 			codeBlockDragger(store, events);
 
@@ -684,7 +684,7 @@ describe('codeBlockDragger', () => {
 				altKey: false,
 			});
 
-			expect(state.graphicHelper.draggedCodeBlock).toBeUndefined();
+			expect(state.codeBlockRendering.draggedCodeBlock).toBeUndefined();
 		});
 	});
 
@@ -700,7 +700,7 @@ describe('codeBlockDragger', () => {
 				blockType: 'module',
 			});
 
-			state.graphicHelper.codeBlocks = [block1];
+			state.codeBlockRendering.codeBlocks = [block1];
 
 			codeBlockDragger(store, events);
 
@@ -717,7 +717,7 @@ describe('codeBlockDragger', () => {
 				altKey: false,
 			});
 
-			expect(state.graphicHelper.selectedCodeBlock).toBe(block1);
+			expect(state.codeBlockRendering.selectedCodeBlock).toBe(block1);
 		});
 
 		it('should not update block position metadata on click without drag', () => {
@@ -733,7 +733,7 @@ describe('codeBlockDragger', () => {
 			});
 			const originalCode = [...block1.code];
 
-			state.graphicHelper.codeBlocks = [block1];
+			state.codeBlockRendering.codeBlocks = [block1];
 
 			codeBlockDragger(store, events);
 
@@ -755,7 +755,7 @@ describe('codeBlockDragger', () => {
 			expect(block1.code).toEqual(originalCode);
 			expect(block1.gridX).toBe(5);
 			expect(block1.gridY).toBe(5);
-			expect(state.graphicHelper.draggedCodeBlock).toBeUndefined();
+			expect(state.codeBlockRendering.draggedCodeBlock).toBeUndefined();
 		});
 
 		it('should clear selected code block when mousedown is on empty space', () => {
@@ -769,8 +769,8 @@ describe('codeBlockDragger', () => {
 				blockType: 'module',
 			});
 
-			state.graphicHelper.codeBlocks = [block1];
-			state.graphicHelper.selectedCodeBlock = block1;
+			state.codeBlockRendering.codeBlocks = [block1];
+			state.codeBlockRendering.selectedCodeBlock = block1;
 
 			codeBlockDragger(store, events);
 
@@ -787,8 +787,8 @@ describe('codeBlockDragger', () => {
 				altKey: false,
 			});
 
-			expect(state.graphicHelper.selectedCodeBlock).toBeUndefined();
-			expect(state.graphicHelper.draggedCodeBlock).toBeUndefined();
+			expect(state.codeBlockRendering.selectedCodeBlock).toBeUndefined();
+			expect(state.codeBlockRendering.draggedCodeBlock).toBeUndefined();
 		});
 	});
 });

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockDragger/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockDragger/effect.ts
@@ -26,16 +26,16 @@ export default function codeBlockDragger(store: StateManager<State>, events: Eve
 			return;
 		}
 
-		state.graphicHelper.draggedCodeBlock = findCodeBlockAtViewportCoordinates(state, x, y);
-		const draggedCodeBlock = state.graphicHelper.draggedCodeBlock;
+		state.codeBlockRendering.draggedCodeBlock = findCodeBlockAtViewportCoordinates(state, x, y);
+		const draggedCodeBlock = state.codeBlockRendering.draggedCodeBlock;
 
 		if (!draggedCodeBlock) {
-			store.set('graphicHelper.selectedCodeBlock', undefined);
+			store.set('codeBlockRendering.selectedCodeBlock', undefined);
 			dragSet = [];
 			didDrag = false;
 			return;
 		}
-		store.set('graphicHelper.selectedCodeBlock', state.graphicHelper.draggedCodeBlock);
+		store.set('codeBlockRendering.selectedCodeBlock', state.codeBlockRendering.draggedCodeBlock);
 		didDrag = false;
 
 		// Compute drag set based on nonstick flag and modifier
@@ -48,7 +48,7 @@ export default function codeBlockDragger(store: StateManager<State>, events: Eve
 			if (draggedCodeBlock.groupNonstick) {
 				// Nonstick group: single-block by default, Alt for group drag
 				if (altKey) {
-					dragSet = getGroupBlocks(state.graphicHelper.codeBlocks, draggedCodeBlock.groupName);
+					dragSet = getGroupBlocks(state.codeBlockRendering.codeBlocks, draggedCodeBlock.groupName);
 				} else {
 					dragSet = [draggedCodeBlock];
 				}
@@ -57,7 +57,7 @@ export default function codeBlockDragger(store: StateManager<State>, events: Eve
 				if (altKey) {
 					dragSet = [draggedCodeBlock];
 				} else {
-					dragSet = getGroupBlocks(state.graphicHelper.codeBlocks, draggedCodeBlock.groupName);
+					dragSet = getGroupBlocks(state.codeBlockRendering.codeBlocks, draggedCodeBlock.groupName);
 				}
 			}
 		} else {
@@ -79,19 +79,19 @@ export default function codeBlockDragger(store: StateManager<State>, events: Eve
 		// Bring dragged module forward within its z-order partition.
 		// Normal blocks move to the end of the normal segment (before always-on-top blocks).
 		// Always-on-top blocks move to the end of the always-on-top segment (end of array).
-		const allOthers = state.graphicHelper.codeBlocks.filter(block => block !== draggedCodeBlock);
+		const allOthers = state.codeBlockRendering.codeBlocks.filter(block => block !== draggedCodeBlock);
 		if (draggedCodeBlock.alwaysOnTop) {
-			state.graphicHelper.codeBlocks = [...allOthers, draggedCodeBlock];
+			state.codeBlockRendering.codeBlocks = [...allOthers, draggedCodeBlock];
 		} else {
 			const normalOthers = allOthers.filter(block => !block.alwaysOnTop);
 			const topBlocks = allOthers.filter(block => block.alwaysOnTop);
-			state.graphicHelper.codeBlocks = [...normalOthers, draggedCodeBlock, ...topBlocks];
+			state.codeBlockRendering.codeBlocks = [...normalOthers, draggedCodeBlock, ...topBlocks];
 		}
 	}
 
 	function onMouseMove(event: InternalMouseEvent) {
 		const { movementX, movementY } = event;
-		if (state.graphicHelper.draggedCodeBlock && dragSet.length > 0) {
+		if (state.codeBlockRendering.draggedCodeBlock && dragSet.length > 0) {
 			if (movementX !== 0 || movementY !== 0) {
 				didDrag = true;
 			}
@@ -106,17 +106,17 @@ export default function codeBlockDragger(store: StateManager<State>, events: Eve
 	}
 
 	function onMouseUp() {
-		if (!state.graphicHelper.draggedCodeBlock || dragSet.length === 0) {
+		if (!state.codeBlockRendering.draggedCodeBlock || dragSet.length === 0) {
 			return;
 		}
 
 		if (!didDrag) {
-			state.graphicHelper.draggedCodeBlock = undefined;
+			state.codeBlockRendering.draggedCodeBlock = undefined;
 			dragSet = [];
 			return;
 		}
 
-		const primaryBlock = state.graphicHelper.draggedCodeBlock;
+		const primaryBlock = state.codeBlockRendering.draggedCodeBlock;
 		const vGrid = state.viewport.vGrid;
 		const hGrid = state.viewport.hGrid;
 
@@ -167,10 +167,10 @@ export default function codeBlockDragger(store: StateManager<State>, events: Eve
 			block.gridY = gridY;
 			block.lastUpdated = Date.now();
 			block.code = upsertPos(block.code, gridX, gridY);
-			store.set('graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger', block);
+			store.set('codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger', block);
 		}
 
-		state.graphicHelper.draggedCodeBlock = undefined;
+		state.codeBlockRendering.draggedCodeBlock = undefined;
 		dragSet = [];
 		didDrag = false;
 	}

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockNavigation/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockNavigation/effect.test.ts
@@ -56,7 +56,7 @@ describe('codeBlockNavigation', () => {
 
 		// Create mock state using shared utility
 		state = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				selectedCodeBlock: selectedBlock,
 				codeBlocks: [selectedBlock, leftBlock, rightBlock, upBlock, downBlock],
 				viewport: { x: 0, y: 0, width: 800, height: 600, vGrid: 8, hGrid: 16 },
@@ -106,9 +106,9 @@ describe('codeBlockNavigation', () => {
 		// Initialize the effect
 		codeBlockNavigation(state, events);
 
-		state.graphicHelper.selectedCodeBlock = undefined;
+		state.codeBlockRendering.selectedCodeBlock = undefined;
 		onNavigateCodeBlockHandler({ direction: 'right' });
-		expect(state.graphicHelper.selectedCodeBlock).toBe(undefined);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(undefined);
 	});
 
 	it('should navigate left when navigateCodeBlock event with left direction is dispatched', () => {
@@ -116,7 +116,7 @@ describe('codeBlockNavigation', () => {
 		codeBlockNavigation(state, events);
 
 		onNavigateCodeBlockHandler({ direction: 'left' });
-		expect(state.graphicHelper.selectedCodeBlock).toBe(leftBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(leftBlock);
 	});
 
 	it('should navigate right when navigateCodeBlock event with right direction is dispatched', () => {
@@ -124,7 +124,7 @@ describe('codeBlockNavigation', () => {
 		codeBlockNavigation(state, events);
 
 		onNavigateCodeBlockHandler({ direction: 'right' });
-		expect(state.graphicHelper.selectedCodeBlock).toBe(rightBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(rightBlock);
 	});
 
 	it('should skip viewport-anchored blocks during directional navigation', () => {
@@ -135,13 +135,13 @@ describe('codeBlockNavigation', () => {
 			id: 'anchored-right',
 			viewportAnchor: 'top-right',
 		});
-		state.graphicHelper.codeBlocks = [selectedBlock, anchoredRight, rightBlock];
+		state.codeBlockRendering.codeBlocks = [selectedBlock, anchoredRight, rightBlock];
 
 		codeBlockNavigation(state, events);
 
 		onNavigateCodeBlockHandler({ direction: 'right' });
 
-		expect(state.graphicHelper.selectedCodeBlock).toBe(rightBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(rightBlock);
 	});
 
 	it('should navigate from a viewport-anchored selected block to a world-space block', () => {
@@ -152,14 +152,14 @@ describe('codeBlockNavigation', () => {
 			id: 'anchored-selected',
 			viewportAnchor: 'top-left',
 		});
-		state.graphicHelper.selectedCodeBlock = anchoredSelected;
-		state.graphicHelper.codeBlocks = [anchoredSelected, rightBlock];
+		state.codeBlockRendering.selectedCodeBlock = anchoredSelected;
+		state.codeBlockRendering.codeBlocks = [anchoredSelected, rightBlock];
 
 		codeBlockNavigation(state, events);
 
 		onNavigateCodeBlockHandler({ direction: 'right' });
 
-		expect(state.graphicHelper.selectedCodeBlock).toBe(rightBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(rightBlock);
 	});
 
 	it('should align the target highlighted line during horizontal navigation', () => {
@@ -176,7 +176,7 @@ describe('codeBlockNavigation', () => {
 
 		onNavigateCodeBlockHandler({ direction: 'right' });
 
-		expect(state.graphicHelper.selectedCodeBlock).toBe(rightBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(rightBlock);
 		expect(rightBlock.cursor.row).toBe(2);
 		expect(rightBlock.cursor.col).toBe(3);
 		expect(rightBlock.cursor.y).toBe(2 * state.viewport.hGrid);
@@ -189,7 +189,7 @@ describe('codeBlockNavigation', () => {
 		selectedBlock.cursor.y = 0;
 
 		onNavigateCodeBlockHandler({ direction: 'up' });
-		expect(state.graphicHelper.selectedCodeBlock).toBe(upBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(upBlock);
 	});
 
 	it('should navigate down when navigateCodeBlock event with down direction is dispatched', () => {
@@ -200,7 +200,7 @@ describe('codeBlockNavigation', () => {
 		selectedBlock.cursor.y = 3 * state.viewport.hGrid;
 
 		onNavigateCodeBlockHandler({ direction: 'down' });
-		expect(state.graphicHelper.selectedCodeBlock).toBe(downBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(downBlock);
 	});
 
 	it('should move to the first line of the current block before navigating upward', () => {
@@ -212,7 +212,7 @@ describe('codeBlockNavigation', () => {
 		const result = navigateToCodeBlockInDirection(state, 'up', events);
 
 		expect(result).toBe(true);
-		expect(state.graphicHelper.selectedCodeBlock).toBe(selectedBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(selectedBlock);
 		expect(selectedBlock.cursor.row).toBe(0);
 		expect(selectedBlock.cursor.y).toBe(0);
 		expect(state.viewport.y).toBe(-176);
@@ -232,12 +232,12 @@ describe('codeBlockNavigation', () => {
 
 		const store = createStateManager(state);
 		const onSelectedRowChanged = vi.fn();
-		store.subscribe('graphicHelper.selectedCodeBlock.cursor.row', onSelectedRowChanged);
+		store.subscribe('codeBlockRendering.selectedCodeBlock.cursor.row', onSelectedRowChanged);
 
 		const result = navigateToCodeBlockInDirection(store, 'up', events);
 
 		expect(result).toBe(true);
-		expect(state.graphicHelper.selectedCodeBlock).toBe(selectedBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(selectedBlock);
 		expect(selectedBlock.cursor.row).toBe(0);
 		expect(onSelectedRowChanged).toHaveBeenCalledWith(0);
 	});
@@ -251,7 +251,7 @@ describe('codeBlockNavigation', () => {
 		const result = navigateToCodeBlockInDirection(state, 'down', events);
 
 		expect(result).toBe(true);
-		expect(state.graphicHelper.selectedCodeBlock).toBe(selectedBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(selectedBlock);
 		expect(selectedBlock.cursor.row).toBe(3);
 		expect(selectedBlock.cursor.y).toBe(3 * state.viewport.hGrid);
 		expect(state.viewport.y).toBe(-128);
@@ -277,7 +277,7 @@ describe('codeBlockNavigation', () => {
 		const result = navigateToCodeBlockInDirection(state, 'up', events);
 
 		expect(result).toBe(true);
-		expect(state.graphicHelper.selectedCodeBlock).toBe(upBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(upBlock);
 		expect(upBlock.cursor.row).toBe(2);
 		expect(upBlock.cursor.col).toBe(2);
 		expect(upBlock.cursor.y).toBe(2 * state.viewport.hGrid);
@@ -297,7 +297,7 @@ describe('codeBlockNavigation', () => {
 		const result = navigateToCodeBlockInDirection(state, 'down', events);
 
 		expect(result).toBe(true);
-		expect(state.graphicHelper.selectedCodeBlock).toBe(downBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(downBlock);
 		expect(downBlock.cursor.row).toBe(0);
 		expect(downBlock.cursor.col).toBe(1);
 		expect(downBlock.cursor.y).toBe(0);
@@ -327,7 +327,7 @@ describe('codeBlockNavigation', () => {
 				}),
 				cancelAnimationFrame: vi.fn(),
 			},
-			graphicHelper: {
+			codeBlockRendering: {
 				selectedCodeBlock: selectedBlock,
 				codeBlocks: [selectedBlock, leftBlock, rightBlock, upBlock, downBlock],
 			},
@@ -347,7 +347,7 @@ describe('codeBlockNavigation', () => {
 
 		onNavigateCodeBlockHandler({ direction: 'right' });
 
-		expect(state.graphicHelper.selectedCodeBlock).toBe(rightBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(rightBlock);
 		expect(state.viewportAnimation.active).toBe(true);
 		expect(state.viewportAnimation.targetX).toBe(48);
 		expect(state.viewportAnimation.targetY).toBe(-96);
@@ -374,17 +374,17 @@ describe('codeBlockNavigation', () => {
 		codeBlockNavigation(state, events);
 
 		// Remove all blocks except selected
-		state.graphicHelper.codeBlocks = [selectedBlock];
+		state.codeBlockRendering.codeBlocks = [selectedBlock];
 
 		onNavigateCodeBlockHandler({ direction: 'right' });
-		expect(state.graphicHelper.selectedCodeBlock).toBe(selectedBlock);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(selectedBlock);
 	});
 
 	describe('jumpToCodeBlock', () => {
 		it('should jump to code block by creationIndex', () => {
 			const result = jumpToCodeBlock(state, 2, 'wrong-id', events);
 			expect(result).toBe(true);
-			expect(state.graphicHelper.selectedCodeBlock).toBe(rightBlock);
+			expect(state.codeBlockRendering.selectedCodeBlock).toBe(rightBlock);
 			expect(events.dispatch).toHaveBeenCalledWith(
 				'viewportChanged',
 				expect.objectContaining({
@@ -397,14 +397,14 @@ describe('codeBlockNavigation', () => {
 		it('should jump to code block by id when creationIndex does not match', () => {
 			const result = jumpToCodeBlock(state, 999, 'left');
 			expect(result).toBe(true);
-			expect(state.graphicHelper.selectedCodeBlock).toBe(leftBlock);
+			expect(state.codeBlockRendering.selectedCodeBlock).toBe(leftBlock);
 		});
 
 		it('should return false when neither creationIndex nor id matches', () => {
 			const result = jumpToCodeBlock(state, 999, 'nonexistent');
 			expect(result).toBe(false);
 			// selectedCodeBlock should remain unchanged
-			expect(state.graphicHelper.selectedCodeBlock).toBe(selectedBlock);
+			expect(state.codeBlockRendering.selectedCodeBlock).toBe(selectedBlock);
 		});
 
 		it('should prefer creationIndex over id when both could match', () => {
@@ -412,7 +412,7 @@ describe('codeBlockNavigation', () => {
 			const result = jumpToCodeBlock(state, 3, 'left');
 			// Should select upBlock (creationIndex=3) not leftBlock (id='left')
 			expect(result).toBe(true);
-			expect(state.graphicHelper.selectedCodeBlock).toBe(upBlock);
+			expect(state.codeBlockRendering.selectedCodeBlock).toBe(upBlock);
 		});
 
 		it('should center viewport on the jumped-to code block', () => {
@@ -430,7 +430,7 @@ describe('codeBlockNavigation', () => {
 			codeBlockNavigation(state, events);
 
 			onJumpToFavoriteCodeBlockHandler({ creationIndex: 2, id: 'right' });
-			expect(state.graphicHelper.selectedCodeBlock).toBe(rightBlock);
+			expect(state.codeBlockRendering.selectedCodeBlock).toBe(rightBlock);
 		});
 
 		it('should handle jumpToFavoriteCodeBlock with non-existent target gracefully', () => {
@@ -442,7 +442,7 @@ describe('codeBlockNavigation', () => {
 				id: 'nonexistent',
 			});
 			// selectedCodeBlock should remain unchanged
-			expect(state.graphicHelper.selectedCodeBlock).toBe(selectedBlock);
+			expect(state.codeBlockRendering.selectedCodeBlock).toBe(selectedBlock);
 		});
 	});
 
@@ -463,7 +463,7 @@ describe('codeBlockNavigation', () => {
 			});
 
 			state = createMockState({
-				graphicHelper: { codeBlocks: [firstHome, secondHome] },
+				codeBlockRendering: { codeBlocks: [firstHome, secondHome] },
 				viewport: {
 					x: 10,
 					y: 20,
@@ -476,7 +476,7 @@ describe('codeBlockNavigation', () => {
 
 			goHome(state);
 
-			expect(state.graphicHelper.selectedCodeBlock).toBe(firstHome);
+			expect(state.codeBlockRendering.selectedCodeBlock).toBe(firstHome);
 			expect(state.viewport.x).toBe(50);
 			expect(state.viewport.y).toBe(50);
 		});
@@ -492,7 +492,7 @@ describe('codeBlockNavigation', () => {
 				homeAlignment: 'bottom',
 			});
 			state = createMockState({
-				graphicHelper: { codeBlocks: [homeBlock] },
+				codeBlockRendering: { codeBlocks: [homeBlock] },
 				viewport: {
 					x: 0,
 					y: 0,
@@ -505,7 +505,7 @@ describe('codeBlockNavigation', () => {
 
 			goHome(state);
 
-			expect(state.graphicHelper.selectedCodeBlock).toBe(homeBlock);
+			expect(state.codeBlockRendering.selectedCodeBlock).toBe(homeBlock);
 			expect(state.viewport.x).toBe(50);
 			expect(state.viewport.y).toBe(100);
 		});
@@ -519,7 +519,7 @@ describe('codeBlockNavigation', () => {
 				y: 100,
 			});
 			state = createMockState({
-				graphicHelper: { codeBlocks: [homeBlock] },
+				codeBlockRendering: { codeBlocks: [homeBlock] },
 			});
 
 			goHome(state, events);
@@ -542,18 +542,18 @@ describe('codeBlockNavigation', () => {
 			const otherHome = createMockCodeBlock({ id: 'home-other', isHome: true });
 
 			state = createMockState({
-				graphicHelper: { codeBlocks: [disabledHome, otherHome] },
+				codeBlockRendering: { codeBlocks: [disabledHome, otherHome] },
 			});
 
 			goHome(state);
 
-			expect(state.graphicHelper.selectedCodeBlock).toBe(disabledHome);
+			expect(state.codeBlockRendering.selectedCodeBlock).toBe(disabledHome);
 		});
 
 		it('should center on origin when no home block exists', () => {
 			state = createMockState({
 				viewport: { x: 25, y: -10 },
-				graphicHelper: {
+				codeBlockRendering: {
 					codeBlocks: [selectedBlock],
 					selectedCodeBlock: selectedBlock,
 				},
@@ -563,7 +563,7 @@ describe('codeBlockNavigation', () => {
 
 			expect(state.viewport.x).toBe(0);
 			expect(state.viewport.y).toBe(0);
-			expect(state.graphicHelper.selectedCodeBlock).toBe(selectedBlock);
+			expect(state.codeBlockRendering.selectedCodeBlock).toBe(selectedBlock);
 		});
 
 		it('should respond to goHome event', () => {
@@ -573,13 +573,13 @@ describe('codeBlockNavigation', () => {
 				x: 160,
 				y: 80,
 			});
-			state.graphicHelper.codeBlocks = [homeBlock, ...state.graphicHelper.codeBlocks];
+			state.codeBlockRendering.codeBlocks = [homeBlock, ...state.codeBlockRendering.codeBlocks];
 
 			codeBlockNavigation(state, events);
 
 			onGoHomeHandler();
 
-			expect(state.graphicHelper.selectedCodeBlock).toBe(homeBlock);
+			expect(state.codeBlockRendering.selectedCodeBlock).toBe(homeBlock);
 		});
 	});
 });

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockNavigation/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockNavigation/effect.ts
@@ -9,25 +9,25 @@ import findClosestCodeBlockInDirection from '../../utils/finders/findClosestCode
 import { deriveDirectiveState } from '../directives/registry';
 
 type StateSource = StateManager<State> | State;
-type CodeBlockCursor = NonNullable<State['graphicHelper']['selectedCodeBlock']>['cursor'];
+type CodeBlockCursor = NonNullable<State['codeBlockRendering']['selectedCodeBlock']>['cursor'];
 type CodeBlockCursorUpdate = Partial<CodeBlockCursor> & Pick<CodeBlockCursor, 'row' | 'col'>;
 
 function getState(source: StateSource): State {
 	return 'getState' in source ? source.getState() : source;
 }
 
-function setSelectedCodeBlock(source: StateSource, codeBlock: State['graphicHelper']['selectedCodeBlock']): void {
+function setSelectedCodeBlock(source: StateSource, codeBlock: State['codeBlockRendering']['selectedCodeBlock']): void {
 	if ('set' in source) {
-		source.set('graphicHelper.selectedCodeBlock', codeBlock);
+		source.set('codeBlockRendering.selectedCodeBlock', codeBlock);
 		return;
 	}
 
-	source.graphicHelper.selectedCodeBlock = codeBlock;
+	source.codeBlockRendering.selectedCodeBlock = codeBlock;
 }
 
 function setSelectedCodeBlockCursor(
 	source: StateSource,
-	block: NonNullable<State['graphicHelper']['selectedCodeBlock']>,
+	block: NonNullable<State['codeBlockRendering']['selectedCodeBlock']>,
 	cursor: CodeBlockCursorUpdate
 ): void {
 	const nextCursor = {
@@ -35,8 +35,8 @@ function setSelectedCodeBlockCursor(
 		...cursor,
 	};
 
-	if ('set' in source && getState(source).graphicHelper.selectedCodeBlock === block) {
-		source.set('graphicHelper.selectedCodeBlock.cursor', nextCursor);
+	if ('set' in source && getState(source).codeBlockRendering.selectedCodeBlock === block) {
+		source.set('codeBlockRendering.selectedCodeBlock.cursor', nextCursor);
 		return;
 	}
 
@@ -45,8 +45,8 @@ function setSelectedCodeBlockCursor(
 
 function alignTargetBlockCursorForHorizontalNavigation(
 	source: StateSource,
-	sourceBlock: State['graphicHelper']['selectedCodeBlock'],
-	targetBlock: State['graphicHelper']['selectedCodeBlock']
+	sourceBlock: State['codeBlockRendering']['selectedCodeBlock'],
+	targetBlock: State['codeBlockRendering']['selectedCodeBlock']
 ): void {
 	if (!sourceBlock || !targetBlock) {
 		return;
@@ -75,7 +75,7 @@ function alignTargetBlockCursorForHorizontalNavigation(
 
 function setBlockCursorToDisplayRow(
 	source: StateSource,
-	block: NonNullable<State['graphicHelper']['selectedCodeBlock']>,
+	block: NonNullable<State['codeBlockRendering']['selectedCodeBlock']>,
 	displayRow: number,
 	sourceCol?: number
 ): void {
@@ -96,7 +96,7 @@ function setBlockCursorToDisplayRow(
 
 function getSelectedBlockDisplayRow(
 	state: State,
-	block: NonNullable<State['graphicHelper']['selectedCodeBlock']>
+	block: NonNullable<State['codeBlockRendering']['selectedCodeBlock']>
 ): number {
 	const physicalRow = Math.max(Math.floor(block.cursor.y / state.viewport.hGrid), 0);
 	return reverseGapCalculator(physicalRow, block.gaps);
@@ -104,7 +104,7 @@ function getSelectedBlockDisplayRow(
 
 function moveSelectionToCurrentBlockVerticalEdge(
 	source: StateSource,
-	block: NonNullable<State['graphicHelper']['selectedCodeBlock']>,
+	block: NonNullable<State['codeBlockRendering']['selectedCodeBlock']>,
 	direction: 'up' | 'down'
 ): boolean {
 	const state = getState(source);
@@ -125,8 +125,8 @@ function moveSelectionToCurrentBlockVerticalEdge(
 
 function alignTargetBlockCursorForVerticalNavigation(
 	source: StateSource,
-	sourceBlock: NonNullable<State['graphicHelper']['selectedCodeBlock']>,
-	targetBlock: NonNullable<State['graphicHelper']['selectedCodeBlock']>,
+	sourceBlock: NonNullable<State['codeBlockRendering']['selectedCodeBlock']>,
+	targetBlock: NonNullable<State['codeBlockRendering']['selectedCodeBlock']>,
 	direction: 'up' | 'down'
 ): void {
 	const targetDirectiveState = deriveDirectiveState(targetBlock.code, targetBlock.parsedDirectives, {
@@ -163,13 +163,13 @@ export function navigateToCodeBlockInDirection(
 ): boolean {
 	const state = getState(stateSource);
 	// Only proceed if a code block is currently selected
-	if (!state.graphicHelper.selectedCodeBlock) {
+	if (!state.codeBlockRendering.selectedCodeBlock) {
 		return false;
 	}
 
 	// Get the current viewport's code blocks
-	const codeBlocks = state.graphicHelper.codeBlocks;
-	const currentBlock = state.graphicHelper.selectedCodeBlock;
+	const codeBlocks = state.codeBlockRendering.codeBlocks;
+	const currentBlock = state.codeBlockRendering.selectedCodeBlock;
 
 	// Find the closest code block in the specified direction
 	if (
@@ -219,7 +219,7 @@ export function jumpToCodeBlock(
 	events?: EventDispatcher
 ): boolean {
 	const state = getState(stateSource);
-	const codeBlocks = state.graphicHelper.codeBlocks;
+	const codeBlocks = state.codeBlockRendering.codeBlocks;
 
 	// Try to resolve by creationIndex first (primary identifier)
 	let targetBlock = codeBlocks.find(block => block.creationIndex === creationIndex);
@@ -251,7 +251,7 @@ export function jumpToCodeBlock(
  */
 export function goHome(stateSource: StateSource, events?: EventDispatcher): void {
 	const state = getState(stateSource);
-	const homeBlock = state.graphicHelper.codeBlocks.find(block => block.isHome);
+	const homeBlock = state.codeBlockRendering.codeBlocks.find(block => block.isHome);
 
 	if (homeBlock) {
 		setSelectedCodeBlock(stateSource, homeBlock);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/bars/resolve.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/bars/resolve.test.ts
@@ -23,7 +23,7 @@ describe('bars directive widget resolution', () => {
 		});
 
 		mockState = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				viewport: {
 					vGrid: 10,
 					hGrid: 20,

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/button/interaction.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/button/interaction.test.ts
@@ -21,7 +21,7 @@ describe('button interaction', () => {
 		});
 
 		mockState = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				viewport: {
 					vGrid: 10,
 					hGrid: 20,

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/button/resolve.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/button/resolve.test.ts
@@ -23,7 +23,7 @@ describe('button directive widget resolution', () => {
 		});
 
 		mockState = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				viewport: {
 					vGrid: 10,
 					hGrid: 20,

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/crossfade/interaction.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/crossfade/interaction.ts
@@ -56,7 +56,7 @@ export default function crossfade(store: StateManager<State>, events: EventDispa
 		}
 
 		activeCrossfade = { crossfade, codeBlock, leftMemory, rightMemory };
-		state.graphicHelper.draggedCodeBlock = undefined;
+		state.codeBlockRendering.draggedCodeBlock = undefined;
 		updateCrossfadeValue(x);
 	};
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/meter/resolve.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/meter/resolve.test.ts
@@ -27,7 +27,7 @@ describe('meter directive widget resolution', () => {
 				vGrid: 10,
 				hGrid: 20,
 			},
-			graphicHelper: {
+			codeBlockRendering: {
 				viewport: {
 					vGrid: 10,
 					hGrid: 20,

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/piano/interaction.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/piano/interaction.test.ts
@@ -16,7 +16,7 @@ describe('pianoKeyboard interaction', () => {
 		memoryStore = new Map();
 
 		mockState = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				viewport: {
 					vGrid: 10,
 					hGrid: 20,
@@ -128,7 +128,7 @@ describe('pianoKeyboard interaction', () => {
 
 		clickKey(codeBlock, 2);
 
-		expect(mockStore.set).toHaveBeenCalledWith('graphicHelper.selectedCodeBlock.code', [
+		expect(mockStore.set).toHaveBeenCalledWith('codeBlockRendering.selectedCodeBlock.code', [
 			'module test-block',
 			'int[] notes 10 50',
 			'int noteCount 1',
@@ -154,7 +154,7 @@ describe('pianoKeyboard interaction', () => {
 
 		clickKey(codeBlock, 2);
 
-		expect(mockStore.set).toHaveBeenCalledWith('graphicHelper.selectedCodeBlock.code', [
+		expect(mockStore.set).toHaveBeenCalledWith('codeBlockRendering.selectedCodeBlock.code', [
 			'module test-block',
 			'int[] notes 10',
 			'int noteCount 0',

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/piano/interaction.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/piano/interaction.ts
@@ -149,7 +149,7 @@ export default function pianoKeyboard(store: StateManager<State>, events: EventD
 
 		codeBlock.code = codeWithUpdatedDefaults;
 
-		store.set('graphicHelper.selectedCodeBlock.code', codeBlock.code);
+		store.set('codeBlockRendering.selectedCodeBlock.code', codeBlock.code);
 	};
 
 	events.on('codeBlockClick', onCodeBlockClick);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/piano/resolve.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/piano/resolve.test.ts
@@ -22,7 +22,7 @@ describe('piano directive widget resolution', () => {
 		});
 
 		mockState = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				viewport: {
 					vGrid: 10,
 					hGrid: 20,

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/plot/resolve.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/plot/resolve.test.ts
@@ -23,7 +23,7 @@ describe('plot directive widget resolution', () => {
 		});
 
 		mockState = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				viewport: {
 					vGrid: 10,
 					hGrid: 20,

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/slider/interaction.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/slider/interaction.ts
@@ -55,7 +55,7 @@ export default function slider(store: StateManager<State>, events: EventDispatch
 
 		// Set active slider for drag handling
 		activeSlider = { slider, codeBlock };
-		state.graphicHelper.draggedCodeBlock = undefined;
+		state.codeBlockRendering.draggedCodeBlock = undefined;
 
 		// Update value on click
 		updateSliderValue(x);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/switch/interaction.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/switch/interaction.test.ts
@@ -21,7 +21,7 @@ describe('switch interaction', () => {
 		getWordFromMemory = vi.fn((wordAlignedAddress: number) => memoryStore.get(wordAlignedAddress) ?? 0);
 
 		mockState = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				viewport: {
 					vGrid: 10,
 					hGrid: 20,

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/switch/resolve.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/switch/resolve.test.ts
@@ -23,7 +23,7 @@ describe('switch directive widget resolution', () => {
 		});
 
 		mockState = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				viewport: {
 					vGrid: 10,
 					hGrid: 20,

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/viewport/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/viewport/effect.ts
@@ -3,7 +3,7 @@ import type { StateManager } from '@8f4e/state-manager';
 import { resolveViewportAnchoredPosition } from './resolve';
 
 function syncViewportAnchoredBlockList(state: State): void {
-	state.graphicHelper.viewportAnchoredCodeBlocks = state.graphicHelper.codeBlocks.filter(
+	state.codeBlockRendering.viewportAnchoredCodeBlocks = state.codeBlockRendering.codeBlocks.filter(
 		block => block.viewportAnchor !== undefined
 	);
 }
@@ -13,7 +13,7 @@ function syncViewportAnchoredBlock(state: State, block: CodeBlockGraphicData | u
 		return;
 	}
 
-	const anchoredBlocks = state.graphicHelper.viewportAnchoredCodeBlocks;
+	const anchoredBlocks = state.codeBlockRendering.viewportAnchoredCodeBlocks;
 	const existingIndex = anchoredBlocks.indexOf(block);
 
 	if (block.viewportAnchor) {
@@ -29,13 +29,13 @@ function syncViewportAnchoredBlock(state: State, block: CodeBlockGraphicData | u
 }
 
 function recomputeViewportAnchoredPositions(state: State): void {
-	for (const codeBlock of state.graphicHelper.viewportAnchoredCodeBlocks) {
+	for (const codeBlock of state.codeBlockRendering.viewportAnchoredCodeBlocks) {
 		recomputeViewportAnchoredPosition(state, codeBlock);
 	}
 }
 
 function recomputeViewportAnchoredPosition(state: State, block: CodeBlockGraphicData | undefined): void {
-	if (!block || !block.viewportAnchor || block === state.graphicHelper.draggedCodeBlock) {
+	if (!block || !block.viewportAnchor || block === state.codeBlockRendering.draggedCodeBlock) {
 		return;
 	}
 
@@ -65,20 +65,23 @@ export default function viewportDirectiveEffect(store: StateManager<State>, even
 	};
 
 	const syncSelectedCodeBlock = () => {
-		syncViewportAnchoredBlock(state, state.graphicHelper.selectedCodeBlock);
-		recomputeViewportAnchoredPosition(state, state.graphicHelper.selectedCodeBlock);
+		syncViewportAnchoredBlock(state, state.codeBlockRendering.selectedCodeBlock);
+		recomputeViewportAnchoredPosition(state, state.codeBlockRendering.selectedCodeBlock);
 	};
 
 	const syncProgrammaticSelectedCodeBlock = () => {
-		syncViewportAnchoredBlock(state, state.graphicHelper.selectedCodeBlockForProgrammaticEdit);
-		recomputeViewportAnchoredPosition(state, state.graphicHelper.selectedCodeBlockForProgrammaticEdit);
+		syncViewportAnchoredBlock(state, state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit);
+		recomputeViewportAnchoredPosition(state, state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit);
 	};
 
 	const syncProgrammaticSelectedCodeBlockWithoutCompilerTrigger = () => {
-		syncViewportAnchoredBlock(state, state.graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger);
+		syncViewportAnchoredBlock(
+			state,
+			state.codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger
+		);
 		recomputeViewportAnchoredPosition(
 			state,
-			state.graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger
+			state.codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger
 		);
 	};
 
@@ -86,11 +89,11 @@ export default function viewportDirectiveEffect(store: StateManager<State>, even
 		recomputeViewportAnchoredPositions(state);
 	};
 
-	store.subscribe('graphicHelper.codeBlocks', syncAllBlocks);
-	store.subscribe('graphicHelper.selectedCodeBlock.code', syncSelectedCodeBlock);
-	store.subscribe('graphicHelper.selectedCodeBlockForProgrammaticEdit.code', syncProgrammaticSelectedCodeBlock);
+	store.subscribe('codeBlockRendering.codeBlocks', syncAllBlocks);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', syncSelectedCodeBlock);
+	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', syncProgrammaticSelectedCodeBlock);
 	store.subscribe(
-		'graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code',
+		'codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code',
 		syncProgrammaticSelectedCodeBlockWithoutCompilerTrigger
 	);
 	events.on('spriteSheetRerendered', recomputeAnchoredPositions);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/watch/resolve.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/watch/resolve.test.ts
@@ -26,7 +26,7 @@ describe('watch directive widget resolution', () => {
 		});
 
 		mockState = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				viewport: {
 					vGrid: 10,
 					hGrid: 20,

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/wave/resolve.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/directives/wave/resolve.test.ts
@@ -23,7 +23,7 @@ describe('wave directive widget resolution', () => {
 		});
 
 		mockState = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				viewport: {
 					vGrid: 10,
 					hGrid: 20,

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/entryOutlines/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/entryOutlines/effect.test.ts
@@ -31,9 +31,9 @@ describe('entryOutlines effect', () => {
 		});
 
 		entryOutlines(store);
-		store.set('graphicHelper.codeBlocks', [first, second]);
+		store.set('codeBlockRendering.codeBlocks', [first, second]);
 
-		expect(state.graphicHelper.entryOutlines).toEqual([
+		expect(state.codeBlockRendering.entryOutlines).toEqual([
 			{
 				entryName: 'main',
 				topLeft: { x: -48, y: -32 },

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/entryOutlines/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/entryOutlines/effect.ts
@@ -7,16 +7,19 @@ export default function entryOutlines(store: StateManager<State>): void {
 
 	function syncEntryOutlines(): void {
 		store.set(
-			'graphicHelper.entryOutlines',
-			deriveEntryOutlines(state.graphicHelper.codeBlocks, state.viewport.vGrid * 8, state.viewport.hGrid * 4)
+			'codeBlockRendering.entryOutlines',
+			deriveEntryOutlines(state.codeBlockRendering.codeBlocks, state.viewport.vGrid * 8, state.viewport.hGrid * 4)
 		);
 	}
 
-	store.subscribe('graphicHelper.codeBlocks', syncEntryOutlines);
-	store.subscribe('graphicHelper.selectedCodeBlock.code', syncEntryOutlines);
-	store.subscribe('graphicHelper.selectedCodeBlockForProgrammaticEdit.code', syncEntryOutlines);
-	store.subscribe('graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger', syncEntryOutlines);
-	store.subscribe('graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code', syncEntryOutlines);
+	store.subscribe('codeBlockRendering.codeBlocks', syncEntryOutlines);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', syncEntryOutlines);
+	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', syncEntryOutlines);
+	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger', syncEntryOutlines);
+	store.subscribe(
+		'codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code',
+		syncEntryOutlines
+	);
 
 	syncEntryOutlines();
 }

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/favoriteToggler/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/favoriteToggler/effect.ts
@@ -16,7 +16,7 @@ export default function favoriteToggler(store: StateManager<State>, events: Even
 		}
 
 		// Set target code block for programmatic edit to avoid re-rendering all code blocks
-		state.graphicHelper.selectedCodeBlockForProgrammaticEdit = codeBlock;
+		state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit = codeBlock;
 
 		// Check if code block has ; @favorite directive
 		const hasFavorite = codeBlock.isFavorite;
@@ -49,7 +49,7 @@ export default function favoriteToggler(store: StateManager<State>, events: Even
 		codeBlock.lastUpdated = Date.now();
 
 		// Trigger store update to re-render only the specific code block
-		store.set('graphicHelper.selectedCodeBlockForProgrammaticEdit', codeBlock);
+		store.set('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', codeBlock);
 	}
 
 	events.on('toggleFavoriteDirective', onToggleFavoriteDirective);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/favorites/deriveFavorites.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/favorites/deriveFavorites.ts
@@ -24,7 +24,7 @@ export interface Favorite {
  *
  * @example
  * ```typescript
- * const favorites = deriveFavorites(state.graphicHelper.codeBlocks);
+ * const favorites = deriveFavorites(state.codeBlockRendering.codeBlocks);
  * // Returns: [{ creationIndex: 5, id: 'osc', blockType: 'module' }, ...]
  * ```
  */

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/group/copier/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/group/copier/effect.test.ts
@@ -34,7 +34,7 @@ describe('groupCopier', () => {
 			groupName: 'audio',
 		});
 
-		mockState.graphicHelper.codeBlocks = [block1, block2];
+		mockState.codeBlockRendering.codeBlocks = [block1, block2];
 
 		groupCopier(store, mockEvents);
 
@@ -62,7 +62,7 @@ describe('groupCopier', () => {
 			groupName: undefined,
 		});
 
-		mockState.graphicHelper.codeBlocks = [block1];
+		mockState.codeBlockRendering.codeBlocks = [block1];
 
 		groupCopier(store, mockEvents);
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/group/copier/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/group/copier/effect.ts
@@ -20,7 +20,7 @@ export default function groupCopier(store: StateManager<State>, events: EventDis
 		}
 
 		// Get all blocks in the group
-		const groupBlocks = state.graphicHelper.codeBlocks.filter(block => block.groupName === groupName);
+		const groupBlocks = state.codeBlockRendering.codeBlocks.filter(block => block.groupName === groupName);
 
 		// Sort by creation index to maintain deterministic order
 		const sortedBlocks = [...groupBlocks].sort((a, b) => a.creationIndex - b.creationIndex);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/group/deleter/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/group/deleter/effect.test.ts
@@ -30,12 +30,12 @@ describe('groupDeleter', () => {
 			blockType: 'function',
 		});
 
-		// Set groupName on blocks (normally done by graphicHelper)
+		// Set groupName on blocks (normally done by codeBlockRendering)
 		codeBlock1.groupName = 'myGroup';
 		codeBlock2.groupName = 'myGroup';
 		codeBlock3.groupName = 'myGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2, codeBlock3];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2, codeBlock3];
 
 		groupDeleter(store, mockEvents);
 
@@ -47,7 +47,7 @@ describe('groupDeleter', () => {
 		deleteCallback({ codeBlock: codeBlock1 });
 
 		const state = store.getState();
-		expect(state.graphicHelper.codeBlocks).toEqual([]);
+		expect(state.codeBlockRendering.codeBlocks).toEqual([]);
 	});
 
 	it('should not delete blocks with different group name', () => {
@@ -68,7 +68,7 @@ describe('groupDeleter', () => {
 		codeBlock2.groupName = 'otherGroup';
 		codeBlock3.groupName = undefined;
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2, codeBlock3];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2, codeBlock3];
 
 		groupDeleter(store, mockEvents);
 
@@ -79,8 +79,8 @@ describe('groupDeleter', () => {
 		deleteCallback({ codeBlock: codeBlock1 });
 
 		const state = store.getState();
-		expect(state.graphicHelper.codeBlocks).toEqual([codeBlock2, codeBlock3]);
-		expect(state.graphicHelper.codeBlocks).toHaveLength(2);
+		expect(state.codeBlockRendering.codeBlocks).toEqual([codeBlock2, codeBlock3]);
+		expect(state.codeBlockRendering.codeBlocks).toHaveLength(2);
 	});
 
 	it('should work with mixed block types in a group', () => {
@@ -101,7 +101,7 @@ describe('groupDeleter', () => {
 		functionBlock.groupName = 'myGroup';
 		envBlock.groupName = 'myGroup';
 
-		mockState.graphicHelper.codeBlocks = [moduleBlock, functionBlock, envBlock];
+		mockState.codeBlockRendering.codeBlocks = [moduleBlock, functionBlock, envBlock];
 
 		groupDeleter(store, mockEvents);
 
@@ -112,7 +112,7 @@ describe('groupDeleter', () => {
 		deleteCallback({ codeBlock: moduleBlock });
 
 		const state = store.getState();
-		expect(state.graphicHelper.codeBlocks).toEqual([]);
+		expect(state.codeBlockRendering.codeBlocks).toEqual([]);
 	});
 
 	it('should clear selectedCodeBlock if it is deleted', () => {
@@ -128,8 +128,8 @@ describe('groupDeleter', () => {
 		codeBlock1.groupName = 'myGroup';
 		codeBlock2.groupName = 'myGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2];
-		mockState.graphicHelper.selectedCodeBlock = codeBlock1;
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2];
+		mockState.codeBlockRendering.selectedCodeBlock = codeBlock1;
 
 		groupDeleter(store, mockEvents);
 
@@ -140,7 +140,7 @@ describe('groupDeleter', () => {
 		deleteCallback({ codeBlock: codeBlock1 });
 
 		const state = store.getState();
-		expect(state.graphicHelper.selectedCodeBlock).toBeUndefined();
+		expect(state.codeBlockRendering.selectedCodeBlock).toBeUndefined();
 	});
 
 	it('should clear draggedCodeBlock if it is deleted', () => {
@@ -156,8 +156,8 @@ describe('groupDeleter', () => {
 		codeBlock1.groupName = 'myGroup';
 		codeBlock2.groupName = 'myGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2];
-		mockState.graphicHelper.draggedCodeBlock = codeBlock2;
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2];
+		mockState.codeBlockRendering.draggedCodeBlock = codeBlock2;
 
 		groupDeleter(store, mockEvents);
 
@@ -168,7 +168,7 @@ describe('groupDeleter', () => {
 		deleteCallback({ codeBlock: codeBlock1 });
 
 		const state = store.getState();
-		expect(state.graphicHelper.draggedCodeBlock).toBeUndefined();
+		expect(state.codeBlockRendering.draggedCodeBlock).toBeUndefined();
 	});
 
 	it('should clear selectedCodeBlockForProgrammaticEdit if it is deleted', () => {
@@ -184,8 +184,8 @@ describe('groupDeleter', () => {
 		codeBlock1.groupName = 'myGroup';
 		codeBlock2.groupName = 'myGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2];
-		mockState.graphicHelper.selectedCodeBlockForProgrammaticEdit = codeBlock1;
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2];
+		mockState.codeBlockRendering.selectedCodeBlockForProgrammaticEdit = codeBlock1;
 
 		groupDeleter(store, mockEvents);
 
@@ -196,7 +196,7 @@ describe('groupDeleter', () => {
 		deleteCallback({ codeBlock: codeBlock1 });
 
 		const state = store.getState();
-		expect(state.graphicHelper.selectedCodeBlockForProgrammaticEdit).toBeUndefined();
+		expect(state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit).toBeUndefined();
 	});
 
 	it('should do nothing when codeBlock has no groupName', () => {
@@ -212,7 +212,7 @@ describe('groupDeleter', () => {
 		codeBlock1.groupName = undefined;
 		codeBlock2.groupName = 'myGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2];
 
 		groupDeleter(store, mockEvents);
 
@@ -223,7 +223,7 @@ describe('groupDeleter', () => {
 		deleteCallback({ codeBlock: codeBlock1 });
 
 		const state = store.getState();
-		expect(state.graphicHelper.codeBlocks).toEqual([codeBlock1, codeBlock2]);
+		expect(state.codeBlockRendering.codeBlocks).toEqual([codeBlock1, codeBlock2]);
 	});
 
 	it('should do nothing when editing is disabled', () => {
@@ -239,7 +239,7 @@ describe('groupDeleter', () => {
 		codeBlock1.groupName = 'myGroup';
 		codeBlock2.groupName = 'myGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2];
 		mockState.featureFlags.editing = false;
 
 		groupDeleter(store, mockEvents);
@@ -251,7 +251,7 @@ describe('groupDeleter', () => {
 		deleteCallback({ codeBlock: codeBlock1 });
 
 		const state = store.getState();
-		expect(state.graphicHelper.codeBlocks).toEqual([codeBlock1, codeBlock2]);
+		expect(state.codeBlockRendering.codeBlocks).toEqual([codeBlock1, codeBlock2]);
 	});
 
 	it('should preserve non-group blocks when deleting a group', () => {
@@ -277,7 +277,7 @@ describe('groupDeleter', () => {
 		standaloneBlock.groupName = undefined;
 		otherGroupBlock.groupName = 'otherGroup';
 
-		mockState.graphicHelper.codeBlocks = [groupBlock1, groupBlock2, standaloneBlock, otherGroupBlock];
+		mockState.codeBlockRendering.codeBlocks = [groupBlock1, groupBlock2, standaloneBlock, otherGroupBlock];
 
 		groupDeleter(store, mockEvents);
 
@@ -288,8 +288,8 @@ describe('groupDeleter', () => {
 		deleteCallback({ codeBlock: groupBlock1 });
 
 		const state = store.getState();
-		expect(state.graphicHelper.codeBlocks).toEqual([standaloneBlock, otherGroupBlock]);
-		expect(state.graphicHelper.codeBlocks).toHaveLength(2);
+		expect(state.codeBlockRendering.codeBlocks).toEqual([standaloneBlock, otherGroupBlock]);
+		expect(state.codeBlockRendering.codeBlocks).toHaveLength(2);
 	});
 
 	it('should handle deleting a large group efficiently', () => {
@@ -309,7 +309,7 @@ describe('groupDeleter', () => {
 			blockType: 'module',
 		});
 
-		mockState.graphicHelper.codeBlocks = [...groupBlocks, otherBlock];
+		mockState.codeBlockRendering.codeBlocks = [...groupBlocks, otherBlock];
 
 		groupDeleter(store, mockEvents);
 
@@ -320,7 +320,7 @@ describe('groupDeleter', () => {
 		deleteCallback({ codeBlock: groupBlocks[0] });
 
 		const state = store.getState();
-		expect(state.graphicHelper.codeBlocks).toEqual([otherBlock]);
-		expect(state.graphicHelper.codeBlocks).toHaveLength(1);
+		expect(state.codeBlockRendering.codeBlocks).toEqual([otherBlock]);
+		expect(state.codeBlockRendering.codeBlocks).toHaveLength(1);
 	});
 });

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/group/deleter/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/group/deleter/effect.ts
@@ -23,41 +23,41 @@ export default function groupDeleter(store: StateManager<State>, events: EventDi
 		}
 
 		// Find all code blocks with the same group name
-		const groupBlocks = getGroupBlocks(state.graphicHelper.codeBlocks, groupName);
+		const groupBlocks = getGroupBlocks(state.codeBlockRendering.codeBlocks, groupName);
 
 		// Create a Set of blocks to delete for O(1) lookup
 		const blocksToDelete = new Set(groupBlocks);
 
 		// Filter out all blocks in the group
-		const remainingBlocks = state.graphicHelper.codeBlocks.filter(block => !blocksToDelete.has(block));
+		const remainingBlocks = state.codeBlockRendering.codeBlocks.filter(block => !blocksToDelete.has(block));
 
 		// Clear selected/dragged references if they point to deleted blocks
-		if (state.graphicHelper.selectedCodeBlock && blocksToDelete.has(state.graphicHelper.selectedCodeBlock)) {
-			store.set('graphicHelper.selectedCodeBlock', undefined);
+		if (state.codeBlockRendering.selectedCodeBlock && blocksToDelete.has(state.codeBlockRendering.selectedCodeBlock)) {
+			store.set('codeBlockRendering.selectedCodeBlock', undefined);
 		}
 
-		if (state.graphicHelper.draggedCodeBlock && blocksToDelete.has(state.graphicHelper.draggedCodeBlock)) {
-			state.graphicHelper.draggedCodeBlock = undefined;
+		if (state.codeBlockRendering.draggedCodeBlock && blocksToDelete.has(state.codeBlockRendering.draggedCodeBlock)) {
+			state.codeBlockRendering.draggedCodeBlock = undefined;
 		}
 
 		// Clear programmatic selection if it points to a deleted block
 		if (
-			state.graphicHelper.selectedCodeBlockForProgrammaticEdit &&
-			blocksToDelete.has(state.graphicHelper.selectedCodeBlockForProgrammaticEdit)
+			state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit &&
+			blocksToDelete.has(state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit)
 		) {
-			state.graphicHelper.selectedCodeBlockForProgrammaticEdit = undefined;
+			state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit = undefined;
 		}
 
 		// Clear non-compiler programmatic selection if it points to a deleted block
 		if (
-			state.graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger &&
-			blocksToDelete.has(state.graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger)
+			state.codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger &&
+			blocksToDelete.has(state.codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger)
 		) {
-			state.graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger = undefined;
+			state.codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger = undefined;
 		}
 
 		// Update the code blocks array
-		store.set('graphicHelper.codeBlocks', remainingBlocks);
+		store.set('codeBlockRendering.codeBlocks', remainingBlocks);
 	}
 
 	events.on('deleteGroup', onDeleteGroup);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/group/nonstickToggler/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/group/nonstickToggler/effect.test.ts
@@ -32,7 +32,7 @@ describe('groupNonstickToggler', () => {
 			blockType: 'module',
 			groupName: 'other-group',
 		});
-		mockState.graphicHelper.codeBlocks = [block1, block2, block3];
+		mockState.codeBlockRendering.codeBlocks = [block1, block2, block3];
 
 		groupNonstickToggler(store, mockEvents);
 
@@ -63,7 +63,7 @@ describe('groupNonstickToggler', () => {
 			groupName: 'audio-chain',
 			groupNonstick: true,
 		});
-		mockState.graphicHelper.codeBlocks = [block1, block2];
+		mockState.codeBlockRendering.codeBlocks = [block1, block2];
 
 		groupNonstickToggler(store, mockEvents);
 
@@ -90,7 +90,7 @@ describe('groupNonstickToggler', () => {
 			blockType: 'module',
 			groupName: 'audio-chain',
 		});
-		mockState.graphicHelper.codeBlocks = [block1, block2];
+		mockState.codeBlockRendering.codeBlocks = [block1, block2];
 
 		groupNonstickToggler(store, mockEvents);
 
@@ -111,7 +111,7 @@ describe('groupNonstickToggler', () => {
 			blockType: 'module',
 			groupName: 'audio-chain',
 		});
-		mockState.graphicHelper.codeBlocks = [block1];
+		mockState.codeBlockRendering.codeBlocks = [block1];
 
 		groupNonstickToggler(store, mockEvents);
 
@@ -136,7 +136,7 @@ describe('groupNonstickToggler', () => {
 			blockType: 'function',
 			groupName: 'audio-chain',
 		});
-		mockState.graphicHelper.codeBlocks = [moduleBlock, functionBlock];
+		mockState.codeBlockRendering.codeBlocks = [moduleBlock, functionBlock];
 
 		groupNonstickToggler(store, mockEvents);
 
@@ -157,7 +157,7 @@ describe('groupNonstickToggler', () => {
 			blockType: 'module',
 			groupName: 'audio-chain',
 		});
-		mockState.graphicHelper.codeBlocks = [block1];
+		mockState.codeBlockRendering.codeBlocks = [block1];
 		mockState.featureFlags.editing = false;
 
 		groupNonstickToggler(store, mockEvents);
@@ -176,7 +176,7 @@ describe('groupNonstickToggler', () => {
 			code: ['module test1', '', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [block1];
+		mockState.codeBlockRendering.codeBlocks = [block1];
 
 		groupNonstickToggler(store, mockEvents);
 
@@ -202,7 +202,7 @@ describe('groupNonstickToggler', () => {
 			groupName: 'audio-chain',
 			lastUpdated: 1000,
 		});
-		mockState.graphicHelper.codeBlocks = [block1, block2];
+		mockState.codeBlockRendering.codeBlocks = [block1, block2];
 
 		groupNonstickToggler(store, mockEvents);
 
@@ -227,7 +227,7 @@ describe('groupNonstickToggler', () => {
 			blockType: 'module',
 			groupName: 'audio-chain',
 		});
-		mockState.graphicHelper.codeBlocks = [block1, block2];
+		mockState.codeBlockRendering.codeBlocks = [block1, block2];
 
 		groupNonstickToggler(store, mockEvents);
 
@@ -241,8 +241,8 @@ describe('groupNonstickToggler', () => {
 
 		// Should be called twice - once for each block
 		expect(setSpy).toHaveBeenCalledTimes(2);
-		expect(setSpy).toHaveBeenCalledWith('graphicHelper.selectedCodeBlockForProgrammaticEdit', block1);
-		expect(setSpy).toHaveBeenCalledWith('graphicHelper.selectedCodeBlockForProgrammaticEdit', block2);
+		expect(setSpy).toHaveBeenCalledWith('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', block1);
+		expect(setSpy).toHaveBeenCalledWith('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', block2);
 	});
 
 	it('should skip blocks with a bare ; @group directive (no group name)', () => {
@@ -251,7 +251,7 @@ describe('groupNonstickToggler', () => {
 			blockType: 'module',
 			groupName: 'audio-chain',
 		});
-		mockState.graphicHelper.codeBlocks = [block1];
+		mockState.codeBlockRendering.codeBlocks = [block1];
 
 		groupNonstickToggler(store, mockEvents);
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/group/nonstickToggler/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/group/nonstickToggler/effect.ts
@@ -27,7 +27,7 @@ export default function groupNonstickToggler(store: StateManager<State>, events:
 		}
 
 		// Find all blocks in the same group
-		const groupBlocks = getGroupBlocks(state.graphicHelper.codeBlocks, codeBlock.groupName);
+		const groupBlocks = getGroupBlocks(state.codeBlockRendering.codeBlocks, codeBlock.groupName);
 
 		if (groupBlocks.length === 0) {
 			return;
@@ -46,7 +46,7 @@ export default function groupNonstickToggler(store: StateManager<State>, events:
 			if (updatedCode.every((line, i) => line === block.code[i])) continue;
 
 			// Set target code block for programmatic edit
-			state.graphicHelper.selectedCodeBlockForProgrammaticEdit = block;
+			state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit = block;
 
 			block.code = updatedCode;
 
@@ -54,7 +54,7 @@ export default function groupNonstickToggler(store: StateManager<State>, events:
 			block.lastUpdated = Date.now();
 
 			// Trigger store update to re-render the specific code block
-			store.set('graphicHelper.selectedCodeBlockForProgrammaticEdit', block);
+			store.set('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', block);
 		}
 	}
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/group/remover/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/group/remover/effect.test.ts
@@ -22,7 +22,7 @@ describe('groupRemover', () => {
 			blockType: 'module',
 			groupName: 'myGroup',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		groupRemover(store, mockEvents);
 
@@ -42,7 +42,7 @@ describe('groupRemover', () => {
 			blockType: 'module',
 			groupName: 'firstGroup',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		groupRemover(store, mockEvents);
 
@@ -61,7 +61,7 @@ describe('groupRemover', () => {
 			blockType: 'module',
 			groupName: 'myGroup',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		groupRemover(store, mockEvents);
 
@@ -80,7 +80,7 @@ describe('groupRemover', () => {
 			blockType: 'module',
 			groupName: 'myGroup',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		groupRemover(store, mockEvents);
 
@@ -99,7 +99,7 @@ describe('groupRemover', () => {
 			blockType: 'module',
 			groupName: 'myGroup',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		groupRemover(store, mockEvents);
 
@@ -118,7 +118,7 @@ describe('groupRemover', () => {
 			blockType: 'module',
 			groupName: 'myGroup',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		groupRemover(store, mockEvents);
 
@@ -137,7 +137,7 @@ describe('groupRemover', () => {
 			blockType: 'module',
 		});
 		const originalCode = [...codeBlock.code];
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		groupRemover(store, mockEvents);
 
@@ -157,7 +157,7 @@ describe('groupRemover', () => {
 			lastUpdated: 1000,
 			groupName: 'myGroup',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		groupRemover(store, mockEvents);
 
@@ -176,7 +176,7 @@ describe('groupRemover', () => {
 			blockType: 'module',
 			groupName: 'myGroup',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		groupRemover(store, mockEvents);
 
@@ -188,7 +188,7 @@ describe('groupRemover', () => {
 
 		removeCallback({ codeBlock });
 
-		expect(setSpy).toHaveBeenCalledWith('graphicHelper.selectedCodeBlockForProgrammaticEdit', codeBlock);
+		expect(setSpy).toHaveBeenCalledWith('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', codeBlock);
 	});
 
 	it('should not remove when editing is disabled', () => {
@@ -196,7 +196,7 @@ describe('groupRemover', () => {
 			code: ['module test', '; @group myGroup', '', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 		mockState.featureFlags.editing = false;
 
 		groupRemover(store, mockEvents);
@@ -216,7 +216,7 @@ describe('groupRemover', () => {
 			blockType: 'function',
 			groupName: 'funcGroup',
 		});
-		mockState.graphicHelper.codeBlocks = [functionBlock];
+		mockState.codeBlockRendering.codeBlocks = [functionBlock];
 
 		groupRemover(store, mockEvents);
 
@@ -235,7 +235,7 @@ describe('groupRemover', () => {
 			blockType: 'module',
 			groupName: 'audio-chain_1',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		groupRemover(store, mockEvents);
 
@@ -254,7 +254,7 @@ describe('groupRemover', () => {
 			blockType: 'module',
 			groupName: 'myGroup',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		groupRemover(store, mockEvents);
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/group/remover/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/group/remover/effect.ts
@@ -16,7 +16,7 @@ export default function groupRemover(store: StateManager<State>, events: EventDi
 		}
 
 		// Set target code block for programmatic edit to avoid re-rendering all code blocks
-		state.graphicHelper.selectedCodeBlockForProgrammaticEdit = codeBlock;
+		state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit = codeBlock;
 
 		// Check if code block has a valid ; @group directive (reflected in derived groupName)
 		if (codeBlock.groupName) {
@@ -27,7 +27,7 @@ export default function groupRemover(store: StateManager<State>, events: EventDi
 			codeBlock.lastUpdated = Date.now();
 
 			// Trigger store update to re-render only the specific code block
-			store.set('graphicHelper.selectedCodeBlockForProgrammaticEdit', codeBlock);
+			store.set('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', codeBlock);
 		}
 	}
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/group/skipExecutionToggler/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/group/skipExecutionToggler/effect.test.ts
@@ -32,7 +32,7 @@ describe('groupSkipExecutionToggler', () => {
 			blockType: 'module',
 			groupName: 'other-group',
 		});
-		mockState.graphicHelper.codeBlocks = [block1, block2, block3];
+		mockState.codeBlockRendering.codeBlocks = [block1, block2, block3];
 
 		groupSkipExecutionToggler(store, mockEvents);
 
@@ -61,7 +61,7 @@ describe('groupSkipExecutionToggler', () => {
 			blockType: 'module',
 			groupName: 'audio-chain',
 		});
-		mockState.graphicHelper.codeBlocks = [block1, block2];
+		mockState.codeBlockRendering.codeBlocks = [block1, block2];
 
 		groupSkipExecutionToggler(store, mockEvents);
 
@@ -87,7 +87,7 @@ describe('groupSkipExecutionToggler', () => {
 			blockType: 'module',
 			groupName: 'audio-chain',
 		});
-		mockState.graphicHelper.codeBlocks = [block1, block2];
+		mockState.codeBlockRendering.codeBlocks = [block1, block2];
 
 		groupSkipExecutionToggler(store, mockEvents);
 
@@ -113,7 +113,7 @@ describe('groupSkipExecutionToggler', () => {
 			blockType: 'function',
 			groupName: 'audio-chain',
 		});
-		mockState.graphicHelper.codeBlocks = [moduleBlock, functionBlock];
+		mockState.codeBlockRendering.codeBlocks = [moduleBlock, functionBlock];
 
 		groupSkipExecutionToggler(store, mockEvents);
 
@@ -135,7 +135,7 @@ describe('groupSkipExecutionToggler', () => {
 			blockType: 'module',
 			groupName: 'audio-chain',
 		});
-		mockState.graphicHelper.codeBlocks = [block1];
+		mockState.codeBlockRendering.codeBlocks = [block1];
 		mockState.featureFlags.editing = false;
 
 		groupSkipExecutionToggler(store, mockEvents);
@@ -154,7 +154,7 @@ describe('groupSkipExecutionToggler', () => {
 			code: ['module test1', '', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [block1];
+		mockState.codeBlockRendering.codeBlocks = [block1];
 
 		groupSkipExecutionToggler(store, mockEvents);
 
@@ -180,7 +180,7 @@ describe('groupSkipExecutionToggler', () => {
 			groupName: 'audio-chain',
 			lastUpdated: 1000,
 		});
-		mockState.graphicHelper.codeBlocks = [block1, block2];
+		mockState.codeBlockRendering.codeBlocks = [block1, block2];
 
 		groupSkipExecutionToggler(store, mockEvents);
 
@@ -205,7 +205,7 @@ describe('groupSkipExecutionToggler', () => {
 			blockType: 'module',
 			groupName: 'audio-chain',
 		});
-		mockState.graphicHelper.codeBlocks = [block1, block2];
+		mockState.codeBlockRendering.codeBlocks = [block1, block2];
 
 		groupSkipExecutionToggler(store, mockEvents);
 
@@ -219,7 +219,7 @@ describe('groupSkipExecutionToggler', () => {
 
 		// Should be called twice - once for each block
 		expect(setSpy).toHaveBeenCalledTimes(2);
-		expect(setSpy).toHaveBeenCalledWith('graphicHelper.selectedCodeBlockForProgrammaticEdit', block1);
-		expect(setSpy).toHaveBeenCalledWith('graphicHelper.selectedCodeBlockForProgrammaticEdit', block2);
+		expect(setSpy).toHaveBeenCalledWith('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', block1);
+		expect(setSpy).toHaveBeenCalledWith('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', block2);
 	});
 });

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/group/skipExecutionToggler/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/group/skipExecutionToggler/effect.ts
@@ -21,7 +21,7 @@ export default function groupSkipExecutionToggler(store: StateManager<State>, ev
 		}
 
 		// Find all module blocks in the same group
-		const groupBlocks = getGroupModuleBlocks(state.graphicHelper.codeBlocks, codeBlock.groupName);
+		const groupBlocks = getGroupModuleBlocks(state.codeBlockRendering.codeBlocks, codeBlock.groupName);
 
 		if (groupBlocks.length === 0) {
 			return;
@@ -33,7 +33,7 @@ export default function groupSkipExecutionToggler(store: StateManager<State>, ev
 		// Apply the same operation to all group blocks
 		for (const block of groupBlocks) {
 			// Set target code block for programmatic edit to avoid re-rendering all code blocks
-			state.graphicHelper.selectedCodeBlockForProgrammaticEdit = block;
+			state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit = block;
 
 			if (allSkipped) {
 				// Remove all #skipExecution directive lines
@@ -60,7 +60,7 @@ export default function groupSkipExecutionToggler(store: StateManager<State>, ev
 			block.lastUpdated = Date.now();
 
 			// Trigger store update to re-render only the specific code block
-			store.set('graphicHelper.selectedCodeBlockForProgrammaticEdit', block);
+			store.set('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', block);
 		}
 	}
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/group/ungroupper/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/group/ungroupper/effect.test.ts
@@ -30,12 +30,12 @@ describe('groupUngroupper', () => {
 			blockType: 'function',
 		});
 
-		// Set groupName on blocks (normally done by graphicHelper)
+		// Set groupName on blocks (normally done by codeBlockRendering)
 		codeBlock1.groupName = 'myGroup';
 		codeBlock2.groupName = 'myGroup';
 		codeBlock3.groupName = 'myGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2, codeBlock3];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2, codeBlock3];
 
 		groupUngroupper(store, mockEvents);
 
@@ -64,7 +64,7 @@ describe('groupUngroupper', () => {
 		codeBlock1.groupName = 'myGroup';
 		codeBlock2.groupName = 'otherGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2];
 
 		groupUngroupper(store, mockEvents);
 
@@ -91,7 +91,7 @@ describe('groupUngroupper', () => {
 		codeBlock1.groupName = 'myGroup';
 		codeBlock2.groupName = 'myGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2];
 
 		groupUngroupper(store, mockEvents);
 
@@ -113,7 +113,7 @@ describe('groupUngroupper', () => {
 
 		codeBlock1.groupName = 'myGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1];
 
 		groupUngroupper(store, mockEvents);
 
@@ -141,7 +141,7 @@ describe('groupUngroupper', () => {
 		codeBlock1.groupName = 'myGroup';
 		codeBlock2.groupName = 'myGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2];
 
 		groupUngroupper(store, mockEvents);
 
@@ -163,7 +163,7 @@ describe('groupUngroupper', () => {
 
 		codeBlock1.groupName = 'myGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1];
 
 		groupUngroupper(store, mockEvents);
 
@@ -175,7 +175,7 @@ describe('groupUngroupper', () => {
 
 		ungroupCallback({ codeBlock: codeBlock1 });
 
-		expect(setSpy).toHaveBeenCalledWith('graphicHelper.codeBlocks', mockState.graphicHelper.codeBlocks);
+		expect(setSpy).toHaveBeenCalledWith('codeBlockRendering.codeBlocks', mockState.codeBlockRendering.codeBlocks);
 	});
 
 	it('should be no-op when selected block has no group name', () => {
@@ -184,7 +184,7 @@ describe('groupUngroupper', () => {
 			blockType: 'module',
 		});
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1];
 
 		groupUngroupper(store, mockEvents);
 
@@ -207,7 +207,7 @@ describe('groupUngroupper', () => {
 
 		codeBlock1.groupName = 'nonexistentGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1];
 
 		groupUngroupper(store, mockEvents);
 
@@ -220,7 +220,7 @@ describe('groupUngroupper', () => {
 		ungroupCallback({ codeBlock: codeBlock1 });
 
 		// Store update should still happen, but no code changes
-		expect(setSpy).toHaveBeenCalledWith('graphicHelper.codeBlocks', mockState.graphicHelper.codeBlocks);
+		expect(setSpy).toHaveBeenCalledWith('codeBlockRendering.codeBlocks', mockState.codeBlockRendering.codeBlocks);
 		expect(codeBlock1.code).toEqual(['module test1', '', 'moduleEnd']);
 	});
 
@@ -237,7 +237,7 @@ describe('groupUngroupper', () => {
 		codeBlock1.groupName = 'myGroup';
 		codeBlock2.groupName = 'myGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2];
 		mockState.featureFlags.editing = false;
 
 		groupUngroupper(store, mockEvents);
@@ -265,7 +265,7 @@ describe('groupUngroupper', () => {
 		codeBlock1.groupName = 'myGroup';
 		codeBlock2.groupName = 'myGroup';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2];
 
 		groupUngroupper(store, mockEvents);
 
@@ -292,7 +292,7 @@ describe('groupUngroupper', () => {
 		codeBlock1.groupName = 'audio-chain_1';
 		codeBlock2.groupName = 'audio-chain_1';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2];
 
 		groupUngroupper(store, mockEvents);
 
@@ -324,7 +324,7 @@ describe('groupUngroupper', () => {
 		codeBlock2.groupName = 'myGroup2';
 		codeBlock3.groupName = 'myGroupExtended';
 
-		mockState.graphicHelper.codeBlocks = [codeBlock1, codeBlock2, codeBlock3];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock1, codeBlock2, codeBlock3];
 
 		groupUngroupper(store, mockEvents);
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/group/ungroupper/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/group/ungroupper/effect.ts
@@ -23,7 +23,7 @@ export default function groupUngroupper(store: StateManager<State>, events: Even
 		}
 
 		// Find all code blocks with the same group name
-		const groupBlocks = getGroupBlocks(state.graphicHelper.codeBlocks, groupName);
+		const groupBlocks = getGroupBlocks(state.codeBlockRendering.codeBlocks, groupName);
 
 		// Remove ; @group directive from all blocks in the group
 		groupBlocks.forEach(block => {
@@ -36,7 +36,7 @@ export default function groupUngroupper(store: StateManager<State>, events: Even
 
 		// Trigger store update to refresh all affected blocks
 		// Using codeBlocks array update to ensure all blocks are refreshed
-		store.set('graphicHelper.codeBlocks', state.graphicHelper.codeBlocks);
+		store.set('codeBlockRendering.codeBlocks', state.codeBlockRendering.codeBlocks);
 	}
 
 	events.on('ungroupByName', onUngroupByName);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/inputs/updateGraphicData.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/inputs/updateGraphicData.test.ts
@@ -16,7 +16,7 @@ describe('updateInputsGraphicData', () => {
 		});
 
 		mockState = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				viewport: {
 					vGrid: 10,
 					hGrid: 20,

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/outputs/updateGraphicData.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/outputs/updateGraphicData.test.ts
@@ -18,7 +18,7 @@ describe('updateOutputsGraphicData', () => {
 		});
 
 		mockState = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				viewport: {
 					vGrid: 10,
 					hGrid: 20,
@@ -54,7 +54,7 @@ describe('updateOutputsGraphicData', () => {
 
 		expect(mockGraphicData.widgets.outputs.length).toBe(1);
 		expect(findWidgetById(mockGraphicData.widgets.outputs, 'output1')).toBeDefined();
-		expect(mockState.graphicHelper.outputsByWordAddress.get(20)?.id).toBe('output1');
+		expect(mockState.codeBlockRendering.outputsByWordAddress.get(20)?.id).toBe('output1');
 	});
 
 	it('should calculate correct dimensions and position', () => {
@@ -70,10 +70,10 @@ describe('updateOutputsGraphicData', () => {
 	it('should register output in outputsByWordAddress', () => {
 		updateOutputsGraphicData(mockGraphicData, mockState);
 
-		expect(mockState.graphicHelper.outputsByWordAddress.size).toBe(1);
-		expect(mockState.graphicHelper.outputsByWordAddress.has(20)).toBe(true);
+		expect(mockState.codeBlockRendering.outputsByWordAddress.size).toBe(1);
+		expect(mockState.codeBlockRendering.outputsByWordAddress.has(20)).toBe(true);
 
-		const output = mockState.graphicHelper.outputsByWordAddress.get(20);
+		const output = mockState.codeBlockRendering.outputsByWordAddress.get(20);
 		expect(output?.id).toBe('output1');
 	});
 
@@ -83,7 +83,7 @@ describe('updateOutputsGraphicData', () => {
 		updateOutputsGraphicData(mockGraphicData, mockState);
 
 		expect(mockGraphicData.widgets.outputs.length).toBe(0);
-		expect(mockState.graphicHelper.outputsByWordAddress.size).toBe(0);
+		expect(mockState.codeBlockRendering.outputsByWordAddress.size).toBe(0);
 	});
 
 	it('should not render outputs for private entities', () => {
@@ -104,7 +104,7 @@ describe('updateOutputsGraphicData', () => {
 		updateOutputsGraphicData(mockGraphicData, mockState);
 
 		expect(mockGraphicData.widgets.outputs.length).toBe(0);
-		expect(mockState.graphicHelper.outputsByWordAddress.size).toBe(0);
+		expect(mockState.codeBlockRendering.outputsByWordAddress.size).toBe(0);
 	});
 
 	it('should render bare anonymous scalar allocations', () => {
@@ -126,7 +126,7 @@ describe('updateOutputsGraphicData', () => {
 
 		expect(mockGraphicData.widgets.outputs.length).toBe(1);
 		expect(findWidgetById(mockGraphicData.widgets.outputs, '__anonymous__1')).toBeDefined();
-		expect(mockState.graphicHelper.outputsByWordAddress.get(32)?.id).toBe('__anonymous__1');
+		expect(mockState.codeBlockRendering.outputsByWordAddress.get(32)?.id).toBe('__anonymous__1');
 	});
 
 	it('should clear existing outputs before updating', () => {
@@ -167,7 +167,7 @@ describe('updateOutputsGraphicData', () => {
 		updateOutputsGraphicData(mockGraphicData, mockState);
 
 		expect(mockGraphicData.widgets.outputs.length).toBe(2);
-		expect(mockState.graphicHelper.outputsByWordAddress.size).toBe(2);
+		expect(mockState.codeBlockRendering.outputsByWordAddress.size).toBe(2);
 
 		// Exclude codeBlock and memory references from snapshot
 		const entries = Object.entries(mockGraphicData.widgets.outputs).map(([key, value]) => {

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/outputs/updateGraphicData.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/outputs/updateGraphicData.ts
@@ -38,6 +38,6 @@ export default function updateOutputsGraphicData(graphicData: CodeBlockGraphicDa
 		};
 
 		graphicData.widgets.outputs.push(out);
-		state.graphicHelper.outputsByWordAddress.set(memory.byteAddress, out);
+		state.codeBlockRendering.outputsByWordAddress.set(memory.byteAddress, out);
 	});
 }

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/parsedDirectivesUpdater/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/parsedDirectivesUpdater/effect.ts
@@ -3,7 +3,7 @@ import type { State } from '@8f4e/editor-state-types';
 import type { StateManager } from '@8f4e/state-manager';
 import { parseBlockDirectives } from '../../utils/parseBlockDirectives';
 
-function updateParsedDirectivesForBlock(block: State['graphicHelper']['codeBlocks'][number] | undefined): void {
+function updateParsedDirectivesForBlock(block: State['codeBlockRendering']['codeBlocks'][number] | undefined): void {
 	if (!block) {
 		return;
 	}
@@ -14,21 +14,21 @@ function updateParsedDirectivesForBlock(block: State['graphicHelper']['codeBlock
 export default function parsedDirectivesUpdater(store: StateManager<State>): void {
 	function updateAllBlocks(): void {
 		const state = store.getState();
-		for (const block of state.graphicHelper.codeBlocks) {
+		for (const block of state.codeBlockRendering.codeBlocks) {
 			updateParsedDirectivesForBlock(block);
 		}
 	}
 
-	store.subscribe('graphicHelper.codeBlocks', updateAllBlocks);
-	store.subscribe('graphicHelper.selectedCodeBlock.code', () => {
-		updateParsedDirectivesForBlock(store.getState().graphicHelper.selectedCodeBlock);
+	store.subscribe('codeBlockRendering.codeBlocks', updateAllBlocks);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', () => {
+		updateParsedDirectivesForBlock(store.getState().codeBlockRendering.selectedCodeBlock);
 	});
-	store.subscribe('graphicHelper.selectedCodeBlockForProgrammaticEdit.code', () => {
-		updateParsedDirectivesForBlock(store.getState().graphicHelper.selectedCodeBlockForProgrammaticEdit);
+	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', () => {
+		updateParsedDirectivesForBlock(store.getState().codeBlockRendering.selectedCodeBlockForProgrammaticEdit);
 	});
-	store.subscribe('graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code', () => {
+	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code', () => {
 		updateParsedDirectivesForBlock(
-			store.getState().graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger
+			store.getState().codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger
 		);
 	});
 }

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/skipExecutionToggler/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/skipExecutionToggler/effect.test.ts
@@ -21,7 +21,7 @@ describe('skipExecutionToggler', () => {
 			code: ['module test', '', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		skipExecutionToggler(store, mockEvents);
 
@@ -40,7 +40,7 @@ describe('skipExecutionToggler', () => {
 			code: ['module test', '#skipExecution', '', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		skipExecutionToggler(store, mockEvents);
 
@@ -58,7 +58,7 @@ describe('skipExecutionToggler', () => {
 			code: ['module test', '#skipExecution', '', '#skipExecution', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		skipExecutionToggler(store, mockEvents);
 
@@ -76,7 +76,7 @@ describe('skipExecutionToggler', () => {
 			code: ['module test', '#skipExecution  ', '', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		skipExecutionToggler(store, mockEvents);
 
@@ -94,7 +94,7 @@ describe('skipExecutionToggler', () => {
 			code: ['module test', '  #skipExecution', '', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		skipExecutionToggler(store, mockEvents);
 
@@ -113,7 +113,7 @@ describe('skipExecutionToggler', () => {
 			blockType: 'module',
 			lastUpdated: 1000,
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		skipExecutionToggler(store, mockEvents);
 
@@ -131,7 +131,7 @@ describe('skipExecutionToggler', () => {
 			code: ['module test', '', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 
 		skipExecutionToggler(store, mockEvents);
 
@@ -143,7 +143,7 @@ describe('skipExecutionToggler', () => {
 
 		toggleCallback({ codeBlock });
 
-		expect(setSpy).toHaveBeenCalledWith('graphicHelper.selectedCodeBlockForProgrammaticEdit', codeBlock);
+		expect(setSpy).toHaveBeenCalledWith('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', codeBlock);
 	});
 
 	it('should not toggle when editing is disabled', () => {
@@ -151,7 +151,7 @@ describe('skipExecutionToggler', () => {
 			code: ['module test', '', 'moduleEnd'],
 			blockType: 'module',
 		});
-		mockState.graphicHelper.codeBlocks = [codeBlock];
+		mockState.codeBlockRendering.codeBlocks = [codeBlock];
 		mockState.featureFlags.editing = false;
 
 		skipExecutionToggler(store, mockEvents);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/skipExecutionToggler/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/skipExecutionToggler/effect.ts
@@ -16,7 +16,7 @@ export default function skipExecutionToggler(store: StateManager<State>, events:
 		}
 
 		// Set target code block for programmatic edit to avoid re-rendering all code blocks
-		state.graphicHelper.selectedCodeBlockForProgrammaticEdit = codeBlock;
+		state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit = codeBlock;
 
 		// Check if module has #skipExecution directive
 		const hasDirective = codeBlock.code.some(line => isSkipExecutionDirective(line));
@@ -42,7 +42,7 @@ export default function skipExecutionToggler(store: StateManager<State>, events:
 		codeBlock.lastUpdated = Date.now();
 
 		// Trigger store update to re-render only the specific code block
-		store.set('graphicHelper.selectedCodeBlockForProgrammaticEdit', codeBlock);
+		store.set('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', codeBlock);
 	}
 
 	events.on('toggleModuleSkipExecutionDirective', onToggleModuleSkipExecutionDirective);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/getCodeBlockGridWidth.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/getCodeBlockGridWidth.test.ts
@@ -40,8 +40,8 @@ describe('getCodeBlockGridWidth', () => {
 		expect(getCodeBlockGridWidth(code)).toBe(CODE_BLOCK_MIN_GRID_WIDTH);
 	});
 
-	it('matches graphicHelper width calculation logic', () => {
-		// This test verifies the exact formula used in graphicHelper
+	it('matches codeBlockRendering width calculation logic', () => {
+		// This test verifies the exact formula used in codeBlockRendering
 		const code = ['module delay', '', 'float[] buffer 44100', 'moduleEnd'];
 		// Lines: "0 module delay", "1 ", "2 float[] buffer 44100", "3 moduleEnd"
 		// Longest: "2 float[] buffer 44100" = 22 chars

--- a/packages/editor/packages/editor-state/src/features/code-blocks/getCodeBlockGridWidth.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/getCodeBlockGridWidth.ts
@@ -3,7 +3,7 @@ import { CODE_BLOCK_MIN_GRID_WIDTH } from './utils/constants';
 
 /**
  * Computes the grid width required for a code block.
- * Matches the sizing logic used by graphicHelper effect.
+ * Matches the sizing logic used by codeBlockRendering effect.
  *
  * @param code - Code block represented as an array of lines
  * @param minGridWidth - Minimum grid width (defaults to CODE_BLOCK_MIN_GRID_WIDTH)
@@ -14,7 +14,7 @@ export default function getCodeBlockGridWidth(code: string[], minGridWidth = COD
 	const lineNumberColumnWidth = code.length.toString().length;
 	const tabStopsByLine = getTabStopsByLine(code);
 
-	// Prepare code with line numbers (matching graphicHelper logic)
+	// Prepare code with line numbers (matching codeBlockRendering logic)
 	const codeWithLineNumbers = code.map((line, index) => {
 		const prefix = `${index}`.padStart(lineNumberColumnWidth, '0') + ' ';
 		return prefix.length + getVisualLineWidth(line, tabStopsByLine[index] || []);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/utils/finders/findClosestCodeBlockInDirection.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/utils/finders/findClosestCodeBlockInDirection.ts
@@ -128,8 +128,8 @@ function findClosestCodeBlockHorizontally(
  * @example
  * ```typescript
  * const closestBlock = findClosestCodeBlockInDirection(
- *   graphicHelper.codeBlocks,
- *   graphicHelper.selectedCodeBlock,
+ *   codeBlockRendering.codeBlocks,
+ *   codeBlockRendering.selectedCodeBlock,
  *   'right'
  * );
  * ```

--- a/packages/editor/packages/editor-state/src/features/code-blocks/utils/finders/findCodeBlockAtViewportCoordinates.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/utils/finders/findCodeBlockAtViewportCoordinates.ts
@@ -4,7 +4,7 @@ import type { CodeBlockGraphicData, State } from '@8f4e/editor-state-types';
  * Searches all code blocks (topmost first) for the one that contains the viewport-relative coordinates.
  * This is used to forward click/drag gestures to the correct block while respecting z-order determined
  * by the rendering stack (`codeBlocks` is iterated in reverse so later blocks, which render on top, win).
- * @param state State providing the current viewport origin and graphic helper.
+ * @param state State providing the current viewport origin and code block rendering state.
  * @param searchX Viewport-relative x coordinate to test.
  * @param searchY Viewport-relative y coordinate to test.
  * @returns The foremost block containing the point, or `undefined` when none overlap it.
@@ -14,8 +14,8 @@ export default function findCodeBlockAtViewportCoordinates(
 	searchX: number,
 	searchY: number
 ): CodeBlockGraphicData | undefined {
-	for (let index = state.graphicHelper.codeBlocks.length - 1; index >= 0; index -= 1) {
-		const graphicData = state.graphicHelper.codeBlocks[index];
+	for (let index = state.codeBlockRendering.codeBlocks.length - 1; index >= 0; index -= 1) {
+		const graphicData = state.codeBlockRendering.codeBlocks[index];
 		const { width, height, x, y, offsetX, offsetY } = graphicData;
 		if (
 			searchX >= x + offsetX - state.viewport.x &&

--- a/packages/editor/packages/editor-state/src/features/code-editing/README.md
+++ b/packages/editor/packages/editor-state/src/features/code-editing/README.md
@@ -24,10 +24,10 @@ Handles low-level text editing operations within code blocks: caret movement, ch
 
 ### State Touched
 
-- `state.graphicHelper.selectedCodeBlock.code` - Array of code lines
-- `state.graphicHelper.selectedCodeBlock.cursor.row` - Current cursor row (line number)
-- `state.graphicHelper.selectedCodeBlock.cursor.col` - Current cursor column position
-- `state.graphicHelper.selectedCodeBlock.lastUpdated` - Timestamp of last edit
+- `state.codeBlockRendering.selectedCodeBlock.code` - Array of code lines
+- `state.codeBlockRendering.selectedCodeBlock.cursor.row` - Current cursor row (line number)
+- `state.codeBlockRendering.selectedCodeBlock.cursor.col` - Current cursor column position
+- `state.codeBlockRendering.selectedCodeBlock.lastUpdated` - Timestamp of last edit
 - `state.editorMode` - Global editor mode (`view`, `edit`, or `presentation`)
 - `state.featureFlags.editing` - Enables text-editing operations
 - `state.featureFlags.codeLineSelection` - Enables caret movement within selected code blocks

--- a/packages/editor/packages/editor-state/src/features/code-editing/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-editing/effect.ts
@@ -14,11 +14,11 @@ export default function codeEditing(store: StateManager<State>, events: EventDis
 			return;
 		}
 
-		if (!state.graphicHelper.selectedCodeBlock) {
+		if (!state.codeBlockRendering.selectedCodeBlock) {
 			return;
 		}
 
-		const codeBlock = state.graphicHelper.selectedCodeBlock;
+		const codeBlock = state.codeBlockRendering.selectedCodeBlock;
 		const tabStopsByLine = getTabStopsByLine(codeBlock.code);
 
 		let newPosition: [number, number];
@@ -41,8 +41,8 @@ export default function codeEditing(store: StateManager<State>, events: EventDis
 		} else {
 			newPosition = moveCaret(codeBlock.code, codeBlock.cursor.row, codeBlock.cursor.col, event.direction);
 		}
-		store.set('graphicHelper.selectedCodeBlock.cursor.row', newPosition[0]);
-		store.set('graphicHelper.selectedCodeBlock.cursor.col', newPosition[1]);
+		store.set('codeBlockRendering.selectedCodeBlock.cursor.row', newPosition[0]);
+		store.set('codeBlockRendering.selectedCodeBlock.cursor.col', newPosition[1]);
 	};
 
 	const onDeleteBackward = () => {
@@ -50,16 +50,16 @@ export default function codeEditing(store: StateManager<State>, events: EventDis
 			return;
 		}
 
-		if (!state.graphicHelper.selectedCodeBlock) {
+		if (!state.codeBlockRendering.selectedCodeBlock) {
 			return;
 		}
 
-		const codeBlock = state.graphicHelper.selectedCodeBlock;
+		const codeBlock = state.codeBlockRendering.selectedCodeBlock;
 		const bp = backSpace(codeBlock.code, codeBlock.cursor.row, codeBlock.cursor.col);
-		store.set('graphicHelper.selectedCodeBlock.cursor.row', bp.row);
-		store.set('graphicHelper.selectedCodeBlock.cursor.col', bp.col);
-		store.set('graphicHelper.selectedCodeBlock.code', bp.code);
-		store.set('graphicHelper.selectedCodeBlock.lastUpdated', Date.now());
+		store.set('codeBlockRendering.selectedCodeBlock.cursor.row', bp.row);
+		store.set('codeBlockRendering.selectedCodeBlock.cursor.col', bp.col);
+		store.set('codeBlockRendering.selectedCodeBlock.code', bp.code);
+		store.set('codeBlockRendering.selectedCodeBlock.lastUpdated', Date.now());
 	};
 
 	const onInsertNewLine = () => {
@@ -67,16 +67,16 @@ export default function codeEditing(store: StateManager<State>, events: EventDis
 			return;
 		}
 
-		if (!state.graphicHelper.selectedCodeBlock) {
+		if (!state.codeBlockRendering.selectedCodeBlock) {
 			return;
 		}
 
-		const codeBlock = state.graphicHelper.selectedCodeBlock;
+		const codeBlock = state.codeBlockRendering.selectedCodeBlock;
 		const ent = enter(codeBlock.code, codeBlock.cursor.row, codeBlock.cursor.col);
-		store.set('graphicHelper.selectedCodeBlock.cursor.row', ent.row);
-		store.set('graphicHelper.selectedCodeBlock.cursor.col', ent.col);
-		store.set('graphicHelper.selectedCodeBlock.code', ent.code);
-		store.set('graphicHelper.selectedCodeBlock.lastUpdated', Date.now());
+		store.set('codeBlockRendering.selectedCodeBlock.cursor.row', ent.row);
+		store.set('codeBlockRendering.selectedCodeBlock.cursor.col', ent.col);
+		store.set('codeBlockRendering.selectedCodeBlock.code', ent.code);
+		store.set('codeBlockRendering.selectedCodeBlock.lastUpdated', Date.now());
 	};
 
 	const onInsertText = (event: InsertTextEvent) => {
@@ -84,16 +84,16 @@ export default function codeEditing(store: StateManager<State>, events: EventDis
 			return;
 		}
 
-		if (!state.graphicHelper.selectedCodeBlock) {
+		if (!state.codeBlockRendering.selectedCodeBlock) {
 			return;
 		}
 
-		const codeBlock = state.graphicHelper.selectedCodeBlock;
+		const codeBlock = state.codeBlockRendering.selectedCodeBlock;
 		const bp = type(codeBlock.code, codeBlock.cursor.row, codeBlock.cursor.col, event.text);
-		store.set('graphicHelper.selectedCodeBlock.cursor.row', bp.row);
-		store.set('graphicHelper.selectedCodeBlock.cursor.col', bp.col);
-		store.set('graphicHelper.selectedCodeBlock.code', bp.code);
-		store.set('graphicHelper.selectedCodeBlock.lastUpdated', Date.now());
+		store.set('codeBlockRendering.selectedCodeBlock.cursor.row', bp.row);
+		store.set('codeBlockRendering.selectedCodeBlock.cursor.col', bp.col);
+		store.set('codeBlockRendering.selectedCodeBlock.code', bp.code);
+		store.set('codeBlockRendering.selectedCodeBlock.lastUpdated', Date.now());
 	};
 
 	events.on<MoveCaretEvent>('moveCaret', onMoveCaret);

--- a/packages/editor/packages/editor-state/src/features/edit-history/README.md
+++ b/packages/editor/packages/editor-state/src/features/edit-history/README.md
@@ -25,7 +25,7 @@ Provides undo/redo functionality for code changes by maintaining snapshots of pr
 
 ### State Subscriptions
 
-- `graphicHelper.selectedCodeBlock.code` - Monitors code changes for history saves
+- `codeBlockRendering.selectedCodeBlock.code` - Monitors code changes for history saves
 
 ### State Touched
 

--- a/packages/editor/packages/editor-state/src/features/edit-history/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/edit-history/effect.ts
@@ -64,7 +64,7 @@ export default function historyTracking(store: StateManager<State>, events: Even
 		}
 	}
 
-	store.subscribe('graphicHelper.selectedCodeBlock.code', onCodeChange);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', onCodeChange);
 	events.on('undo', undo);
 	events.on('redo', redo);
 }

--- a/packages/editor/packages/editor-state/src/features/global-editor-directives/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/global-editor-directives/effect.ts
@@ -16,7 +16,7 @@ function withOwnerId(errors: CodeError[]): CodeError[] {
 /**
  * Global-editor-directives effect.
  *
- * Scans all code blocks in `graphicHelper.codeBlocks` for global `; @<name>`
+ * Scans all code blocks in `codeBlockRendering.codeBlocks` for global `; @<name>`
  * editor directives and updates `state.globalEditorDirectives` with the resolved values.
  *
  * Conflicting directive values are written to `state.codeErrors.editorDirectiveErrors`.
@@ -24,7 +24,7 @@ function withOwnerId(errors: CodeError[]): CodeError[] {
 export default function globalEditorDirectivesEffect(store: StateManager<State>): void {
 	function resolve(): void {
 		const state = store.getState();
-		const { resolved, errors } = resolveGlobalEditorDirectives(state.graphicHelper.codeBlocks);
+		const { resolved, errors } = resolveGlobalEditorDirectives(state.codeBlockRendering.codeBlocks);
 		const { configEntries, ...globalEditorDirectives } = resolved;
 		const nextEditorConfig = resolveEditorConfigEntries(configEntries ?? [], state.editorConfigValidators);
 		const nextErrors = [...errors, ...validateEditorConfigEntries(configEntries ?? [], state.editorConfigValidators)];
@@ -52,8 +52,8 @@ export default function globalEditorDirectivesEffect(store: StateManager<State>)
 		}
 	}
 
-	store.subscribe('graphicHelper.codeBlocks', resolve);
-	store.subscribe('graphicHelper.selectedCodeBlock.code', resolve);
-	store.subscribe('graphicHelper.selectedCodeBlockForProgrammaticEdit.code', resolve);
+	store.subscribe('codeBlockRendering.codeBlocks', resolve);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', resolve);
+	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', resolve);
 	store.subscribe('editorConfigSchemaContributions', resolve);
 }

--- a/packages/editor/packages/editor-state/src/features/menu/menus/favoritesMenu.ts
+++ b/packages/editor/packages/editor-state/src/features/menu/menus/favoritesMenu.ts
@@ -14,7 +14,7 @@ import deriveFavorites from '../../code-blocks/features/favorites/deriveFavorite
  * @returns Array of context menu items
  */
 export const favoritesMenu: MenuGenerator = state => {
-	const favorites = deriveFavorites(state.graphicHelper.codeBlocks);
+	const favorites = deriveFavorites(state.codeBlockRendering.codeBlocks);
 
 	// If no favorites, show a disabled placeholder
 	if (favorites.length === 0) {

--- a/packages/editor/packages/editor-state/src/features/menu/menus/moduleMenu.ts
+++ b/packages/editor/packages/editor-state/src/features/menu/menus/moduleMenu.ts
@@ -12,7 +12,7 @@ export interface OpenGroupEvent {
 }
 
 export const moduleMenu: MenuGenerator = state => {
-	const blockType = state.graphicHelper.selectedCodeBlock?.blockType;
+	const blockType = state.codeBlockRendering.selectedCodeBlock?.blockType;
 	let blockLabel = 'module';
 
 	if (blockType === functionBlockType) {
@@ -21,31 +21,31 @@ export const moduleMenu: MenuGenerator = state => {
 		blockLabel = 'note';
 	}
 
-	const isDisabled = state.graphicHelper.selectedCodeBlock?.disabled ?? false;
+	const isDisabled = state.codeBlockRendering.selectedCodeBlock?.disabled ?? false;
 
 	// Check if module has #skipExecution directive
 	const hasSkipExecutionDirective =
 		blockType === moduleBlockType &&
-		state.graphicHelper.selectedCodeBlock?.code.some((line: string) => isSkipExecutionDirective(line));
+		state.codeBlockRendering.selectedCodeBlock?.code.some((line: string) => isSkipExecutionDirective(line));
 
 	// Check if code block has ; @favorite directive
-	const hasFavoriteDirective = state.graphicHelper.selectedCodeBlock?.isFavorite ?? false;
+	const hasFavoriteDirective = state.codeBlockRendering.selectedCodeBlock?.isFavorite ?? false;
 
 	// Check if code block has a group name and compute group skip/nonstick status
-	const groupName = state.graphicHelper.selectedCodeBlock?.groupName;
+	const groupName = state.codeBlockRendering.selectedCodeBlock?.groupName;
 	const hasGroup = !!groupName;
 	let allGroupBlocksSkipped = false;
 	let allGroupBlocksNonstick = false;
 
 	if (hasGroup) {
 		// Find all blocks in the same group for nonstick check
-		const groupBlocks = getGroupBlocks(state.graphicHelper.codeBlocks, groupName);
+		const groupBlocks = getGroupBlocks(state.codeBlockRendering.codeBlocks, groupName);
 		// Check if all group blocks have nonstick flag
 		allGroupBlocksNonstick = groupBlocks.every((block: CodeBlockGraphicData) => block.groupNonstick);
 
 		if (blockType === moduleBlockType) {
 			// Find all module blocks in the same group
-			const groupModuleBlocks = getGroupModuleBlocks(state.graphicHelper.codeBlocks, groupName);
+			const groupModuleBlocks = getGroupModuleBlocks(state.codeBlockRendering.codeBlocks, groupName);
 			// Check if all group module blocks have #skipExecution directive
 			allGroupBlocksSkipped = groupModuleBlocks.every((block: CodeBlockGraphicData) =>
 				block.code.some((line: string) => isSkipExecutionDirective(line))
@@ -59,13 +59,13 @@ export const moduleMenu: MenuGenerator = state => {
 					{
 						title: `Delete ${blockLabel}`,
 						action: 'deleteCodeBlock',
-						payload: { codeBlock: state.graphicHelper.selectedCodeBlock },
+						payload: { codeBlock: state.codeBlockRendering.selectedCodeBlock },
 						close: true,
 					},
 					{
 						title: isDisabled ? `Enable ${blockLabel}` : `Disable ${blockLabel}`,
 						action: 'toggleCodeBlockDisabled',
-						payload: { codeBlock: state.graphicHelper.selectedCodeBlock },
+						payload: { codeBlock: state.codeBlockRendering.selectedCodeBlock },
 						close: true,
 					},
 					...(blockType === moduleBlockType
@@ -73,13 +73,13 @@ export const moduleMenu: MenuGenerator = state => {
 								{
 									title: hasSkipExecutionDirective ? 'Unskip module' : 'Skip module',
 									action: 'toggleModuleSkipExecutionDirective',
-									payload: { codeBlock: state.graphicHelper.selectedCodeBlock },
+									payload: { codeBlock: state.codeBlockRendering.selectedCodeBlock },
 									close: true,
 								},
 								{
 									title: 'Clear watch probes',
 									action: 'clearDebugProbes',
-									payload: { codeBlock: state.graphicHelper.selectedCodeBlock },
+									payload: { codeBlock: state.codeBlockRendering.selectedCodeBlock },
 									close: true,
 								},
 							]
@@ -89,7 +89,7 @@ export const moduleMenu: MenuGenerator = state => {
 								{
 									title: allGroupBlocksSkipped ? 'Unskip group' : 'Skip group',
 									action: 'toggleGroupSkipExecutionDirective',
-									payload: { codeBlock: state.graphicHelper.selectedCodeBlock },
+									payload: { codeBlock: state.codeBlockRendering.selectedCodeBlock },
 									close: true,
 								},
 							]
@@ -99,20 +99,20 @@ export const moduleMenu: MenuGenerator = state => {
 								{
 									title: 'Remove from group',
 									action: 'removeFromGroupDirective',
-									payload: { codeBlock: state.graphicHelper.selectedCodeBlock },
+									payload: { codeBlock: state.codeBlockRendering.selectedCodeBlock },
 									close: true,
 								},
 								{
 									title: `Ungroup "${groupName}"`,
 									action: 'ungroupByName',
-									payload: { codeBlock: state.graphicHelper.selectedCodeBlock },
+									payload: { codeBlock: state.codeBlockRendering.selectedCodeBlock },
 									close: true,
 								},
 								{
 									title: allGroupBlocksNonstick ? 'Make Group Sticky' : 'Make Group Nonstick',
 									action: 'toggleGroupNonstick',
 									payload: {
-										codeBlock: state.graphicHelper.selectedCodeBlock,
+										codeBlock: state.codeBlockRendering.selectedCodeBlock,
 										makeNonstick: !allGroupBlocksNonstick,
 									},
 									close: true,
@@ -120,7 +120,7 @@ export const moduleMenu: MenuGenerator = state => {
 								{
 									title: 'Delete group',
 									action: 'deleteGroup',
-									payload: { codeBlock: state.graphicHelper.selectedCodeBlock },
+									payload: { codeBlock: state.codeBlockRendering.selectedCodeBlock },
 									close: true,
 								},
 							]
@@ -128,7 +128,7 @@ export const moduleMenu: MenuGenerator = state => {
 					{
 						title: hasFavoriteDirective ? 'Unfavorite' : 'Favorite',
 						action: 'toggleFavoriteDirective',
-						payload: { codeBlock: state.graphicHelper.selectedCodeBlock },
+						payload: { codeBlock: state.codeBlockRendering.selectedCodeBlock },
 						close: true,
 					},
 				]
@@ -136,7 +136,7 @@ export const moduleMenu: MenuGenerator = state => {
 		{
 			title: `Copy ${blockLabel}`,
 			action: 'copyCodeBlock',
-			payload: { codeBlock: state.graphicHelper.selectedCodeBlock },
+			payload: { codeBlock: state.codeBlockRendering.selectedCodeBlock },
 			close: true,
 			disabled: !state.callbacks.writeClipboardText,
 		},
@@ -145,7 +145,7 @@ export const moduleMenu: MenuGenerator = state => {
 					{
 						title: 'Copy group',
 						action: 'copyGroupBlocks',
-						payload: { codeBlock: state.graphicHelper.selectedCodeBlock },
+						payload: { codeBlock: state.codeBlockRendering.selectedCodeBlock },
 						close: true,
 						disabled: !state.callbacks.writeClipboardText,
 					},
@@ -154,7 +154,7 @@ export const moduleMenu: MenuGenerator = state => {
 		{
 			title: `Log ${blockLabel} info to console`,
 			action: 'consoleLog',
-			payload: { codeBlock: state.graphicHelper.selectedCodeBlock },
+			payload: { codeBlock: state.codeBlockRendering.selectedCodeBlock },
 			close: true,
 		},
 	];

--- a/packages/editor/packages/editor-state/src/features/presentation/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/presentation/effect.test.ts
@@ -55,7 +55,7 @@ describe('presentation effect', () => {
 			},
 			featureFlags: {},
 			editorMode: 'view',
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [createCodeBlock(1, 100, 200, 1, 5), createCodeBlock(2, 400, 500, 2, 3)],
 				selectedCodeBlock: undefined,
 			},
@@ -85,15 +85,15 @@ describe('presentation effect', () => {
 					state.editorMode = value as State['editorMode'];
 					modeSubscribers.forEach(callback => callback(value as State['editorMode']));
 				}
-				if (path === 'graphicHelper.selectedCodeBlock') {
-					state.graphicHelper.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
+				if (path === 'codeBlockRendering.selectedCodeBlock') {
+					state.codeBlockRendering.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
 				}
 			}),
 			subscribe: vi.fn((path: string, callback: (value: unknown) => void) => {
 				if (path === 'editorMode') {
 					modeSubscribers.push(callback as (value: State['editorMode']) => void);
 				}
-				if (path === 'graphicHelper.codeBlocks') {
+				if (path === 'codeBlockRendering.codeBlocks') {
 					codeBlockSubscribers.push(callback as (value: CodeBlockGraphicData[]) => void);
 				}
 				return { selector: path, callback };
@@ -112,7 +112,7 @@ describe('presentation effect', () => {
 
 		store.set('editorMode', 'presentation');
 		scheduledFrame?.(16);
-		expect(state.graphicHelper.selectedCodeBlock).toBe(state.graphicHelper.codeBlocks[0]);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[0]);
 		expect(state.viewportAnimation.durationMs).toBe(2000);
 		expect(state.presentation.activeStopIndex).toBe(0);
 		expect(state.presentation.totalStops).toBe(2);
@@ -123,13 +123,13 @@ describe('presentation effect', () => {
 
 		vi.advanceTimersByTime(2000);
 		scheduledFrame?.(2016);
-		expect(state.graphicHelper.selectedCodeBlock).toBe(state.graphicHelper.codeBlocks[0]);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[0]);
 		expect(state.viewport.x).toBe(10);
 		expect(state.viewport.y).toBe(140);
 
 		vi.advanceTimersByTime(3000);
 		scheduledFrame?.(5016);
-		expect(state.graphicHelper.selectedCodeBlock).toBe(state.graphicHelper.codeBlocks[1]);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[1]);
 		expect(state.presentation.activeStopIndex).toBe(1);
 		expect(state.presentation.totalStops).toBe(2);
 		expect(state.presentation.remainingMs).toBe(3000);
@@ -154,7 +154,7 @@ describe('presentation effect', () => {
 			},
 			featureFlags: {},
 			editorMode: 'view',
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [createCodeBlock(1, 100, 200, 1, 5, 'left'), createCodeBlock(2, 400, 500, 2, 3, 'right')],
 				selectedCodeBlock: undefined,
 			},
@@ -184,8 +184,8 @@ describe('presentation effect', () => {
 					state.editorMode = value as State['editorMode'];
 					modeSubscribers.forEach(callback => callback(value as State['editorMode']));
 				}
-				if (path === 'graphicHelper.selectedCodeBlock') {
-					state.graphicHelper.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
+				if (path === 'codeBlockRendering.selectedCodeBlock') {
+					state.codeBlockRendering.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
 				}
 			}),
 			subscribe: vi.fn((path: string, callback: (value: unknown) => void) => {
@@ -211,7 +211,7 @@ describe('presentation effect', () => {
 
 		vi.advanceTimersByTime(5000);
 		scheduledFrame?.(5016);
-		expect(state.graphicHelper.selectedCodeBlock).toBe(state.graphicHelper.codeBlocks[1]);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[1]);
 		expect(state.viewportAnimation.targetX).toBe(235);
 		expect(state.presentation.activeStopIndex).toBe(1);
 	});
@@ -229,7 +229,7 @@ describe('presentation effect', () => {
 			},
 			featureFlags: {},
 			editorMode: 'view',
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [createCodeBlock(1, 100, 200, 1, 5, 'top'), createCodeBlock(2, 400, 500, 2, 3, 'bottom')],
 				selectedCodeBlock: undefined,
 			},
@@ -258,8 +258,8 @@ describe('presentation effect', () => {
 					state.editorMode = value as State['editorMode'];
 					modeSubscribers.forEach(callback => callback(value as State['editorMode']));
 				}
-				if (path === 'graphicHelper.selectedCodeBlock') {
-					state.graphicHelper.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
+				if (path === 'codeBlockRendering.selectedCodeBlock') {
+					state.codeBlockRendering.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
 				}
 			}),
 			subscribe: vi.fn((path: string, callback: (value: unknown) => void) => {
@@ -285,7 +285,7 @@ describe('presentation effect', () => {
 
 		vi.advanceTimersByTime(5000);
 		scheduledFrame?.(5016);
-		expect(state.graphicHelper.selectedCodeBlock).toBe(state.graphicHelper.codeBlocks[1]);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[1]);
 		expect(state.viewportAnimation.targetY).toBe(390);
 		expect(state.presentation.activeStopIndex).toBe(1);
 	});
@@ -300,7 +300,7 @@ describe('presentation effect', () => {
 			},
 			featureFlags: {},
 			editorMode: 'view',
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [createCodeBlock(1, 100, 200, 1, 5), createCodeBlock(2, 400, 500, 2, 3)],
 				selectedCodeBlock: undefined,
 			},
@@ -329,8 +329,8 @@ describe('presentation effect', () => {
 					state.editorMode = value as State['editorMode'];
 					modeSubscribers.forEach(callback => callback(value as State['editorMode']));
 				}
-				if (path === 'graphicHelper.selectedCodeBlock') {
-					state.graphicHelper.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
+				if (path === 'codeBlockRendering.selectedCodeBlock') {
+					state.codeBlockRendering.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
 				}
 			}),
 			subscribe: vi.fn((path: string, callback: (value: unknown) => void) => {
@@ -356,7 +356,7 @@ describe('presentation effect', () => {
 		store.set('editorMode', 'presentation');
 
 		eventHandlers.get('nextPresentationStop')?.();
-		expect(state.graphicHelper.selectedCodeBlock).toBe(state.graphicHelper.codeBlocks[1]);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[1]);
 		expect(state.presentation.activeStopIndex).toBe(1);
 		expect(state.presentation.totalStops).toBe(2);
 		expect(state.presentation.remainingMs).toBe(3000);
@@ -364,7 +364,7 @@ describe('presentation effect', () => {
 		expect(state.viewportAnimation.targetY).toBe(440);
 
 		eventHandlers.get('previousPresentationStop')?.();
-		expect(state.graphicHelper.selectedCodeBlock).toBe(state.graphicHelper.codeBlocks[0]);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[0]);
 		expect(state.presentation.activeStopIndex).toBe(0);
 		expect(state.presentation.remainingMs).toBe(5000);
 		expect(state.viewportAnimation.targetX).toBe(10);
@@ -381,7 +381,7 @@ describe('presentation effect', () => {
 			},
 			featureFlags: {},
 			editorMode: 'view',
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [createCodeBlock(1, 100, 200, 1, 5), createCodeBlock(2, 400, 500, 2, 3)],
 				selectedCodeBlock: undefined,
 			},
@@ -410,8 +410,8 @@ describe('presentation effect', () => {
 					state.editorMode = value as State['editorMode'];
 					modeSubscribers.forEach(callback => callback(value as State['editorMode']));
 				}
-				if (path === 'graphicHelper.selectedCodeBlock') {
-					state.graphicHelper.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
+				if (path === 'codeBlockRendering.selectedCodeBlock') {
+					state.codeBlockRendering.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
 				}
 			}),
 			subscribe: vi.fn((path: string, callback: (value: unknown) => void) => {
@@ -438,15 +438,15 @@ describe('presentation effect', () => {
 
 		vi.advanceTimersByTime(4000);
 		eventHandlers.get('nextPresentationStop')?.();
-		expect(state.graphicHelper.selectedCodeBlock).toBe(state.graphicHelper.codeBlocks[1]);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[1]);
 		expect(state.presentation.deadlineAt).toBe(Date.now() + 3000);
 
 		vi.advanceTimersByTime(2999);
-		expect(state.graphicHelper.selectedCodeBlock).toBe(state.graphicHelper.codeBlocks[1]);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[1]);
 
 		vi.advanceTimersByTime(1);
 		expect(state.editorMode).toBe('view');
-		expect(state.graphicHelper.selectedCodeBlock).toBeUndefined();
+		expect(state.codeBlockRendering.selectedCodeBlock).toBeUndefined();
 		expect(state.viewportAnimation.targetX).toBe(50);
 		expect(state.viewportAnimation.targetY).toBe(60);
 		expect(state.presentation.totalStops).toBe(0);
@@ -462,7 +462,7 @@ describe('presentation effect', () => {
 			},
 			featureFlags: {},
 			editorMode: 'view',
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [createCodeBlock(1, 100, 200, 1, 2), createCodeBlock(2, 400, 500, 2, 3)],
 				selectedCodeBlock: undefined,
 			},
@@ -491,8 +491,8 @@ describe('presentation effect', () => {
 					state.editorMode = value as State['editorMode'];
 					modeSubscribers.forEach(callback => callback(value as State['editorMode']));
 				}
-				if (path === 'graphicHelper.selectedCodeBlock') {
-					state.graphicHelper.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
+				if (path === 'codeBlockRendering.selectedCodeBlock') {
+					state.codeBlockRendering.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
 				}
 			}),
 			subscribe: vi.fn((path: string, callback: (value: unknown) => void) => {
@@ -514,12 +514,12 @@ describe('presentation effect', () => {
 		store.set('editorMode', 'presentation');
 
 		vi.advanceTimersByTime(2000);
-		expect(state.graphicHelper.selectedCodeBlock).toBe(state.graphicHelper.codeBlocks[1]);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[1]);
 		expect(state.presentation.activeStopIndex).toBe(1);
 
 		vi.advanceTimersByTime(3000);
 		expect(state.editorMode).toBe('view');
-		expect(state.graphicHelper.selectedCodeBlock).toBeUndefined();
+		expect(state.codeBlockRendering.selectedCodeBlock).toBeUndefined();
 		expect(state.viewportAnimation.targetX).toBe(80);
 		expect(state.viewportAnimation.targetY).toBe(120);
 		expect(state.presentation.totalStops).toBe(0);
@@ -532,7 +532,7 @@ describe('presentation effect', () => {
 			callbacks: {},
 			featureFlags: {},
 			editorMode: 'view',
-			graphicHelper: { codeBlocks: [] },
+			codeBlockRendering: { codeBlocks: [] },
 			viewport: createMockViewport(0, 0, 300, 200),
 			viewportAnimation: {
 				startX: 0,
@@ -590,7 +590,7 @@ describe('presentation effect', () => {
 			callbacks: {},
 			featureFlags: {},
 			editorMode: 'view',
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [],
 			},
 			viewport: createMockViewport(0, 0, 300, 200),
@@ -616,7 +616,7 @@ describe('presentation effect', () => {
 			getState: () => state,
 			set: vi.fn(),
 			subscribe: vi.fn((path: string, callback: (value: unknown) => void) => {
-				if (path === 'graphicHelper.codeBlocks') {
+				if (path === 'codeBlockRendering.codeBlocks') {
 					codeBlockSubscribers.push(callback as (value: CodeBlockGraphicData[]) => void);
 				}
 				return { selector: path, callback };
@@ -633,12 +633,12 @@ describe('presentation effect', () => {
 		presentation(store, events);
 		expect(state.presentation.canPresent).toBe(false);
 
-		state.graphicHelper.codeBlocks = [createCodeBlock(1, 100, 200, 1, 5)];
-		codeBlockSubscribers.forEach(callback => callback(state.graphicHelper.codeBlocks));
+		state.codeBlockRendering.codeBlocks = [createCodeBlock(1, 100, 200, 1, 5)];
+		codeBlockSubscribers.forEach(callback => callback(state.codeBlockRendering.codeBlocks));
 		expect(state.presentation.canPresent).toBe(true);
 
-		state.graphicHelper.codeBlocks = [];
-		codeBlockSubscribers.forEach(callback => callback(state.graphicHelper.codeBlocks));
+		state.codeBlockRendering.codeBlocks = [];
+		codeBlockSubscribers.forEach(callback => callback(state.codeBlockRendering.codeBlocks));
 		expect(state.presentation.canPresent).toBe(false);
 	});
 
@@ -655,7 +655,7 @@ describe('presentation effect', () => {
 			},
 			featureFlags: {},
 			editorMode: 'view',
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [createCodeBlock(1, 100, 200, 1, 2)],
 				selectedCodeBlock: undefined,
 			},
@@ -684,8 +684,8 @@ describe('presentation effect', () => {
 					state.editorMode = value as State['editorMode'];
 					modeSubscribers.forEach(callback => callback(value as State['editorMode']));
 				}
-				if (path === 'graphicHelper.selectedCodeBlock') {
-					state.graphicHelper.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
+				if (path === 'codeBlockRendering.selectedCodeBlock') {
+					state.codeBlockRendering.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
 				}
 			}),
 			subscribe: vi.fn((path: string, callback: (value: unknown) => void) => {
@@ -732,7 +732,7 @@ describe('presentation effect', () => {
 			},
 			featureFlags: {},
 			editorMode: 'view',
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [createCodeBlock(1, 100, 200, 1, 5), createCodeBlock(2, 400, 500, 2, 3)],
 				selectedCodeBlock: undefined,
 			},
@@ -761,8 +761,8 @@ describe('presentation effect', () => {
 					state.editorMode = value as State['editorMode'];
 					modeSubscribers.forEach(callback => callback(value as State['editorMode']));
 				}
-				if (path === 'graphicHelper.selectedCodeBlock') {
-					state.graphicHelper.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
+				if (path === 'codeBlockRendering.selectedCodeBlock') {
+					state.codeBlockRendering.selectedCodeBlock = value as CodeBlockGraphicData | undefined;
 				}
 			}),
 			subscribe: vi.fn((path: string, callback: (value: unknown) => void) => {
@@ -786,7 +786,7 @@ describe('presentation effect', () => {
 		vi.advanceTimersByTime(5000);
 		scheduledFrame?.(5016);
 
-		expect(state.graphicHelper.selectedCodeBlock).toBe(state.graphicHelper.codeBlocks[1]);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[1]);
 		expect(state.presentation.activeStopIndex).toBe(1);
 
 		store.set('editorMode', 'view');
@@ -796,7 +796,7 @@ describe('presentation effect', () => {
 		store.set('editorMode', 'presentation');
 		scheduledFrame?.(5032);
 
-		expect(state.graphicHelper.selectedCodeBlock).toBe(state.graphicHelper.codeBlocks[1]);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[1]);
 		expect(state.presentation.activeStopIndex).toBe(1);
 		expect(state.presentation.totalStops).toBe(2);
 		expect(state.presentation.remainingMs).toBe(3000);

--- a/packages/editor/packages/editor-state/src/features/presentation/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/presentation/effect.ts
@@ -16,7 +16,7 @@ function centerCurrentStop(
 		return;
 	}
 
-	store.set('graphicHelper.selectedCodeBlock', stop.codeBlock);
+	store.set('codeBlockRendering.selectedCodeBlock', stop.codeBlock);
 	const { x, y } = centerViewportOnCodeBlock(state.viewport, stop.codeBlock, {
 		alignment: stop.alignment,
 	});
@@ -25,7 +25,7 @@ function centerCurrentStop(
 
 export default function presentation(store: StateManager<State>, events: EventDispatcher): () => void {
 	const state = store.getState();
-	let stops = getPresentationStops(state.graphicHelper.codeBlocks);
+	let stops = getPresentationStops(state.codeBlockRendering.codeBlocks);
 	let stopIndex = 0;
 	let timeoutId: ReturnType<typeof setTimeout> | undefined;
 	let returnToViewportTimeoutId: ReturnType<typeof setTimeout> | undefined;
@@ -33,7 +33,7 @@ export default function presentation(store: StateManager<State>, events: EventDi
 	let isReturningToStartViewport = false;
 
 	function refreshStops(): void {
-		stops = getPresentationStops(state.graphicHelper.codeBlocks);
+		stops = getPresentationStops(state.codeBlockRendering.codeBlocks);
 		state.presentation.canPresent = stops.length > 0;
 	}
 
@@ -80,7 +80,7 @@ export default function presentation(store: StateManager<State>, events: EventDi
 		isReturningToStartViewport = false;
 		if (options.restoreStartViewport && presentationStartViewport) {
 			isReturningToStartViewport = true;
-			store.set('graphicHelper.selectedCodeBlock', undefined);
+			store.set('codeBlockRendering.selectedCodeBlock', undefined);
 			animateViewport(state, presentationStartViewport.x, presentationStartViewport.y, events);
 			returnToViewportTimeoutId = setTimeout(() => {
 				isReturningToStartViewport = false;
@@ -198,7 +198,7 @@ export default function presentation(store: StateManager<State>, events: EventDi
 	}
 
 	store.subscribe('editorMode', onPresentationChanged);
-	store.subscribe('graphicHelper.codeBlocks', syncStops);
+	store.subscribe('codeBlockRendering.codeBlocks', syncStops);
 	events.on('viewportResized', onViewportResized);
 	events.on('previousPresentationStop', onPreviousPresentationStop);
 	events.on('nextPresentationStop', onNextPresentationStop);
@@ -210,7 +210,7 @@ export default function presentation(store: StateManager<State>, events: EventDi
 		stopViewportAnimation(state);
 		clearPresentationState();
 		store.unsubscribe('editorMode', onPresentationChanged);
-		store.unsubscribe('graphicHelper.codeBlocks', syncStops);
+		store.unsubscribe('codeBlockRendering.codeBlocks', syncStops);
 		events.off('viewportResized', onViewportResized);
 		events.off('previousPresentationStop', onPreviousPresentationStop);
 		events.off('nextPresentationStop', onNextPresentationStop);

--- a/packages/editor/packages/editor-state/src/features/program-compiler/README.md
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/README.md
@@ -35,8 +35,8 @@ Compiles 8f4e code blocks into executable WASM bytecode. Coordinates with the co
 
 ### Subscriptions
 
-- `graphicHelper.selectedCodeBlock.code` - Schedules compilation when the selected compilable block changes
-- `graphicHelper.selectedCodeBlockForProgrammaticEdit.code` - Schedules compilation when programmatic edits change a compilable block
+- `codeBlockRendering.selectedCodeBlock.code` - Schedules compilation when the selected compilable block changes
+- `codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code` - Schedules compilation when programmatic edits change a compilable block
 
 ### Callbacks Used
 

--- a/packages/editor/packages/editor-state/src/features/program-compiler/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/effect.test.ts
@@ -36,8 +36,8 @@ describe('program compiler effect', () => {
 			blockType: 'function',
 		});
 
-		mockState.graphicHelper.codeBlocks.push(helperBlock);
-		mockState.graphicHelper.selectedCodeBlockForProgrammaticEdit = helperBlock;
+		mockState.codeBlockRendering.codeBlocks.push(helperBlock);
+		mockState.codeBlockRendering.selectedCodeBlockForProgrammaticEdit = helperBlock;
 
 		store = createStateManager(mockState);
 		subscribeSpy = vi.spyOn(store, 'subscribe') as MockInstance;
@@ -51,7 +51,7 @@ describe('program compiler effect', () => {
 	async function triggerProgrammaticCompile(delayMs = 500): Promise<void> {
 		compilerEffect(store);
 		const programmaticChangeCall = subscribeSpy.mock.calls.find(
-			call => call[0] === 'graphicHelper.selectedCodeBlockForProgrammaticEdit.code'
+			call => call[0] === 'codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code'
 		);
 		expect(programmaticChangeCall).toBeDefined();
 
@@ -230,7 +230,7 @@ describe('program compiler effect', () => {
 		mockState.editorConfig.recompileDebounceDelay = 120;
 		compilerEffect(store);
 		const programmaticChangeCall = subscribeSpy.mock.calls.find(
-			call => call[0] === 'graphicHelper.selectedCodeBlockForProgrammaticEdit.code'
+			call => call[0] === 'codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code'
 		);
 		expect(programmaticChangeCall).toBeDefined();
 
@@ -245,7 +245,7 @@ describe('program compiler effect', () => {
 	it('uses the default recompile debounce delay when the config value is absent', async () => {
 		compilerEffect(store);
 		const programmaticChangeCall = subscribeSpy.mock.calls.find(
-			call => call[0] === 'graphicHelper.selectedCodeBlockForProgrammaticEdit.code'
+			call => call[0] === 'codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code'
 		);
 		expect(programmaticChangeCall).toBeDefined();
 

--- a/packages/editor/packages/editor-state/src/features/program-compiler/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/effect.ts
@@ -84,7 +84,7 @@ export default function compiler(store: StateManager<State>) {
 	async function onForceCompile() {
 		scheduleRecompile.cancel();
 
-		const compilerInput = flattenProjectForCompiler(state.graphicHelper.codeBlocks);
+		const compilerInput = flattenProjectForCompiler(state.codeBlockRendering.codeBlocks);
 		const compilationStart = performance.now();
 
 		store.set('compiler.isCompiling', true);
@@ -162,18 +162,18 @@ export default function compiler(store: StateManager<State>) {
 		onForceCompile();
 	}
 
-	store.subscribe('graphicHelper.selectedCodeBlock.code', () => {
-		if (state.graphicHelper.selectedCodeBlock?.disabled) {
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', () => {
+		if (state.codeBlockRendering.selectedCodeBlock?.disabled) {
 			return;
 		}
 
-		if (!isCompilableBlockType(state.graphicHelper.selectedCodeBlock?.blockType)) {
+		if (!isCompilableBlockType(state.codeBlockRendering.selectedCodeBlock?.blockType)) {
 			return;
 		}
 		scheduleRecompile();
 	});
-	store.subscribe('graphicHelper.selectedCodeBlockForProgrammaticEdit.code', () => {
-		if (!isCompilableBlockType(state.graphicHelper.selectedCodeBlockForProgrammaticEdit?.blockType)) {
+	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', () => {
+		if (!isCompilableBlockType(state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit?.blockType)) {
 			return;
 		}
 		scheduleRecompile();

--- a/packages/editor/packages/editor-state/src/features/project-export/README.md
+++ b/packages/editor/packages/editor-state/src/features/project-export/README.md
@@ -32,7 +32,7 @@ WASM export is separate from project serialization and writes compiled binary mo
 ## State Sources
 
 Serializes from:
-- `state.graphicHelper.codeBlocks` - Code block data
+- `state.codeBlockRendering.codeBlocks` - Code block data
 
 ## Integration Points
 

--- a/packages/editor/packages/editor-state/src/features/project-export/__tests__/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/__tests__/effect.test.ts
@@ -53,9 +53,9 @@ describe('projectExport', () => {
 
 			projectExport(store, mockEvents);
 
-			expect(subscribeSpy).toHaveBeenCalledWith('graphicHelper.selectedCodeBlock.code', expect.any(Function));
+			expect(subscribeSpy).toHaveBeenCalledWith('codeBlockRendering.selectedCodeBlock.code', expect.any(Function));
 			expect(subscribeSpy).toHaveBeenCalledWith(
-				'graphicHelper.selectedCodeBlockForProgrammaticEdit.code',
+				'codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code',
 				expect.any(Function)
 			);
 
@@ -198,7 +198,7 @@ describe('projectExport', () => {
 			const mockGetStorageQuota = vi.fn().mockResolvedValue({ usedBytes: 1024, totalBytes: 10240 });
 			mockState.callbacks.saveSession = mockSaveSession;
 			mockState.callbacks.getStorageQuota = mockGetStorageQuota;
-			mockState.graphicHelper.codeBlocks = [
+			mockState.codeBlockRendering.codeBlocks = [
 				createMockCodeBlock({
 					blockType: 'module',
 					code: ['module other', 'moduleEnd'],
@@ -263,10 +263,12 @@ describe('projectExport', () => {
 			projectExport(store, mockEvents);
 
 			// Find the code change callback
-			const codeChangeCall = subscribeSpy.mock.calls.find(call => call[0] === 'graphicHelper.selectedCodeBlock.code');
+			const codeChangeCall = subscribeSpy.mock.calls.find(
+				call => call[0] === 'codeBlockRendering.selectedCodeBlock.code'
+			);
 			expect(codeChangeCall).toBeDefined();
 			const programmaticChangeCall = subscribeSpy.mock.calls.find(
-				call => call[0] === 'graphicHelper.selectedCodeBlockForProgrammaticEdit.code'
+				call => call[0] === 'codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code'
 			);
 			expect(programmaticChangeCall).toBeDefined();
 

--- a/packages/editor/packages/editor-state/src/features/project-export/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/effect.ts
@@ -64,10 +64,10 @@ export default function projectExport(store: StateManager<State>, events: EventD
 		});
 	}
 
-	store.subscribe('graphicHelper.codeBlocks', onSaveSession);
-	store.subscribe('graphicHelper.selectedCodeBlock.code', onSaveSession);
-	store.subscribe('graphicHelper.selectedCodeBlockForProgrammaticEdit.code', onSaveSession);
-	store.subscribe('graphicHelper.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code', onSaveSession);
+	store.subscribe('codeBlockRendering.codeBlocks', onSaveSession);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', onSaveSession);
+	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', onSaveSession);
+	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code', onSaveSession);
 	events.on('saveSession', onSaveSession);
 	events.on('exportProject', onExportProject);
 	events.on('exportWasm', onExportWasm);

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeToProject.test.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeToProject.test.ts
@@ -5,7 +5,7 @@ import serializeToProject from './serializeToProject';
 describe('serializeToProject', () => {
 	it('serializes basic project state without compiled data', () => {
 		const state = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [
 					createMockCodeBlock({
 						id: 'block-1',

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeToProject.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeToProject.ts
@@ -7,7 +7,7 @@ import convertGraphicDataToProjectStructure from './serializeCodeBlocks';
  * @returns Project object ready for session persistence or `.8f4e` conversion
  */
 export default function serializeToProject(state: State): Project {
-	const { graphicHelper } = state;
+	const { codeBlockRendering } = state;
 
-	return convertGraphicDataToProjectStructure(graphicHelper.codeBlocks);
+	return convertGraphicDataToProjectStructure(codeBlockRendering.codeBlocks);
 }

--- a/packages/editor/packages/editor-state/src/features/project-import/README.md
+++ b/packages/editor/packages/editor-state/src/features/project-import/README.md
@@ -47,7 +47,7 @@ Handles loading projects into the editor from persistent storage, `.8f4e` file u
 ### State Touched
 
 - `state.initialProjectState` - Initial project loaded on startup
-- `state.graphicHelper` - Populated from loaded code blocks
+- `state.codeBlockRendering` - Populated from loaded code blocks
 - `state.binaryAssets` - Runtime asset metadata populated by the editor environment binary-assets plugin when asset directives are active
 
 ## Integration Points

--- a/packages/editor/packages/editor-state/src/features/shader-effects/README.md
+++ b/packages/editor/packages/editor-state/src/features/shader-effects/README.md
@@ -30,7 +30,7 @@ A single post-process effect is derived from shader notes:
 
 ### State Touched
 
-- `state.graphicHelper.codeBlocks` - Source of shader notes
+- `state.codeBlockRendering.codeBlocks` - Source of shader notes
 - `state.postProcessEffects` - Derived array of effect descriptors (if stored)
 - Shader compilation errors are added to error state
 

--- a/packages/editor/packages/editor-state/src/features/shader-effects/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/shader-effects/effect.ts
@@ -17,7 +17,7 @@ export default function shaderEffectsDeriver(store: StateManager<State>, events:
 	 * Recompute shader effects from all shader blocks
 	 */
 	function recomputeShaderEffects(): void {
-		const { postProcessEffects, backgroundEffects, errors } = deriveShaderEffects(state.graphicHelper.codeBlocks);
+		const { postProcessEffects, backgroundEffects, errors } = deriveShaderEffects(state.codeBlockRendering.codeBlocks);
 
 		log(state, 'Recomputed shader effects', 'Shaders');
 
@@ -33,16 +33,16 @@ export default function shaderEffectsDeriver(store: StateManager<State>, events:
 		events.dispatch('loadBackgroundEffect', backgroundEffects[0] ?? null);
 	}
 
-	store.subscribe('graphicHelper.codeBlocks', () => {
+	store.subscribe('codeBlockRendering.codeBlocks', () => {
 		recomputeShaderEffects();
 	});
-	store.subscribe('graphicHelper.selectedCodeBlock.code', () => {
-		if (isShaderNoteCode(state.graphicHelper.selectedCodeBlock?.code ?? [])) {
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', () => {
+		if (isShaderNoteCode(state.codeBlockRendering.selectedCodeBlock?.code ?? [])) {
 			recomputeShaderEffects();
 		}
 	});
-	store.subscribe('graphicHelper.selectedCodeBlockForProgrammaticEdit.code', () => {
-		if (isShaderNoteCode(state.graphicHelper.selectedCodeBlockForProgrammaticEdit?.code ?? [])) {
+	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', () => {
+		if (isShaderNoteCode(state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit?.code ?? [])) {
 			recomputeShaderEffects();
 		}
 	});

--- a/packages/editor/packages/editor-state/src/features/tooltip/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/tooltip/effect.test.ts
@@ -44,7 +44,7 @@ describe('tooltip effect', () => {
 					} as never,
 				},
 			},
-			graphicHelper: {
+			codeBlockRendering: {
 				selectedCodeBlock: selectedBlock,
 			},
 			tooltip: {
@@ -124,7 +124,7 @@ describe('tooltip effect', () => {
 					} as never,
 				},
 			},
-			graphicHelper: {
+			codeBlockRendering: {
 				selectedCodeBlock: selectedBlock,
 			},
 			tooltip: {
@@ -177,7 +177,7 @@ describe('tooltip effect', () => {
 					} as never,
 				},
 			},
-			graphicHelper: {
+			codeBlockRendering: {
 				selectedCodeBlock: selectedBlock,
 			},
 			spriteLookups: {
@@ -216,7 +216,7 @@ describe('tooltip effect', () => {
 		expect(state.tooltip.lineCount).toBe(state.tooltip.text.length);
 		expect(state.tooltip.widthChars).toBeGreaterThanOrEqual(19);
 
-		store.set('graphicHelper.selectedCodeBlock.cursor.row', 1);
+		store.set('codeBlockRendering.selectedCodeBlock.cursor.row', 1);
 
 		expect(state.tooltip.liveValues).toEqual([]);
 	});
@@ -232,7 +232,7 @@ describe('tooltip effect', () => {
 			},
 		});
 		const state = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				selectedCodeBlock: selectedBlock,
 			},
 			tooltip: {
@@ -249,7 +249,7 @@ describe('tooltip effect', () => {
 			'type and pushes the result.',
 		]);
 
-		store.set('graphicHelper.selectedCodeBlock.cursor.row', 1);
+		store.set('codeBlockRendering.selectedCodeBlock.cursor.row', 1);
 
 		expect(state.tooltip.text).toEqual(['drop (T -- )', 'Removes the top value from the', 'stack.']);
 	});
@@ -273,7 +273,7 @@ describe('tooltip effect', () => {
 					'module-b': {} as never,
 				},
 			},
-			graphicHelper: {
+			codeBlockRendering: {
 				selectedCodeBlock: selectedBlock,
 			},
 			tooltip: {
@@ -286,7 +286,7 @@ describe('tooltip effect', () => {
 
 		expect(state.tooltip.text).toEqual(['Starts a module block.', 'execution order: 2']);
 
-		store.set('graphicHelper.selectedCodeBlock.cursor.row', 1);
+		store.set('codeBlockRendering.selectedCodeBlock.cursor.row', 1);
 
 		expect(state.tooltip.text).not.toContain('execution order: 2');
 	});
@@ -302,7 +302,7 @@ describe('tooltip effect', () => {
 			},
 		});
 		const state = createMockState({
-			graphicHelper: {
+			codeBlockRendering: {
 				selectedCodeBlock: selectedBlock,
 			},
 			tooltip: {
@@ -313,7 +313,7 @@ describe('tooltip effect', () => {
 
 		tooltip(store);
 
-		store.set('graphicHelper.selectedCodeBlock.code', ['drop']);
+		store.set('codeBlockRendering.selectedCodeBlock.code', ['drop']);
 
 		expect(state.tooltip.text).toEqual(['drop (T -- )', 'Removes the top value from the', 'stack.']);
 	});
@@ -324,7 +324,7 @@ describe('tooltip effect', () => {
 			featureFlags: {
 				codeLineSelection: false,
 			},
-			graphicHelper: {
+			codeBlockRendering: {
 				selectedCodeBlock: selectedBlock,
 			},
 			tooltip: {

--- a/packages/editor/packages/editor-state/src/features/tooltip/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/tooltip/effect.ts
@@ -75,7 +75,7 @@ export default function tooltip(store: StateManager<State>): void {
 	const state = store.getState();
 
 	function syncSelectedLineTooltip(): void {
-		const selectedCodeBlock = state.graphicHelper.selectedCodeBlock;
+		const selectedCodeBlock = state.codeBlockRendering.selectedCodeBlock;
 
 		if (!state.featureFlags.codeLineSelection || !selectedCodeBlock) {
 			store.set('tooltip', createEmptyTooltipState());
@@ -96,10 +96,10 @@ export default function tooltip(store: StateManager<State>): void {
 		store.set('tooltip', getTooltipState(content, state, selectedCodeBlock));
 	}
 
-	store.subscribe('graphicHelper.selectedCodeBlock', syncSelectedLineTooltip);
-	store.subscribe('graphicHelper.selectedCodeBlock.code', syncSelectedLineTooltip);
-	store.subscribe('graphicHelper.selectedCodeBlock.cursor.row', syncSelectedLineTooltip);
-	store.subscribe('graphicHelper.selectedCodeBlock.cursor.y', syncSelectedLineTooltip);
+	store.subscribe('codeBlockRendering.selectedCodeBlock', syncSelectedLineTooltip);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', syncSelectedLineTooltip);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.cursor.row', syncSelectedLineTooltip);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.cursor.y', syncSelectedLineTooltip);
 	store.subscribe('featureFlags.codeLineSelection', syncSelectedLineTooltip);
 	store.subscribe('compiler.compiledModules', syncSelectedLineTooltip);
 	store.subscribe('compiler.compiledFunctions', syncSelectedLineTooltip);

--- a/packages/editor/packages/editor-state/src/features/viewport/README.md
+++ b/packages/editor/packages/editor-state/src/features/viewport/README.md
@@ -22,12 +22,12 @@ Manages viewport interactions and transformations: panning, resizing, snap-to-gr
 
 ### State Touched
 
-- `state.graphicHelper.viewport.x` - Viewport horizontal position (pixels)
-- `state.graphicHelper.viewport.y` - Viewport vertical position (pixels)
-- `state.graphicHelper.viewport.vGrid` - Vertical grid size (pixels)
-- `state.graphicHelper.viewport.hGrid` - Horizontal grid size (pixels)
-- `state.graphicHelper.viewport.width` - Viewport width (pixels)
-- `state.graphicHelper.viewport.height` - Viewport height (pixels)
+- `state.codeBlockRendering.viewport.x` - Viewport horizontal position (pixels)
+- `state.codeBlockRendering.viewport.y` - Viewport vertical position (pixels)
+- `state.codeBlockRendering.viewport.vGrid` - Vertical grid size (pixels)
+- `state.codeBlockRendering.viewport.hGrid` - Horizontal grid size (pixels)
+- `state.codeBlockRendering.viewport.width` - Viewport width (pixels)
+- `state.codeBlockRendering.viewport.height` - Viewport height (pixels)
 
 ## Coordinate Systems
 

--- a/packages/editor/packages/editor-state/src/index.ts
+++ b/packages/editor/packages/editor-state/src/index.ts
@@ -2,7 +2,7 @@ import type { EventDispatcher, Options, State } from '@8f4e/editor-state-types';
 import createStateManager, { type StateManager } from '@8f4e/state-manager';
 import browserLocalNotes from './features/browser-local-notes/effect';
 import canvasScreenshot from './features/canvas-screenshot/effect';
-import graphicHelper from './features/code-blocks/effect';
+import codeBlockRendering from './features/code-blocks/effect';
 import autoEnvConstants from './features/code-blocks/features/auto-env-constants/effect';
 import blockTypeUpdater from './features/code-blocks/features/blockTypeUpdater/effect';
 import clearDebugProbes from './features/code-blocks/features/clearDebugProbes/effect';
@@ -112,7 +112,7 @@ export default function init(events: EventDispatcher, options: Options): StateMa
 	shaderEffectsDeriver(store, events); // Must run after blockTypeUpdater to derive shader effects
 	globalEditorDirectivesEffect(store);
 	compiler(store);
-	graphicHelper(store, events);
+	codeBlockRendering(store, events);
 	viewportDirectiveEffect(store, events);
 	entryOutlines(store);
 	browserLocalNotes(store, events);

--- a/packages/editor/packages/editor-state/src/pureHelpers/resolveMemoryIdentifier.ts
+++ b/packages/editor/packages/editor-state/src/pureHelpers/resolveMemoryIdentifier.ts
@@ -59,7 +59,7 @@ export default function resolveMemoryIdentifier(
 	}
 
 	if (operator === '*' && memory.pointeeBaseType) {
-		memory = state.graphicHelper.outputsByWordAddress.get(
+		memory = state.codeBlockRendering.outputsByWordAddress.get(
 			state.callbacks?.getWordFromMemory?.(memory.wordAlignedAddress) || 0
 		)?.memory;
 	}

--- a/packages/editor/packages/editor-state/src/pureHelpers/state/createDefaultState.ts
+++ b/packages/editor/packages/editor-state/src/pureHelpers/state/createDefaultState.ts
@@ -6,7 +6,7 @@ export default function createDefaultState() {
 			isCompiling: false,
 			compiledModules: {},
 		},
-		graphicHelper: {
+		codeBlockRendering: {
 			codeBlocks: [],
 			entryOutlines: [],
 			viewportAnchoredCodeBlocks: [],

--- a/packages/editor/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
+++ b/packages/editor/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
@@ -187,12 +187,12 @@ export function findWidgetById<T extends { id: string }>(array: T[], id: string)
 }
 
 /**
- * Helper to create a mock viewport for testing (GraphicHelper viewport type)
+ * Helper to create a mock viewport for testing (code block rendering viewport type)
  * @param x - X coordinate (defaults to 0)
  * @param y - Y coordinate (defaults to 0)
  * @param width - Viewport width (defaults to 800)
  * @param height - Viewport height (defaults to 600)
- * @returns A GraphicHelper viewport object
+ * @returns A code block rendering viewport object
  *
  * @example
  * const viewport = createMockViewport();
@@ -270,7 +270,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			},
 		},
 		defaultRuntimeId: 'WebWorkerRuntime',
-		graphicHelper: {
+		codeBlockRendering: {
 			codeBlocks: [],
 			entryOutlines: [],
 			viewportAnchoredCodeBlocks: [],

--- a/packages/editor/packages/editor-state/tests/code-blocks/viewportAnchoredDragging.test.ts
+++ b/packages/editor/packages/editor-state/tests/code-blocks/viewportAnchoredDragging.test.ts
@@ -50,7 +50,7 @@ describe('viewport-anchored dragging', () => {
 			blockType: 'module',
 		});
 
-		state.graphicHelper.codeBlocks = [block];
+		state.codeBlockRendering.codeBlocks = [block];
 
 		codeBlockDragger(store, events);
 
@@ -103,7 +103,7 @@ describe('viewport-anchored dragging', () => {
 			blockType: 'module',
 		});
 
-		state.graphicHelper.codeBlocks = [block];
+		state.codeBlockRendering.codeBlocks = [block];
 
 		codeBlockDragger(store, events);
 
@@ -153,7 +153,7 @@ describe('viewport-anchored dragging', () => {
 			blockType: 'module',
 		});
 
-		state.graphicHelper.codeBlocks = [block];
+		state.codeBlockRendering.codeBlocks = [block];
 
 		codeBlockDragger(store, events);
 

--- a/packages/editor/packages/editor-state/tests/menu/clipboard.test.ts
+++ b/packages/editor/packages/editor-state/tests/menu/clipboard.test.ts
@@ -48,7 +48,7 @@ describe('menus - clipboard callback disabled state', () => {
 			const mockCodeBlock = createMockCodeBlock({ id: 'test', blockType: 'module' });
 			const mockState = createMockState({
 				callbacks: { writeClipboardText: undefined },
-				graphicHelper: { selectedCodeBlock: mockCodeBlock },
+				codeBlockRendering: { selectedCodeBlock: mockCodeBlock },
 			});
 
 			const menu = moduleMenu(mockState as State);
@@ -62,7 +62,7 @@ describe('menus - clipboard callback disabled state', () => {
 			const mockCodeBlock = createMockCodeBlock({ id: 'test', blockType: 'module' });
 			const mockState = createMockState({
 				callbacks: { writeClipboardText: async () => {} },
-				graphicHelper: { selectedCodeBlock: mockCodeBlock },
+				codeBlockRendering: { selectedCodeBlock: mockCodeBlock },
 			});
 
 			const menu = moduleMenu(mockState as State);
@@ -76,7 +76,7 @@ describe('menus - clipboard callback disabled state', () => {
 			const mockCodeBlock = createMockCodeBlock({ id: 'test', blockType: 'function' });
 			const mockState = createMockState({
 				callbacks: { writeClipboardText: undefined },
-				graphicHelper: { selectedCodeBlock: mockCodeBlock },
+				codeBlockRendering: { selectedCodeBlock: mockCodeBlock },
 			});
 
 			const menu = moduleMenu(mockState as State);
@@ -90,7 +90,7 @@ describe('menus - clipboard callback disabled state', () => {
 			const mockCodeBlock = createMockCodeBlock({ id: 'test', blockType: 'note' });
 			const mockState = createMockState({
 				callbacks: { writeClipboardText: undefined },
-				graphicHelper: { selectedCodeBlock: mockCodeBlock },
+				codeBlockRendering: { selectedCodeBlock: mockCodeBlock },
 			});
 
 			const menu = moduleMenu(mockState as State);

--- a/packages/editor/packages/editor-state/tests/menu/mainMenu.test.ts
+++ b/packages/editor/packages/editor-state/tests/menu/mainMenu.test.ts
@@ -21,7 +21,7 @@ describe('menus - go home entry', () => {
 	it('shows "Go @home" even when no home block exists', () => {
 		const mockState = createMockState({
 			editorMode: 'edit',
-			graphicHelper: { codeBlocks: [] },
+			codeBlockRendering: { codeBlocks: [] },
 		});
 
 		const menu = mainMenu(mockState as State);

--- a/packages/editor/packages/web-ui/screenshot-tests/dragged-modules.test.ts
+++ b/packages/editor/packages/web-ui/screenshot-tests/dragged-modules.test.ts
@@ -36,9 +36,9 @@ test('dragged module', async () => {
 			codeColors: generateColorMapWithAllColors(mockState.spriteLookups),
 		});
 
-		mockState.graphicHelper.draggedCodeBlock = codeBlockMock;
+		mockState.codeBlockRendering.draggedCodeBlock = codeBlockMock;
 
-		mockState.graphicHelper.codeBlocks.push(codeBlockMock);
+		mockState.codeBlockRendering.codeBlocks.push(codeBlockMock);
 	}
 
 	await expect(canvas).toMatchScreenshot();

--- a/packages/editor/packages/web-ui/screenshot-tests/font-color-rendering.test.ts
+++ b/packages/editor/packages/web-ui/screenshot-tests/font-color-rendering.test.ts
@@ -57,7 +57,7 @@ test('font color rendering', async () => {
 		const codeLines = ['', colorName, ...lines.map(line => line.join('')), ''];
 		const codeToRender = codeLines.map(line => line.split('').map(char => char.charCodeAt(0)));
 
-		mockState.graphicHelper.codeBlocks.push(
+		mockState.codeBlockRendering.codeBlocks.push(
 			createMockCodeBlock({
 				id: `codeBlock${index}`,
 				x: (index % 4) * 8 * 32,

--- a/packages/editor/packages/web-ui/screenshot-tests/switches.test.ts
+++ b/packages/editor/packages/web-ui/screenshot-tests/switches.test.ts
@@ -51,14 +51,14 @@ test('switches', async () => {
 			},
 		});
 
-		mockState.graphicHelper.selectedCodeBlock = codeBlockMock;
+		mockState.codeBlockRendering.selectedCodeBlock = codeBlockMock;
 
-		mockState.graphicHelper.codeBlocks.push(codeBlockMock);
+		mockState.codeBlockRendering.codeBlocks.push(codeBlockMock);
 
 		const lines2 = ['not selected code block', '', '', '', '', '', '', '', ''];
 		const codeToRender2 = lines2.map(line => line.split('').map(char => char.charCodeAt(0)));
 
-		mockState.graphicHelper.codeBlocks.push(
+		mockState.codeBlockRendering.codeBlocks.push(
 			createMockCodeBlock({
 				x: 288,
 				y: 16,

--- a/packages/editor/packages/web-ui/src/drawers/codeBlocks/drawEntryOutlines.ts
+++ b/packages/editor/packages/web-ui/src/drawers/codeBlocks/drawEntryOutlines.ts
@@ -24,7 +24,7 @@ export default function drawEntryOutlines(engine: Engine, state: State): void {
 
 	engine.setSpriteLookup(state.spriteLookups.fillColors);
 
-	for (const outline of state.graphicHelper.entryOutlines) {
+	for (const outline of state.codeBlockRendering.entryOutlines) {
 		drawOutline(engine, outline, thickness);
 	}
 }

--- a/packages/editor/packages/web-ui/src/drawers/codeBlocks/drawSelectedLineHint.ts
+++ b/packages/editor/packages/web-ui/src/drawers/codeBlocks/drawSelectedLineHint.ts
@@ -90,7 +90,11 @@ export default function drawSelectedLineHint(
 ): void {
 	const spriteLookups = state.spriteLookups;
 
-	if (!spriteLookups || !state.featureFlags.codeLineSelection || state.graphicHelper.selectedCodeBlock !== codeBlock) {
+	if (
+		!spriteLookups ||
+		!state.featureFlags.codeLineSelection ||
+		state.codeBlockRendering.selectedCodeBlock !== codeBlock
+	) {
 		return;
 	}
 

--- a/packages/editor/packages/web-ui/src/drawers/codeBlocks/index.test.ts
+++ b/packages/editor/packages/web-ui/src/drawers/codeBlocks/index.test.ts
@@ -79,7 +79,7 @@ describe('drawModules', () => {
 			spriteLookups: {
 				fillColors: {},
 			} as never,
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [],
 				entryOutlines: [
 					{
@@ -153,7 +153,7 @@ describe('drawModules', () => {
 				fontLineNumber: {},
 				fontCodeComment: {},
 			} as never,
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [hiddenBlock],
 			},
 			featureFlags: {
@@ -190,7 +190,7 @@ describe('drawModules', () => {
 				fontLineNumber: {},
 				fontCodeComment: {},
 			} as never,
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [hiddenBlock],
 				showHiddenCodeBlocks: true,
 			},
@@ -271,7 +271,7 @@ describe('drawModules', () => {
 				fontLineNumber: {},
 				fontCodeComment: {},
 			} as never,
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [block],
 			},
 		});
@@ -318,7 +318,7 @@ describe('drawModules', () => {
 				fontTooltipHighlight,
 				fontTooltipText,
 			} as never,
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [block],
 				selectedCodeBlock: block,
 			},
@@ -462,7 +462,7 @@ describe('drawModules', () => {
 				fontTooltipHighlight: {},
 				fontTooltipText: {},
 			} as never,
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [block],
 				selectedCodeBlock: block,
 			},
@@ -556,7 +556,7 @@ describe('drawModules', () => {
 			spriteLookups: {
 				fontArrow: {},
 			} as never,
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [offscreenBlock],
 			},
 			viewport: {

--- a/packages/editor/packages/web-ui/src/drawers/codeBlocks/index.ts
+++ b/packages/editor/packages/web-ui/src/drawers/codeBlocks/index.ts
@@ -37,8 +37,8 @@ export default function drawModules(engine: Engine, state: State, memoryViews: M
 	engine.startGroup(offsetX, offsetY);
 	drawEntryOutlines(engine, state);
 
-	for (const codeBlock of state.graphicHelper.codeBlocks) {
-		const renderHiddenPreview = codeBlock.hidden && !state.graphicHelper.showHiddenCodeBlocks;
+	for (const codeBlock of state.codeBlockRendering.codeBlocks) {
+		const renderHiddenPreview = codeBlock.hidden && !state.codeBlockRendering.showHiddenCodeBlocks;
 
 		// Read position offsets from memory only if the feature is enabled
 		if (state.featureFlags.positionOffsetters) {
@@ -70,7 +70,7 @@ export default function drawModules(engine: Engine, state: State, memoryViews: M
 					if (!renderHiddenPreview) {
 						engine.setSpriteLookup(spriteLookups.fillColors);
 
-						if (codeBlock === state.graphicHelper.draggedCodeBlock) {
+						if (codeBlock === state.codeBlockRendering.draggedCodeBlock) {
 							engine.drawSprite(0, 0, 'moduleBackgroundDragged', codeBlock.width, codeBlock.height);
 						} else if (codeBlock.disabled) {
 							engine.drawSprite(0, 0, 'moduleBackgroundDisabled', codeBlock.width, codeBlock.height);
@@ -80,13 +80,15 @@ export default function drawModules(engine: Engine, state: State, memoryViews: M
 
 						drawBlockHighlights(engine, state, codeBlock);
 
-						if (state.featureFlags.codeLineSelection && state.graphicHelper.selectedCodeBlock === codeBlock) {
+						if (state.featureFlags.codeLineSelection && state.codeBlockRendering.selectedCodeBlock === codeBlock) {
 							engine.drawSprite(0, codeBlock.cursor.y, 'highlightedCodeLine', codeBlock.width, state.viewport.hGrid);
 						}
 					}
 
 					engine.setSpriteLookup(
-						state.graphicHelper.selectedCodeBlock === codeBlock ? spriteLookups.fontNumbers : spriteLookups.fontCode
+						state.codeBlockRendering.selectedCodeBlock === codeBlock
+							? spriteLookups.fontNumbers
+							: spriteLookups.fontCode
 					);
 
 					engine.drawText(0, 0, corner);
@@ -120,16 +122,16 @@ export default function drawModules(engine: Engine, state: State, memoryViews: M
 						}
 					}
 
-					if (state.featureFlags.editing && state.graphicHelper.selectedCodeBlock === codeBlock) {
+					if (state.featureFlags.editing && state.codeBlockRendering.selectedCodeBlock === codeBlock) {
 						engine.drawText(codeBlock.cursor.x, codeBlock.cursor.y, '_');
 					}
 				},
 				// Enable caching only when the block is NOT selected
-				state.graphicHelper.selectedCodeBlock !== codeBlock,
+				state.codeBlockRendering.selectedCodeBlock !== codeBlock,
 				codeBlock.opacity
 			);
 
-			if (state.editorMode === 'presentation' && state.graphicHelper.selectedCodeBlock === codeBlock) {
+			if (state.editorMode === 'presentation' && state.codeBlockRendering.selectedCodeBlock === codeBlock) {
 				drawSelectedOutline(engine, state, codeBlock.width, codeBlock.height);
 			}
 

--- a/packages/editor/packages/web-ui/src/drawers/codeBlocks/widgets/connections.test.ts
+++ b/packages/editor/packages/web-ui/src/drawers/codeBlocks/widgets/connections.test.ts
@@ -95,7 +95,7 @@ describe('drawConnections', () => {
 			spriteLookups: {
 				fillColors: {},
 			} as never,
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [inputBlock, outputBlock],
 				selectedCodeBlock: inputBlock,
 				outputsByWordAddress: new Map([[80, output]]),

--- a/packages/editor/packages/web-ui/src/drawers/codeBlocks/widgets/connections.ts
+++ b/packages/editor/packages/web-ui/src/drawers/codeBlocks/widgets/connections.ts
@@ -14,8 +14,8 @@ export default function drawConnections(engine: Engine, state: State, memoryView
 
 	engine.startGroup(-state.viewport.x, -state.viewport.y);
 
-	for (const codeBlock of state.graphicHelper.codeBlocks) {
-		const isSelected = codeBlock === state.graphicHelper.selectedCodeBlock;
+	for (const codeBlock of state.codeBlockRendering.codeBlocks) {
+		const isSelected = codeBlock === state.codeBlockRendering.selectedCodeBlock;
 
 		if (!codeBlock.moduleId) {
 			continue;
@@ -28,7 +28,7 @@ export default function drawConnections(engine: Engine, state: State, memoryView
 				continue;
 			}
 
-			const output = state.graphicHelper.outputsByWordAddress.get(outputAddress);
+			const output = state.codeBlockRendering.outputsByWordAddress.get(outputAddress);
 
 			if (!output) {
 				continue;

--- a/packages/editor/packages/web-ui/src/drawers/infoOverlay.ts
+++ b/packages/editor/packages/web-ui/src/drawers/infoOverlay.ts
@@ -41,8 +41,8 @@ export default function drawInfoOverlay(
 	const debugText: string[] = [];
 
 	const selectedModule =
-		state.graphicHelper.selectedCodeBlock && state.graphicHelper.selectedCodeBlock.moduleId
-			? state.compiler.compiledModules[state.graphicHelper.selectedCodeBlock.moduleId]
+		state.codeBlockRendering.selectedCodeBlock && state.codeBlockRendering.selectedCodeBlock.moduleId
+			? state.compiler.compiledModules[state.codeBlockRendering.selectedCodeBlock.moduleId]
 			: undefined;
 
 	if (selectedModule) {

--- a/packages/editor/src/editorEnvironmentPlugins/binaryAssets/directiveSync.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/binaryAssets/directiveSync.ts
@@ -21,7 +21,7 @@ export default function createBinaryAssetDirectiveSync({
 
 	async function syncBinaryAssetsFromDirectives(): Promise<void> {
 		const state = store.getState();
-		const parsed = parseBinaryAssetDirectives(state.graphicHelper.codeBlocks);
+		const parsed = parseBinaryAssetDirectives(state.codeBlockRendering.codeBlocks);
 		const loadRequests = parsed.loadDirectives
 			.map(loadDirective => {
 				const definition = parsed.definitionsById.get(loadDirective.assetId);
@@ -102,14 +102,14 @@ export default function createBinaryAssetDirectiveSync({
 		}
 	}
 
-	store.subscribe('graphicHelper.codeBlocks', syncBinaryAssetsFromDirectives);
-	store.subscribe('graphicHelper.selectedCodeBlock.code', syncBinaryAssetsFromDirectives);
+	store.subscribe('codeBlockRendering.codeBlocks', syncBinaryAssetsFromDirectives);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', syncBinaryAssetsFromDirectives);
 
 	void syncBinaryAssetsFromDirectives();
 
 	return () => {
 		fetchGeneration++;
-		store.unsubscribe('graphicHelper.codeBlocks', syncBinaryAssetsFromDirectives);
-		store.unsubscribe('graphicHelper.selectedCodeBlock.code', syncBinaryAssetsFromDirectives);
+		store.unsubscribe('codeBlockRendering.codeBlocks', syncBinaryAssetsFromDirectives);
+		store.unsubscribe('codeBlockRendering.selectedCodeBlock.code', syncBinaryAssetsFromDirectives);
 	};
 }

--- a/packages/editor/src/editorEnvironmentPlugins/binaryAssets/plugin.test.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/binaryAssets/plugin.test.ts
@@ -25,7 +25,7 @@ function createState({
 	byteAddress?: number;
 } = {}): State {
 	return {
-		graphicHelper: {
+		codeBlockRendering: {
 			codeBlocks: [
 				{
 					moduleId: 'samples',
@@ -162,7 +162,7 @@ describe('binary assets plugin', () => {
 		});
 		await flushPromises();
 
-		store.set('graphicHelper.codeBlocks', [
+		store.set('codeBlockRendering.codeBlocks', [
 			{
 				moduleId: 'samples',
 				code: [
@@ -172,7 +172,7 @@ describe('binary assets plugin', () => {
 					'moduleEnd',
 				],
 			},
-		] as State['graphicHelper']['codeBlocks']);
+		] as State['codeBlockRendering']['codeBlocks']);
 		await flushPromises();
 
 		store.set('compiler.compiledModules', {
@@ -232,7 +232,7 @@ describe('binary assets plugin', () => {
 		await flushPromises();
 		expect(store.getState().binaryAssets[0].assetByteLength).toBe(12);
 
-		store.set('graphicHelper.codeBlocks', [
+		store.set('codeBlockRendering.codeBlocks', [
 			{
 				moduleId: 'samples',
 				code: [
@@ -242,7 +242,7 @@ describe('binary assets plugin', () => {
 					'moduleEnd',
 				],
 			},
-		] as State['graphicHelper']['codeBlocks']);
+		] as State['codeBlockRendering']['codeBlocks']);
 
 		expect(store.getState().binaryAssets).toEqual([]);
 
@@ -286,14 +286,14 @@ describe('binary assets plugin', () => {
 		});
 		expect(store.getState().binaryAssets).toEqual([]);
 
-		store.set('graphicHelper.codeBlocks', [
-			...store.getState().graphicHelper.codeBlocks,
+		store.set('codeBlockRendering.codeBlocks', [
+			...store.getState().codeBlockRendering.codeBlocks,
 			{
 				id: 'constants_env',
 				moduleId: 'env',
 				code: ['constants env', 'constantsEnd'],
 			},
-		] as State['graphicHelper']['codeBlocks']);
+		] as State['codeBlockRendering']['codeBlocks']);
 		expect(store.getState().binaryAssets).toEqual([]);
 
 		resolveFetch([

--- a/packages/editor/src/editorEnvironmentPlugins/codeBlocks.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/codeBlocks.ts
@@ -1,8 +1,8 @@
 import type { CodeBlockGraphicData, State } from '@8f4e/editor-state-types';
 
 export function getActiveCodeBlocksForEnvironmentPlugins(state: State): CodeBlockGraphicData[] {
-	const blocks = [...state.graphicHelper.codeBlocks];
-	const selectedBlock = state.graphicHelper.selectedCodeBlock;
+	const blocks = [...state.codeBlockRendering.codeBlocks];
+	const selectedBlock = state.codeBlockRendering.selectedCodeBlock;
 
 	if (selectedBlock && !blocks.some(block => block.id === selectedBlock.id)) {
 		blocks.push(selectedBlock);

--- a/packages/editor/src/editorEnvironmentPlugins/manager.test.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/manager.test.ts
@@ -6,7 +6,7 @@ import type { EditorEnvironmentPluginContext, EditorEnvironmentPluginRegistryEnt
 
 function createState(codeBlocks: CodeBlockGraphicData[] = []): State {
 	return {
-		graphicHelper: {
+		codeBlockRendering: {
 			codeBlocks,
 		},
 		codeErrors: {
@@ -72,7 +72,7 @@ describe('editor environment plugin manager', () => {
 
 		expect(load).not.toHaveBeenCalled();
 
-		store.set('graphicHelper.codeBlocks', [createCodeBlockWithEditorDirective('testDirective')]);
+		store.set('codeBlockRendering.codeBlocks', [createCodeBlockWithEditorDirective('testDirective')]);
 		await flushPromises();
 
 		expect(load).toHaveBeenCalledTimes(1);
@@ -112,7 +112,7 @@ describe('editor environment plugin manager', () => {
 		});
 		await flushPromises();
 
-		store.set('graphicHelper.codeBlocks', []);
+		store.set('codeBlockRendering.codeBlocks', []);
 
 		expect(dispose).toHaveBeenCalledTimes(1);
 	});
@@ -147,7 +147,7 @@ describe('editor environment plugin manager', () => {
 
 		expect(store.getState().codeErrors.editorDirectiveErrors).toEqual([{ ...pluginError, ownerId: 'test-plugin' }]);
 
-		store.set('graphicHelper.codeBlocks', []);
+		store.set('codeBlockRendering.codeBlocks', []);
 
 		expect(store.getState().codeErrors.editorDirectiveErrors).toEqual([]);
 	});
@@ -178,8 +178,8 @@ describe('editor environment plugin manager', () => {
 			registry,
 		});
 
-		store.set('graphicHelper.codeBlocks', [createCodeBlockWithEditorDirective('testDirective')]);
-		store.set('graphicHelper.codeBlocks', []);
+		store.set('codeBlockRendering.codeBlocks', [createCodeBlockWithEditorDirective('testDirective')]);
+		store.set('codeBlockRendering.codeBlocks', []);
 
 		resolveLoad({ default: start });
 		await flushPromises();

--- a/packages/editor/src/editorEnvironmentPlugins/manager.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/manager.ts
@@ -154,15 +154,15 @@ export function createEditorEnvironmentPluginManager(
 		}
 	}
 
-	store.subscribe('graphicHelper.codeBlocks', syncPlugins);
-	store.subscribe('graphicHelper.selectedCodeBlock.code', syncPlugins);
+	store.subscribe('codeBlockRendering.codeBlocks', syncPlugins);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', syncPlugins);
 
 	syncPlugins();
 
 	return () => {
 		disposed = true;
-		store.unsubscribe('graphicHelper.codeBlocks', syncPlugins);
-		store.unsubscribe('graphicHelper.selectedCodeBlock.code', syncPlugins);
+		store.unsubscribe('codeBlockRendering.codeBlocks', syncPlugins);
+		store.unsubscribe('codeBlockRendering.selectedCodeBlock.code', syncPlugins);
 
 		for (const entry of registry) {
 			disposePlugin(entry);

--- a/packages/editor/src/editorEnvironmentPlugins/midi/directives.test.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/midi/directives.test.ts
@@ -23,7 +23,7 @@ function codeBlock(id: string, directives: ParsedDirectiveRecord[]): CodeBlockGr
 
 function stateWithBlocks(blocks: CodeBlockGraphicData[]): State {
 	return {
-		graphicHelper: {
+		codeBlockRendering: {
 			codeBlocks: blocks,
 		},
 	} as unknown as State;

--- a/packages/editor/src/editorEnvironmentPlugins/midi/midiIn.test.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/midi/midiIn.test.ts
@@ -31,7 +31,7 @@ function codeBlock(id: string, directives: ParsedDirectiveRecord[]): CodeBlockGr
 
 function createStore(blocks: CodeBlockGraphicData[]) {
 	return createStateManager({
-		graphicHelper: {
+		codeBlockRendering: {
 			codeBlocks: blocks,
 		},
 		compiler: {

--- a/packages/editor/src/editorEnvironmentPlugins/midi/midiIn.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/midi/midiIn.ts
@@ -209,8 +209,8 @@ export default function createMidiIn({ store, setErrors, getInputPort, getWasmEx
 			});
 	}
 
-	store.subscribe('graphicHelper.codeBlocks', sync);
-	store.subscribe('graphicHelper.selectedCodeBlock.code', sync);
+	store.subscribe('codeBlockRendering.codeBlocks', sync);
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', sync);
 	store.subscribe('compiler.isCompiling', sync);
 	sync();
 
@@ -220,8 +220,8 @@ export default function createMidiIn({ store, setErrors, getInputPort, getWasmEx
 			disposed = true;
 			syncGeneration++;
 			removeInputListeners(activeListeners);
-			store.unsubscribe('graphicHelper.codeBlocks', sync);
-			store.unsubscribe('graphicHelper.selectedCodeBlock.code', sync);
+			store.unsubscribe('codeBlockRendering.codeBlocks', sync);
+			store.unsubscribe('codeBlockRendering.selectedCodeBlock.code', sync);
 			store.unsubscribe('compiler.isCompiling', sync);
 		},
 	};

--- a/packages/editor/src/editorEnvironmentPlugins/midi/plugin.test.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/midi/plugin.test.ts
@@ -8,7 +8,7 @@ function createContext(): EditorEnvironmentPluginContext {
 	return {
 		store: createStateManager({
 			info: {},
-			graphicHelper: {
+			codeBlockRendering: {
 				codeBlocks: [],
 			},
 			compiler: {

--- a/packages/editor/src/events/keyboardEvents.test.ts
+++ b/packages/editor/src/events/keyboardEvents.test.ts
@@ -52,7 +52,7 @@ describe('keyboardEvents mode switching', () => {
 	let mockWindow: MockWindow;
 	let featureFlags: State['featureFlags'];
 	let editorMode: State['editorMode'];
-	let graphicHelper: Pick<State['graphicHelper'], 'showHiddenCodeBlocks'>;
+	let codeBlockRendering: Pick<State['codeBlockRendering'], 'showHiddenCodeBlocks'>;
 	let set: ReturnType<typeof vi.fn>;
 	let events: EventDispatcher;
 	let store: StateManager<State>;
@@ -74,11 +74,11 @@ describe('keyboardEvents mode switching', () => {
 			positionOffsetters: true,
 		};
 		editorMode = 'view';
-		graphicHelper = { showHiddenCodeBlocks: false };
+		codeBlockRendering = { showHiddenCodeBlocks: false };
 
 		set = vi.fn((path: string, value: unknown) => {
-			if (path === 'graphicHelper.showHiddenCodeBlocks') {
-				graphicHelper.showHiddenCodeBlocks = value as boolean;
+			if (path === 'codeBlockRendering.showHiddenCodeBlocks') {
+				codeBlockRendering.showHiddenCodeBlocks = value as boolean;
 			}
 			if (path === 'featureFlags.positionOffsetters') {
 				featureFlags.positionOffsetters = value as boolean;
@@ -92,7 +92,7 @@ describe('keyboardEvents mode switching', () => {
 		};
 
 		store = {
-			getState: () => ({ featureFlags, editorMode, graphicHelper }) as State,
+			getState: () => ({ featureFlags, editorMode, codeBlockRendering }) as State,
 			set,
 		} as unknown as StateManager<State>;
 	});
@@ -235,14 +235,14 @@ describe('keyboardEvents mode switching', () => {
 
 		mockWindow.emit('keydown', keydownEvent);
 
-		expect(set).toHaveBeenCalledWith('graphicHelper.showHiddenCodeBlocks', true);
-		expect(graphicHelper.showHiddenCodeBlocks).toBe(true);
+		expect(set).toHaveBeenCalledWith('codeBlockRendering.showHiddenCodeBlocks', true);
+		expect(codeBlockRendering.showHiddenCodeBlocks).toBe(true);
 		expect(keydownEvent.preventDefault as ReturnType<typeof vi.fn>).toHaveBeenCalled();
 
 		mockWindow.emit('keyup', keyupEvent);
 
-		expect(set).toHaveBeenCalledWith('graphicHelper.showHiddenCodeBlocks', false);
-		expect(graphicHelper.showHiddenCodeBlocks).toBe(false);
+		expect(set).toHaveBeenCalledWith('codeBlockRendering.showHiddenCodeBlocks', false);
+		expect(codeBlockRendering.showHiddenCodeBlocks).toBe(false);
 		expect(keyupEvent.preventDefault as ReturnType<typeof vi.fn>).toHaveBeenCalled();
 		cleanup();
 	});

--- a/packages/editor/src/events/keyboardEvents.ts
+++ b/packages/editor/src/events/keyboardEvents.ts
@@ -93,8 +93,8 @@ export default function keyboardEvents(events: EventDispatcher, store: StateMana
 
 		if (key === 'F9') {
 			event.preventDefault();
-			if (!state.graphicHelper.showHiddenCodeBlocks) {
-				store.set('graphicHelper.showHiddenCodeBlocks', true);
+			if (!state.codeBlockRendering.showHiddenCodeBlocks) {
+				store.set('codeBlockRendering.showHiddenCodeBlocks', true);
 			}
 			return;
 		}
@@ -203,8 +203,8 @@ export default function keyboardEvents(events: EventDispatcher, store: StateMana
 
 		event.preventDefault();
 
-		if (store.getState().graphicHelper.showHiddenCodeBlocks) {
-			store.set('graphicHelper.showHiddenCodeBlocks', false);
+		if (store.getState().codeBlockRendering.showHiddenCodeBlocks) {
+			store.set('codeBlockRendering.showHiddenCodeBlocks', false);
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Rename root editor state `graphicHelper` to `codeBlockRendering`
- Rename the exported `GraphicHelper` type to `CodeBlockRendering`
- Update store subscription paths, tests, web-ui drawers, editor plugins, and package-local docs to use the new state name
- Run git housekeeping to clear the stale gc warning and prune unreachable loose objects

## Verification
- `npx biome check --write packages/editor/packages/editor-state-types/src packages/editor/packages/editor-state/src packages/editor/packages/editor-state-testing/src packages/editor/packages/web-ui/src packages/editor/packages/web-ui/screenshot-tests packages/editor/src`
- `npx nx run @8f4e/editor-state-types:typecheck`
- `npx nx run @8f4e/editor-state:typecheck`
- `npx nx run @8f4e/web-ui:typecheck`
- `npx nx run @8f4e/editor:typecheck`
- `npx nx run @8f4e/editor-state:test`
- `npx nx run @8f4e/web-ui:test`
- `npx nx run @8f4e/editor:test`
- `npx nx run-many --target=typecheck --all`
- `npx nx run-many --target=test --all`
- pre-commit: Biome and affected typecheck