### PR TITLE
fix(compiler): clean pass helper exports

### DIFF
--- a/packages/compiler/AGENTS.md
+++ b/packages/compiler/AGENTS.md
@@ -9,7 +9,6 @@
 - Syntax parsing now lives in the nested subpackage `@8f4e/tokenizer` (`packages/compiler/packages/tokenizer`).
 - Project preparsing lives in the nested standalone subpackage `@8f4e/project-preparser` (`packages/compiler/packages/project-preparser`).
 - Standard library sources live in the nested source package `@8f4e/stdlib` (`packages/compiler/packages/stdlib`).
-- `@8f4e/compiler` should consume parsed AST input and semantic/codegen utilities, not source-to-AST parsing helpers.
 
 ## Build, Test, Dev
 - From root: `npx nx run compiler:build|test|typecheck`.
@@ -19,125 +18,13 @@
 
 ## Coding Style
 - TypeScript (strict). Use Biome for linting and import organization.
-- Use Biome as the fixer (`npx biome check --write <files>`); it owns formatting rules such as tabs, single quotes, semicolons, width 120, and trailing commas.
+- Use Biome as the fixer (`npx biome check --write <files>`);
 
 ## Testing
 - Vitest (via Nx). Keep narrow unit tests colocated with the source under test using `*.test.ts` or `__tests__/`.
 - Put broader compiler behavior, multi-module, integration-style, and generic regression coverage in `tests/`.
-- Focus on deterministic, fast tests for semantic analysis, IR, transforms, and codegen behavior.
 - Syntax/parser in-source tests live with `@8f4e/tokenizer`; compiler tests should focus on semantic and codegen behavior.
 - To update snapshots after intentional changes, use `npx nx run compiler:test -- --update`.
-
-## Function Purity and `#impure`
-
-### Overview
-The compiler now supports pure functions alongside modules. Functions are pure by default and may opt into explicit memory IO with `#impure`.
-- **Pure by default**: No memory IO, only stack and locals
-- **Impure by directive**: `#impure` allows explicit address-driven reads/writes
-- **Stateless**: No memory access, only stack and locals
-- **Reusable**: Can be called from multiple modules
-- **Type-safe**: Explicit signatures with int/float parameters and returns
-- **Compiled once**: Shared across all modules that call them
-
-### Syntax
-
-#### Function Declaration
-```
-function <name> [<param1Type> <param2Type> ...]
-  ; function body (stack-only operations)
-functionEnd [<return1Type> <return2Type> ...]
-```
-
-#### Calling Functions
-```
-module myModule
-  loop
-    push 5
-    call square  ; Call a defined function
-    drop
-  loopEnd
-moduleEnd
-```
-
-### Constraints
-- **Parameters**: Maximum 8, types must be `int` or `float`
-- **Returns**: Maximum 8, types must be `int` or `float`
-- **No memory declarations in functions**: Functions cannot declare `int`, `float`, pointers, or buffers
-- **Pure by default**: `load`, `store`, `storeBytes`, and pointer dereference require `#impure`
-- **No direct module memory namespace access**: Even impure functions still operate only on explicit addresses
-- **Stack-only operations**: Supports locals, constants, arithmetic, logic, control flow
-
-### Allowed Instructions in Functions
-- **Arithmetic**: `add`, `sub`, `mul`, `div`, `remainder`, `min`, `max`, `abs`, `sqrt`, `round`
-- **Logic**: `and`, `or`, `xor`, `equal`, `equalToZero`, `greaterThan`, `lessThan`, `greaterOrEqual`, `lessOrEqual`
-- **Stack**: `push`, `drop`, `clearStack`
-- **Locals**: `local`, `localSet`
-- **Control flow**: `if`, `ifEnd`, `else`, `loop`, `loopEnd`, `block`, `blockEnd`, `branch`, `branchIfTrue`
-- **Type conversion**: `castToInt`, `castToFloat`
-- **Bitwise**: `shiftLeft`, `shiftRight`, `shiftRightUnsigned`
-- **Constants**: `const` (can be defined at top level or in function body)
-
-### API Usage
-
-```typescript
-import compile from '@8f4e/compiler';
-
-// Define pure functions
-const functions = [
-  {
-    code: [
-      'function square',
-      'param int x',
-      'push x',
-      'push x',
-      'mul',
-      'functionEnd int'
-    ]
-  },
-  {
-    code: [
-      'function add int int',
-      'add',
-      'functionEnd int'
-    ]
-  }
-];
-
-// Define modules that use functions
-const modules = [
-  {
-    code: [
-      'module test',
-      'loop',
-      'push 5',
-      'call square',
-      'drop',
-      'loopEnd',
-      'moduleEnd'
-    ]
-  }
-];
-
-const options = {
-  startingMemoryWordAddress: 1,
-  environmentExtensions: {
-    constants: {},
-    ignoredKeywords: []
-  }
-};
-
-const result = compile(modules, options, functions);
-
-// Access compiled functions
-console.log(result.compiledFunctions);
-// {
-//   square: { id: 'square', signature: { parameters: ['int'], returns: ['int'] }, ... },
-//   add: { id: 'add', signature: { parameters: ['int', 'int'], returns: ['int'] }, ... }
-// }
-
-// Access WASM bytecode
-console.log(result.codeBuffer);
-```
 
 ### Examples
 
@@ -176,21 +63,6 @@ function clampMin
 functionEnd int
 ```
 
-#### Example 3: Multiple return values
-```
-function divMod
-  param int dividend
-  param int divisor
-
-  push dividend
-  push divisor
-  div
-  push dividend
-  push divisor
-  remainder
-functionEnd int int
-```
-
 ## Error Domains
 
 The compiler uses two separate error modules. **Always choose based on detection phase**:
@@ -221,12 +93,3 @@ This means:
 
 - Do **not** add defensive runtime checks for argument-shape states that can only happen if compiler-owned normalization/manipulation code is wrong.
 - Do **not** compensate for broad internal types by repeatedly checking the same invariant in semantic/codegen steps.
-- If a phase requires a narrower shape, encode that requirement in the type boundary and route only the correct staged type there.
-
-Exception:
-
-- Runtime validation is still appropriate for real semantic/codegen concerns that depend on program state rather than token shape, such as stack validity, resolved type compatibility, scope legality, or symbol existence when that ownership has not yet been moved earlier.
-
-## Commits & PRs
-- Commits: `compiler: <scope> <change>` (e.g., `compiler: parser fix for arrays`).
-- PRs: include rationale, test coverage notes, and linked issues.

--- a/packages/compiler/packages/constant-resolver/src/index.ts
+++ b/packages/compiler/packages/constant-resolver/src/index.ts
@@ -292,7 +292,7 @@ function collectConstantNamespacesFromAsts(
 	return namespaces;
 }
 
-export function collectConstantNamespaces(
+function collectConstantNamespaces(
 	input: ResolveConstantsInput,
 	options: ResolveConstantsOptions = {}
 ): ConstantNamespaceMap {

--- a/packages/compiler/packages/memory-reference-resolver/src/index.test.ts
+++ b/packages/compiler/packages/memory-reference-resolver/src/index.test.ts
@@ -1,11 +1,12 @@
 import { ArgumentType, type ValidatedModuleAST } from '@8f4e/language-spec';
 import type { MemoryLayoutPlan, PlannedMemoryDeclaration, PlannedMemoryModule } from '@8f4e/memory-planner';
 import { describe, expect, it } from 'vitest';
-import { resolveMemoryReferences, tryResolveValueArgument } from './index';
+import { resolveMemoryReferences } from './index';
 import {
 	type MemoryReferenceResolutionContext,
 	resolveMemoryExpressionOperand,
 } from './resolveMemoryExpressionOperand';
+import { tryResolveValueArgument } from './tryResolveValueArgument';
 
 const { classifyIdentifier, parseArgument, parseCompileTimeOperand } = await import('@8f4e/tokenizer');
 

--- a/packages/compiler/packages/memory-reference-resolver/src/index.ts
+++ b/packages/compiler/packages/memory-reference-resolver/src/index.ts
@@ -2,7 +2,6 @@ import type {
 	AddressMetadata,
 	Argument,
 	CompilerASTLine,
-	CompileTimeOperand,
 	Const,
 	ConstantResolutionBlockFacts,
 	ConstantResolutionLineFacts,
@@ -27,13 +26,12 @@ import type {
 } from '@8f4e/language-spec';
 import { ArgumentType, isScalarMemoryDeclarationLine, POINTER_FUNCTION_TYPE_IDENTIFIERS } from '@8f4e/language-spec';
 import type { MemoryLayoutPlan, PlannedMemoryModule } from '@8f4e/memory-planner';
-import { evaluateResolvedValueExpression } from './evaluateResolvedValueExpression';
-import {
-	type MemoryReferenceModuleNamespace,
-	type MemoryReferencePointerMetadataByModuleId,
-	type MemoryReferenceResolutionContext,
-	resolveMemoryExpressionOperand,
+import type {
+	MemoryReferenceModuleNamespace,
+	MemoryReferencePointerMetadataByModuleId,
+	MemoryReferenceResolutionContext,
 } from './resolveMemoryExpressionOperand';
+import { tryResolveValueArgument } from './tryResolveValueArgument';
 
 export type {
 	MemoryReferenceResolutionBlockFacts,
@@ -206,21 +204,6 @@ function updatePointerMemoryMetadata(line: CompilerASTLine, context: MemoryRefer
 	};
 }
 
-function resolveValueOperand(
-	operand: CompileTimeOperand,
-	context: MemoryReferenceResolutionContext
-): Const | undefined {
-	if (operand.type === ArgumentType.LITERAL) {
-		return {
-			value: operand.value,
-			isInteger: operand.isInteger,
-			...(operand.isFloat64 ? { isFloat64: true } : {}),
-		};
-	}
-
-	return resolveMemoryExpressionOperand(operand, context);
-}
-
 function resolvedValueToLiteral(resolved: Const): ResolvedArgumentLiteral {
 	return {
 		type: ArgumentType.LITERAL,
@@ -229,40 +212,6 @@ function resolvedValueToLiteral(resolved: Const): ResolvedArgumentLiteral {
 		...(resolved.isFloat64 ? { isFloat64: true } : {}),
 		...(resolved.address ? { address: resolved.address } : {}),
 	};
-}
-
-/**
- * Attempts to fold an argument into a semantic value using the current memory layout context.
- * Constant identifiers are expected to have been resolved before this pass runs.
- *
- * @param context - Compilation context used by the operation.
- * @param argument - Argument whose resolved value or metadata should be used.
- * @returns Resolved value, or `undefined` when the argument cannot be folded.
- */
-export function tryResolveValueArgument(
-	context: MemoryReferenceResolutionContext,
-	argument: Argument
-): Const | undefined {
-	if (argument.type !== ArgumentType.IDENTIFIER && argument.type !== ArgumentType.COMPILE_TIME_EXPRESSION) {
-		return undefined;
-	}
-
-	if (argument.type === ArgumentType.COMPILE_TIME_EXPRESSION) {
-		const leftConst = resolveValueOperand(argument.left, context);
-		const rightConst = resolveValueOperand(argument.right, context);
-
-		if (leftConst === undefined || rightConst === undefined) {
-			return undefined;
-		}
-
-		if (argument.operator === '/' && rightConst.value === 0) {
-			return undefined;
-		}
-
-		return evaluateResolvedValueExpression(leftConst, rightConst, argument.operator);
-	}
-
-	return resolveValueOperand(argument, context);
 }
 
 function resolveMemoryReferenceArgument(

--- a/packages/compiler/packages/memory-reference-resolver/src/tryResolveValueArgument.ts
+++ b/packages/compiler/packages/memory-reference-resolver/src/tryResolveValueArgument.ts
@@ -1,0 +1,54 @@
+import type { Argument, CompileTimeOperand, Const } from '@8f4e/language-spec';
+import { ArgumentType } from '@8f4e/language-spec';
+import { evaluateResolvedValueExpression } from './evaluateResolvedValueExpression';
+import type { MemoryReferenceResolutionContext } from './resolveMemoryExpressionOperand';
+import { resolveMemoryExpressionOperand } from './resolveMemoryExpressionOperand';
+
+function resolveValueOperand(
+	operand: CompileTimeOperand,
+	context: MemoryReferenceResolutionContext
+): Const | undefined {
+	if (operand.type === ArgumentType.LITERAL) {
+		return {
+			value: operand.value,
+			isInteger: operand.isInteger,
+			...(operand.isFloat64 ? { isFloat64: true } : {}),
+		};
+	}
+
+	return resolveMemoryExpressionOperand(operand, context);
+}
+
+/**
+ * Attempts to fold an argument into a semantic value using the current memory layout context.
+ * Constant identifiers are expected to have been resolved before this pass runs.
+ *
+ * @param context - Compilation context used by the operation.
+ * @param argument - Argument whose resolved value or metadata should be used.
+ * @returns Resolved value, or `undefined` when the argument cannot be folded.
+ */
+export function tryResolveValueArgument(
+	context: MemoryReferenceResolutionContext,
+	argument: Argument
+): Const | undefined {
+	if (argument.type !== ArgumentType.IDENTIFIER && argument.type !== ArgumentType.COMPILE_TIME_EXPRESSION) {
+		return undefined;
+	}
+
+	if (argument.type === ArgumentType.COMPILE_TIME_EXPRESSION) {
+		const leftConst = resolveValueOperand(argument.left, context);
+		const rightConst = resolveValueOperand(argument.right, context);
+
+		if (leftConst === undefined || rightConst === undefined) {
+			return undefined;
+		}
+
+		if (argument.operator === '/' && rightConst.value === 0) {
+			return undefined;
+		}
+
+		return evaluateResolvedValueExpression(leftConst, rightConst, argument.operator);
+	}
+
+	return resolveValueOperand(argument, context);
+}

--- a/packages/compiler/packages/stack-analyzer/README.md
+++ b/packages/compiler/packages/stack-analyzer/README.md
@@ -40,5 +40,3 @@ The stack analyzer is responsible for:
 - `push`, pointer dereference, and `pushShape` stack item production from resolved semantic facts
 
 It is not responsible for parsing, syntax validation, namespace construction, memory layout planning, memory default resolution, memory-reference resolution, semantic reference resolution, or WASM/codegen emission. Those earlier passes provide the AST and semantic metadata; later codegen consumes the stack report and does not perform stack analysis.
-
-`@8f4e/stack-analyzer/testing` exposes the package-private one-line analyzer for instruction compiler tests only. Compiler production code should use the project-level `analyzeStack` report.

--- a/packages/compiler/packages/stack-analyzer/package.json
+++ b/packages/compiler/packages/stack-analyzer/package.json
@@ -10,10 +10,6 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
-    },
-    "./testing": {
-      "types": "./dist/testing.d.ts",
-      "default": "./dist/testing.js"
     }
   },
   "sideEffects": false,

--- a/packages/compiler/packages/stack-analyzer/src/testing.ts
+++ b/packages/compiler/packages/stack-analyzer/src/testing.ts
@@ -1,1 +1,0 @@
-export { analyzeInstruction } from './analyzeInstruction';

--- a/packages/compiler/packages/stack-analyzer/vite.config.ts
+++ b/packages/compiler/packages/stack-analyzer/vite.config.ts
@@ -13,14 +13,6 @@ export default defineConfig({
 	...baseConfig,
 	build: {
 		...baseConfig.build,
-		lib: {
-			entry: {
-				index: './src/index.ts',
-				testing: './src/testing.ts',
-			},
-			formats: ['es'],
-			fileName: (_format, entryName) => `${entryName}.js`,
-		},
 		emptyOutDir: false,
 	},
 });

--- a/packages/compiler/packages/wasm-codegen/src/emitWasmProgram.ts
+++ b/packages/compiler/packages/wasm-codegen/src/emitWasmProgram.ts
@@ -60,7 +60,7 @@ export type WasmProgramInput = {
 };
 
 /** Calculates required byte size for each WebAssembly memory index. */
-export function getRequiredMemoryBytesByIndex(
+function getRequiredMemoryBytesByIndex(
 	items: Pick<CompiledModule, 'memoryIndex' | 'byteAddress' | 'wordAlignedSize'>[]
 ) {
 	return items.reduce<Record<number, number>>((result, item) => {
@@ -72,7 +72,7 @@ export function getRequiredMemoryBytesByIndex(
 }
 
 /** Converts non-default memory byte requirements into configured memory region names. */
-export function getRequiredMemoryBytesByRegion(
+function getRequiredMemoryBytesByRegion(
 	requiredMemoryBytesByIndex: Record<number, number>,
 	memoryRegions: readonly string[]
 ): Record<string, number> {

--- a/packages/compiler/packages/wasm-codegen/src/index.ts
+++ b/packages/compiler/packages/wasm-codegen/src/index.ts
@@ -1,12 +1,5 @@
 export { deriveEffectiveMemorySize } from '@8f4e/compiler-wasm-utils';
 export { compileFunction } from './compileFunction';
-export { compileCodegenLine } from './compileLine';
-export { compileModule } from './compileModule';
 export { compileModules } from './compileModules';
 export type { WasmProgramInput } from './emitWasmProgram';
-export { emitWasmProgram, getRequiredMemoryBytesByIndex, getRequiredMemoryBytesByRegion } from './emitWasmProgram';
-export { default as createInitialMemoryDataSegments } from './initialMemoryDataSegments/createInitialMemoryDataSegments';
-export type {
-	InitialMemoryDataSegment,
-	InitialMemoryDataSegmentCandidate,
-} from './initialMemoryDataSegments/types';
+export { emitWasmProgram } from './emitWasmProgram';

--- a/packages/compiler/packages/wasm-codegen/src/initialMemoryDataSegments/index.ts
+++ b/packages/compiler/packages/wasm-codegen/src/initialMemoryDataSegments/index.ts
@@ -1,2 +1,0 @@
-export { default as createInitialMemoryDataSegments } from './createInitialMemoryDataSegments';
-export type { InitialMemoryDataSegment, InitialMemoryDataSegmentCandidate } from './types';

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/and.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/and.test.ts
@@ -1,7 +1,9 @@
 import type { CompilerASTLine } from '@8f4e/language-spec';
-import { analyzeInstruction } from '@8f4e/stack-analyzer/testing';
 import { describe, expect, it } from 'vitest';
-import createInstructionCompilerTestContext, { analyzeAndCompileInstruction } from '../testUtils';
+import createInstructionCompilerTestContext, {
+	analyzeAndCompileInstruction,
+	analyzeInstructionForCodegenTest,
+} from '../testUtils';
 import and from './and';
 
 describe('and instruction compiler', () => {
@@ -41,7 +43,7 @@ describe('and instruction compiler', () => {
 		} as CompilerASTLine;
 
 		expect(() => {
-			analyzeInstruction(line, context);
+			analyzeInstructionForCodegenTest(line, context);
 		}).toThrowError();
 	});
 

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/call.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/call.test.ts
@@ -5,10 +5,10 @@ import type {
 	StackAnalysisLineFacts,
 } from '@8f4e/language-spec';
 import { ArgumentType, createFunctionId, ErrorCode } from '@8f4e/language-spec';
-import { analyzeInstruction } from '@8f4e/stack-analyzer/testing';
 import { describe, expect, it } from 'vitest';
 import createInstructionCompilerTestContext, {
 	analyzeAndCompileInstruction,
+	analyzeInstructionForCodegenTest,
 	seedTestMemoryDeclarations,
 } from '../testUtils';
 import call from './call';
@@ -30,7 +30,7 @@ function registerFunction(context: CompilationContext, ...targetFunctions: Funct
 }
 
 function analyzeAndCompileCall(line: CompilerASTLine, context: CompilationContext): StackAnalysisLineFacts {
-	const facts = analyzeInstruction(line, context);
+	const facts = analyzeInstructionForCodegenTest(line, context);
 	call(line, context, facts);
 	return facts;
 }
@@ -187,7 +187,7 @@ describe('call instruction compiler', () => {
 		} satisfies FunctionMetadata;
 		registerFunction(context, targetFunction);
 
-		analyzeInstruction(
+		analyzeInstructionForCodegenTest(
 			{
 				lineNumber: 1,
 				instruction: 'push',
@@ -195,7 +195,7 @@ describe('call instruction compiler', () => {
 			},
 			context
 		);
-		analyzeInstruction(
+		analyzeInstructionForCodegenTest(
 			{
 				lineNumber: 2,
 				instruction: 'push',
@@ -318,7 +318,7 @@ describe('call instruction compiler', () => {
 		context.stack.push({ kind: 'value', valueType: 'float64', isNonZero: false });
 
 		try {
-			analyzeInstruction(
+			analyzeInstructionForCodegenTest(
 				{
 					lineNumber: 1,
 					instruction: 'call',
@@ -353,7 +353,7 @@ describe('call instruction compiler', () => {
 		context.stack.push({ kind: 'value', valueType: 'int', isNonZero: false });
 
 		try {
-			analyzeInstruction(
+			analyzeInstructionForCodegenTest(
 				{
 					lineNumber: 1,
 					instruction: 'call',

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/storeBytes.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/storeBytes.test.ts
@@ -1,9 +1,11 @@
 import { WASM_MEMORY_SIZE } from '@8f4e/compiler-wasm-utils';
 import type { CompilerASTLine } from '@8f4e/language-spec';
 import { ArgumentType } from '@8f4e/language-spec';
-import { analyzeInstruction } from '@8f4e/stack-analyzer/testing';
 import { describe, expect, it } from 'vitest';
-import createInstructionCompilerTestContext, { analyzeAndCompileInstruction } from '../testUtils';
+import createInstructionCompilerTestContext, {
+	analyzeAndCompileInstruction,
+	analyzeInstructionForCodegenTest,
+} from '../testUtils';
 import storeBytes from './storeBytes';
 
 describe('storeBytes instruction compiler', () => {
@@ -21,7 +23,7 @@ describe('storeBytes instruction compiler', () => {
 		} as CompilerASTLine;
 
 		expect(() => {
-			analyzeInstruction(line, context);
+			analyzeInstructionForCodegenTest(line, context);
 		}).toThrow();
 	});
 

--- a/packages/compiler/packages/wasm-codegen/src/testUtils.ts
+++ b/packages/compiler/packages/wasm-codegen/src/testUtils.ts
@@ -1,17 +1,92 @@
 import { WASM_IF, WASM_MEMORY_SIZE } from '@8f4e/compiler-wasm-utils';
 import type {
+	AddressMetadata,
 	CompilationContext,
 	CompilerASTLine,
+	ErrorCodeValue,
+	FunctionMetadata,
+	FunctionValueType,
 	InstructionCompiler,
+	InstructionSpec,
+	LocalBinding,
+	MemoryAddressRange,
 	MemoryDefaultValue,
 	MemoryPointerMetadata,
 	MemoryPointerMetadataMap,
+	OperandRule,
 	PlannedMemoryDeclaration,
+	PointeeMetadata,
+	ResolvedMemoryDeclaration,
+	Stack,
+	StackAnalysisLineFacts,
+	StackAnalysisLocalPointerFact,
+	StackAnalysisNumericValueKind,
+	StackItem,
+	StackMutationSpec,
+	StackProducedItemSpec,
+	StackValueType,
 } from '@8f4e/language-spec';
-import { BlockType, GLOBAL_ALIGNMENT_BOUNDARY } from '@8f4e/language-spec';
-import { createCompilationContext } from '@8f4e/semantic-utils';
-import { analyzeInstruction } from '@8f4e/stack-analyzer/testing';
+import {
+	ArgumentType,
+	BASE_TYPE_METADATA,
+	BlockType,
+	createFunctionId,
+	ErrorCode,
+	functionValueTypeToStackItem,
+	GLOBAL_ALIGNMENT_BOUNDARY,
+	getDereferencedValueKindFromMetadata,
+	getError,
+	getInstructionSpec,
+	getMemoryRegionFields,
+	getPointerDepthFromMetadata,
+	stackItemMatchesFunctionValueType,
+} from '@8f4e/language-spec';
+import {
+	createCompilationContext,
+	getClampAccessByteWidth,
+	getClampedAddressStackItem,
+	getModuleAddressRange,
+	resolveMapKind,
+} from '@8f4e/semantic-utils';
 import { expect } from 'vitest';
+import { kindToStackItem, resolveArgumentValueKind, resolveMemoryValueKind } from './pushValueKind';
+
+type CodegenTestResolvedTarget =
+	| { kind: 'memory'; memoryItem: ResolvedMemoryDeclaration }
+	| { kind: 'memory-pointer'; memoryItem: ResolvedMemoryDeclaration }
+	| { kind: 'local'; localName: string }
+	| { kind: 'local-pointer'; localName: string };
+
+type CodegenTestLine = CompilerASTLine & {
+	resolvedTarget?: CodegenTestResolvedTarget;
+	inlineArgumentPushes?: CodegenTestLine[];
+};
+
+type CodegenTestArgument = CompilerASTLine['arguments'][number] & {
+	value?: string | number;
+	isInteger?: boolean;
+	isFloat64?: boolean;
+	address?: AddressMetadata;
+	dereferenceDepth?: number;
+};
+
+interface CodegenTestAnalysis {
+	consumed: Stack;
+	produced: Stack;
+	dropped?: Stack;
+	targetFunctionId?: string;
+	localPointer?: StackAnalysisLocalPointerFact;
+	map?: StackAnalysisLineFacts['map'];
+	clamp?: StackAnalysisLineFacts['clamp'];
+}
+
+function codegenTestLine(line: CompilerASTLine): CodegenTestLine {
+	return line as CodegenTestLine;
+}
+
+function getCodegenTestArgument(line: CompilerASTLine, index = 0): CodegenTestArgument {
+	return line.arguments[index] as CodegenTestArgument;
+}
 
 export type MemoryFixture = PlannedMemoryDeclaration &
 	MemoryPointerMetadata & {
@@ -137,6 +212,844 @@ export function seedTestMemoryDeclarations(
 	return context;
 }
 
+function cloneStack(stack: Stack): Stack {
+	return stack.map(item => ({
+		...item,
+		...(item.kind === 'address' ? { address: { ...item.address } } : {}),
+		...(item.kind === 'address' && item.pointsTo ? { pointsTo: { ...item.pointsTo } } : {}),
+	}));
+}
+
+function consume(context: CompilationContext, count: number): Stack {
+	if (count === 0) {
+		return [];
+	}
+	return context.stack.splice(context.stack.length - count, count);
+}
+
+function produce(context: CompilationContext, items: Stack): void {
+	context.stack.push(...items);
+}
+
+function createStackValue(
+	valueType: StackValueType,
+	metadata: Pick<StackItem, 'isNonZero' | 'knownIntegerValue'> = {}
+): StackItem {
+	return {
+		kind: 'value',
+		valueType,
+		...(metadata.isNonZero !== undefined ? { isNonZero: metadata.isNonZero } : {}),
+		...(metadata.knownIntegerValue !== undefined ? { knownIntegerValue: metadata.knownIntegerValue } : {}),
+	};
+}
+
+function areAllOperandsIntegers(...operands: StackItem[]): boolean {
+	return operands.every(operand => operand.valueType === 'int');
+}
+
+function areAllOperandsFloats(...operands: StackItem[]): boolean {
+	return operands.every(operand => operand.valueType === 'float' || operand.valueType === 'float64');
+}
+
+function hasMixedFloatWidth(...operands: StackItem[]): boolean {
+	const floats = operands.filter(operand => operand.valueType === 'float' || operand.valueType === 'float64');
+	return (
+		floats.some(operand => operand.valueType === 'float64') && floats.some(operand => operand.valueType === 'float')
+	);
+}
+
+function getOperandRuleErrorCode(rule: OperandRule | OperandRule[]): ErrorCodeValue {
+	const firstRule = Array.isArray(rule) ? rule[0] : rule;
+	return firstRule === 'int'
+		? ErrorCode.ONLY_INTEGERS
+		: firstRule === 'float'
+			? ErrorCode.ONLY_FLOATS
+			: ErrorCode.UNMATCHING_OPERANDS;
+}
+
+function validateOperandTypesForTest(
+	operands: StackItem[],
+	rule: OperandRule | OperandRule[],
+	line: CompilerASTLine,
+	context: CompilationContext
+): void {
+	const errorCode = getOperandRuleErrorCode(rule);
+	if (Array.isArray(rule)) {
+		for (let index = 0; index < rule.length && index < operands.length; index++) {
+			const expectedType = rule[index];
+			const operand = operands[index];
+			if (expectedType === 'int' && operand.valueType !== 'int') {
+				throw getError(errorCode, line, context);
+			}
+			if (expectedType === 'float' && operand.valueType === 'int') {
+				throw getError(errorCode, line, context);
+			}
+		}
+		return;
+	}
+
+	if (rule === 'int' && !areAllOperandsIntegers(...operands)) {
+		throw getError(errorCode, line, context);
+	}
+	if (rule === 'float' && !areAllOperandsFloats(...operands)) {
+		throw getError(errorCode, line, context);
+	}
+	if (rule === 'matching') {
+		if (!areAllOperandsIntegers(...operands) && !areAllOperandsFloats(...operands)) {
+			throw getError(errorCode, line, context);
+		}
+		if (hasMixedFloatWidth(...operands)) {
+			throw getError(ErrorCode.MIXED_FLOAT_WIDTH, line, context);
+		}
+	}
+}
+
+function validateInstructionForTest(line: CompilerASTLine, context: CompilationContext): void {
+	const spec = getInstructionSpec(line.instruction) as InstructionSpec<CompilerASTLine> | undefined;
+	const validatedOperands = spec?.validateOperands?.(line, context);
+	const operandsNeeded = validatedOperands?.minOperands ?? spec?.minOperands ?? 0;
+	const operandTypes = validatedOperands?.operandTypes ?? spec?.operandTypes;
+	if (operandsNeeded === 0) {
+		return;
+	}
+
+	const operands = context.stack.slice(context.stack.length - operandsNeeded);
+	if (operands.length < operandsNeeded) {
+		throw getError(ErrorCode.INSUFFICIENT_OPERANDS, line, context);
+	}
+	if (operandTypes) {
+		validateOperandTypesForTest(operands, operandTypes, line, context);
+	}
+}
+
+function getNumericOperandKind(left: StackItem, right: StackItem): StackAnalysisNumericValueKind {
+	if (areAllOperandsIntegers(left, right)) {
+		return 'int32';
+	}
+	return left.valueType === 'float64' || right.valueType === 'float64' ? 'float64' : 'float32';
+}
+
+function deriveKnownIntegerValue(
+	operand1: StackItem,
+	operand2: StackItem,
+	operation: (operand1: number, operand2: number) => number | undefined
+): Partial<StackItem> {
+	if (operand1.knownIntegerValue === undefined || operand2.knownIntegerValue === undefined) {
+		return {};
+	}
+
+	const knownIntegerValue = operation(operand1.knownIntegerValue, operand2.knownIntegerValue);
+	return knownIntegerValue === undefined ? {} : { knownIntegerValue, isNonZero: knownIntegerValue !== 0 };
+}
+
+function shiftSafeRange(safeRange: MemoryAddressRange, byteOffset: number): MemoryAddressRange | undefined {
+	if (!Number.isInteger(byteOffset) || byteOffset < 0 || byteOffset > safeRange.safeByteLength) {
+		return undefined;
+	}
+
+	return {
+		...safeRange,
+		byteAddress: safeRange.byteAddress + byteOffset,
+		safeByteLength: safeRange.safeByteLength - byteOffset,
+	};
+}
+
+function deriveAddStackMetadata(operand1: StackItem, operand2: StackItem): Partial<StackItem> {
+	const knownIntegerValue =
+		operand1.knownIntegerValue !== undefined && operand2.knownIntegerValue !== undefined
+			? operand1.knownIntegerValue + operand2.knownIntegerValue
+			: undefined;
+	const safeRange =
+		operand1.kind === 'address' && operand1.address.safeRange && operand2.knownIntegerValue !== undefined
+			? shiftSafeRange(operand1.address.safeRange, operand2.knownIntegerValue)
+			: operand2.kind === 'address' && operand2.address.safeRange && operand1.knownIntegerValue !== undefined
+				? shiftSafeRange(operand2.address.safeRange, operand1.knownIntegerValue)
+				: undefined;
+	const clampRange =
+		(operand1.kind === 'address' ? (operand1.address.clampRange ?? operand1.address.safeRange) : undefined) ??
+		(operand2.kind === 'address' ? (operand2.address.clampRange ?? operand2.address.safeRange) : undefined);
+	const pointsTo =
+		operand1.kind === 'address' && operand1.pointsTo
+			? operand1.pointsTo
+			: operand2.kind === 'address'
+				? operand2.pointsTo
+				: undefined;
+
+	return {
+		...(knownIntegerValue !== undefined ? { knownIntegerValue } : {}),
+		...(safeRange || clampRange
+			? {
+					kind: 'address',
+					valueType: 'int',
+					address: {
+						...getMemoryRegionFields(
+							(safeRange ?? clampRange)!.memoryIndex,
+							(safeRange ?? clampRange)!.memoryRegionName
+						),
+						...(safeRange ? { safeRange } : {}),
+						...(clampRange ? { clampRange } : {}),
+					},
+					...(pointsTo ? { pointsTo } : {}),
+				}
+			: {}),
+	} as Partial<StackItem>;
+}
+
+function deriveSubStackMetadata(operand1: StackItem, operand2: StackItem): Partial<StackItem> {
+	const knownIntegerValue =
+		operand1.knownIntegerValue !== undefined && operand2.knownIntegerValue !== undefined
+			? operand1.knownIntegerValue - operand2.knownIntegerValue
+			: undefined;
+	const safeRange =
+		operand1.kind === 'address' && operand1.address.safeRange && operand2.knownIntegerValue !== undefined
+			? shiftSafeRange(operand1.address.safeRange, -operand2.knownIntegerValue)
+			: undefined;
+	const clampRange =
+		operand1.kind === 'address' ? (operand1.address.clampRange ?? operand1.address.safeRange) : undefined;
+	const pointsTo = operand1.kind === 'address' ? operand1.pointsTo : undefined;
+
+	return {
+		...(knownIntegerValue !== undefined ? { knownIntegerValue } : {}),
+		...(safeRange || clampRange
+			? {
+					kind: 'address',
+					valueType: 'int',
+					address: {
+						...getMemoryRegionFields(
+							(safeRange ?? clampRange)!.memoryIndex,
+							(safeRange ?? clampRange)!.memoryRegionName
+						),
+						...(safeRange ? { safeRange } : {}),
+						...(clampRange ? { clampRange } : {}),
+					},
+					...(pointsTo ? { pointsTo } : {}),
+				}
+			: {}),
+	} as Partial<StackItem>;
+}
+
+function knownIntegerResult(knownIntegerValue: number | undefined, isNonZero = false): StackItem {
+	return createStackValue('int', {
+		isNonZero: knownIntegerValue !== undefined ? knownIntegerValue !== 0 : isNonZero,
+		knownIntegerValue,
+	});
+}
+
+function numericResult(
+	left: StackItem,
+	right: StackItem,
+	deriveIntegerMetadata?: (left: StackItem, right: StackItem) => Partial<StackItem>
+): StackItem {
+	const numericOperandKind = getNumericOperandKind(left, right);
+	const isInteger = numericOperandKind === 'int32';
+	const integerMetadata = isInteger ? (deriveIntegerMetadata?.(left, right) ?? {}) : {};
+	const valueType: StackValueType = isInteger ? 'int' : numericOperandKind === 'float64' ? 'float64' : 'float';
+	if (isInteger && 'kind' in integerMetadata && integerMetadata.kind === 'address' && 'address' in integerMetadata) {
+		return {
+			kind: 'address',
+			valueType: 'int',
+			address: integerMetadata.address!,
+			...(integerMetadata.pointsTo ? { pointsTo: integerMetadata.pointsTo } : {}),
+			...(integerMetadata.knownIntegerValue !== undefined
+				? {
+						knownIntegerValue: integerMetadata.knownIntegerValue,
+						isNonZero: integerMetadata.knownIntegerValue !== 0,
+					}
+				: {}),
+		};
+	}
+
+	return createStackValue(valueType, {
+		isNonZero: integerMetadata.knownIntegerValue !== undefined ? integerMetadata.knownIntegerValue !== 0 : false,
+		knownIntegerValue: integerMetadata.knownIntegerValue,
+	});
+}
+
+function getPointeeMetadata(pointerMetadata: ResolvedMemoryDeclaration | LocalBinding): PointeeMetadata | undefined {
+	return pointerMetadata.pointeeBaseType
+		? {
+				baseType: pointerMetadata.pointeeBaseType,
+				memoryIndex: pointerMetadata.pointeeMemoryIndex ?? 0,
+				...(pointerMetadata.pointeeMemoryRegionName
+					? { memoryRegionName: pointerMetadata.pointeeMemoryRegionName }
+					: {}),
+				pointerDepth: getPointerDepthFromMetadata(pointerMetadata),
+				...(pointerMetadata.pointeeElementCount !== undefined
+					? { elementCount: pointerMetadata.pointeeElementCount }
+					: {}),
+			}
+		: undefined;
+}
+
+function getAddressMemoryItem(
+	context: CompilationContext,
+	address: AddressMetadata
+): ResolvedMemoryDeclaration | undefined {
+	const range = address.safeRange ?? address.clampRange;
+	const memoryId = range?.memoryId;
+	if (!memoryId) {
+		return undefined;
+	}
+
+	const moduleId = range.moduleId ?? context.namespace.moduleName ?? context.currentPlannedModule?.id;
+	return moduleId ? context.memoryPlan.modules[moduleId]?.memory[memoryId] : undefined;
+}
+
+function getAddressPointeeMetadata(context: CompilationContext, address: AddressMetadata): PointeeMetadata | undefined {
+	const memoryItem = getAddressMemoryItem(context, address);
+	if (!memoryItem) {
+		return undefined;
+	}
+
+	const pointerDepth = memoryItem.pointerDepth + 1;
+	if (pointerDepth > 2) {
+		return undefined;
+	}
+
+	const baseType = memoryItem.pointeeBaseType ?? memoryItem.type.replace(/\*+$/, '');
+	return {
+		baseType: baseType as PointeeMetadata['baseType'],
+		memoryIndex: memoryItem.memoryIndex,
+		...(memoryItem.memoryRegionName ? { memoryRegionName: memoryItem.memoryRegionName } : {}),
+		pointerDepth,
+		elementCount: memoryItem.numberOfElements,
+	};
+}
+
+function pushLiteralStackItems(line: CompilerASTLine, context: CompilationContext): Stack {
+	const argument = getCodegenTestArgument(line);
+	if (argument.type === ArgumentType.STRING_LITERAL) {
+		return Array.from(String(argument.value ?? ''), ch =>
+			createStackValue('int', { isNonZero: (ch.charCodeAt(0) & 0xff) !== 0 })
+		);
+	}
+	if (argument.type === ArgumentType.COMPILE_TIME_EXPRESSION || argument.type === ArgumentType.IDENTIFIER) {
+		return [];
+	}
+
+	const address = argument.address
+		? {
+				...argument.address,
+				clampRange: argument.address.clampRange ?? argument.address.safeRange,
+			}
+		: undefined;
+	return [
+		kindToStackItem(resolveArgumentValueKind(argument), {
+			isNonZero: argument.value !== 0,
+			...(argument.isInteger && Number.isInteger(argument.value) ? { knownIntegerValue: argument.value } : {}),
+			...(address ? { address, pointsTo: getAddressPointeeMetadata(context, address) } : {}),
+		}),
+	];
+}
+
+function pushDereferencedPointerStackItems(line: CompilerASTLine, context: CompilationContext): Stack {
+	const testLine = codegenTestLine(line);
+	const pointerMetadata =
+		testLine.resolvedTarget?.kind === 'memory-pointer'
+			? testLine.resolvedTarget.memoryItem
+			: testLine.resolvedTarget?.kind === 'local-pointer'
+				? context.locals[testLine.resolvedTarget.localName]!
+				: undefined;
+	if (!pointerMetadata?.pointeeBaseType) {
+		return [];
+	}
+
+	const dereferenceDepth = getCodegenTestArgument(line).dereferenceDepth ?? 1;
+	const remainingPointerDepth = getPointerDepthFromMetadata(pointerMetadata) - dereferenceDepth;
+	if (remainingPointerDepth > 0) {
+		const pointsTo = {
+			baseType: pointerMetadata.pointeeBaseType,
+			memoryIndex: pointerMetadata.pointeeMemoryIndex ?? 0,
+			...(pointerMetadata.pointeeMemoryRegionName ? { memoryRegionName: pointerMetadata.pointeeMemoryRegionName } : {}),
+			pointerDepth: remainingPointerDepth,
+			...(pointerMetadata.pointeeElementCount !== undefined
+				? { elementCount: pointerMetadata.pointeeElementCount }
+				: {}),
+		} satisfies PointeeMetadata;
+		return [
+			kindToStackItem('int32', {
+				isNonZero: false,
+				address: getMemoryRegionFields(pointsTo.memoryIndex, pointsTo.memoryRegionName),
+				pointsTo,
+			}),
+		];
+	}
+
+	return [
+		kindToStackItem(getDereferencedValueKindFromMetadata(pointerMetadata, dereferenceDepth), { isNonZero: false }),
+	];
+}
+
+function pushResolvedTargetStackItems(line: CompilerASTLine, context: CompilationContext): Stack {
+	const testLine = codegenTestLine(line);
+	switch (testLine.resolvedTarget?.kind) {
+		case 'memory': {
+			const memoryItem = testLine.resolvedTarget.memoryItem;
+			const pointsTo = getPointeeMetadata(memoryItem);
+			return [
+				kindToStackItem(resolveMemoryValueKind(memoryItem), {
+					isNonZero: false,
+					...(pointsTo ? { pointsTo } : {}),
+					...(pointsTo ? { address: getMemoryRegionFields(pointsTo.memoryIndex, pointsTo.memoryRegionName) } : {}),
+				}),
+			];
+		}
+		case 'memory-pointer':
+		case 'local-pointer':
+			return pushDereferencedPointerStackItems(line, context);
+		case 'local': {
+			const local = context.locals[testLine.resolvedTarget.localName]!;
+			const pointsTo = getPointeeMetadata(local);
+			return [
+				local.pointeeBaseType
+					? kindToStackItem('int32', {
+							isNonZero: false,
+							address: getMemoryRegionFields(local.pointeeMemoryIndex ?? 0, local.pointeeMemoryRegionName),
+							...(pointsTo ? { pointsTo } : {}),
+						})
+					: createStackValue(local.isInteger ? 'int' : local.isFloat64 ? 'float64' : 'float', { isNonZero: false }),
+			];
+		}
+		default:
+			return [];
+	}
+}
+
+function analyzePushForTest(line: CompilerASTLine, context: CompilationContext): Stack {
+	const produced = codegenTestLine(line).resolvedTarget
+		? pushResolvedTargetStackItems(line, context)
+		: pushLiteralStackItems(line, context);
+	produce(context, produced);
+	return produced;
+}
+
+function stackItemToExactFunctionValueType(stackItem: StackItem): FunctionValueType {
+	if (stackItem.kind === 'address' && stackItem.pointsTo) {
+		return `${stackItem.pointsTo.baseType}${'*'.repeat(stackItem.pointsTo.pointerDepth)}` as FunctionValueType;
+	}
+	return stackItem.valueType as FunctionValueType;
+}
+
+function stackItemsToFunctionId(functionName: string, stackItems: readonly StackItem[]): string {
+	return createFunctionId(functionName, stackItems.map(stackItemToExactFunctionValueType));
+}
+
+function formatFunctionCallSignature(functionName: string, parameters: readonly FunctionValueType[]): string {
+	return `${functionName}(${parameters.join(', ')})`;
+}
+
+function resolveTargetFunctionForTest(line: CompilerASTLine, context: CompilationContext): FunctionMetadata {
+	const functionName = String(getCodegenTestArgument(line).value);
+	const functionRegistry = context.namespace.functions;
+	if (!functionRegistry) {
+		throw getError(ErrorCode.UNDEFINED_FUNCTION, line, context, { identifier: functionName });
+	}
+
+	const arity = functionRegistry.arityByName[functionName];
+	if (arity === undefined) {
+		throw getError(ErrorCode.UNDEFINED_FUNCTION, line, context, { identifier: functionName });
+	}
+	if (context.stack.length < arity) {
+		throw getError(ErrorCode.INSUFFICIENT_OPERANDS, line, context);
+	}
+
+	const operands = context.stack.slice(context.stack.length - arity);
+	const exactMatch = functionRegistry.byId[stackItemsToFunctionId(functionName, operands)];
+	if (exactMatch) {
+		return exactMatch;
+	}
+
+	const inferredParameterTypes = operands.map(stackItemToExactFunctionValueType);
+	const availableOverloadSignatures = Object.values(functionRegistry.byId)
+		.filter(functionMetadata => functionMetadata.name === functionName)
+		.map(functionMetadata => formatFunctionCallSignature(functionName, functionMetadata.signature.parameters))
+		.sort((left, right) => left.localeCompare(right));
+	throw getError(ErrorCode.FUNCTION_OVERLOAD_NO_MATCH, line, context, {
+		identifier: functionName,
+		inferredCallSignature: formatFunctionCallSignature(functionName, inferredParameterTypes),
+		availableOverloadSignatures,
+	});
+}
+
+function analyzeCallForTest(
+	line: CompilerASTLine,
+	context: CompilationContext
+): { consumed: Stack; produced: Stack; targetFunctionId: string } {
+	for (const inlinePushLine of codegenTestLine(line).inlineArgumentPushes ?? []) {
+		analyzePushForTest(inlinePushLine, context);
+	}
+
+	const targetFunction = resolveTargetFunctionForTest(line, context);
+	const consumed = consume(context, targetFunction.signature.parameters.length);
+	const produced = targetFunction.signature.returns.map(returnType => functionValueTypeToStackItem(returnType));
+	produce(context, produced);
+	return { consumed, produced, targetFunctionId: targetFunction.id };
+}
+
+function analyzeLocalSetForTest(line: CompilerASTLine, context: CompilationContext): CodegenTestAnalysis {
+	const consumed = consume(context, 1);
+	const operand = consumed[0];
+	const localName = String(getCodegenTestArgument(line).value);
+	const local = context.locals[localName]!;
+
+	if (local.isInteger && operand.valueType !== 'int') {
+		throw getError(ErrorCode.ONLY_INTEGERS, line, context);
+	}
+	if (!local.isInteger && operand.valueType === 'int') {
+		throw getError(ErrorCode.ONLY_FLOATS, line, context);
+	}
+
+	const localPointer =
+		local.pointeeBaseType && operand.kind === 'address'
+			? {
+					localName,
+					pointeeMemoryIndex: operand.address.memoryIndex,
+					...(operand.address.memoryRegionName ? { pointeeMemoryRegionName: operand.address.memoryRegionName } : {}),
+				}
+			: undefined;
+
+	return {
+		consumed,
+		produced: [],
+		...(localPointer ? { localPointer } : {}),
+	};
+}
+
+function resolveStackConsumeCount(
+	line: CompilerASTLine,
+	context: CompilationContext,
+	consumes: StackMutationSpec['consumes']
+): number {
+	if (consumes === 'all') {
+		return context.stack.length;
+	}
+	if (typeof consumes === 'number') {
+		return consumes;
+	}
+	const argument = getCodegenTestArgument(line, consumes.argumentValueIndex);
+	return typeof argument.value === 'number' ? argument.value + consumes.add : consumes.add;
+}
+
+function resolveProducedStackItem(consumed: Stack, spec: StackProducedItemSpec): StackItem {
+	const input = consumed[spec.inputIndex ?? 0];
+	const isNonZero =
+		spec.isNonZero === 'fromInput'
+			? input?.isNonZero
+			: spec.isNonZero !== undefined
+				? spec.isNonZero
+				: input?.isNonZero;
+	switch (spec.kind) {
+		case 'int':
+			return createStackValue('int', { isNonZero: isNonZero ?? false });
+		case 'float':
+			return createStackValue('float', { isNonZero: isNonZero ?? false });
+		case 'float64':
+			return createStackValue('float64', { isNonZero: isNonZero ?? false });
+		case 'same':
+		default:
+			return createStackValue(input?.valueType ?? 'float', { isNonZero });
+	}
+}
+
+function analyzeStackEffectFromSpecForTest(
+	line: CompilerASTLine,
+	context: CompilationContext,
+	stackEffect: StackMutationSpec
+): CodegenTestAnalysis {
+	const consumed = consume(context, resolveStackConsumeCount(line, context, stackEffect.consumes));
+	const produced = (stackEffect.produces ?? []).map(producedSpec => resolveProducedStackItem(consumed, producedSpec));
+	produce(context, produced);
+	return {
+		consumed,
+		produced,
+		...(stackEffect.dropped === 'consumed' ? { dropped: consumed } : {}),
+	};
+}
+
+function analyzeExpectedBlockResultForTest(
+	line: CompilerASTLine,
+	context: CompilationContext,
+	{ restore = false, validateFloatResult = false } = {}
+): CodegenTestAnalysis {
+	const expectedResultTypes = context.blockStack[context.blockStack.length - 1]?.expectedResultTypes ?? [];
+	if (expectedResultTypes.length === 0) {
+		return { consumed: [], produced: [] };
+	}
+
+	const consumed = consume(context, expectedResultTypes.length);
+	if (consumed.length < expectedResultTypes.length) {
+		throw getError(ErrorCode.INSUFFICIENT_OPERANDS, line, context);
+	}
+	for (let index = 0; index < expectedResultTypes.length; index++) {
+		const expectedResultType = expectedResultTypes[index];
+		const operand = consumed[index];
+		if (expectedResultType === 'int' && operand.valueType !== 'int') {
+			throw getError(ErrorCode.ONLY_INTEGERS, line, context);
+		}
+		if (validateFloatResult && expectedResultType === 'float' && operand.valueType === 'int') {
+			throw getError(ErrorCode.ONLY_FLOATS, line, context);
+		}
+	}
+
+	if (restore) {
+		produce(context, consumed);
+		return { consumed, produced: consumed };
+	}
+	return { consumed, produced: [] };
+}
+
+function analyzeFromSpecForTest(line: CompilerASTLine, context: CompilationContext): CodegenTestAnalysis {
+	const spec = getInstructionSpec(line.instruction) as InstructionSpec<CompilerASTLine> | undefined;
+	const blockClose = spec?.effects?.blockClose;
+	if (blockClose) {
+		return analyzeExpectedBlockResultForTest(line, context, {
+			restore: blockClose.restoreResult,
+			validateFloatResult: blockClose.validateFloatResult,
+		});
+	}
+	if (spec?.stack?.effect) {
+		return analyzeStackEffectFromSpecForTest(line, context, spec.stack.effect);
+	}
+	return { consumed: [], produced: [] };
+}
+
+function analyzeNumericBinaryForTest(line: CompilerASTLine, context: CompilationContext): CodegenTestAnalysis {
+	const consumed = consume(context, 2);
+	const [left, right] = consumed;
+	if ((line.instruction === 'div' || line.instruction === 'remainder') && !right.isNonZero) {
+		throw getError(ErrorCode.DIVISION_BY_ZERO, line, context);
+	}
+
+	const produced =
+		line.instruction === 'add'
+			? [numericResult(left, right, deriveAddStackMetadata)]
+			: line.instruction === 'sub'
+				? [numericResult(left, right, deriveSubStackMetadata)]
+				: line.instruction === 'mul'
+					? [numericResult(left, right, (a, b) => deriveKnownIntegerValue(a, b, (x, y) => Math.imul(x, y)))]
+					: line.instruction === 'div'
+						? [
+								numericResult(left, right, (a, b) =>
+									deriveKnownIntegerValue(a, b, (x, y) =>
+										x === BASE_TYPE_METADATA.int.min && y === -1 ? undefined : Math.trunc(x / y) | 0
+									)
+								),
+							]
+						: line.instruction === 'remainder'
+							? [knownIntegerResult(deriveKnownIntegerValue(left, right, (x, y) => (x % y) | 0).knownIntegerValue)]
+							: line.instruction === 'and'
+								? [knownIntegerResult(deriveKnownIntegerValue(left, right, (x, y) => x & y).knownIntegerValue)]
+								: line.instruction === 'or'
+									? [
+											knownIntegerResult(
+												deriveKnownIntegerValue(left, right, (x, y) => x | y).knownIntegerValue,
+												Boolean(left.isNonZero || right.isNonZero)
+											),
+										]
+									: line.instruction === 'xor'
+										? [knownIntegerResult(deriveKnownIntegerValue(left, right, (x, y) => x ^ y).knownIntegerValue)]
+										: line.instruction === 'shiftLeft'
+											? [
+													knownIntegerResult(
+														deriveKnownIntegerValue(left, right, (x, y) => (x << (y & 31)) | 0).knownIntegerValue
+													),
+												]
+											: line.instruction === 'shiftRight'
+												? [
+														knownIntegerResult(
+															deriveKnownIntegerValue(left, right, (x, y) => x >> (y & 31)).knownIntegerValue
+														),
+													]
+												: line.instruction === 'shiftRightUnsigned'
+													? [
+															knownIntegerResult(
+																deriveKnownIntegerValue(left, right, (x, y) => x >>> (y & 31)).knownIntegerValue
+															),
+														]
+													: undefined;
+
+	if (produced) {
+		produce(context, produced);
+		return { consumed, produced };
+	}
+
+	context.stack.push(...consumed);
+	return analyzeFromSpecForTest(line, context);
+}
+
+function analyzeAbsForTest(_line: CompilerASTLine, context: CompilationContext): CodegenTestAnalysis {
+	const consumed = consume(context, 1);
+	const operand = consumed[0];
+	const knownAbsValue =
+		operand.knownIntegerValue === undefined
+			? undefined
+			: operand.knownIntegerValue < 0
+				? (0 - operand.knownIntegerValue) | 0
+				: operand.knownIntegerValue;
+	const produced = [
+		operand.valueType === 'int'
+			? createStackValue('int', {
+					isNonZero: operand.isNonZero,
+					knownIntegerValue: knownAbsValue,
+				})
+			: createStackValue(operand.valueType === 'float64' ? 'float64' : 'float', { isNonZero: operand.isNonZero }),
+	];
+	produce(context, produced);
+	return { consumed, produced };
+}
+
+function analyzeClampAddressForTest(line: CompilerASTLine, context: CompilationContext): CodegenTestAnalysis {
+	const consumed = consume(context, 1);
+	const accessByteWidth = getClampAccessByteWidth(line);
+	const range =
+		line.instruction === 'clampAddress'
+			? consumed[0].kind === 'address'
+				? (consumed[0].address.clampRange ?? consumed[0].address.safeRange)
+				: undefined
+			: line.instruction === 'clampModuleAddress'
+				? getModuleAddressRange(context)
+				: undefined;
+	if (line.instruction === 'clampAddress' && !range) {
+		throw getError(ErrorCode.ADDRESS_RANGE_REQUIRED, line, context);
+	}
+	if (range && range.safeByteLength < accessByteWidth) {
+		throw getError(ErrorCode.ADDRESS_RANGE_TOO_SMALL, line, context);
+	}
+
+	const produced = [getClampedAddressStackItem(consumed[0], range, accessByteWidth)];
+	produce(context, produced);
+	return {
+		consumed,
+		produced,
+		clamp: {
+			accessByteWidth,
+			memoryIndex: produced[0].address.memoryIndex,
+			...(range ? { range } : {}),
+		},
+	};
+}
+
+function analyzeFunctionEndForTest(line: CompilerASTLine, context: CompilationContext): CodegenTestAnalysis {
+	const returnTypes = line.arguments.map(argument =>
+		'value' in argument ? (argument.value as FunctionValueType) : undefined
+	);
+	if (context.stack.length !== returnTypes.length) {
+		throw getError(ErrorCode.STACK_MISMATCH_FUNCTION_RETURN, line, context);
+	}
+	for (let index = 0; index < returnTypes.length; index++) {
+		const returnType = returnTypes[index];
+		if (!returnType || !stackItemMatchesFunctionValueType(context.stack[index], returnType)) {
+			throw getError(ErrorCode.STACK_MISMATCH_FUNCTION_RETURN, line, context);
+		}
+	}
+	return { consumed: consume(context, returnTypes.length), produced: [] };
+}
+
+function analyzeMapEndForTest(line: CompilerASTLine, context: CompilationContext): CodegenTestAnalysis {
+	const outputType = String(getCodegenTestArgument(line).value);
+	const inputKind = resolveMapKind({
+		valueType: context.activeMapBlock?.mapState.inputIsInteger
+			? 'int'
+			: context.activeMapBlock?.mapState.inputIsFloat64
+				? 'float64'
+				: 'float',
+	});
+	const outputKind = resolveMapKind({
+		valueType: outputType === 'int' ? 'int' : outputType === 'float64' ? 'float64' : 'float',
+	});
+	const consumed = consume(context, 1);
+	const produced = [createStackValue(outputType === 'int' ? 'int' : outputType === 'float64' ? 'float64' : 'float')];
+	produce(context, produced);
+	return { consumed, produced, map: { inputKind, outputKind } };
+}
+
+export function analyzeInstructionForCodegenTest(
+	line: CompilerASTLine,
+	context: CompilationContext
+): StackAnalysisLineFacts {
+	validateInstructionForTest(line, context);
+	const stackBefore = cloneStack(context.stack);
+	const analysis: CodegenTestAnalysis =
+		line.instruction === 'push'
+			? { consumed: [], produced: analyzePushForTest(line, context) }
+			: line.instruction === 'call'
+				? analyzeCallForTest(line, context)
+				: line.instruction === 'localSet'
+					? analyzeLocalSetForTest(line, context)
+					: line.instruction === 'abs'
+						? analyzeAbsForTest(line, context)
+						: line.instruction === 'clampAddress' ||
+								line.instruction === 'clampModuleAddress' ||
+								line.instruction === 'clampGlobalAddress'
+							? analyzeClampAddressForTest(line, context)
+							: line.instruction === 'functionEnd'
+								? analyzeFunctionEndForTest(line, context)
+								: line.instruction === 'exitIfTrue'
+									? (() => {
+											const consumed = consume(context, 1);
+											return { consumed, produced: [], dropped: cloneStack(context.stack) };
+										})()
+									: line.instruction === 'mapEnd'
+										? analyzeMapEndForTest(line, context)
+										: [
+													'add',
+													'sub',
+													'mul',
+													'div',
+													'and',
+													'or',
+													'xor',
+													'remainder',
+													'shiftLeft',
+													'shiftRight',
+													'shiftRightUnsigned',
+												].includes(line.instruction)
+											? analyzeNumericBinaryForTest(line, context)
+											: analyzeFromSpecForTest(line, context);
+
+	const numericOperandKind =
+		analysis.consumed.length >= 2 &&
+		[
+			'add',
+			'sub',
+			'mul',
+			'div',
+			'min',
+			'max',
+			'equal',
+			'notEqual',
+			'greaterThan',
+			'lessThan',
+			'greaterOrEqual',
+			'lessOrEqual',
+			'greaterOrEqualUnsigned',
+			'and',
+			'or',
+			'xor',
+			'remainder',
+			'shiftLeft',
+			'shiftRight',
+			'shiftRightUnsigned',
+		].includes(line.instruction)
+			? getNumericOperandKind(analysis.consumed[0], analysis.consumed[1])
+			: undefined;
+
+	return {
+		stackAnalysis: {
+			stackBefore,
+			stackAfter: cloneStack(context.stack),
+			consumedOperands: cloneStack(analysis.consumed),
+			producedStackItems: cloneStack(analysis.produced),
+			...(analysis.dropped ? { droppedStackItems: cloneStack(analysis.dropped) } : {}),
+		},
+		...(analysis.targetFunctionId ? { targetFunctionId: analysis.targetFunctionId } : {}),
+		...(analysis.localPointer ? { localPointer: analysis.localPointer } : {}),
+		...(numericOperandKind ? { numericOperandKind } : {}),
+		...(analysis.map ? { map: analysis.map } : {}),
+		...(analysis.clamp ? { clamp: analysis.clamp } : {}),
+	};
+}
+
 /**
  * Runs stack analysis for a line and immediately compiles it with the provided compiler.
  *
@@ -150,7 +1063,7 @@ export function analyzeAndCompileInstruction<TLine extends CompilerASTLine>(
 	line: TLine,
 	context: CompilationContext
 ): CompilationContext {
-	const facts = analyzeInstruction(line, context);
+	const facts = analyzeInstructionForCodegenTest(line, context);
 	compileInstruction(line, context, facts);
 	return context;
 }


### PR DESCRIPTION
## Summary

- remove exported/test-only helper surfaces from compiler pass packages
- move memory-reference value resolution behind a package-local module
- replace the stack-analyzer testing subpath usage with wasm-codegen-local test support
- narrow wasm-codegen public exports and remove unused internal barrels
- trim the compiler AGENTS guidance so it no longer documents stale API/tutorial material

## Rationale

The pass packages should expose their actual pass entrypoints and public report types, not internal helpers or cross-package test utilities. This keeps compiler orchestration explicit and avoids compatibility layers for unreleased internal contracts.

## Validation

- `npx nx run-many --target=typecheck --projects=@8f4e/constant-resolver,@8f4e/memory-reference-resolver,@8f4e/stack-analyzer,@8f4e/wasm-codegen`
- `npx nx run-many --target=test --projects=@8f4e/constant-resolver,@8f4e/memory-reference-resolver,@8f4e/stack-analyzer,@8f4e/wasm-codegen`
- `npx nx run-many --target=build --projects=@8f4e/constant-resolver,@8f4e/memory-reference-resolver,@8f4e/stack-analyzer,@8f4e/wasm-codegen`
- `npx nx run @8f4e/compiler:typecheck`
- pre-commit hook: `npx nx affected --target=typecheck --files ...`
