### PR TITLE
Track compiler pipeline coverage

### DIFF
--- a/packages/metrics-dashboard/src/main.ts
+++ b/packages/metrics-dashboard/src/main.ts
@@ -42,7 +42,7 @@ type BytecodeSizeEntry = {
 	emittedBytes: number;
 };
 
-type CoverageComponent = 'compiler' | 'tokenizer';
+type CoverageComponent = string;
 type CoverageMetric = 'rangeExecutions' | 'functionEntries' | 'coveredFunctions';
 
 type CoverageDashboardTab = 'ranges' | 'functionEntries' | 'coveredFunctions';
@@ -52,6 +52,7 @@ type CoverageMetricConfig = {
 	emptyLabel: string;
 	axisLabel: string;
 	cardLabel: string;
+	pipelineSummaryLabel: string;
 	compilerSummaryLabel: string;
 	tokenizerSummaryLabel: string;
 };
@@ -62,7 +63,8 @@ const coverageMetricConfigs: Record<CoverageDashboardTab, CoverageMetricConfig> 
 		emptyLabel: 'range execution data',
 		axisLabel: 'Range executions',
 		cardLabel: 'Ranges',
-		compilerSummaryLabel: 'Compiler Ranges',
+		pipelineSummaryLabel: 'Pipeline Ranges',
+		compilerSummaryLabel: 'Compiler Core Ranges',
 		tokenizerSummaryLabel: 'Tokenizer Ranges',
 	},
 	functionEntries: {
@@ -70,7 +72,8 @@ const coverageMetricConfigs: Record<CoverageDashboardTab, CoverageMetricConfig> 
 		emptyLabel: 'function entry data',
 		axisLabel: 'Function entries',
 		cardLabel: 'Entries',
-		compilerSummaryLabel: 'Compiler Entries',
+		pipelineSummaryLabel: 'Pipeline Entries',
+		compilerSummaryLabel: 'Compiler Core Entries',
 		tokenizerSummaryLabel: 'Tokenizer Entries',
 	},
 	coveredFunctions: {
@@ -78,9 +81,40 @@ const coverageMetricConfigs: Record<CoverageDashboardTab, CoverageMetricConfig> 
 		emptyLabel: 'covered function data',
 		axisLabel: 'Covered functions',
 		cardLabel: 'Functions',
-		compilerSummaryLabel: 'Compiler Functions',
+		pipelineSummaryLabel: 'Pipeline Functions',
+		compilerSummaryLabel: 'Compiler Core Functions',
 		tokenizerSummaryLabel: 'Tokenizer Functions',
 	},
+};
+
+const coverageComponentOrder = [
+	'compilerPipeline',
+	'compiler',
+	'tokenizer',
+	'constantInliner',
+	'memoryPlanner',
+	'memoryReferenceInliner',
+	'memoryDefaultResolver',
+	'semanticUtils',
+	'stackAnalyzer',
+	'wasmCodegen',
+	'compilerWasmUtils',
+	'languageSpec',
+];
+
+const coverageComponentLabels: Record<CoverageComponent, string> = {
+	compilerPipeline: 'Compiler Pipeline',
+	compiler: 'Compiler Core',
+	tokenizer: 'Tokenizer',
+	constantInliner: 'Constant Inliner',
+	memoryPlanner: 'Memory Planner',
+	memoryReferenceInliner: 'Memory Reference Inliner',
+	memoryDefaultResolver: 'Memory Default Resolver',
+	semanticUtils: 'Semantic Utils',
+	stackAnalyzer: 'Stack Analyzer',
+	wasmCodegen: 'Wasm Codegen',
+	compilerWasmUtils: 'Compiler Wasm Utils',
+	languageSpec: 'Language Spec',
 };
 
 type CompilerCoverageBucket = {
@@ -91,10 +125,11 @@ type CompilerCoverageBucket = {
 };
 
 type CompilerCoverageEntry = {
+	schemaVersion?: number;
 	commit: string;
 	version: string | null;
 	benchmark: string;
-	coverage: Record<CoverageComponent, CompilerCoverageBucket>;
+	coverage: Partial<Record<CoverageComponent, CompilerCoverageBucket>>;
 };
 
 type TsdocCoverageManifest = {
@@ -649,24 +684,26 @@ function toCoveragePoints(log: BytecodeTrackedLog, entries: CompilerCoverageEntr
 		const version = entry.version ?? 'unknown';
 		const releaseTag = `@8f4e/compiler@${version}`;
 
-		return (['compiler', 'tokenizer'] as const).map(component => {
-			const componentLabel = component === 'compiler' ? 'Compiler' : 'Tokenizer';
-
+		return getSortedCoverageComponents(Object.keys(entry.coverage)).flatMap(component => {
+			const bucket = entry.coverage[component];
+			if (!bucket) {
+				return [];
+			}
 			return {
 				benchmark: log.benchmark,
 				label: log.label,
 				component,
-				componentLabel,
-				seriesLabel: `${log.label} ${componentLabel}`,
+				componentLabel: getCoverageComponentLabel(component),
+				seriesLabel: `${log.label} ${getCoverageComponentLabel(component)}`,
 				version,
 				releaseTag,
 				commit: entry.commit,
 				releaseKey: entry.commit || version,
 				releaseIndex: 0,
 				releaseLabel: '',
-				coveredFunctions: entry.coverage[component].coveredFunctions,
-				functionEntries: entry.coverage[component].functionEntries,
-				rangeExecutions: entry.coverage[component].rangeExecutions,
+				coveredFunctions: bucket.coveredFunctions,
+				functionEntries: bucket.functionEntries,
+				rangeExecutions: bucket.rangeExecutions,
 			};
 		});
 	});
@@ -957,6 +994,7 @@ function renderCoverage(config: CoverageMetricConfig) {
 	const summaryPoints = toCoverageSummaryPoints(state.coveragePoints, config.metric);
 	const latestReleasePoints = getLatestCoverageReleasePoints(summaryPoints);
 	const latestPoint = latestReleasePoints[0] ?? null;
+	const latestPipelinePoint = latestReleasePoints.find(point => point.component === 'compilerPipeline') ?? null;
 	const latestCompilerPoint = latestReleasePoints.find(point => point.component === 'compiler') ?? null;
 	const latestTokenizerPoint = latestReleasePoints.find(point => point.component === 'tokenizer') ?? null;
 	const snapshotCount = new Set(state.coveragePoints.map(point => point.releaseKey)).size;
@@ -968,6 +1006,11 @@ function renderCoverage(config: CoverageMetricConfig) {
 	coverageBenchmarkCaption.textContent = `${config.axisLabel} by benchmark`;
 
 	rangesSummaryGrid.innerHTML = [
+		renderSummaryItem(
+			config.pipelineSummaryLabel,
+			latestPipelinePoint ? formatCount(latestPipelinePoint.value) : 'n/a',
+			`${state.coverageLogs.length} benchmarks`
+		),
 		renderSummaryItem(
 			config.compilerSummaryLabel,
 			latestCompilerPoint ? formatCount(latestCompilerPoint.value) : 'n/a',
@@ -1278,9 +1321,10 @@ function renderCoverageGrid(points: CoveragePoint[], config: CoverageMetricConfi
 	for (const log of state.coverageLogs) {
 		const benchmarkPoints = points.filter(point => point.benchmark === log.benchmark);
 		const latestPoints = getLatestCoverageReleasePoints(benchmarkPoints);
+		const latestPipelinePoint = latestPoints.find(point => point.component === 'compilerPipeline') ?? null;
 		const latestCompilerPoint = latestPoints.find(point => point.component === 'compiler') ?? null;
 		const latestTokenizerPoint = latestPoints.find(point => point.component === 'tokenizer') ?? null;
-		const latestPoint = latestCompilerPoint ?? latestTokenizerPoint;
+		const latestPoint = latestPipelinePoint ?? latestCompilerPoint ?? latestTokenizerPoint;
 		const card = document.createElement('article');
 		card.className = 'package-card';
 		card.innerHTML = `
@@ -1289,7 +1333,7 @@ function renderCoverageGrid(points: CoveragePoint[], config: CoverageMetricConfi
 					<h3>${escapeHtml(log.label)}</h3>
 					<p>${latestPoint ? escapeHtml(formatCoveragePointMeta(latestPoint)) : ''}</p>
 				</div>
-				<strong>${latestCompilerPoint ? escapeHtml(formatCount(getCoverageMetricValue(latestCompilerPoint, config.metric))) : 'n/a'}</strong>
+				<strong>${latestPoint ? escapeHtml(formatCount(getCoverageMetricValue(latestPoint, config.metric))) : 'n/a'}</strong>
 			</div>
 			<div class="package-card-chart"></div>
 			${renderCoverageTable(benchmarkPoints, config)}
@@ -1653,6 +1697,7 @@ function renderCoverageTable(points: CoveragePoint[], config: CoverageMetricConf
 	}
 
 	const releases = [...new Map(points.map(point => [point.releaseKey, point])).values()].slice(-8).reverse();
+	const components = getSortedCoverageComponents([...new Set(points.map(point => point.component))]);
 
 	return `
 		<div class="file-table-wrap">
@@ -1660,22 +1705,23 @@ function renderCoverageTable(points: CoveragePoint[], config: CoverageMetricConf
 				<thead>
 					<tr>
 						<th>Release</th>
-						<th>Compiler</th>
-						<th>Tokenizer</th>
+						${components.map(component => `<th>${escapeHtml(getCoverageComponentLabel(component))}</th>`).join('')}
 					</tr>
 				</thead>
 				<tbody>
 					${releases
 						.map(release => {
 							const releasePoints = points.filter(point => point.releaseKey === release.releaseKey);
-							const compilerPoint = releasePoints.find(point => point.component === 'compiler');
-							const tokenizerPoint = releasePoints.find(point => point.component === 'tokenizer');
 
 							return `
 								<tr>
 									<td>${escapeHtml(release.releaseTag)}</td>
-									<td>${compilerPoint ? formatCount(getCoverageMetricValue(compilerPoint, config.metric)) : 'n/a'}</td>
-									<td>${tokenizerPoint ? formatCount(getCoverageMetricValue(tokenizerPoint, config.metric)) : 'n/a'}</td>
+									${components
+										.map(component => {
+											const point = releasePoints.find(releasePoint => releasePoint.component === component);
+											return `<td>${point ? formatCount(getCoverageMetricValue(point, config.metric)) : 'n/a'}</td>`;
+										})
+										.join('')}
 								</tr>
 							`;
 						})
@@ -1931,6 +1977,28 @@ function getLatestDate(points: Point[]) {
 
 function getCoverageMetricValue(point: CoveragePoint, metric: CoverageMetric) {
 	return point[metric];
+}
+
+function getSortedCoverageComponents(components: readonly CoverageComponent[]) {
+	return [...components].sort((left, right) => {
+		const leftIndex = coverageComponentOrder.indexOf(left);
+		const rightIndex = coverageComponentOrder.indexOf(right);
+
+		if (leftIndex !== -1 || rightIndex !== -1) {
+			return getCoverageComponentSortIndex(left) - getCoverageComponentSortIndex(right);
+		}
+
+		return left.localeCompare(right);
+	});
+}
+
+function getCoverageComponentSortIndex(component: CoverageComponent) {
+	const index = coverageComponentOrder.indexOf(component);
+	return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+}
+
+function getCoverageComponentLabel(component: CoverageComponent) {
+	return coverageComponentLabels[component] ?? component;
 }
 
 function getChartWidth(container: HTMLElement) {

--- a/scripts/log-compiler-coverage-counts.mjs
+++ b/scripts/log-compiler-coverage-counts.mjs
@@ -12,9 +12,69 @@ const workspaceRoot = process.cwd();
 const benchmarkDir = path.resolve(workspaceRoot, 'packages/examples/src/benchmarks/bytecode-size');
 const outputDir = path.resolve(workspaceRoot, 'logs/compiler-coverage-counts');
 const suiteName = 'compiler-coverage-counts';
+const schemaVersion = 2;
 const compilerOptions = {
 	startingMemoryWordAddress: 0,
 };
+const aggregateComponentId = 'compilerPipeline';
+const coverageComponents = [
+	{
+		id: 'compiler',
+		label: 'compiler core',
+		pathFragment: '/packages/compiler/dist/',
+	},
+	{
+		id: 'tokenizer',
+		label: 'tokenizer',
+		pathFragment: '/packages/compiler/packages/tokenizer/dist/',
+	},
+	{
+		id: 'constantInliner',
+		label: 'constant inliner',
+		pathFragment: '/packages/compiler/packages/constant-inliner/dist/',
+	},
+	{
+		id: 'memoryPlanner',
+		label: 'memory planner',
+		pathFragment: '/packages/compiler/packages/memory-planner/dist/',
+	},
+	{
+		id: 'memoryReferenceInliner',
+		label: 'memory reference inliner',
+		pathFragment: '/packages/compiler/packages/memory-reference-inliner/dist/',
+	},
+	{
+		id: 'memoryDefaultResolver',
+		label: 'memory default resolver',
+		pathFragment: '/packages/compiler/packages/memory-default-resolver/dist/',
+	},
+	{
+		id: 'semanticUtils',
+		label: 'semantic utils',
+		pathFragment: '/packages/compiler/packages/semantic-utils/dist/',
+	},
+	{
+		id: 'stackAnalyzer',
+		label: 'stack analyzer',
+		pathFragment: '/packages/compiler/packages/stack-analyzer/dist/',
+	},
+	{
+		id: 'wasmCodegen',
+		label: 'wasm codegen',
+		pathFragment: '/packages/compiler/packages/wasm-codegen/dist/',
+	},
+	{
+		id: 'compilerWasmUtils',
+		label: 'compiler wasm utils',
+		pathFragment: '/packages/compiler/packages/wasm-utils/dist/',
+	},
+	{
+		id: 'languageSpec',
+		label: 'language spec',
+		pathFragment: '/packages/compiler/packages/language-spec/dist/',
+	},
+];
+const coverageComponentById = new Map(coverageComponents.map(component => [component.id, component]));
 
 await main();
 
@@ -66,7 +126,9 @@ async function main() {
 		for (const benchmarkCase of parsedCases) {
 			const outputPath = getCaseLogPath(outputDir, benchmarkCase);
 
-			if (await hasLoggedBenchmarkVersion(outputPath, version)) {
+			const existingEntry = await getLoggedBenchmarkVersion(outputPath, version);
+
+			if (isCurrentSchemaEntry(existingEntry)) {
 				skippedCases.push({
 					sourcePath: benchmarkCase.path,
 					version,
@@ -81,13 +143,14 @@ async function main() {
 			assertCoverageMatched(coverage, benchmarkCase);
 
 			const entry = {
+				schemaVersion,
 				commit: gitMetadata.commit,
 				version,
 				benchmark: benchmarkCase.relativePath,
 				coverage,
 			};
 
-			await appendLogEntry(outputPath, entry);
+			await upsertLogEntry(outputPath, entry);
 			loggedCases.push({
 				...entry,
 				sourcePath: benchmarkCase.path,
@@ -149,36 +212,30 @@ async function collectFiles(root, dir, files) {
 }
 
 function summarizeCoverage(coverageResult) {
-	const compiler = createCoverageBucket();
-	const tokenizer = createCoverageBucket();
+	const coverage = {
+		[aggregateComponentId]: createCoverageBucket(),
+		...Object.fromEntries(coverageComponents.map(component => [component.id, createCoverageBucket()])),
+	};
 
 	for (const script of coverageResult) {
 		const url = script.url.split(path.sep).join('/');
-		const bucket = getCoverageBucket(url, compiler, tokenizer);
+		const component = getCoverageComponent(url);
 
-		if (!bucket) {
+		if (!component) {
 			continue;
 		}
 
 		for (const fn of script.functions) {
-			const entryCount = fn.ranges[0]?.count ?? 0;
-			bucket.functionEntries += entryCount;
-			bucket.maxRangesPerFunction = Math.max(bucket.maxRangesPerFunction, fn.ranges.length);
-
-			if (entryCount > 0) {
-				bucket.coveredFunctions += 1;
-			}
-
-			for (const range of fn.ranges) {
-				bucket.rangeExecutions += range.count;
-			}
+			recordFunctionCoverage(coverage[component.id], fn);
+			recordFunctionCoverage(coverage[aggregateComponentId], fn);
 		}
 	}
 
-	return {
-		compiler,
-		tokenizer,
-	};
+	return Object.fromEntries(
+		Object.entries(coverage).filter(
+			([componentId, bucket]) => componentId === aggregateComponentId || bucket.rangeExecutions > 0
+		)
+	);
 }
 
 function createCoverageBucket() {
@@ -190,24 +247,34 @@ function createCoverageBucket() {
 	};
 }
 
-function getCoverageBucket(url, compiler, tokenizer) {
-	if (url.includes('/packages/compiler/dist/')) {
-		return compiler;
+function recordFunctionCoverage(bucket, fn) {
+	const entryCount = fn.ranges[0]?.count ?? 0;
+	bucket.functionEntries += entryCount;
+	bucket.maxRangesPerFunction = Math.max(bucket.maxRangesPerFunction, fn.ranges.length);
+
+	if (entryCount > 0) {
+		bucket.coveredFunctions += 1;
 	}
 
-	if (url.includes('/packages/compiler/packages/tokenizer/dist/')) {
-		return tokenizer;
+	for (const range of fn.ranges) {
+		bucket.rangeExecutions += range.count;
 	}
+}
 
-	return null;
+function getCoverageComponent(url) {
+	return coverageComponents.find(component => url.includes(component.pathFragment)) ?? null;
 }
 
 function assertCoverageMatched(coverage, benchmarkCase) {
-	if (coverage.compiler.coveredFunctions === 0) {
-		throw new Error(`No @8f4e/compiler coverage matched for ${benchmarkCase.relativePath}`);
+	if (coverage[aggregateComponentId].coveredFunctions === 0) {
+		throw new Error(`No compiler pipeline coverage matched for ${benchmarkCase.relativePath}`);
 	}
 
-	if (coverage.tokenizer.coveredFunctions === 0) {
+	if (!coverage.compiler || coverage.compiler.coveredFunctions === 0) {
+		throw new Error(`No @8f4e/compiler core coverage matched for ${benchmarkCase.relativePath}`);
+	}
+
+	if (!coverage.tokenizer || coverage.tokenizer.coveredFunctions === 0) {
 		throw new Error(`No @8f4e/tokenizer coverage matched for ${benchmarkCase.relativePath}`);
 	}
 }
@@ -236,8 +303,7 @@ function printResults(loggedCases, skippedCases, version) {
 		console.log(
 			[
 				benchmarkCase.sourcePath,
-				`compiler ${benchmarkCase.coverage.compiler.coveredFunctions} covered functions / ${benchmarkCase.coverage.compiler.rangeExecutions} ranges / ${benchmarkCase.coverage.compiler.functionEntries} calls`,
-				`tokenizer ${benchmarkCase.coverage.tokenizer.coveredFunctions} covered functions / ${benchmarkCase.coverage.tokenizer.rangeExecutions} ranges / ${benchmarkCase.coverage.tokenizer.functionEntries} calls`,
+				...formatCoverageBuckets(benchmarkCase.coverage),
 				path.relative(workspaceRoot, benchmarkCase.outputPath),
 			].join(' | ')
 		);
@@ -258,9 +324,40 @@ function printResults(loggedCases, skippedCases, version) {
 function sumCases(cases) {
 	return {
 		cases: cases.length,
-		compilerRangeExecutions: sumNested(cases, ['coverage', 'compiler', 'rangeExecutions']),
+		compilerRangeExecutions: sumNested(cases, ['coverage', aggregateComponentId, 'rangeExecutions']),
 		tokenizerRangeExecutions: sumNested(cases, ['coverage', 'tokenizer', 'rangeExecutions']),
 	};
+}
+
+function formatCoverageBuckets(coverage) {
+	return getSortedCoverageComponentIds(coverage).map(componentId => {
+		const bucket = coverage[componentId];
+		return `${getCoverageComponentLabel(componentId)} ${bucket.coveredFunctions} covered functions / ${bucket.rangeExecutions} ranges / ${bucket.functionEntries} calls`;
+	});
+}
+
+function getSortedCoverageComponentIds(coverage) {
+	const componentOrder = [aggregateComponentId, ...coverageComponents.map(component => component.id)];
+
+	return Object.keys(coverage).sort((left, right) => {
+		const leftIndex = componentOrder.indexOf(left);
+		const rightIndex = componentOrder.indexOf(right);
+
+		if (leftIndex !== -1 || rightIndex !== -1) {
+			return (
+				(leftIndex === -1 ? Number.MAX_SAFE_INTEGER : leftIndex) -
+				(rightIndex === -1 ? Number.MAX_SAFE_INTEGER : rightIndex)
+			);
+		}
+
+		return left.localeCompare(right);
+	});
+}
+
+function getCoverageComponentLabel(componentId) {
+	return componentId === aggregateComponentId
+		? 'compiler pipeline'
+		: (coverageComponentById.get(componentId)?.label ?? componentId);
 }
 
 function sumNested(items, keys) {
@@ -277,9 +374,9 @@ function getCaseLogPath(outputDir, benchmarkCase) {
 	return path.join(outputDir, benchmarkCase.logPath);
 }
 
-async function hasLoggedBenchmarkVersion(filePath, version) {
+async function getLoggedBenchmarkVersion(filePath, version) {
 	if (!(await pathExists(filePath))) {
-		return false;
+		return null;
 	}
 
 	const existingEntries = await readJson(filePath);
@@ -288,10 +385,14 @@ async function hasLoggedBenchmarkVersion(filePath, version) {
 		throw new Error(`${path.relative(workspaceRoot, filePath)} must contain a JSON array`);
 	}
 
-	return existingEntries.some(entry => entry?.version === version);
+	return existingEntries.find(entry => entry?.version === version) ?? null;
 }
 
-async function appendLogEntry(filePath, entry) {
+function isCurrentSchemaEntry(entry) {
+	return entry?.version !== undefined && entry?.schemaVersion === schemaVersion;
+}
+
+async function upsertLogEntry(filePath, entry) {
 	await fs.mkdir(path.dirname(filePath), { recursive: true });
 
 	const existingEntries = (await pathExists(filePath)) ? await readJson(filePath) : [];
@@ -300,7 +401,14 @@ async function appendLogEntry(filePath, entry) {
 		throw new Error(`${path.relative(workspaceRoot, filePath)} must contain a JSON array`);
 	}
 
-	existingEntries.push(entry);
+	const entryIndex = existingEntries.findIndex(existingEntry => existingEntry?.version === entry.version);
+
+	if (entryIndex === -1) {
+		existingEntries.push(entry);
+	} else {
+		existingEntries[entryIndex] = entry;
+	}
+
 	await fs.writeFile(filePath, `${JSON.stringify(existingEntries, null, '\t')}\n`);
 }
 


### PR DESCRIPTION
## Summary
- record compiler coverage as a full pipeline aggregate plus individual compiler pass buckets
- keep compiler core and tokenizer buckets visible while adding extracted packages like memory planner, stack analyzer, and wasm codegen
- render compiler coverage dashboard tables from the components present in each log entry

## Testing
- PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH" npx biome check --write scripts/log-compiler-coverage-counts.mjs packages/metrics-dashboard/src/main.ts
- PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH" npx nx run @8f4e/metrics-dashboard:typecheck
- PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH" npx nx run @8f4e/metrics-dashboard:build
- PATH="$HOME/.nvm/versions/node/v24.16.0/bin:$PATH" npx nx run @8f4e/examples:log-compiler-coverage-counts

Generated compiler coverage log updates were restored after verification so this PR only changes the producer and dashboard code.