### PR TITLE
fix(editor-state): derive includes from code blocks

### DIFF
--- a/packages/compiler/packages/tokenizer/src/index.ts
+++ b/packages/compiler/packages/tokenizer/src/index.ts
@@ -12,15 +12,20 @@ export type {
 } from './projectParsing';
 export {
 	BLOCK_DELIMITERS,
+	collectProjectIncludeIdsFromText,
 	FORMAT_HEADER,
 	getDocumentProjectBlockType,
 	getExpectedProjectCloserPrefix,
 	getProjectBlockType,
 	getProjectCloserKeyword,
 	getProjectOpenerKeyword,
+	ProjectIncludeError,
 	parse8f4eProject,
 	parse8f4eProjectAsync,
 	pickProjectCompilerBlocks,
+	resolveFunctionIncludeSource,
+	resolveProjectIncludes,
+	resolveProjectIncludesAsync,
 } from './projectParsing';
 
 import { hashSource } from './cache';

--- a/packages/compiler/packages/tokenizer/src/projectParsing/functionIncludes.test.ts
+++ b/packages/compiler/packages/tokenizer/src/projectParsing/functionIncludes.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { resolveFunctionIncludeSource } from './functionIncludes';
+import {
+	type ProjectIncludeError,
+	resolveFunctionIncludeSource,
+	resolveProjectIncludesAsync,
+} from './functionIncludes';
 
 describe('resolveFunctionIncludeSource', () => {
 	it('splits a resolved include source into function blocks with include metadata', () => {
@@ -36,5 +40,57 @@ describe('resolveFunctionIncludeSource', () => {
 				},
 			},
 		]);
+	});
+});
+
+describe('resolveProjectIncludesAsync', () => {
+	it('resolves include lines from project includes blocks into function blocks', async () => {
+		await expect(
+			resolveProjectIncludesAsync(
+				[
+					{
+						id: 10,
+						code: [
+							'includes',
+							'; @pos 0 0',
+							'include std/events/risingEdge',
+							'include std/memory/wrapPointer',
+							'includesEnd',
+						],
+					},
+				],
+				async includeId => {
+					if (includeId === 'std/events/risingEdge') {
+						return ['function risingEdge', 'functionEnd int'].join('\n');
+					}
+					if (includeId === 'std/memory/wrapPointer') {
+						return ['function wrapPointer', 'functionEnd int*'].join('\n');
+					}
+					return undefined;
+				}
+			)
+		).resolves.toEqual([
+			{
+				code: ['function risingEdge', 'functionEnd int'],
+				source: { kind: 'include', includeId: 'std/events/risingEdge', symbolName: 'risingEdge' },
+			},
+			{
+				code: ['function wrapPointer', 'functionEnd int*'],
+				source: { kind: 'include', includeId: 'std/memory/wrapPointer', symbolName: 'wrapPointer' },
+			},
+		]);
+	});
+
+	it('throws structured include errors with project line numbers', async () => {
+		await expect(
+			resolveProjectIncludesAsync(
+				[{ id: 10, code: ['includes', 'include std/missing', 'includesEnd'] }],
+				() => undefined
+			)
+		).rejects.toMatchObject({
+			name: 'ProjectIncludeError',
+			lineNumber: 11,
+			message: 'Parse error at line 11: unresolved include "std/missing"',
+		} satisfies Partial<ProjectIncludeError>);
 	});
 });

--- a/packages/compiler/packages/tokenizer/src/projectParsing/functionIncludes.ts
+++ b/packages/compiler/packages/tokenizer/src/projectParsing/functionIncludes.ts
@@ -1,3 +1,21 @@
+import type { Module } from '@8f4e/compiler-spec';
+import { INCLUDES_BLOCK_DELIMITER } from './delimiters';
+import { isProjectGapLine } from './projectLines';
+import type { ProjectCodeBlock } from './types';
+
+export type ProjectIncludeResolver = (includeId: string) => string | undefined;
+export type ProjectIncludeResolverAsync = (includeId: string) => string | Promise<string | undefined> | undefined;
+
+export class ProjectIncludeError extends Error {
+	constructor(
+		message: string,
+		readonly lineNumber: number
+	) {
+		super(`Parse error at line ${lineNumber}: ${message}`);
+		this.name = 'ProjectIncludeError';
+	}
+}
+
 function getFunctionName(line: string): string {
 	return line.trim().split(/\s+/)[1] ?? '';
 }
@@ -39,7 +57,7 @@ function splitFunctionBlocks(lines: string[]): string[][] {
 /**
  * Converts resolved include source text into function source blocks.
  */
-export function resolveFunctionIncludeSource(includeId: string, source: string) {
+export function resolveFunctionIncludeSource(includeId: string, source: string): Module[] {
 	return splitFunctionBlocks(normalizeSourceLines(source)).map(code => ({
 		code,
 		source: {
@@ -48,4 +66,100 @@ export function resolveFunctionIncludeSource(includeId: string, source: string) 
 			symbolName: getFunctionName(code[0] ?? ''),
 		},
 	}));
+}
+
+export function collectProjectIncludeIdsFromBlock(block: Pick<ProjectCodeBlock, 'code' | 'id'>) {
+	const includeIds: Array<{ includeId: string; lineNumber: number }> = [];
+
+	for (const [index, line] of block.code.entries()) {
+		const lineNumber = block.id + index;
+		const trimmed = line.trim();
+		if (
+			trimmed === INCLUDES_BLOCK_DELIMITER.opener ||
+			trimmed === INCLUDES_BLOCK_DELIMITER.closer ||
+			isProjectGapLine(trimmed)
+		) {
+			continue;
+		}
+
+		const [instruction, includeId, ...extraArgs] = trimmed.split(/\s+/);
+		if (instruction !== 'include' || !includeId || extraArgs.length > 0) {
+			throw new ProjectIncludeError('include requires exactly one include id', lineNumber);
+		}
+		includeIds.push({ includeId, lineNumber });
+	}
+
+	return includeIds;
+}
+
+export function collectProjectIncludeIdsFromText(text: string): string[] {
+	const includeIds: string[] = [];
+	const lines = text.split('\n');
+
+	for (let i = 1; i < lines.length; i += 1) {
+		const trimmed = lines[i].trim();
+		if (trimmed !== INCLUDES_BLOCK_DELIMITER.opener) {
+			continue;
+		}
+
+		const blockLines = [lines[i]];
+		const blockStartLineNumber = i + 1;
+		for (i += 1; i < lines.length; i += 1) {
+			blockLines.push(lines[i]);
+			if (lines[i].trim() === INCLUDES_BLOCK_DELIMITER.closer) {
+				break;
+			}
+		}
+
+		includeIds.push(
+			...collectProjectIncludeIdsFromBlock({ id: blockStartLineNumber, code: blockLines }).map(
+				({ includeId }) => includeId
+			)
+		);
+	}
+
+	return includeIds;
+}
+
+export function resolveProjectIncludes(
+	includeBlocks: readonly Pick<ProjectCodeBlock, 'code' | 'id' | 'disabled'>[],
+	resolveInclude: ProjectIncludeResolver
+): Module[] {
+	const includedFunctionBlocks: Module[] = [];
+
+	for (const block of includeBlocks) {
+		if (block.disabled) {
+			continue;
+		}
+		for (const { includeId, lineNumber } of collectProjectIncludeIdsFromBlock(block)) {
+			const source = resolveInclude(includeId);
+			if (source === undefined) {
+				throw new ProjectIncludeError(`unresolved include "${includeId}"`, lineNumber);
+			}
+
+			includedFunctionBlocks.push(...resolveFunctionIncludeSource(includeId, source));
+		}
+	}
+
+	return includedFunctionBlocks;
+}
+
+export async function resolveProjectIncludesAsync(
+	includeBlocks: readonly Pick<ProjectCodeBlock, 'code' | 'id' | 'disabled'>[],
+	resolveInclude: ProjectIncludeResolverAsync
+): Promise<Module[]> {
+	const includeSources = new Map<string, string | undefined>();
+
+	for (const block of includeBlocks) {
+		if (block.disabled) {
+			continue;
+		}
+		for (const { includeId } of collectProjectIncludeIdsFromBlock(block)) {
+			if (!includeSources.has(includeId)) {
+				includeSources.set(includeId, await resolveInclude(includeId));
+			}
+		}
+	}
+
+	return resolveProjectIncludes(includeBlocks, includeId => includeSources.get(includeId));
 }

--- a/packages/compiler/packages/tokenizer/src/projectParsing/index.ts
+++ b/packages/compiler/packages/tokenizer/src/projectParsing/index.ts
@@ -1,12 +1,21 @@
 import { documentBlockInstructionByType } from '@8f4e/compiler-spec';
 import { ENTRY_BLOCK_DELIMITER, FORMAT_HEADER, GROUP_BLOCK_DELIMITER, INCLUDES_BLOCK_DELIMITER } from './delimiters';
-import { resolveFunctionIncludeSource } from './functionIncludes';
+import type { ProjectIncludeResolver, ProjectIncludeResolverAsync } from './functionIncludes';
+import { collectProjectIncludeIdsFromText, resolveProjectIncludes } from './functionIncludes';
 import { getExpectedProjectCloserPrefix, getProjectCloserKeyword, getProjectOpenerKeyword } from './projectKeywords';
 import { getProjectBlockName, isProjectGapLine } from './projectLines';
 import type { ProjectCodeBlock, ProjectCodeGroup, ProjectInput } from './types';
 
 export { getDocumentProjectBlockType, getProjectBlockType } from './blockClassification';
 export { BLOCK_DELIMITERS, FORMAT_HEADER, INCLUDES_BLOCK_DELIMITER } from './delimiters';
+export type { ProjectIncludeResolver, ProjectIncludeResolverAsync } from './functionIncludes';
+export {
+	collectProjectIncludeIdsFromText,
+	ProjectIncludeError,
+	resolveFunctionIncludeSource,
+	resolveProjectIncludes,
+	resolveProjectIncludesAsync,
+} from './functionIncludes';
 export { pickProjectCompilerBlocks } from './pickProjectCompilerBlocks';
 export { getExpectedProjectCloserPrefix, getProjectCloserKeyword, getProjectOpenerKeyword } from './projectKeywords';
 export type {
@@ -28,44 +37,12 @@ type ProjectContainerContentOptions = {
 	validateDocumentOpener: (opener: string, line: string, lineNumber: number) => void;
 };
 
-export type ProjectIncludeResolver = (includeId: string) => string | undefined;
-export type ProjectIncludeResolverAsync = (includeId: string) => string | Promise<string | undefined> | undefined;
-
 export interface Parse8f4eProjectOptions {
 	resolveInclude?: ProjectIncludeResolver;
 }
 
 export interface Parse8f4eProjectAsyncOptions {
 	resolveInclude?: ProjectIncludeResolverAsync;
-}
-
-function collectProjectIncludeIds(text: string): string[] {
-	const includeIds: string[] = [];
-	const lines = text.split('\n');
-
-	for (let i = 1; i < lines.length; i += 1) {
-		const trimmed = lines[i].trim();
-		if (trimmed !== INCLUDES_BLOCK_DELIMITER.opener) {
-			continue;
-		}
-
-		for (i += 1; i < lines.length; i += 1) {
-			const includeLine = lines[i].trim();
-			if (includeLine === INCLUDES_BLOCK_DELIMITER.closer) {
-				break;
-			}
-			if (isProjectGapLine(includeLine)) {
-				continue;
-			}
-
-			const [instruction, includeId] = includeLine.split(/\s+/);
-			if (instruction === 'include' && includeId) {
-				includeIds.push(includeId);
-			}
-		}
-	}
-
-	return includeIds;
 }
 
 /**
@@ -152,10 +129,12 @@ export function parse8f4eProject(text: string, options: Parse8f4eProjectOptions 
 
 			const closer = getProjectCloserKeyword(trimmed);
 			if (closer === INCLUDES_BLOCK_DELIMITER.closer) {
-				codeBlocks.push({
+				const block = {
 					id: startIndex + 1,
 					code: currentBlockLines,
-				});
+				};
+				codeBlocks.push(block);
+				includedFunctionBlocks.push(...resolveProjectIncludes([block], options.resolveInclude ?? (() => undefined)));
 				return i + 1;
 			}
 			if (closer) {
@@ -164,17 +143,7 @@ export function parse8f4eProject(text: string, options: Parse8f4eProjectOptions 
 				);
 			}
 
-			const [instruction, includeId, ...extraArgs] = trimmed.split(/\s+/);
-			if (instruction !== 'include' || !includeId || extraArgs.length > 0) {
-				throw new Error(`Parse error at line ${i + 1}: include requires exactly one include id`);
-			}
-
-			const source = options.resolveInclude?.(includeId);
-			if (source === undefined) {
-				throw new Error(`Parse error at line ${i + 1}: unresolved include "${includeId}"`);
-			}
-
-			includedFunctionBlocks.push(...resolveFunctionIncludeSource(includeId, source));
+			// Include line syntax and source resolution are applied once the complete block is collected.
 		}
 
 		throw new Error(`Parse error: unclosed block with opener "${INCLUDES_BLOCK_DELIMITER.opener}"`);
@@ -327,7 +296,7 @@ export async function parse8f4eProjectAsync(
 	}
 
 	const includeSources = new Map<string, string | undefined>();
-	for (const includeId of new Set(collectProjectIncludeIds(text))) {
+	for (const includeId of new Set(collectProjectIncludeIdsFromText(text))) {
 		includeSources.set(includeId, await options.resolveInclude(includeId));
 	}
 

--- a/packages/editor/packages/editor-state/src/features/program-compiler/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/effect.test.ts
@@ -223,6 +223,110 @@ describe('program compiler effect', () => {
 		expect(mockState.editorConfigValidators.recompileDebounceDelay).toBe(recompileDebounceDelayEditorConfigValidator);
 	});
 
+	it('resolves functions from the current includes block before compiling', async () => {
+		mockCompileCode.mockResolvedValue({
+			codeBuffer: new Uint8Array([0x00]),
+			compiledModules: {},
+			compiledFunctions: {},
+			requiredMemoryBytes: 0,
+			allocatedMemoryBytes: 65536,
+			astCacheStats: { hits: 0, misses: 0 },
+			hasWasmInstanceBeenReset: false,
+			memoryAction: { action: 'reused' },
+			initOnlyReran: false,
+			byteCodeSize: 1,
+		});
+		mockState.callbacks.resolveInclude = vi.fn(async includeId => {
+			if (includeId === 'std/events/risingEdge') {
+				return ['function risingEdge', 'functionEnd int'].join('\n');
+			}
+			if (includeId === 'std/memory/wrapPointer') {
+				return ['function wrapPointer', 'functionEnd int*', '', 'function wrapPointer', 'functionEnd float*'].join(
+					'\n'
+				);
+			}
+			return undefined;
+		});
+		mockState.initialProjectState = {
+			codeBlocks: [],
+			groups: [],
+			includedFunctionBlocks: [
+				{
+					code: ['function staleInclude', 'functionEnd'],
+				},
+			],
+		};
+		const includesBlock = createMockCodeBlock({
+			name: 'includes',
+			code: [
+				'includes',
+				'; @pos 0 0',
+				'include std/events/risingEdge',
+				'include std/memory/wrapPointer',
+				'includesEnd',
+			],
+			creationIndex: 10,
+			blockType: 'includes',
+		});
+		mockState.codeBlockRendering.codeBlocks.unshift(includesBlock);
+		mockState.codeBlockRendering.selectedCodeBlockForProgrammaticEdit = includesBlock;
+
+		await triggerProgrammaticCompile();
+
+		expect(mockCompileCode).toHaveBeenCalledWith(
+			expect.objectContaining({
+				functions: expect.arrayContaining([
+					expect.objectContaining({
+						code: ['function risingEdge', 'functionEnd int'],
+						source: { kind: 'include', includeId: 'std/events/risingEdge', symbolName: 'risingEdge' },
+					}),
+					expect.objectContaining({
+						code: ['function wrapPointer', 'functionEnd int*'],
+						source: { kind: 'include', includeId: 'std/memory/wrapPointer', symbolName: 'wrapPointer' },
+					}),
+					expect.objectContaining({
+						code: ['function wrapPointer', 'functionEnd float*'],
+						source: { kind: 'include', includeId: 'std/memory/wrapPointer', symbolName: 'wrapPointer' },
+					}),
+				]),
+			}),
+			expect.any(Object)
+		);
+		expect(mockCompileCode.mock.calls[0][0].functions).not.toContainEqual(
+			expect.objectContaining({ code: ['function staleInclude', 'functionEnd'] })
+		);
+	});
+
+	it('does not compile stale include functions from the initial project when no includes block is present', async () => {
+		mockCompileCode.mockResolvedValue({
+			codeBuffer: new Uint8Array([0x00]),
+			compiledModules: {},
+			compiledFunctions: {},
+			requiredMemoryBytes: 0,
+			allocatedMemoryBytes: 65536,
+			astCacheStats: { hits: 0, misses: 0 },
+			hasWasmInstanceBeenReset: false,
+			memoryAction: { action: 'reused' },
+			initOnlyReran: false,
+			byteCodeSize: 1,
+		});
+		mockState.initialProjectState = {
+			codeBlocks: [],
+			groups: [],
+			includedFunctionBlocks: [
+				{
+					code: ['function staleInclude', 'functionEnd'],
+				},
+			],
+		};
+
+		await triggerProgrammaticCompile();
+
+		expect(mockCompileCode.mock.calls[0][0].functions).not.toContainEqual(
+			expect.objectContaining({ code: ['function staleInclude', 'functionEnd'] })
+		);
+	});
+
 	it('uses the configured recompile debounce delay', async () => {
 		mockState.editorConfig.recompileDebounceDelay = 120;
 		compilerEffect(store);

--- a/packages/editor/packages/editor-state/src/features/program-compiler/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/effect.ts
@@ -1,8 +1,8 @@
 import type { CompileInput, CompilerDiagnostic, Module } from '@8f4e/compiler-spec';
-import { documentBlockInstructionByType, WASM_MEMORY_PAGE_SIZE } from '@8f4e/compiler-spec';
+import { documentBlockInstructionByType, ErrorCode, WASM_MEMORY_PAGE_SIZE } from '@8f4e/compiler-spec';
 import type { CodeBlockGraphicData, InfoRecord, Project, State } from '@8f4e/editor-state-types';
 import type { StateManager } from '@8f4e/state-manager';
-import { isCompilableBlockType } from '@8f4e/tokenizer';
+import { isCompilableBlockType, ProjectIncludeError, resolveProjectIncludesAsync } from '@8f4e/tokenizer';
 import debounceTrailing from '../../pureHelpers/debounceTrailing';
 import sortCodeBlocksByGridPosition from '../code-blocks/sortCodeBlocksByGridPosition';
 import { log } from '../logger/logger';
@@ -12,6 +12,7 @@ const moduleBlockType = documentBlockInstructionByType.module.type;
 const constantsBlockType = documentBlockInstructionByType.constants.type;
 const functionBlockType = documentBlockInstructionByType.function.type;
 const prototypeBlockType = documentBlockInstructionByType.prototype.type;
+const includesBlockType = documentBlockInstructionByType.includes.type;
 
 function toCompilerModule(block: CodeBlockGraphicData): Module {
 	return {
@@ -69,6 +70,52 @@ export function flattenProjectForCompiler(
 	return { entries, constants, functions, prototypes };
 }
 
+function createIncludesDiagnostic(
+	block: CodeBlockGraphicData,
+	lineNumber: number,
+	message: string
+): CompilerDiagnostic {
+	return {
+		code: ErrorCode.UNKNOWN_ERROR,
+		message,
+		line: { lineNumber },
+		context: {
+			projectBlockId: block.creationIndex,
+		},
+	};
+}
+
+async function resolveIncludedFunctionBlocksFromCurrentIncludes(
+	codeBlocks: CodeBlockGraphicData[],
+	resolveInclude: State['callbacks']['resolveInclude']
+): Promise<Module[] | undefined> {
+	if (!resolveInclude) {
+		return undefined;
+	}
+
+	const includesBlocks = codeBlocks.filter(block => !block.disabled && block.blockType === includesBlockType);
+	if (includesBlocks.length === 0) {
+		return undefined;
+	}
+
+	const includedFunctionBlocks: Module[] = [];
+
+	for (const block of includesBlocks) {
+		try {
+			includedFunctionBlocks.push(
+				...(await resolveProjectIncludesAsync([{ id: 1, code: block.code }], resolveInclude))
+			);
+		} catch (error) {
+			if (error instanceof ProjectIncludeError) {
+				throw createIncludesDiagnostic(block, error.lineNumber, error.message);
+			}
+			throw error;
+		}
+	}
+
+	return includedFunctionBlocks;
+}
+
 export default function compiler(store: StateManager<State>) {
 	const state = store.getState();
 	registerRecompileDebounceDelayEditorConfigValidator(store);
@@ -87,11 +134,6 @@ export default function compiler(store: StateManager<State>) {
 
 	async function onForceCompile() {
 		scheduleRecompile.cancel();
-
-		const compilerInput = flattenProjectForCompiler(
-			state.codeBlockRendering.codeBlocks,
-			state.initialProjectState?.includedFunctionBlocks
-		);
 		const compilationStart = performance.now();
 
 		store.set('compiler.isCompiling', true);
@@ -108,6 +150,11 @@ export default function compiler(store: StateManager<State>) {
 				startingMemoryWordAddress: 0,
 				includeStackAnalysis: state.featureFlags.codeLineSelection,
 			};
+			const includedFunctionBlocks = await resolveIncludedFunctionBlocksFromCurrentIncludes(
+				state.codeBlockRendering.codeBlocks,
+				state.callbacks.resolveInclude
+			);
+			const compilerInput = flattenProjectForCompiler(state.codeBlockRendering.codeBlocks, includedFunctionBlocks);
 
 			const result = await state.callbacks.compileCode(compilerInput, compilerOptions);
 			const compilationTimeMs = performance.now() - compilationStart;
@@ -174,13 +221,15 @@ export default function compiler(store: StateManager<State>) {
 			return;
 		}
 
-		if (!isCompilableBlockType(state.codeBlockRendering.selectedCodeBlock?.blockType)) {
+		const blockType = state.codeBlockRendering.selectedCodeBlock?.blockType;
+		if (!isCompilableBlockType(blockType) && blockType !== includesBlockType) {
 			return;
 		}
 		scheduleRecompile();
 	});
 	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', () => {
-		if (!isCompilableBlockType(state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit?.blockType)) {
+		const blockType = state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit?.blockType;
+		if (!isCompilableBlockType(blockType) && blockType !== includesBlockType) {
 			return;
 		}
 		scheduleRecompile();

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeTo8f4e.test.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeTo8f4e.test.ts
@@ -22,42 +22,7 @@ describe('serializeProjectTo8f4e', () => {
 		expect(result).toContain('moduleEnd\nentryEnd');
 	});
 
-	it('serializes unique top-level includes from included function metadata', () => {
-		const project = {
-			codeBlocks: [{ code: validBlock, entry: 'main' }],
-			includedFunctionBlocks: [
-				{
-					code: ['function risingEdge', 'functionEnd int'],
-					source: { kind: 'include' as const, includeId: 'std/events/risingEdge', symbolName: 'risingEdge' },
-				},
-				{
-					code: ['function risingEdge', 'functionEnd float'],
-					source: { kind: 'include' as const, includeId: 'std/events/risingEdge', symbolName: 'risingEdge' },
-				},
-				{
-					code: ['function hasChanged', 'functionEnd int'],
-					source: { kind: 'include' as const, includeId: 'std/events/hasChanged', symbolName: 'hasChanged' },
-				},
-			],
-		};
-
-		expect(serializeProjectTo8f4e(project)).toBe(
-			[
-				'8f4e/v1',
-				'',
-				'includes',
-				'include std/events/risingEdge',
-				'include std/events/hasChanged',
-				'includesEnd',
-				'',
-				'entry main',
-				...validBlock,
-				'entryEnd',
-			].join('\n')
-		);
-	});
-
-	it('serializes a visible includes block instead of regenerating one from metadata', () => {
+	it('serializes the visible includes block from code blocks and ignores include metadata', () => {
 		const visibleIncludesBlock = ['includes', 'include std/events/risingEdge', 'includesEnd'];
 		const project = {
 			codeBlocks: [{ code: visibleIncludesBlock }, { code: validBlock, entry: 'main' }],

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeTo8f4e.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeTo8f4e.ts
@@ -63,37 +63,6 @@ function getModuleEntryName(block: CodeBlock, blockIndex: number): string {
 	return block.entry;
 }
 
-function getIncludeIds(project: Project): string[] {
-	const seen = new Set<string>();
-	const includeIds: string[] = [];
-
-	for (const block of project.includedFunctionBlocks ?? []) {
-		if (block.source?.kind !== 'include') {
-			continue;
-		}
-
-		const includeId = block.source.includeId;
-		if (seen.has(includeId)) {
-			continue;
-		}
-
-		seen.add(includeId);
-		includeIds.push(includeId);
-	}
-
-	return includeIds;
-}
-
-function hasVisibleIncludesBlock(project: Project): boolean {
-	for (const block of project.codeBlocks) {
-		if (getDocumentProjectBlockType(block.code) === 'includes') {
-			return true;
-		}
-	}
-
-	return false;
-}
-
 /**
  * Serializes a Project to .8f4e text format.
  * Throws if any code block fails export-gate validation.
@@ -106,13 +75,8 @@ export function serializeProjectTo8f4e(project: Project): string {
 	}
 
 	const blockStrings: string[] = [];
-	const includeIds = hasVisibleIncludesBlock(project) ? [] : getIncludeIds(project);
 	const emittedEntries = new Set<string>();
 	const modulesByEntry = new Map<string, Project['codeBlocks']>();
-
-	if (includeIds.length > 0) {
-		blockStrings.push(['includes', ...includeIds.map(includeId => `include ${includeId}`), 'includesEnd'].join('\n'));
-	}
 
 	for (let blockIndex = 0; blockIndex < codeBlocks.length; blockIndex += 1) {
 		const block = codeBlocks[blockIndex];

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeToProject.test.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeToProject.test.ts
@@ -28,4 +28,38 @@ describe('serializeToProject', () => {
 
 		expect(project).toMatchSnapshot();
 	});
+
+	it('derives serialized project data from current code blocks instead of initial project metadata', () => {
+		const state = createMockState({
+			initialProjectState: {
+				codeBlocks: [],
+				groups: [],
+				includedFunctionBlocks: [
+					{
+						code: ['function staleInclude', 'functionEnd'],
+						source: { kind: 'include', includeId: 'std/stale', symbolName: 'staleInclude' },
+					},
+				],
+			},
+			codeBlockRendering: {
+				codeBlocks: [
+					createMockCodeBlock({
+						name: 'includes',
+						code: ['includes', 'include std/current', 'includesEnd'],
+						x: 0,
+						y: 0,
+					}),
+				],
+			},
+		});
+
+		expect(serializeToProject(state)).toEqual({
+			codeBlocks: [
+				expect.objectContaining({
+					code: ['includes', 'include std/current', 'includesEnd'],
+				}),
+			],
+		});
+		expect(serializeToProject(state)).not.toHaveProperty('includedFunctionBlocks');
+	});
 });

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeToProject.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeToProject.ts
@@ -8,12 +8,5 @@ import convertGraphicDataToProjectStructure from './serializeCodeBlocks';
  */
 export default function serializeToProject(state: State): Project {
 	const { codeBlockRendering } = state;
-	const project = convertGraphicDataToProjectStructure(codeBlockRendering.codeBlocks);
-
-	return {
-		...project,
-		...(state.initialProjectState?.includedFunctionBlocks
-			? { includedFunctionBlocks: state.initialProjectState.includedFunctionBlocks }
-			: {}),
-	};
+	return convertGraphicDataToProjectStructure(codeBlockRendering.codeBlocks);
 }

--- a/src/compiler-callback.ts
+++ b/src/compiler-callback.ts
@@ -44,6 +44,16 @@ export async function compileCode(
 
 		compilerWorker.addEventListener('message', handleMessage, { once: true });
 
+		console.log(
+			'[Compiler] Functions sent to compiler:',
+			input.functions.map((func, index) => ({
+				index,
+				projectBlockId: func.projectBlockId,
+				firstLine: func.code[0],
+			})),
+			input.functions
+		);
+
 		compilerWorker.postMessage({
 			type: 'compile',
 			payload: {


### PR DESCRIPTION
## Summary
- move project include parsing/resolution helpers into the tokenizer and reuse them from editor-state
- compile includes from the current visible code blocks instead of stale initial project metadata
- serialize/export projects from current code blocks only
- log the functions sent from the editor to the compiler

## Tests
- npx biome check --write packages/compiler/packages/tokenizer/src/index.ts packages/compiler/packages/tokenizer/src/projectParsing/functionIncludes.test.ts packages/compiler/packages/tokenizer/src/projectParsing/functionIncludes.ts packages/compiler/packages/tokenizer/src/projectParsing/index.ts packages/editor/packages/editor-state/src/features/program-compiler/effect.test.ts packages/editor/packages/editor-state/src/features/program-compiler/effect.ts packages/editor/packages/editor-state/src/features/project-export/serializeTo8f4e.test.ts packages/editor/packages/editor-state/src/features/project-export/serializeTo8f4e.ts packages/editor/packages/editor-state/src/features/project-export/serializeToProject.test.ts packages/editor/packages/editor-state/src/features/project-export/serializeToProject.ts src/compiler-callback.ts
- npx nx run @8f4e/tokenizer:test -- --run src/projectParsing/functionIncludes.test.ts src/projectParsing/index.test.ts
- npx nx run @8f4e/editor-state:test -- --run src/features/program-compiler/effect.test.ts src/features/project-export/serializeToProject.test.ts src/features/project-export/serializeTo8f4e.test.ts
- npx nx run app:typecheck
- git diff --check

## Notes
- The existing unstaged deletion of packages/examples/src/modules/functions/memory/wrapPointer.8f4em is intentionally not included in this PR.