### PR TITLE
fix(stdlib): cast sample rate inside advancePhase

### DIFF
--- a/docs/todos/453-add-indirect-calls-and-function-reference-type.md
+++ b/docs/todos/453-add-indirect-calls-and-function-reference-type.md
@@ -1,0 +1,128 @@
+---
+title: 'TODO: Add indirect calls and function reference type'
+priority: Medium
+effort: 2-4d
+created: 2026-06-11
+issue: null
+status: Open
+completed: null
+---
+
+# TODO: Add Indirect Calls And Function Reference Type
+
+## Problem Description
+
+8f4e can call known functions directly, but it has no source-level way to treat functions as values. This prevents users
+from building dispatch tables, callback slots, state-machine jump tables, or runtime-selected behavior without encoding
+large conditional call chains.
+
+WebAssembly does not allow arbitrary function pointers to be manufactured from linear-memory bytes. Indirect calls must
+go through a table: code loads an integer table index, `call_indirect` checks the expected function signature, and the
+runtime calls the table entry if the index and type are valid. 8f4e should expose that model deliberately instead of
+pretending function references are raw memory addresses.
+
+## Proposed Solution
+
+Add a first-class function reference value type to 8f4e and use it as the source-level representation for WebAssembly
+table indices.
+
+The design should support:
+
+- declaring or deriving function references for concrete 8f4e functions
+- storing function-reference table indices in memory when users need runtime dispatch
+- loading a function reference from memory or locals
+- calling a function reference through a checked indirect-call instruction
+- preserving function signature metadata so indirect calls can validate arguments before emitting `call_indirect`
+
+The implementation should keep the WebAssembly table as the authoritative callable storage. Linear memory may store
+typed table indices, but raw integers should not automatically become callable without function-reference metadata.
+
+## Anti-Patterns
+
+- Do not model function references as arbitrary byte addresses in linear memory.
+- Do not allow `push 7` followed by an indirect call to silently target table slot `7` without type metadata.
+- Do not bypass WebAssembly's `call_indirect` type check or assume all function signatures share one table type.
+- Do not add dynamic dispatch by emitting long compiler-generated chains of direct calls when a table call is the real
+  target behavior.
+
+## Implementation Plan
+
+### Step 1: Define the function reference type
+
+- Add a function reference type to compiler-spec value/type metadata.
+- Decide its source syntax, such as a `funcref` scalar type or a signature-aware spelling like `fn<int,float>`.
+- Encode the referenced function signature in compiler metadata so stack analysis can validate indirect call arguments.
+- Decide whether function references are initially limited to concrete non-overloaded function ids or can refer to
+  resolved overloads.
+
+### Step 2: Build table metadata during function collection
+
+- Assign table indices to functions that can be referenced indirectly.
+- Preserve the mapping from source function identity to Wasm table index.
+- Keep table-index assignment deterministic across builds.
+- Ensure pruned functions that remain reachable only through function references are retained by the reachability pass.
+
+### Step 3: Add reference creation and storage paths
+
+- Add syntax for taking a function reference, such as `&functionName` or a dedicated instruction.
+- Allow storing typed function references in memory and locals.
+- Keep memory representation as an integer table index while preserving type metadata in stack, local, and memory
+  declarations.
+- Reject untyped integer-to-function-reference conversion until there is an explicit checked cast design.
+
+### Step 4: Add indirect call instruction support
+
+- Add an instruction for calling a function reference, such as `callRef`, that consumes arguments and a typed function
+  reference from the stack.
+- Emit WebAssembly `call_indirect` with the expected function type index and table index operand.
+- Validate argument count and value types during stack analysis before codegen.
+- Surface clear diagnostics for missing function-reference metadata, signature mismatches, and invalid call placement.
+
+### Step 5: Add tests and documentation
+
+- Add compiler tests for table index assignment, function-reference creation, storage/load, and indirect calls.
+- Add negative tests for raw integer calls, signature mismatches, missing references, and pruned indirectly referenced
+  functions.
+- Add example `.8f4e` programs showing a callback slot and a small dispatch table.
+- Document the distinction between table indices and raw linear-memory function pointers.
+
+## Success Criteria
+
+- [ ] 8f4e has a first-class function reference type with signature metadata.
+- [ ] Users can store and load function references without treating them as arbitrary memory addresses.
+- [ ] Indirect calls lower to WebAssembly `call_indirect`.
+- [ ] Stack analysis validates indirect call argument and return types.
+- [ ] Functions reachable through function references are not incorrectly pruned.
+- [ ] Tests cover valid indirect dispatch and invalid raw-integer/function-signature cases.
+
+## Affected Components
+
+- `packages/compiler/packages/compiler-spec/src/` - value type, function metadata, and compiled output contracts.
+- `packages/compiler/src/semantic/` - function reference parsing, resolution, and reachability metadata.
+- `packages/compiler/src/stackAnalysis/` - function-reference stack metadata and indirect-call validation.
+- `packages/compiler/src/instructionCompilers/` - `call_indirect` bytecode emission.
+- `packages/compiler/packages/wasm-utils/src/` - table and element-section helpers, if table emission needs shared utils.
+- `packages/compiler/docs/` - user-facing function reference and indirect-call documentation.
+
+## Risks & Considerations
+
+- **Type design**: a plain `funcref` may be too broad for useful compile-time validation; signature-aware metadata is likely
+  required even if the source syntax stays compact.
+- **Overloads**: overloaded source names must resolve to a concrete function signature before a reference can be taken.
+- **Reachability**: function pruning must account for references stored in memory or tables, not just direct calls.
+- **Runtime compatibility**: table and element-section emission should be checked against the browser and native runtime
+  targets supported by the project.
+- **Future reference types**: WebAssembly reference-types support may eventually allow richer `funcref` handling, but the
+  initial implementation can target MVP-style tables and `call_indirect`.
+
+## Related Items
+
+- **Related**: `docs/todos/435-add-polymorphic-function-overloads.md`
+- **Related**: `docs/todos/452-add-reachability-based-function-pruning.md`
+- **Related**: `docs/todos/449-add-function-param-shape.md`
+- **Related**: `docs/todos/451-add-push-shape-instruction.md`
+
+## Notes
+
+- This TODO intentionally frames function references as typed table indices, not raw pointers. That matches WebAssembly's
+  execution model while still allowing memory-backed dispatch tables in 8f4e source.

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -74,6 +74,7 @@ Active todo files are listed below.
 | 450 | Generalize instruction placement config | 🟡 | 4-8h | 2026-06-08 | Make instruction placement metadata generic enough to express shared source-placement checks, starting with named prologue rules for directives and function parameters. |
 | 451 | Add pushShape instruction | 🟡 | 4-8h | 2026-06-08 | Add `pushShape <prototypeId>` so shaped modules can push effective memory addresses in prototype order and feed functions that use `paramShape`. |
 | 452 | Add Reachability-Based Function Pruning | 🟡 | 1-2d | 2026-06-10 | Replace conservative function pruning with a reachability pass so functions only called by uncalled functions are also omitted. |
+| 453 | Add indirect calls and function reference type | 🟡 | 2-4d | 2026-06-11 | Add typed function references backed by WebAssembly table indices so 8f4e can store, load, and call runtime-selected functions through `call_indirect`. |
 
 ### 🟢 Low Priority
 

--- a/packages/compiler/docs/standard-library.md
+++ b/packages/compiler/docs/standard-library.md
@@ -16,7 +16,9 @@ include std/math/fract
 include std/math/pow2
 include std/math/trig/advancePhase
 include std/math/trig/cosine
+include std/math/trig/saw
 include std/math/trig/sine
+include std/math/trig/triangle
 include std/bitwise/extractBit
 include std/bitwise/extractByte
 include std/events/risingEdge
@@ -423,6 +425,54 @@ module cosineExamples
 push 0.0
 call cosine
 ; stack: about 1.0
+moduleEnd
+entryEnd
+```
+
+## `std/math/trig/triangle`
+
+Provides `triangle`, which maps a phase in `[-PI, PI]` to a triangle waveform in `[-1, 1]`.
+
+Available overloads:
+
+- `triangle(float x) -> float`
+
+Examples:
+
+```8f4e
+includes
+include std/math/trig/triangle
+includesEnd
+
+entry test
+module triangleExamples
+push 0.0
+call triangle
+; stack: 1.0
+moduleEnd
+entryEnd
+```
+
+## `std/math/trig/saw`
+
+Provides `saw`, which maps a phase in `[-PI, PI]` to a sawtooth ramp in `[-1, 1]`.
+
+Available overloads:
+
+- `saw(float x) -> float`
+
+Examples:
+
+```8f4e
+includes
+include std/math/trig/saw
+includesEnd
+
+entry test
+module sawExamples
+push 0.0
+call saw
+; stack: 0.0
 moduleEnd
 entryEnd
 ```

--- a/packages/compiler/docs/standard-library.md
+++ b/packages/compiler/docs/standard-library.md
@@ -351,9 +351,9 @@ Provides `advancePhase`, which advances a mutable float phase by one sample and 
 
 Available overloads:
 
-- `advancePhase(float* phase, float frequency, float sampleRate) -> float`
+- `advancePhase(float* phase, float frequency, int sampleRate) -> float`
 
-The phase increment is `TAU * frequency / sampleRate`, where `TAU` is derived from the built-in `[-PI, PI]` phase range. The updated phase is stored through the `phase` pointer and returned on the stack.
+The phase increment is `TAU * frequency / sampleRate`, where `TAU` is derived from the built-in `[-PI, PI]` phase range. The `sampleRate` argument is cast to float inside the helper. The updated phase is stored through the `phase` pointer and returned on the stack.
 
 Examples:
 
@@ -368,7 +368,7 @@ float phase -3.141592653589793
 
 push &phase
 push 440.0
-push 48000.0
+push 48000
 call advancePhase
 ; stack: next phase
 moduleEnd

--- a/packages/compiler/tests/__snapshots__/stdlib/advance-phase.test.8f4e.compile-result.snap
+++ b/packages/compiler/tests/__snapshots__/stdlib/advance-phase.test.8f4e.compile-result.snap
@@ -1,6 +1,6 @@
 {
   "functionAst": {
-    "advancePhase__float_p__float__float": {
+    "advancePhase__float_p__float__int": {
       "lines": [
         {
           "arguments": [
@@ -58,7 +58,7 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "float",
+              "value": "int",
             },
             {
               "referenceKind": "plain",
@@ -179,6 +179,10 @@
         },
         {
           "arguments": [],
+          "instruction": "castToFloat",
+        },
+        {
+          "arguments": [],
           "instruction": "ensureNonZero",
         },
         {
@@ -285,13 +289,13 @@
     },
   },
   "functionOverview": {
-    "advancePhase__float_p__float__float": {
-      "id": "advancePhase__float_p__float__float",
+    "advancePhase__float_p__float__int": {
+      "id": "advancePhase__float_p__float__int",
       "signature": {
         "parameters": [
           "float*",
           "float",
-          "float",
+          "int",
         ],
         "returns": [
           "float",
@@ -357,7 +361,7 @@
         {
           "arguments": [
             {
-              "isInteger": false,
+              "isInteger": true,
               "type": "literal",
               "value": 4,
             },
@@ -444,7 +448,7 @@
         {
           "arguments": [
             {
-              "isInteger": false,
+              "isInteger": true,
               "type": "literal",
               "value": 4,
             },
@@ -536,7 +540,7 @@
   },
   "overview": {
     "compiledFunctions": [
-      "advancePhase__float_p__float__float",
+      "advancePhase__float_p__float__int",
     ],
     "compiledModules": [
       "advancePhaseAssertions",

--- a/packages/compiler/tests/__snapshots__/stdlib/saw.test.8f4e.compile-result.snap
+++ b/packages/compiler/tests/__snapshots__/stdlib/saw.test.8f4e.compile-result.snap
@@ -1,0 +1,332 @@
+{
+  "functionAst": {
+    "saw__float": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "saw",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "x",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "constant",
+              "scope": "local",
+              "type": "identifier",
+              "value": "INV_PI",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 0.31830988618379,
+            },
+          ],
+          "instruction": "const",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "x",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "constant",
+              "scope": "local",
+              "type": "identifier",
+              "value": "INV_PI",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "mul",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "saw",
+      "type": "function",
+    },
+  },
+  "functionOverview": {
+    "saw__float": {
+      "id": "saw__float",
+      "signature": {
+        "parameters": [
+          "float",
+        ],
+        "returns": [
+          "float",
+        ],
+      },
+    },
+  },
+  "moduleAst": {
+    "sawAssertions": {
+      "id": "sawAssertions",
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "sawAssertions",
+            },
+          ],
+          "instruction": "module",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": -3.141592653589793,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "saw",
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "assertf",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": -1,
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": -1.570796326794896,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "saw",
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "assertf",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": -0.5,
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 0,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "saw",
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "assertf",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 0,
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 1.570796326794896,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "saw",
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "assertf",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 0.5,
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 3.141592653589793,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "saw",
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "assertf",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 1,
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [],
+          "instruction": "moduleEnd",
+        },
+      ],
+      "type": "module",
+    },
+  },
+  "moduleMemory": {
+    "sawAssertions": {
+      "memoryMap": {},
+    },
+  },
+  "overview": {
+    "compiledFunctions": [
+      "saw__float",
+    ],
+    "compiledModules": [
+      "sawAssertions",
+    ],
+    "requiredMemoryBytes": 4,
+    "requiredMemoryBytesByRegion": {},
+    "wasmExports": [
+      "initDefaults",
+      "main",
+      "test",
+    ],
+  },
+}

--- a/packages/compiler/tests/__snapshots__/stdlib/triangle.test.8f4e.compile-result.snap
+++ b/packages/compiler/tests/__snapshots__/stdlib/triangle.test.8f4e.compile-result.snap
@@ -1,0 +1,364 @@
+{
+  "functionAst": {
+    "triangle__float": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "triangle",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "x",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "constant",
+              "scope": "local",
+              "type": "identifier",
+              "value": "INV_PI",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 0.31830988618379,
+            },
+          ],
+          "instruction": "const",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 1,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "x",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "abs",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "constant",
+              "scope": "local",
+              "type": "identifier",
+              "value": "INV_PI",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "mul",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 2,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "mul",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "triangle",
+      "type": "function",
+    },
+  },
+  "functionOverview": {
+    "triangle__float": {
+      "id": "triangle__float",
+      "signature": {
+        "parameters": [
+          "float",
+        ],
+        "returns": [
+          "float",
+        ],
+      },
+    },
+  },
+  "moduleAst": {
+    "triangleAssertions": {
+      "id": "triangleAssertions",
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "triangleAssertions",
+            },
+          ],
+          "instruction": "module",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": -3.141592653589793,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "triangle",
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "assertf",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": -1,
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": -1.570796326794896,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "triangle",
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "assertf",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 0,
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 0,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "triangle",
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "assertf",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 1,
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 1.570796326794896,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "triangle",
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "assertf",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 0,
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": 3.141592653589793,
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "triangle",
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "assertf",
+            },
+            {
+              "isInteger": false,
+              "type": "literal",
+              "value": -1,
+            },
+          ],
+          "instruction": "call",
+        },
+        {
+          "arguments": [],
+          "instruction": "moduleEnd",
+        },
+      ],
+      "type": "module",
+    },
+  },
+  "moduleMemory": {
+    "triangleAssertions": {
+      "memoryMap": {},
+    },
+  },
+  "overview": {
+    "compiledFunctions": [
+      "triangle__float",
+    ],
+    "compiledModules": [
+      "triangleAssertions",
+    ],
+    "requiredMemoryBytes": 4,
+    "requiredMemoryBytesByRegion": {},
+    "wasmExports": [
+      "initDefaults",
+      "main",
+      "test",
+    ],
+  },
+}

--- a/packages/compiler/tests/stdlib/advance-phase.test.8f4e
+++ b/packages/compiler/tests/stdlib/advance-phase.test.8f4e
@@ -12,7 +12,7 @@ float phase 0.0
 
 push &phase
 push 1.0
-push 4.0
+push 4
 call advancePhase
 call assertf 1.570796326794896
 
@@ -23,7 +23,7 @@ call assertf 1.570796326794896
 ; after crossing the upper bound.
 push &phase
 push 2.0
-push 4.0
+push 4
 call advancePhase
 call assertf -3.141592653589793
 

--- a/packages/compiler/tests/stdlib/saw.test.8f4e
+++ b/packages/compiler/tests/stdlib/saw.test.8f4e
@@ -1,0 +1,31 @@
+8f4e/v1
+
+includes
+include std/math/trig/saw
+includesEnd
+
+entry test
+module sawAssertions
+; it maps [-PI, PI] to a
+; sawtooth ramp in [-1, 1].
+push -3.141592653589793
+call saw
+call assertf -1.0
+
+push -1.570796326794896
+call saw
+call assertf -0.5
+
+push 0.0
+call saw
+call assertf 0.0
+
+push 1.570796326794896
+call saw
+call assertf 0.5
+
+push 3.141592653589793
+call saw
+call assertf 1.0
+moduleEnd
+entryEnd

--- a/packages/compiler/tests/stdlib/triangle.test.8f4e
+++ b/packages/compiler/tests/stdlib/triangle.test.8f4e
@@ -1,0 +1,31 @@
+8f4e/v1
+
+includes
+include std/math/trig/triangle
+includesEnd
+
+entry test
+module triangleAssertions
+; it maps [-PI, PI] to a
+; triangle in [-1, 1].
+push -3.141592653589793
+call triangle
+call assertf -1.0
+
+push -1.570796326794896
+call triangle
+call assertf 0.0
+
+push 0.0
+call triangle
+call assertf 1.0
+
+push 1.570796326794896
+call triangle
+call assertf 0.0
+
+push 3.141592653589793
+call triangle
+call assertf -1.0
+moduleEnd
+entryEnd

--- a/packages/stdlib/manifest.json
+++ b/packages/stdlib/manifest.json
@@ -37,8 +37,16 @@
       "path": "std/math/trig/cosine.8f4e"
     },
     {
+      "id": "std/math/trig/saw",
+      "path": "std/math/trig/saw.8f4e"
+    },
+    {
       "id": "std/math/trig/sine",
       "path": "std/math/trig/sine.8f4e"
+    },
+    {
+      "id": "std/math/trig/triangle",
+      "path": "std/math/trig/triangle.8f4e"
     },
     {
       "id": "std/memory/advancePointer",

--- a/packages/stdlib/std/math/trig/advancePhase.8f4e
+++ b/packages/stdlib/std/math/trig/advancePhase.8f4e
@@ -4,7 +4,7 @@ function advancePhase
 ; and wraps from PI to -PI.
 param float* phase
 param float frequency
-param float sampleRate
+param int sampleRate
 
 const PI 3.141592653589793
 const NEG_PI -3.141592653589793
@@ -17,6 +17,7 @@ sub
 push frequency
 mul
 push sampleRate
+castToFloat
 ensureNonZero
 div
 add

--- a/packages/stdlib/std/math/trig/saw.8f4e
+++ b/packages/stdlib/std/math/trig/saw.8f4e
@@ -1,0 +1,13 @@
+function saw
+; Sawtooth function for
+; the input range [-PI, PI].
+; Output range: [-1, 1].
+param float x
+
+const INV_PI 0.318309886183790
+
+push x
+push INV_PI
+mul
+
+functionEnd float

--- a/packages/stdlib/std/math/trig/triangle.8f4e
+++ b/packages/stdlib/std/math/trig/triangle.8f4e
@@ -1,0 +1,18 @@
+function triangle
+; Triangle function for
+; the input range [-PI, PI].
+; Output range: [-1, 1].
+param float x
+
+const INV_PI 0.318309886183790
+
+push 1.0
+push x
+abs
+push INV_PI
+mul
+push 2.0
+mul
+sub
+
+functionEnd float


### PR DESCRIPTION
## Summary
- change advancePhase to accept an int sampleRate
- cast sampleRate to float inside the helper before division
- update stdlib docs and fixture snapshot for the new signature

## Tests
- npx nx run @8f4e/compiler:test -- --run tests/fixturePrograms.test.ts