### PR TITLE
fix(editor): remove default runtime

### DIFF
--- a/packages/editor/docs/editor-directives.md
+++ b/packages/editor/docs/editor-directives.md
@@ -784,7 +784,8 @@ Select the runtime host the editor should load for the project.
 
 - `runtimeId` must be a known runtime id such as `WebWorkerRuntime`, `MainThreadRuntime`, or `AudioWorkletRuntime`
 - Duplicate declarations use normal config last-write-wins behavior
-- Unknown runtime ids produce an editor error and the editor falls back to the default runtime
+- If no runtime is configured, the editor does not load a runtime
+- Unknown runtime ids produce an editor error and no runtime is loaded
 
 **Example**:
 

--- a/packages/editor/packages/editor-state-testing/src/index.ts
+++ b/packages/editor/packages/editor-state-testing/src/index.ts
@@ -141,7 +141,6 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 				factory: mockRuntimeFactory,
 			},
 		},
-		defaultRuntimeId: 'WebWorkerRuntime',
 		graphicHelper: {
 			codeBlocks: [],
 			entryOutlines: [],

--- a/packages/editor/packages/editor-state-types/src/index.ts
+++ b/packages/editor/packages/editor-state-types/src/index.ts
@@ -346,11 +346,6 @@ export interface Options {
 	 * Runtime registry mapping runtime IDs to runtime implementations.
 	 */
 	runtimeRegistry: RuntimeRegistry;
-	/**
-	 * Default runtime ID to use when no runtime is specified or when an unknown runtime ID is encountered.
-	 * Must match a key in the runtimeRegistry.
-	 */
-	defaultRuntimeId: string;
 	/** Optional host-provided schema contributions for project-level editor config. */
 	editorConfigSchemaContributions?: EditorConfigSchemaContributionRegistry;
 }
@@ -386,8 +381,6 @@ export interface State {
 	};
 	/** Runtime registry for available runtime implementations */
 	runtimeRegistry: RuntimeRegistry;
-	/** Default runtime ID to use when no runtime is specified */
-	defaultRuntimeId: string;
 	/** Resolved global editor directives from `; @<name>` comments */
 	globalEditorDirectives: ResolvedGlobalEditorDirectives;
 	codeErrors: {

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/auto-env-constants/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/auto-env-constants/effect.test.ts
@@ -56,7 +56,10 @@ describe('autoEnvConstants', () => {
 					factory: () => () => {},
 				},
 			},
-			defaultRuntimeId: 'WebWorkerRuntime',
+			editorConfig: {
+				...createDefaultState().editorConfig,
+				runtime: 'WebWorkerRuntime',
+			},
 			initialProjectState: {
 				...EMPTY_DEFAULT_PROJECT,
 			},
@@ -123,7 +126,6 @@ describe('autoEnvConstants', () => {
 				factory: () => () => {},
 			},
 		});
-		store.set('defaultRuntimeId', 'SecondaryRuntime');
 		store.set('editorConfig.runtime', 'SecondaryRuntime');
 		store.set('initialProjectState', { ...PROJECT_WITH_CODE_BLOCK });
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/auto-env-constants/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/auto-env-constants/effect.ts
@@ -29,12 +29,8 @@ function generateEnvConstantsBlock(state: State, existingPos?: { x: number; y: n
 	lines.push('; Changes will be overwritten');
 	lines.push('');
 
-	const runtimeEntry = getSelectedRuntimeEntry(
-		state.editorConfig.runtime,
-		state.runtimeRegistry,
-		state.defaultRuntimeId
-	);
-	lines.push(...(runtimeEntry.getEnvConstants?.(state.editorConfig) ?? []));
+	const runtimeEntry = getSelectedRuntimeEntry(state.editorConfig.runtime, state.runtimeRegistry);
+	lines.push(...(runtimeEntry?.getEnvConstants?.(state.editorConfig) ?? []));
 
 	// Binary asset sizes
 	const binaryAssets = state.binaryAssets || [];

--- a/packages/editor/packages/editor-state/src/features/runtime/README.md
+++ b/packages/editor/packages/editor-state/src/features/runtime/README.md
@@ -10,7 +10,7 @@ Manages the lifecycle of runtime instances that execute compiled 8f4e programs. 
 - **Runtime Selection**: Determines which runtime to use from `state.editorConfig.runtime`
 - **Lifecycle Management**: Creates and destroys runtime instances as needed
 - **Runtime Switching**: Recreates runtime when the selected runtime changes
-- **Fallback Handling**: Falls back to default runtime ID if unknown runtime is requested
+- **No Default Runtime**: Does not initialize a runtime unless `state.editorConfig.runtime` names a registered runtime
 - **Initialization Locking**: Prevents concurrent initialization attempts
 
 ## Runtime Registry
@@ -48,7 +48,6 @@ strings must match exactly. Each entry contains a `factory` function that create
 ### State Touched
 
 - `state.runtimeRegistry` - Registry of available runtime factories
-- `state.defaultRuntimeId` - Fallback runtime identifier
 - `state.editorConfig.runtime` - Selected runtime id
 
 ## Integration Points
@@ -82,5 +81,5 @@ Runtime lifecycle events are logged:
 - Only one runtime can be active at a time
 - Runtime switching requires destroying previous runtime completely
 - Initialization is locked to prevent race conditions
-- Unknown runtimes fall back to default silently (with log message)
+- Missing or unknown runtime selections leave the editor without an active runtime
 - Runtime factories must be registered before runtime feature initializes

--- a/packages/editor/packages/editor-state/src/features/runtime/__tests__/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/runtime/__tests__/effect.test.ts
@@ -24,7 +24,6 @@ describe('Runtime System', () => {
 						factory: mainThreadRuntimeFactory,
 					},
 				},
-				defaultRuntimeId: 'AudioWorkletRuntime',
 			});
 
 			const store = createStateManager(state);
@@ -73,7 +72,6 @@ describe('Runtime System', () => {
 						factory: webWorkerRuntimeFactory,
 					},
 				},
-				defaultRuntimeId: 'AudioWorkletRuntime',
 			});
 
 			const store = createStateManager(state);
@@ -122,7 +120,7 @@ describe('Runtime System', () => {
 						factory: () => () => {},
 					},
 				},
-				defaultRuntimeId: 'WebWorkerRuntime',
+				editorConfig: { runtime: 'WebWorkerRuntime' },
 			});
 
 			const store = createStateManager(state);
@@ -135,6 +133,29 @@ describe('Runtime System', () => {
 				'runtime:WebWorkerRuntime',
 				'runtime:AudioWorkletRuntime',
 			]);
+		});
+
+		it('should not initialize a runtime when no runtime is selected', async () => {
+			const webWorkerRuntimeFactory = vi.fn(() => () => {});
+			const state = createMockState({
+				runtimeRegistry: {
+					WebWorkerRuntime: {
+						id: 'WebWorkerRuntime',
+						factory: webWorkerRuntimeFactory,
+					},
+				},
+			});
+
+			const store = createStateManager(state);
+			const events = createMockEventDispatcherWithVitest();
+
+			await runtimeEffect(store, events);
+
+			store.set('compiler.isCompiling', true);
+			store.set('compiler.isCompiling', false);
+			await new Promise(resolve => setTimeout(resolve, 10));
+
+			expect(webWorkerRuntimeFactory).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/editor/packages/editor-state/src/features/runtime/editorConfig.test.ts
+++ b/packages/editor/packages/editor-state/src/features/runtime/editorConfig.test.ts
@@ -31,32 +31,35 @@ const runtimeRegistry = {
 };
 
 describe('runtime editor config', () => {
-	it('resolves selected runtime ids with default fallback', () => {
-		expect(resolveSelectedRuntimeId('AudioWorkletRuntime', runtimeRegistry, 'WebWorkerRuntime')).toBe(
-			'AudioWorkletRuntime'
-		);
-		expect(resolveSelectedRuntimeId('UnknownRuntime', runtimeRegistry, 'WebWorkerRuntime')).toBe('WebWorkerRuntime');
-		expect(resolveSelectedRuntimeId('toString', runtimeRegistry, 'WebWorkerRuntime')).toBe('WebWorkerRuntime');
-		expect(resolveSelectedRuntimeId(undefined, runtimeRegistry, 'WebWorkerRuntime')).toBe('WebWorkerRuntime');
+	it('resolves only registered runtime ids', () => {
+		expect(resolveSelectedRuntimeId('AudioWorkletRuntime', runtimeRegistry)).toBe('AudioWorkletRuntime');
+		expect(resolveSelectedRuntimeId('UnknownRuntime', runtimeRegistry)).toBeUndefined();
+		expect(resolveSelectedRuntimeId('toString', runtimeRegistry)).toBeUndefined();
+		expect(resolveSelectedRuntimeId(undefined, runtimeRegistry)).toBeUndefined();
 	});
 
 	it('resolves the selected runtime registry entry', () => {
-		expect(getSelectedRuntimeEntry('AudioWorkletRuntime', runtimeRegistry, 'WebWorkerRuntime').id).toBe(
-			'AudioWorkletRuntime'
-		);
+		expect(getSelectedRuntimeEntry('AudioWorkletRuntime', runtimeRegistry)?.id).toBe('AudioWorkletRuntime');
+		expect(getSelectedRuntimeEntry(undefined, runtimeRegistry)).toBeUndefined();
 	});
 
 	it('collects runtime editor config schema contributions with the selected runtime first', () => {
-		expect(
-			Object.keys(
-				collectRuntimeEditorConfigSchemaContributions('AudioWorkletRuntime', runtimeRegistry, 'WebWorkerRuntime')
-			)
-		).toEqual(['runtime:AudioWorkletRuntime', 'runtime:WebWorkerRuntime']);
+		expect(Object.keys(collectRuntimeEditorConfigSchemaContributions('AudioWorkletRuntime', runtimeRegistry))).toEqual([
+			'runtime:AudioWorkletRuntime',
+			'runtime:WebWorkerRuntime',
+		]);
+	});
+
+	it('collects runtime editor config schema contributions without selecting a runtime', () => {
+		expect(Object.keys(collectRuntimeEditorConfigSchemaContributions(undefined, runtimeRegistry))).toEqual([
+			'runtime:WebWorkerRuntime',
+			'runtime:AudioWorkletRuntime',
+		]);
 	});
 
 	it('validates runtime selection values', () => {
 		const store = {
-			getState: () => ({ editorConfig: {}, runtimeRegistry, defaultRuntimeId: 'WebWorkerRuntime' }),
+			getState: () => ({ editorConfig: {}, runtimeRegistry }),
 		} as StateManager<State>;
 		const validator = createRuntimeSelectionEditorConfigValidator(store);
 

--- a/packages/editor/packages/editor-state/src/features/runtime/editorConfig.ts
+++ b/packages/editor/packages/editor-state/src/features/runtime/editorConfig.ts
@@ -16,39 +16,36 @@ function isRegisteredRuntimeId(runtimeRegistry: RuntimeRegistry, runtimeId: stri
 
 export function resolveSelectedRuntimeId(
 	requestedRuntimeId: string | undefined,
-	runtimeRegistry: RuntimeRegistry,
-	defaultRuntimeId: string
-): string {
+	runtimeRegistry: RuntimeRegistry
+): string | undefined {
 	if (requestedRuntimeId && isRegisteredRuntimeId(runtimeRegistry, requestedRuntimeId)) {
 		return requestedRuntimeId;
 	}
 
-	return defaultRuntimeId;
+	return undefined;
 }
 
 export function getSelectedRuntimeEntry(
 	requestedRuntimeId: string | undefined,
-	runtimeRegistry: RuntimeRegistry,
-	defaultRuntimeId: string
-): RuntimeRegistryEntry {
-	const resolvedRuntimeId = resolveSelectedRuntimeId(requestedRuntimeId, runtimeRegistry, defaultRuntimeId);
-	return runtimeRegistry[resolvedRuntimeId];
+	runtimeRegistry: RuntimeRegistry
+): RuntimeRegistryEntry | undefined {
+	const resolvedRuntimeId = resolveSelectedRuntimeId(requestedRuntimeId, runtimeRegistry);
+	return resolvedRuntimeId ? runtimeRegistry[resolvedRuntimeId] : undefined;
 }
 
 export function collectRuntimeEditorConfigSchemaContributions(
 	requestedRuntimeId: string | undefined,
-	runtimeRegistry: RuntimeRegistry,
-	defaultRuntimeId: string
+	runtimeRegistry: RuntimeRegistry
 ): EditorConfigSchemaContributionRegistry {
 	const contributions: EditorConfigSchemaContributionRegistry = {};
-	const selectedEntry = getSelectedRuntimeEntry(requestedRuntimeId, runtimeRegistry, defaultRuntimeId);
+	const selectedEntry = getSelectedRuntimeEntry(requestedRuntimeId, runtimeRegistry);
 
-	if (selectedEntry.editorConfigSchema) {
+	if (selectedEntry?.editorConfigSchema) {
 		contributions[`runtime:${selectedEntry.id}`] = selectedEntry.editorConfigSchema;
 	}
 
 	for (const entry of Object.values(runtimeRegistry)) {
-		if (entry.id === selectedEntry.id || !entry.editorConfigSchema) {
+		if (entry.id === selectedEntry?.id || !entry.editorConfigSchema) {
 			continue;
 		}
 		contributions[`runtime:${entry.id}`] = entry.editorConfigSchema;

--- a/packages/editor/packages/editor-state/src/features/runtime/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/runtime/effect.ts
@@ -14,7 +14,7 @@ export default async function runtime(store: StateManager<State>, events: EventD
 	const state = store.getState();
 
 	let runtimeDestroyer: null | (() => void) = null;
-	let onlineRuntime: null | string;
+	let onlineRuntime: null | string = null;
 	let isInitializing = false;
 
 	async function initOrDestroyOrUpdateRuntime() {
@@ -23,14 +23,10 @@ export default async function runtime(store: StateManager<State>, events: EventD
 			return;
 		}
 
-		const selectedRuntimeId = resolveSelectedRuntimeId(
-			state.editorConfig.runtime,
-			state.runtimeRegistry,
-			state.defaultRuntimeId
-		);
-		const selectedRuntimeEntry = state.runtimeRegistry[selectedRuntimeId];
+		const selectedRuntimeId = resolveSelectedRuntimeId(state.editorConfig.runtime, state.runtimeRegistry);
+		const nextRuntimeId = selectedRuntimeId ?? null;
 
-		if (onlineRuntime === selectedRuntimeId) {
+		if (onlineRuntime === nextRuntimeId) {
 			return;
 		}
 
@@ -44,6 +40,12 @@ export default async function runtime(store: StateManager<State>, events: EventD
 				onlineRuntime = null;
 			}
 
+			if (!selectedRuntimeId) {
+				onlineRuntime = null;
+				return;
+			}
+
+			const selectedRuntimeEntry = state.runtimeRegistry[selectedRuntimeId];
 			log(state, `Requesting runtime: ${selectedRuntimeId}`, 'Runtime');
 
 			const runtimeFactory = selectedRuntimeEntry.factory;
@@ -74,11 +76,7 @@ export default async function runtime(store: StateManager<State>, events: EventD
 
 		store.set('editorConfigSchemaContributions', {
 			...retainedContributions,
-			...collectRuntimeEditorConfigSchemaContributions(
-				state.editorConfig.runtime,
-				state.runtimeRegistry,
-				state.defaultRuntimeId
-			),
+			...collectRuntimeEditorConfigSchemaContributions(state.editorConfig.runtime, state.runtimeRegistry),
 		});
 	}
 

--- a/packages/editor/packages/editor-state/src/index.ts
+++ b/packages/editor/packages/editor-state/src/index.ts
@@ -58,17 +58,12 @@ export {
 export default function init(events: EventDispatcher, options: Options): StateManager<State> {
 	const featureFlags = validateFeatureFlags(options.featureFlags);
 
-	if (!options.runtimeRegistry[options.defaultRuntimeId]) {
-		throw new Error(`Default runtime ID "${options.defaultRuntimeId}" not found in runtime registry`);
-	}
-
 	// Create base state
 	const baseState = {
 		...createDefaultState(),
 		callbacks: options.callbacks,
 		featureFlags,
 		runtimeRegistry: options.runtimeRegistry,
-		defaultRuntimeId: options.defaultRuntimeId,
 		editorConfigSchemaContributions: options.editorConfigSchemaContributions ?? {},
 	};
 

--- a/packages/editor/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
+++ b/packages/editor/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
@@ -269,7 +269,6 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 				factory: mockRuntimeFactory,
 			},
 		},
-		defaultRuntimeId: 'WebWorkerRuntime',
 		graphicHelper: {
 			codeBlocks: [],
 			entryOutlines: [],

--- a/packages/editor/packages/web-ui/src/drawers/infoOverlay.ts
+++ b/packages/editor/packages/web-ui/src/drawers/infoOverlay.ts
@@ -89,10 +89,13 @@ export default function drawInfoOverlay(
 
 	// Runtime stats
 
-	const selectedRuntimeId = state.editorConfig.runtime ?? state.defaultRuntimeId;
+	const selectedRuntimeId =
+		state.editorConfig.runtime && Object.hasOwn(state.runtimeRegistry, state.editorConfig.runtime)
+			? state.editorConfig.runtime
+			: undefined;
 
 	debugText.push('');
-	debugText.push('Runtime: ' + selectedRuntimeId);
+	debugText.push('Runtime: ' + (selectedRuntimeId ?? 'None'));
 
 	const timerExpectedIntervalTimeMs = getRuntimeInfoNumber(state, 'timerExpectedIntervalTimeMs');
 	if (timerExpectedIntervalTimeMs) {

--- a/packages/editor/src/index.test.ts
+++ b/packages/editor/src/index.test.ts
@@ -102,7 +102,6 @@ describe('editor init', () => {
 					factory: () => () => {},
 				},
 			},
-			defaultRuntimeId: 'WebWorkerRuntime',
 			callbacks: {
 				loadSession: async () => null,
 			},
@@ -134,7 +133,6 @@ describe('editor init', () => {
 					factory: () => () => {},
 				},
 			},
-			defaultRuntimeId: 'WebWorkerRuntime',
 			callbacks: {
 				loadSession: async () => null,
 				exportCanvasScreenshot,
@@ -163,7 +161,6 @@ describe('editor init', () => {
 					factory: () => () => {},
 				},
 			},
-			defaultRuntimeId: 'WebWorkerRuntime',
 			renderStatsIntervalFrames: 12,
 			frameTexture: {
 				entry: 'renderFrame',

--- a/packages/editor/src/index.ts
+++ b/packages/editor/src/index.ts
@@ -75,7 +75,6 @@ interface Options {
 		exportCanvasScreenshot?: (blob: Blob, fileName: string) => Promise<void>;
 	};
 	runtimeRegistry: RuntimeRegistry;
-	defaultRuntimeId: string;
 	editorConfigSchemaContributions?: EditorConfigSchemaContributionRegistry;
 	renderStatsIntervalFrames?: number;
 	frameTexture?: WebUiOptions['frameTexture'];

--- a/packages/vscode-extension/src/webview/main.ts
+++ b/packages/vscode-extension/src/webview/main.ts
@@ -28,7 +28,6 @@ type ExtensionMessage =
 
 const vscode = getVsCodeApi();
 const bridge = createRequestBridge(vscode);
-const DEFAULT_RUNTIME_ID = 'MainThreadRuntime';
 let editor: Editor | null = null;
 let loadedProjectSource = '';
 let localNotes: BrowserLocalNoteStorageBlock[] | null = null;
@@ -92,7 +91,6 @@ async function init(): Promise<void> {
 			saveBrowserLocalNotes,
 			saveSession,
 		},
-		defaultRuntimeId: DEFAULT_RUNTIME_ID,
 		runtimeRegistry,
 	});
 

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -2,7 +2,7 @@ import initEditor from '@8f4e/editor';
 import { compileCode } from './compiler-callback';
 import { getListOfModules, getModule, getModuleDependencies } from './examples/moduleRegistry';
 import { getListOfProjects, getProject } from './examples/projectRegistry';
-import { DEFAULT_RUNTIME_ID, runtimeRegistry } from './runtime-registry';
+import { runtimeRegistry } from './runtime-registry';
 import {
 	exportBinaryCode,
 	exportCanvasScreenshot,
@@ -47,7 +47,6 @@ async function init(options: InitOptions = {}) {
 	applyCanvasSize(canvas, initialCanvasSize);
 	const editor = await initEditor(canvas, {
 		runtimeRegistry,
-		defaultRuntimeId: DEFAULT_RUNTIME_ID,
 		callbacks: {
 			getListOfModules,
 			getModule,

--- a/src/runtime-registry.ts
+++ b/src/runtime-registry.ts
@@ -4,15 +4,7 @@ import type {
 	RuntimeRegistry,
 	RuntimeRegistryEntry,
 } from '@8f4e/editor';
-import { createWebWorkerRuntimeDef } from '@8f4e/runtime-web-worker/runtime-def';
-import WebWorkerRuntime from '@8f4e/runtime-web-worker?worker';
 import { getCodeBuffer, getMemory } from './compiler-callback';
-
-/**
- * Default runtime ID for the application.
- * This is used as the fallback when no runtime is specified or when an unknown runtime is requested.
- */
-export const DEFAULT_RUNTIME_ID = 'WebWorkerRuntime';
 
 /**
  * Creates a lazy runtime registry entry that defers loading the runtime implementation and schema
@@ -70,12 +62,21 @@ function createLazyRuntimeEntry(
 /**
  * Runtime registry for the application.
  * Maps runtime IDs to their editor-config schema contributions and factory functions.
- * The default runtime (WebWorkerRuntime) is loaded eagerly; optional runtimes are lazy-loaded
- * on first selection. Each optional runtime starts with a minimal stub schema and replaces it with
- * the full schema after loading.
+ * Runtimes are lazy-loaded on first selection. Each runtime starts with a minimal stub schema
+ * and replaces it with the full schema after loading.
  */
 export const runtimeRegistry: RuntimeRegistry = {
-	WebWorkerRuntime: createWebWorkerRuntimeDef(getCodeBuffer, getMemory, WebWorkerRuntime),
+	WebWorkerRuntime: createLazyRuntimeEntry(
+		'WebWorkerRuntime',
+		{ root: 'workerRuntime', defaults: { sampleRate: 50 }, schema: { type: 'object' } },
+		async () => {
+			const [{ createWebWorkerRuntimeDef }, { default: WebWorkerRuntime }] = await Promise.all([
+				import('@8f4e/runtime-web-worker/runtime-def'),
+				import('@8f4e/runtime-web-worker?worker'),
+			]);
+			return createWebWorkerRuntimeDef(getCodeBuffer, getMemory, WebWorkerRuntime);
+		}
+	),
 
 	MainThreadRuntime: createLazyRuntimeEntry(
 		'MainThreadRuntime',


### PR DESCRIPTION
## Summary
- remove `defaultRuntimeId` from editor/editor-state options and state
- leave the editor without an active runtime when no valid `; @config runtime ...` is present
- lazy-load all app runtimes only after explicit selection and update docs/tests

## Verification
- `npx vitest --run src/features/runtime/editorConfig.test.ts src/features/runtime/__tests__/effect.test.ts src/features/code-blocks/features/auto-env-constants/effect.test.ts`
- `npx nx run-many --target=typecheck --projects=@8f4e/editor-state-types,@8f4e/editor-state-testing,@8f4e/editor-state,@8f4e/web-ui,@8f4e/editor,@8f4e/vscode-extension,app`
- `npx nx run app:build`
- `npx nx run @8f4e/editor:test`

Note: `npx nx run @8f4e/editor-state:test` ran the full suite despite file args and hit an unrelated existing `entryOutlines` mock-state failure; the focused changed-file Vitest run passed cleanly.