### PR TITLE
fix(compiler): keep plain memory ints as stack values

### DIFF
--- a/packages/compiler/src/instructionCompilers/push.test.ts
+++ b/packages/compiler/src/instructionCompilers/push.test.ts
@@ -427,7 +427,7 @@ describe('push instruction compiler', () => {
 				byteCode: [] as typeof context.byteCode,
 			};
 			analyzeAndCompileInstruction(push, resolvedMemoryPushLine('myInt', context.namespace.memory.myInt), contextInt);
-			expect(contextInt.stack[0]).toMatchObject({ kind: 'address', valueType: 'int' });
+			expect(contextInt.stack[0]).toMatchObject({ kind: 'value', valueType: 'int' });
 			expect(contextInt.byteCode).not.toContain(42);
 			expect(contextInt.byteCode).not.toContain(43);
 
@@ -452,6 +452,42 @@ describe('push instruction compiler', () => {
 			analyzeAndCompileInstruction(push, resolvedMemoryPushLine('myF64', context.namespace.memory.myF64), contextF64);
 			expect(contextF64.stack[0]).toMatchObject({ kind: 'value', valueType: 'float64' });
 			expect(contextF64.byteCode).toContain(43); // F64_LOAD
+		});
+
+		it('tracks pointer metadata when pushing a pointer-typed memory identifier', () => {
+			const context = createInstructionCompilerTestContext({
+				namespace: {
+					...createInstructionCompilerTestContext().namespace,
+					memory: {
+						ptr: {
+							byteAddress: 0,
+							elementWordSize: 4,
+							isInteger: true,
+							pointeeBaseType: 'int',
+							pointerDepth: 1,
+							pointeeMemoryIndex: 2,
+							pointeeMemoryRegionName: 'slow',
+						} as unknown as MemoryMap[string],
+					},
+				},
+			});
+
+			analyzeAndCompileInstruction(push, resolvedMemoryPushLine('ptr', context.namespace.memory.ptr), context);
+
+			expect(context.stack[0]).toMatchObject({
+				kind: 'address',
+				valueType: 'int',
+				address: {
+					memoryIndex: 2,
+					memoryRegionName: 'slow',
+				},
+				pointsTo: {
+					baseType: 'int',
+					memoryIndex: 2,
+					memoryRegionName: 'slow',
+					pointerDepth: 1,
+				},
+			});
 		});
 	});
 });

--- a/packages/compiler/src/stackAnalysis/instructionAnalyzers/push.ts
+++ b/packages/compiler/src/stackAnalysis/instructionAnalyzers/push.ts
@@ -149,7 +149,7 @@ function pushResolvedTargetStackItems(line: ResolvedPushLine): Stack {
 				kindToStackItem(kind, {
 					isNonZero: false,
 					...(pointsTo ? { pointsTo } : {}),
-					address: getMemoryRegionFields(memoryItem.memoryIndex ?? 0, memoryItem.memoryRegionName),
+					...(pointsTo ? { address: getMemoryRegionFields(pointsTo.memoryIndex, pointsTo.memoryRegionName) } : {}),
 				}),
 			];
 		}

--- a/packages/examples/src/projects/machine-learning/digitClassifier.8f4e
+++ b/packages/examples/src/projects/machine-learning/digitClassifier.8f4e
@@ -22,7 +22,7 @@ add
 functionEnd float64
 
 note
-; @pos -310 -6
+; @pos -310 -8
 
 ; This project runs a feedforward neural network
 ; in inference mode to classify hand-drawn digits.
@@ -36,6 +36,8 @@ note
 ; so the fixed-weight multiplies, sums, biases,
 ; sigmoid activations, and connections remain
 ; visible in the editor.
+
+; @config runtime WebWorkerRuntime
 noteEnd
 
 note


### PR DESCRIPTION
## Summary
- keep plain integer memory pushes as value stack items instead of address stack items
- keep pointer-typed memory pushes as address stack items with pointee metadata
- add regression coverage for plain int memory and pointer memory stack analysis

## Tests
- npx biome check --write packages/compiler/src/stackAnalysis/instructionAnalyzers/push.ts packages/compiler/src/instructionCompilers/push.test.ts
- npx nx run compiler:typecheck
- npx nx run compiler:test -- src/instructionCompilers/push.test.ts src/stackAnalysis/analyzeInstruction.test.ts
- npx nx run @8f4e/editor-state:test -- src/features/tooltip/stackAnalysisTooltip.test.ts src/features/tooltip/content.test.ts src/features/tooltip/effect.test.ts
- npx nx run @8f4e/editor-state:typecheck
- git diff --check