### PR TITLE
Report codegen facts from stack analysis

### DIFF
--- a/packages/compiler/packages/language-spec/src/__snapshots__/instructions.test.ts.snap
+++ b/packages/compiler/packages/language-spec/src/__snapshots__/instructions.test.ts.snap
@@ -90,6 +90,21 @@ exports[`function instruction classification > snapshots function classification
 
 exports[`instruction block classification > snapshots derived block tables 1`] = `
 {
+  "binaryMatchingInstructionNames": [
+    "add",
+    "div",
+    "equal",
+    "greaterOrEqual",
+    "greaterOrEqualUnsigned",
+    "greaterThan",
+    "lessOrEqual",
+    "lessThan",
+    "min",
+    "max",
+    "mul",
+    "notEqual",
+    "sub",
+  ],
   "compiledModuleBlockTypes": [
     "module",
   ],

--- a/packages/compiler/packages/language-spec/src/instructions.test.ts
+++ b/packages/compiler/packages/language-spec/src/instructions.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import { instructionSpecs } from './instructionSpecs';
 import {
 	compiledModuleBlockTypes,
 	compilerBlockInstructionPairs,
 	compilerSourceBlockInstructionPairs,
 	functionPreBodyInstructionNames,
+	hasBinaryMatchingOperands,
 	importedFunctionDeclarationInstructionNames,
 	isFunctionBodyInstructionName,
 	isFunctionPreBodyInstructionName,
@@ -28,7 +30,12 @@ const functionInstructionClassificationSamples = [
 
 describe('instruction block classification', () => {
 	it('snapshots derived block tables', () => {
+		const binaryMatchingInstructionNames = Object.entries(instructionSpecs)
+			.filter(([, spec]) => hasBinaryMatchingOperands(spec))
+			.map(([instruction]) => instruction);
+
 		expect({
+			binaryMatchingInstructionNames,
 			compiledModuleBlockTypes,
 			compilerBlockInstructionPairs,
 			compilerSourceBlockInstructionPairs,

--- a/packages/compiler/packages/language-spec/src/instructions.ts
+++ b/packages/compiler/packages/language-spec/src/instructions.ts
@@ -190,6 +190,15 @@ export const codegenInstructionNames = instructionSpecEntries
 	.filter(([, spec]) => spec.sourceInstruction !== false && spec.codegen !== false)
 	.map(([instruction]) => instruction) as CodegenInstructionName[];
 
+export function hasBinaryMatchingOperands(spec: InstructionSpec | undefined): boolean {
+	return (
+		spec?.operandTypes === 'matching' &&
+		spec.minOperands === 2 &&
+		spec.stack?.inputs.length === 2 &&
+		spec.stack.inputs.every(input => input === 'T')
+	);
+}
+
 export type FunctionPreBodyInstructionName = FunctionDeclarationInstructionsByFlag<'preBody'>;
 
 export const functionPreBodyInstructionNames = instructionSpecEntries

--- a/packages/compiler/packages/language-spec/src/semantic.ts
+++ b/packages/compiler/packages/language-spec/src/semantic.ts
@@ -268,10 +268,26 @@ export interface StackAnalysisLocalPointerFact {
 	pointeeMemoryRegionName?: string;
 }
 
+export type StackAnalysisNumericValueKind = 'int32' | 'float32' | 'float64';
+
+export interface StackAnalysisMapFact {
+	inputKind: StackAnalysisNumericValueKind;
+	outputKind: StackAnalysisNumericValueKind;
+}
+
+export interface StackAnalysisClampFact {
+	accessByteWidth: number;
+	memoryIndex: number;
+	range?: MemoryAddressRange;
+}
+
 export interface StackAnalysisLineFacts {
 	stackAnalysis: StackAnalysisResult;
 	targetFunctionId?: string;
 	localPointer?: StackAnalysisLocalPointerFact;
+	numericOperandKind?: StackAnalysisNumericValueKind;
+	map?: StackAnalysisMapFact;
+	clamp?: StackAnalysisClampFact;
 }
 
 export interface ConstantResolutionLineFacts {

--- a/packages/compiler/packages/semantic-utils/src/addressClamp.ts
+++ b/packages/compiler/packages/semantic-utils/src/addressClamp.ts
@@ -3,6 +3,7 @@ import type {
 	CompilationContext,
 	CompilerASTLine,
 	MemoryAddressRange,
+	StackAddress,
 	StackItem,
 } from '@8f4e/language-spec';
 import { ArgumentType, getMemoryRegionFields, WORD_MEMORY_ACCESS_WIDTH } from '@8f4e/language-spec';
@@ -53,7 +54,7 @@ export function getClampedAddressStackItem(
 	operand: StackItem,
 	range: MemoryAddressRange | undefined,
 	accessByteWidth: number
-): StackItem {
+): StackAddress {
 	const safeAccessByteWidth = Math.min(accessByteWidth, range?.safeByteLength ?? accessByteWidth);
 	const memoryIndex = range?.memoryIndex ?? (operand.kind === 'address' ? operand.address.memoryIndex : 0);
 	const memoryRegionName =

--- a/packages/compiler/packages/semantic-utils/src/mapValueKind.ts
+++ b/packages/compiler/packages/semantic-utils/src/mapValueKind.ts
@@ -1,15 +1,12 @@
-import type { StackValueType } from '@8f4e/language-spec';
-
-/** Internal scalar kind used to choose typed WASM operations for map rows and values. */
-export type MapKind = 'int32' | 'float32' | 'float64';
+import type { StackAnalysisNumericValueKind, StackValueType } from '@8f4e/language-spec';
 
 /**
- * Resolves map value metadata to the internal map kind used for typed WASM emission.
+ * Resolves map value metadata to the scalar kind recorded in stack-analysis facts.
  *
  * @param valueKind - Map or stack value metadata to resolve.
  * @returns The computed result.
  */
-export function resolveMapKind(valueKind: { valueType: StackValueType }): MapKind {
+export function resolveMapKind(valueKind: { valueType: StackValueType }): StackAnalysisNumericValueKind {
 	if (valueKind.valueType === 'int') {
 		return 'int32';
 	}

--- a/packages/compiler/packages/stack-analyzer/src/analyzeInstruction.test.ts
+++ b/packages/compiler/packages/stack-analyzer/src/analyzeInstruction.test.ts
@@ -1,5 +1,5 @@
-import type { CompilationContext, CompilerASTLine } from '@8f4e/language-spec';
-import { ArgumentType, BlockType, ErrorCode } from '@8f4e/language-spec';
+import type { CompilationContext, CompilerASTLine, MapBlockStackFrame, MemoryAddressRange } from '@8f4e/language-spec';
+import { ArgumentType, BlockType, ErrorCode, GLOBAL_ALIGNMENT_BOUNDARY } from '@8f4e/language-spec';
 import { describe, expect, it } from 'vitest';
 
 import { analyzeInstruction } from './analyzeInstruction';
@@ -86,6 +86,7 @@ describe('analyzeInstruction', () => {
 			stackAfter: [{ kind: 'value', valueType: 'int', isNonZero: false }],
 		});
 		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: false }]);
+		expect(facts.numericOperandKind).toBe('int32');
 	});
 
 	it('owns stack errors before codegen runs', () => {
@@ -113,5 +114,85 @@ describe('analyzeInstruction', () => {
 			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 7 },
 		]);
 		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 7 }]);
+	});
+
+	it('records map input and output kinds', () => {
+		const mapBlock: MapBlockStackFrame = {
+			blockType: BlockType.MAP,
+			expectedResultTypes: [],
+			mapState: {
+				inputIsInteger: false,
+				inputIsFloat64: true,
+				rows: [],
+				defaultSet: false,
+			},
+		};
+		const context = createStackAnalyzerTestContext({
+			stack: [{ kind: 'value', valueType: 'float64' }],
+			blockStack: [
+				{
+					blockType: BlockType.MODULE,
+					expectedResultTypes: [],
+				},
+				mapBlock,
+			],
+			activeMapBlock: mapBlock,
+			insideMapBlock: true,
+			activeBlockDepths: {
+				[BlockType.MODULE]: 1,
+				[BlockType.LOOP]: 0,
+				[BlockType.CONDITION]: 0,
+				[BlockType.FUNCTION]: 0,
+				[BlockType.BLOCK]: 0,
+				[BlockType.CONSTANTS]: 0,
+				[BlockType.MAP]: 1,
+			},
+		});
+		const line = {
+			lineNumber: 1,
+			instruction: 'mapEnd',
+			arguments: [
+				{
+					type: ArgumentType.IDENTIFIER,
+					value: 'float',
+					referenceKind: 'plain',
+					scope: 'local',
+				},
+			],
+		} as CompilerASTLine;
+
+		const facts = analyzeInstruction(line, context);
+
+		expect(facts.map).toEqual({ inputKind: 'float64', outputKind: 'float32' });
+	});
+
+	it('records clamp address facts', () => {
+		const range: MemoryAddressRange = {
+			source: 'memory-start',
+			memoryIndex: 2,
+			memoryRegionName: 'aux',
+			byteAddress: 16,
+			safeByteLength: 64,
+			memoryId: 'buffer',
+		};
+		const context = createStackAnalyzerTestContext();
+		context.stack.push({
+			kind: 'address',
+			valueType: 'int',
+			address: { clampRange: range },
+		});
+		const line = {
+			lineNumber: 1,
+			instruction: 'clampAddress',
+			arguments: [{ type: ArgumentType.LITERAL, value: GLOBAL_ALIGNMENT_BOUNDARY * 2, isInteger: true }],
+		} as CompilerASTLine;
+
+		const facts = analyzeInstruction(line, context);
+
+		expect(facts.clamp).toEqual({
+			accessByteWidth: GLOBAL_ALIGNMENT_BOUNDARY * 2,
+			memoryIndex: 2,
+			range,
+		});
 	});
 });

--- a/packages/compiler/packages/stack-analyzer/src/analyzeInstruction.ts
+++ b/packages/compiler/packages/stack-analyzer/src/analyzeInstruction.ts
@@ -4,26 +4,11 @@ import type {
 	StackAnalysisLineFacts,
 	StackAnalysisResult,
 } from '@8f4e/language-spec';
+import { getInstructionSpec, hasBinaryMatchingOperands } from '@8f4e/language-spec';
 import { analyzeByInstruction } from './instructionAnalyzers';
 import { getNumericOperandKind } from './instructionAnalyzers/numeric/shared';
 import { cloneStack } from './instructionAnalyzers/stack';
 import { validateInstruction } from './validateInstruction';
-
-const numericOperandKindInstructions = new Set<CompilerASTLine['instruction']>([
-	'add',
-	'sub',
-	'mul',
-	'div',
-	'equal',
-	'notEqual',
-	'greaterThan',
-	'lessThan',
-	'greaterOrEqual',
-	'lessOrEqual',
-	'greaterOrEqualUnsigned',
-	'min',
-	'max',
-]);
 
 /**
  * Validates one AST line, updates stack state, and records the before/after stack analysis metadata.
@@ -42,7 +27,7 @@ export function analyzeInstruction(line: CompilerASTLine, context: CompilationCo
 	);
 	const derivedNumericOperandKind =
 		numericOperandKind ??
-		(numericOperandKindInstructions.has(line.instruction)
+		(hasBinaryMatchingOperands(getInstructionSpec(line.instruction))
 			? getNumericOperandKind(consumed[0], consumed[1])
 			: undefined);
 	const stackAnalysis: StackAnalysisResult = {

--- a/packages/compiler/packages/stack-analyzer/src/analyzeInstruction.ts
+++ b/packages/compiler/packages/stack-analyzer/src/analyzeInstruction.ts
@@ -5,8 +5,25 @@ import type {
 	StackAnalysisResult,
 } from '@8f4e/language-spec';
 import { analyzeByInstruction } from './instructionAnalyzers';
+import { getNumericOperandKind } from './instructionAnalyzers/numeric/shared';
 import { cloneStack } from './instructionAnalyzers/stack';
 import { validateInstruction } from './validateInstruction';
+
+const numericOperandKindInstructions = new Set<CompilerASTLine['instruction']>([
+	'add',
+	'sub',
+	'mul',
+	'div',
+	'equal',
+	'notEqual',
+	'greaterThan',
+	'lessThan',
+	'greaterOrEqual',
+	'lessOrEqual',
+	'greaterOrEqualUnsigned',
+	'min',
+	'max',
+]);
 
 /**
  * Validates one AST line, updates stack state, and records the before/after stack analysis metadata.
@@ -19,7 +36,15 @@ export function analyzeInstruction(line: CompilerASTLine, context: CompilationCo
 	validateInstruction(line, context);
 
 	const stackBefore = cloneStack(context.stack);
-	const { consumed, produced, dropped, targetFunctionId } = analyzeByInstruction(line, context);
+	const { consumed, produced, dropped, targetFunctionId, numericOperandKind, map, clamp } = analyzeByInstruction(
+		line,
+		context
+	);
+	const derivedNumericOperandKind =
+		numericOperandKind ??
+		(numericOperandKindInstructions.has(line.instruction)
+			? getNumericOperandKind(consumed[0], consumed[1])
+			: undefined);
 	const stackAnalysis: StackAnalysisResult = {
 		stackBefore,
 		stackAfter: cloneStack(context.stack),
@@ -31,5 +56,8 @@ export function analyzeInstruction(line: CompilerASTLine, context: CompilationCo
 	return {
 		stackAnalysis,
 		...(targetFunctionId ? { targetFunctionId } : {}),
+		...(derivedNumericOperandKind ? { numericOperandKind: derivedNumericOperandKind } : {}),
+		...(map ? { map } : {}),
+		...(clamp ? { clamp } : {}),
 	};
 }

--- a/packages/compiler/packages/stack-analyzer/src/instructionAnalyzers/mapEnd.ts
+++ b/packages/compiler/packages/stack-analyzer/src/instructionAnalyzers/mapEnd.ts
@@ -2,6 +2,7 @@ import type { CompilationContext, MapEndLine, Stack } from '@8f4e/language-spec'
 import { resolveMapKind } from '@8f4e/semantic-utils';
 import { validateMapValueKind } from '../mapValueKind';
 import { consume, createStackValue, produce } from './stack';
+import type { InstructionAnalysisResult } from './types';
 
 /**
  * Validates active map input/output values and produces the map result stack item.
@@ -10,7 +11,7 @@ import { consume, createStackValue, produce } from './stack';
  * @param context - Compilation context used by the operation.
  * @returns Stack-analysis result for the map end instruction.
  */
-export function analyzeMapEnd(line: MapEndLine, context: CompilationContext): { consumed: Stack; produced: Stack } {
+export function analyzeMapEnd(line: MapEndLine, context: CompilationContext): InstructionAnalysisResult {
 	const { mapState } = context.activeMapBlock!;
 
 	const outputType = line.arguments[0].value;
@@ -51,5 +52,5 @@ export function analyzeMapEnd(line: MapEndLine, context: CompilationContext): { 
 	const consumed = consume(context, 1);
 	const produced: Stack = [createStackValue(outputIsInteger ? 'int' : outputIsFloat64 ? 'float64' : 'float')];
 	produce(context, produced);
-	return { consumed, produced };
+	return { consumed, produced, map: { inputKind, outputKind } };
 }

--- a/packages/compiler/packages/stack-analyzer/src/instructionAnalyzers/memory.ts
+++ b/packages/compiler/packages/stack-analyzer/src/instructionAnalyzers/memory.ts
@@ -33,5 +33,13 @@ export function analyzeClampAddress(line: CompilerASTLine, context: CompilationC
 
 	const produced = [getClampedAddressStackItem(consumed[0], range, accessByteWidth)];
 	produce(context, produced);
-	return { consumed, produced };
+	return {
+		consumed,
+		produced,
+		clamp: {
+			accessByteWidth,
+			memoryIndex: produced[0].address.memoryIndex,
+			...(range ? { range } : {}),
+		},
+	};
 }

--- a/packages/compiler/packages/stack-analyzer/src/instructionAnalyzers/numeric/shared.ts
+++ b/packages/compiler/packages/stack-analyzer/src/instructionAnalyzers/numeric/shared.ts
@@ -1,6 +1,21 @@
-import type { StackItem, StackValueType } from '@8f4e/language-spec';
+import type { StackAnalysisNumericValueKind, StackItem, StackValueType } from '@8f4e/language-spec';
 import { areAllOperandsFloat64, areAllOperandsIntegers } from '@8f4e/semantic-utils';
 import { createStackValue } from '../stack';
+
+/**
+ * Resolves two numeric operands to the concrete value kind used by downstream codegen.
+ *
+ * @param left - Left stack operand.
+ * @param right - Right stack operand.
+ * @returns The numeric value kind shared through stack-analysis facts.
+ */
+export function getNumericOperandKind(left: StackItem, right: StackItem): StackAnalysisNumericValueKind {
+	if (areAllOperandsIntegers(left, right)) {
+		return 'int32';
+	}
+
+	return areAllOperandsFloat64(left, right) ? 'float64' : 'float32';
+}
 
 /**
  * Builds the stack item produced by a two-operand numeric instruction.
@@ -15,10 +30,10 @@ export function numericResult(
 	right: StackItem,
 	deriveIntegerMetadata?: (left: StackItem, right: StackItem) => Partial<StackItem>
 ): StackItem {
-	const isInteger = areAllOperandsIntegers(left, right);
-	const isFloat64 = areAllOperandsFloat64(left, right);
+	const numericOperandKind = getNumericOperandKind(left, right);
+	const isInteger = numericOperandKind === 'int32';
 	const integerMetadata = isInteger ? (deriveIntegerMetadata?.(left, right) ?? {}) : {};
-	const valueType: StackValueType = isInteger ? 'int' : isFloat64 ? 'float64' : 'float';
+	const valueType: StackValueType = isInteger ? 'int' : numericOperandKind === 'float64' ? 'float64' : 'float';
 	if (isInteger && 'kind' in integerMetadata && integerMetadata.kind === 'address' && integerMetadata.address) {
 		return {
 			kind: 'address',

--- a/packages/compiler/packages/stack-analyzer/src/instructionAnalyzers/types.ts
+++ b/packages/compiler/packages/stack-analyzer/src/instructionAnalyzers/types.ts
@@ -1,4 +1,11 @@
-import type { CompilationContext, CompilerASTLine, Stack } from '@8f4e/language-spec';
+import type {
+	CompilationContext,
+	CompilerASTLine,
+	Stack,
+	StackAnalysisClampFact,
+	StackAnalysisMapFact,
+	StackAnalysisNumericValueKind,
+} from '@8f4e/language-spec';
 
 /** Stack delta produced by analyzing one compiler instruction. */
 export type InstructionAnalysisResult = {
@@ -6,6 +13,9 @@ export type InstructionAnalysisResult = {
 	produced: Stack;
 	dropped?: Stack;
 	targetFunctionId?: string;
+	numericOperandKind?: StackAnalysisNumericValueKind;
+	map?: StackAnalysisMapFact;
+	clamp?: StackAnalysisClampFact;
 };
 
 /** Function shape shared by stack analyzers that handle specific compiler instructions. */

--- a/packages/compiler/packages/stack-analyzer/src/mapValueKind.ts
+++ b/packages/compiler/packages/stack-analyzer/src/mapValueKind.ts
@@ -1,6 +1,10 @@
-import type { CompilationContext, CompilerASTLine, StackValueType } from '@8f4e/language-spec';
+import type {
+	CompilationContext,
+	CompilerASTLine,
+	StackAnalysisNumericValueKind,
+	StackValueType,
+} from '@8f4e/language-spec';
 import { ErrorCode, getError } from '@8f4e/language-spec';
-import type { MapKind } from '@8f4e/semantic-utils';
 
 /**
  * Validates that a map input, row value, or default value matches the expected map kind.
@@ -13,7 +17,7 @@ import type { MapKind } from '@8f4e/semantic-utils';
  */
 export function validateMapValueKind(
 	valueKind: { valueType: StackValueType },
-	expectedKind: MapKind,
+	expectedKind: StackAnalysisNumericValueKind,
 	line: CompilerASTLine,
 	context: CompilationContext
 ) {

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/clampAddress.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/clampAddress.ts
@@ -1,21 +1,14 @@
-import type { CompilerASTLine, InstructionCompiler, MemoryAddressRange, StackItem } from '@8f4e/language-spec';
-import {
-	clampAddressByteCode,
-	getClampAccessByteWidth,
-	getModuleAddressRange,
-	rangeUpperByteAddressCode,
-} from './utils/addressClamp';
+import type { CompilerASTLine, InstructionCompiler, MemoryAddressRange } from '@8f4e/language-spec';
+import { clampAddressByteCode, rangeUpperByteAddressCode } from './utils/addressClamp';
 import { linearLastValidStartAddress } from './utils/memoryAccessGuard';
 import { saveByteCode } from './utils/saveByteCode';
-import { requireStackAddress } from './utils/stackItem';
 
 function clampToRange(
 	line: CompilerASTLine,
 	context: Parameters<InstructionCompiler>[1],
-	operand: StackItem,
-	range: MemoryAddressRange
+	range: MemoryAddressRange,
+	accessByteWidth: number
 ) {
-	const accessByteWidth = getClampAccessByteWidth(line);
 	return saveByteCode(
 		context,
 		clampAddressByteCode(context, line, range.byteAddress, rangeUpperByteAddressCode(range, accessByteWidth))
@@ -30,11 +23,9 @@ function clampToRange(
  * @returns The updated compilation context.
  */
 export const clampAddress: InstructionCompiler = (line, context, facts) => {
-	const [rawOperand] = facts.stackAnalysis.consumedOperands;
-	const operand = requireStackAddress(rawOperand, line, context);
-	const range = operand.address.clampRange ?? operand.address.safeRange;
+	const { accessByteWidth, range } = facts.clamp!;
 
-	return clampToRange(line, context, operand, range!);
+	return clampToRange(line, context, range!, accessByteWidth);
 };
 
 /**
@@ -45,9 +36,9 @@ export const clampAddress: InstructionCompiler = (line, context, facts) => {
  * @returns The updated compilation context.
  */
 export const clampModuleAddress: InstructionCompiler = (line, context, facts) => {
-	const [rawOperand] = facts.stackAnalysis.consumedOperands;
-	const operand = requireStackAddress(rawOperand, line, context);
-	return clampToRange(line, context, operand, getModuleAddressRange(context));
+	const { accessByteWidth, range } = facts.clamp!;
+
+	return clampToRange(line, context, range!, accessByteWidth);
 };
 
 /**
@@ -58,12 +49,10 @@ export const clampModuleAddress: InstructionCompiler = (line, context, facts) =>
  * @returns The updated compilation context.
  */
 export const clampGlobalAddress: InstructionCompiler = (line, context, facts) => {
-	const [rawOperand] = facts.stackAnalysis.consumedOperands;
-	const operand = requireStackAddress(rawOperand, line, context);
-	const accessByteWidth = getClampAccessByteWidth(line);
+	const { accessByteWidth, memoryIndex } = facts.clamp!;
 
 	return saveByteCode(
 		context,
-		clampAddressByteCode(context, line, 0, linearLastValidStartAddress(accessByteWidth, operand.address.memoryIndex))
+		clampAddressByteCode(context, line, 0, linearLastValidStartAddress(accessByteWidth, memoryIndex))
 	);
 };

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/createMinMax.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/createMinMax.ts
@@ -14,15 +14,14 @@ import {
 } from '@8f4e/compiler-wasm-utils';
 import type { InstructionCompiler } from '@8f4e/language-spec';
 
-import { areAllOperandsFloat64, areAllOperandsIntegers } from '@8f4e/semantic-utils';
 import { saveByteCode } from './utils/saveByteCode';
 
 const createMinMax =
 	(instruction: 'min' | 'max'): InstructionCompiler =>
 	(line, context, facts) => {
-		const [operand1, operand2] = facts.stackAnalysis.consumedOperands;
-		const isInteger = areAllOperandsIntegers(operand1, operand2);
-		const isFloat64 = areAllOperandsFloat64(operand1, operand2);
+		const numericOperandKind = facts.numericOperandKind!;
+		const isInteger = numericOperandKind === 'int32';
+		const isFloat64 = numericOperandKind === 'float64';
 
 		if (isInteger) {
 			const leftName = `__${instruction}_left${line.lineNumber}`;

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/mapEnd.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/mapEnd.ts
@@ -14,18 +14,22 @@ import {
 	WASM_I32_OR,
 	WASM_SELECT,
 } from '@8f4e/compiler-wasm-utils';
-import type { InstructionCompiler, MapBlockStackFrame, MapEndLine } from '@8f4e/language-spec';
-import type { MapKind } from '@8f4e/semantic-utils';
-import { popBlock, resolveMapKind } from '@8f4e/semantic-utils';
+import type {
+	InstructionCompiler,
+	MapBlockStackFrame,
+	MapEndLine,
+	StackAnalysisNumericValueKind,
+} from '@8f4e/language-spec';
+import { popBlock } from '@8f4e/semantic-utils';
 import { saveByteCode } from './utils/saveByteCode';
 
-const constOp: Record<MapKind, (v: number) => number[]> = {
+const constOp: Record<StackAnalysisNumericValueKind, (v: number) => number[]> = {
 	int32: i32const,
 	float32: f32const,
 	float64: f64const,
 };
 
-const eqOpcode: Record<MapKind, WASMInstructionCode> = {
+const eqOpcode: Record<StackAnalysisNumericValueKind, WASMInstructionCode> = {
 	int32: WASM_I32_EQ,
 	float32: WASM_F32_EQ,
 	float64: WASM_F64_EQ,
@@ -50,24 +54,19 @@ const eqOpcode: Record<MapKind, WASMInstructionCode> = {
  *
  * @see [Instruction docs](../../docs/instructions/control-flow.md)
  */
-const mapEnd: InstructionCompiler<MapEndLine> = (line: MapEndLine, context) => {
-	const outputType = line.arguments[0].value;
-	const outputIsInteger = outputType === 'int';
-	const outputIsFloat64 = outputType === 'float64';
-	const outputKind = resolveMapKind({ valueType: outputIsInteger ? 'int' : outputIsFloat64 ? 'float64' : 'float' });
+const mapEnd: InstructionCompiler<MapEndLine> = (_line: MapEndLine, context, facts) => {
+	const { inputKind, outputKind } = facts.map!;
+	const outputIsInteger = outputKind === 'int32';
+	const outputIsFloat64 = outputKind === 'float64';
 
 	const { mapState } = popBlock(context) as MapBlockStackFrame;
-
-	const inputKind = resolveMapKind({
-		valueType: mapState.inputIsInteger ? 'int' : mapState.inputIsFloat64 ? 'float64' : 'float',
-	});
 
 	const rows = mapState.rows;
 	const hasDefault = mapState.defaultSet;
 	const defaultValue = hasDefault ? mapState.defaultValue! : 0;
 
-	const inputIsFloat64 = mapState.inputIsFloat64;
-	const inputIsInteger = mapState.inputIsInteger;
+	const inputIsFloat64 = inputKind === 'float64';
+	const inputIsInteger = inputKind === 'int32';
 
 	if (rows.length === 0) {
 		// No rows: discard the input and push the default/zero value

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/utils/addressClamp.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/utils/addressClamp.ts
@@ -1,10 +1,6 @@
 import { i32const, localGet, localSet, WASM_I32_GT_U, WASM_I32_LT_S, WASM_SELECT } from '@8f4e/compiler-wasm-utils';
-
-import { getOrCreateMemoryGuardLocal } from './memoryAccessGuard';
-
-export { getClampAccessByteWidth, getClampedAddressStackItem, getModuleAddressRange } from '@8f4e/semantic-utils';
-
 import type { CodegenContext, CompilationContext, CompilerASTLine, MemoryAddressRange } from '@8f4e/language-spec';
+import { getOrCreateMemoryGuardLocal } from './memoryAccessGuard';
 
 /**
  * Builds bytecode that clamps the top stack address between lower and upper bounds.

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/utils/createNumericBinaryCompiler.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/utils/createNumericBinaryCompiler.ts
@@ -1,6 +1,5 @@
 import type { InstructionCompiler, StackItem } from '@8f4e/language-spec';
 
-import { areAllOperandsFloat64, areAllOperandsIntegers } from '@8f4e/semantic-utils';
 import { saveByteCode } from './saveByteCode';
 
 type NumericBinaryOpcodes = {
@@ -35,11 +34,12 @@ export default function createNumericBinaryCompiler({
 }: NumericBinaryCompilerOptions): InstructionCompiler {
 	return (line, context, facts) => {
 		const [left, right] = facts.stackAnalysis.consumedOperands;
-		const isInteger = areAllOperandsIntegers(left, right);
-		const isFloat64 = areAllOperandsFloat64(left, right);
+		const numericOperandKind = facts.numericOperandKind!;
+		const isInteger = numericOperandKind === 'int32';
+		const isFloat64 = numericOperandKind === 'float64';
 
 		validate?.({ left, right, isInteger, isFloat64, line, context });
 
-		return saveByteCode(context, [isInteger ? opcodes.int32 : isFloat64 ? opcodes.float64 : opcodes.float32]);
+		return saveByteCode(context, [opcodes[numericOperandKind]]);
 	};
 }


### PR DESCRIPTION
## Summary
- add stack-analysis facts for numeric operand kind, map kinds, and clamp address details
- have wasm-codegen consume those facts instead of re-deriving them through semantic-utils helpers
- add stack-analyzer regression coverage for the new report fields

## Rationale
The stack analyzer already owns these semantic decisions. Reporting them explicitly keeps wasm-codegen focused on bytecode emission and removes duplicate helper calls at the codegen boundary.

## Validation
- npx nx run-many --target=typecheck --projects=@8f4e/language-spec,@8f4e/semantic-utils,@8f4e/stack-analyzer,@8f4e/wasm-codegen,@8f4e/compiler
- npx nx run-many --target=test --projects=@8f4e/semantic-utils,@8f4e/stack-analyzer,@8f4e/wasm-codegen,@8f4e/compiler
- npx nx run @8f4e/cli:test
- pre-commit affected typecheck