### PR TITLE
feat(stdlib): add advancePhase helper

### DIFF
--- a/packages/compiler/docs/standard-library.md
+++ b/packages/compiler/docs/standard-library.md
@@ -14,6 +14,7 @@ includes
 include std/math/clamp
 include std/math/fract
 include std/math/pow2
+include std/math/trig/advancePhase
 include std/math/trig/cosine
 include std/math/trig/sine
 include std/bitwise/extractBit
@@ -340,6 +341,36 @@ module pow2Examples
 push 5
 call pow2
 ; stack: 32
+moduleEnd
+entryEnd
+```
+
+## `std/math/trig/advancePhase`
+
+Provides `advancePhase`, which advances a mutable float phase by one sample and wraps it from `PI` back to `-PI`.
+
+Available overloads:
+
+- `advancePhase(float* phase, float frequency, float sampleRate) -> float`
+
+The phase increment is `TAU * frequency / sampleRate`, where `TAU` is derived from the built-in `[-PI, PI]` phase range. The updated phase is stored through the `phase` pointer and returned on the stack.
+
+Examples:
+
+```8f4e
+includes
+include std/math/trig/advancePhase
+includesEnd
+
+entry test
+module advancePhaseExamples
+float phase -3.141592653589793
+
+push &phase
+push 440.0
+push 48000.0
+call advancePhase
+; stack: next phase
 moduleEnd
 entryEnd
 ```

--- a/packages/compiler/tests/__snapshots__/stdlib/advance-phase.test.8f4e.compile-result.snap
+++ b/packages/compiler/tests/__snapshots__/stdlib/advance-phase.test.8f4e.compile-result.snap
@@ -1,0 +1,552 @@
+{
+  "functionAst": {
+    "advancePhase__float_p__float__float": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "advancePhase",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [],
+          "instruction": "#impure",
+          "isBlockPrologue": true,
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float*",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "phase",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "frequency",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "sampleRate",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "constant",
+              "scope": "local",
+              "type": "identifier",
+              "value": "PI",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 3.141592653589793,
+            },
+          ],
+          "instruction": "const",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "constant",
+              "scope": "local",
+              "type": "identifier",
+              "value": "NEG_PI",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": -3.141592653589793,
+            },
+          ],
+          "instruction": "const",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "phase",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "dereferenceDepth": 1,
+              "referenceKind": "memory-pointer",
+              "scope": "local",
+              "targetMemoryId": "phase",
+              "type": "identifier",
+              "value": "*phase",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "constant",
+              "scope": "local",
+              "type": "identifier",
+              "value": "PI",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "constant",
+              "scope": "local",
+              "type": "identifier",
+              "value": "NEG_PI",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "frequency",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "mul",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "sampleRate",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "div",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [],
+          "instruction": "store",
+        },
+        {
+          "arguments": [
+            {
+              "dereferenceDepth": 1,
+              "referenceKind": "memory-pointer",
+              "scope": "local",
+              "targetMemoryId": "phase",
+              "type": "identifier",
+              "value": "*phase",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "constant",
+              "scope": "local",
+              "type": "identifier",
+              "value": "PI",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "greaterThan",
+        },
+        {
+          "arguments": [],
+          "instruction": "if",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "phase",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "constant",
+              "scope": "local",
+              "type": "identifier",
+              "value": "NEG_PI",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "store",
+        },
+        {
+          "arguments": [],
+          "instruction": "ifEnd",
+        },
+        {
+          "arguments": [
+            {
+              "dereferenceDepth": 1,
+              "referenceKind": "memory-pointer",
+              "scope": "local",
+              "targetMemoryId": "phase",
+              "type": "identifier",
+              "value": "*phase",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "advancePhase",
+      "type": "function",
+    },
+  },
+  "functionOverview": {
+    "advancePhase__float_p__float__float": {
+      "id": "advancePhase__float_p__float__float",
+      "signature": {
+        "parameters": [
+          "float*",
+          "float",
+          "float",
+        ],
+        "returns": [
+          "float",
+        ],
+      },
+    },
+  },
+  "moduleAst": {
+    "advancePhaseAssertions": {
+      "id": "advancePhaseAssertions",
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "advancePhaseAssertions",
+            },
+          ],
+          "instruction": "module",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "phase",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 0,
+            },
+          ],
+          "hasExplicitMemoryDefault": true,
+          "instruction": "float",
+        },
+        {
+          "arguments": [
+            {
+              "isEndAddress": false,
+              "referenceKind": "memory-reference",
+              "scope": "local",
+              "targetMemoryId": "phase",
+              "type": "identifier",
+              "value": "&phase",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 1,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 4,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "advancePhase",
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "assertf",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 1.570796326794896,
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "phase",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "assertf",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 1.570796326794896,
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "isEndAddress": false,
+              "referenceKind": "memory-reference",
+              "scope": "local",
+              "targetMemoryId": "phase",
+              "type": "identifier",
+              "value": "&phase",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 2,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 4,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "advancePhase",
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "assertf",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": -3.141592653589793,
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "phase",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "assertf",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": -3.141592653589793,
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [],
+          "instruction": "moduleEnd",
+        },
+      ],
+      "type": "module",
+    },
+  },
+  "moduleMemory": {
+    "advancePhaseAssertions": {
+      "memoryMap": {
+        "phase": {
+          "byteAddress": 4,
+          "default": 0,
+          "elementWordSize": 4,
+          "hasExplicitDefault": true,
+          "id": "phase",
+          "isInteger": false,
+          "isUnsigned": false,
+          "memoryIndex": 0,
+          "numberOfElements": 1,
+          "pointerDepth": 0,
+          "type": "float",
+          "wordAlignedAddress": 1,
+          "wordAlignedSize": 1,
+        },
+      },
+    },
+  },
+  "overview": {
+    "compiledFunctions": [
+      "advancePhase__float_p__float__float",
+    ],
+    "compiledModules": [
+      "advancePhaseAssertions",
+    ],
+    "requiredMemoryBytes": 8,
+    "requiredMemoryBytesByRegion": {},
+    "wasmExports": [
+      "initDefaults",
+      "main",
+      "test",
+    ],
+  },
+}

--- a/packages/compiler/tests/stdlib/advance-phase.test.8f4e
+++ b/packages/compiler/tests/stdlib/advance-phase.test.8f4e
@@ -1,0 +1,33 @@
+8f4e/v1
+
+includes
+include std/math/trig/advancePhase
+includesEnd
+
+entry test
+module advancePhaseAssertions
+; it advances phase by one
+; sample in the [-PI, PI] range.
+float phase 0.0
+
+push &phase
+push 1.0
+push 4.0
+call advancePhase
+call assertf 1.570796326794896
+
+push phase
+call assertf 1.570796326794896
+
+; it wraps to the lower bound
+; after crossing the upper bound.
+push &phase
+push 2.0
+push 4.0
+call advancePhase
+call assertf -3.141592653589793
+
+push phase
+call assertf -3.141592653589793
+moduleEnd
+entryEnd

--- a/packages/stdlib/manifest.json
+++ b/packages/stdlib/manifest.json
@@ -29,6 +29,10 @@
       "path": "std/math/pow2.8f4e"
     },
     {
+      "id": "std/math/trig/advancePhase",
+      "path": "std/math/trig/advancePhase.8f4e"
+    },
+    {
       "id": "std/math/trig/cosine",
       "path": "std/math/trig/cosine.8f4e"
     },

--- a/packages/stdlib/std/math/trig/advancePhase.8f4e
+++ b/packages/stdlib/std/math/trig/advancePhase.8f4e
@@ -1,0 +1,35 @@
+function advancePhase
+#impure
+; Advances a phase by one sample
+; and wraps from PI to -PI.
+param float* phase
+param float frequency
+param float sampleRate
+
+const PI 3.141592653589793
+const NEG_PI -3.141592653589793
+
+push phase
+push *phase
+push PI
+push NEG_PI
+sub
+push frequency
+mul
+push sampleRate
+ensureNonZero
+div
+add
+store
+
+push *phase
+push PI
+greaterThan
+if
+push phase
+push NEG_PI
+store
+ifEnd
+
+push *phase
+functionEnd float


### PR DESCRIPTION
## Summary
- add std/math/trig/advancePhase for mutable [-PI, PI] phase advancement
- document the new stdlib include and regenerate the manifest
- add fixture coverage and compile snapshot for advancing and wrapping phase

## Tests
- npx nx run @8f4e/compiler:test -- --run tests/fixturePrograms.test.ts