### PR TITLE
[codex] Remove redundant compiler output fields

### DIFF
--- a/packages/cli/tests/__snapshots__/compileProjectAudioBuffer.test.ts.snap
+++ b/packages/cli/tests/__snapshots__/compileProjectAudioBuffer.test.ts.snap
@@ -618,7 +618,6 @@ exports[`compileProject (audioBuffer example) > compiles build artifacts without
       "executionEntryName": "main",
       "id": "audioout",
       "index": 2,
-      "initFunctionBody": [],
       "skipExecutionInCycle": undefined,
     },
     "notes": {
@@ -666,7 +665,6 @@ exports[`compileProject (audioBuffer example) > compiles build artifacts without
       "executionEntryName": "main",
       "id": "notes",
       "index": 3,
-      "initFunctionBody": [],
       "skipExecutionInCycle": undefined,
     },
     "phaseAccumulator": {
@@ -1113,7 +1111,6 @@ exports[`compileProject (audioBuffer example) > compiles build artifacts without
       "executionEntryName": "main",
       "id": "phaseAccumulator",
       "index": 1,
-      "initFunctionBody": [],
       "skipExecutionInCycle": undefined,
     },
     "projectConfig": {
@@ -1161,7 +1158,6 @@ exports[`compileProject (audioBuffer example) > compiles build artifacts without
       "executionEntryName": "main",
       "id": "projectConfig",
       "index": 0,
-      "initFunctionBody": [],
       "skipExecutionInCycle": undefined,
     },
   },

--- a/packages/cli/tests/__snapshots__/exampleProjectsCompilation/packages_examples_src_projects_audio_audioBuffer_8f4e.snap
+++ b/packages/cli/tests/__snapshots__/exampleProjectsCompilation/packages_examples_src_projects_audio_audioBuffer_8f4e.snap
@@ -10,7 +10,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "projectConfig",
@@ -155,7 +154,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "phaseAccumulator",
@@ -588,7 +586,6 @@
         11,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "audioout",
@@ -869,7 +866,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "notes",

--- a/packages/cli/tests/__snapshots__/exampleProjectsCompilation/packages_examples_src_projects_audio_keyboardControlledMonoSynth_8f4e.snap
+++ b/packages/cli/tests/__snapshots__/exampleProjectsCompilation/packages_examples_src_projects_audio_keyboardControlledMonoSynth_8f4e.snap
@@ -10,7 +10,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "projectConfig",
@@ -57,7 +56,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "keyboard",
@@ -145,7 +143,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "janko",
@@ -270,7 +267,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "midiLUT",
@@ -1784,7 +1780,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "midiNote2Freq",
@@ -2072,7 +2067,6 @@
         11,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "arEnv",
@@ -2742,7 +2736,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "phaseAccumulator",
@@ -3116,7 +3109,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "vca",
@@ -3354,7 +3346,6 @@
         11,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "audioout",

--- a/packages/cli/tests/__snapshots__/exampleProjectsCompilation/packages_examples_src_projects_digital_bistableMultivibrators_8f4e.snap
+++ b/packages/cli/tests/__snapshots__/exampleProjectsCompilation/packages_examples_src_projects_digital_bistableMultivibrators_8f4e.snap
@@ -10,7 +10,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "projectConfig",
@@ -57,7 +56,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "notes",
@@ -104,7 +102,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "setButton",
@@ -163,7 +160,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "resetButton",
@@ -255,7 +251,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "norGate2",
@@ -514,7 +509,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "norGate",
@@ -827,7 +821,6 @@
         11,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "scope",
@@ -1095,7 +1088,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "buttons",
@@ -1190,7 +1182,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "negate",
@@ -1410,7 +1401,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "orGate",
@@ -1669,7 +1659,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "andGate",
@@ -1982,7 +1971,6 @@
         11,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "scope2",

--- a/packages/cli/tests/__snapshots__/exampleProjectsCompilation/packages_examples_src_projects_machine-learning_xorProblem_8f4e.snap
+++ b/packages/cli/tests/__snapshots__/exampleProjectsCompilation/packages_examples_src_projects_machine-learning_xorProblem_8f4e.snap
@@ -10,7 +10,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "projectConfig",
@@ -57,7 +56,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "result",
@@ -125,7 +123,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "notes",
@@ -172,7 +169,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "switches",
@@ -293,7 +289,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "perceptron",
@@ -588,7 +583,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "perceptron2",
@@ -858,7 +852,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "activationFn",
@@ -998,7 +991,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "activationFn2",
@@ -1163,7 +1155,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "perceptron3",
@@ -1447,7 +1438,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "activationFn3",

--- a/packages/cli/tests/__snapshots__/exampleProjectsCompilation/packages_examples_src_projects_visuals_dancingWithTheSineLT_8f4e.snap
+++ b/packages/cli/tests/__snapshots__/exampleProjectsCompilation/packages_examples_src_projects_visuals_dancingWithTheSineLT_8f4e.snap
@@ -10,7 +10,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "projectConfig",
@@ -57,7 +56,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "sineLT",
@@ -4514,7 +4512,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "dancer1",
@@ -4874,7 +4871,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "dancer2",
@@ -5234,7 +5230,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "dancer3",
@@ -5595,7 +5590,6 @@
         0,
         11
       ],
-      "initFunctionBody": [],
       "ast": {
         "type": "module",
         "id": "dancer4",

--- a/packages/compiler-worker/src/didProgramOrMemoryStructureChange.ts
+++ b/packages/compiler-worker/src/didProgramOrMemoryStructureChange.ts
@@ -64,10 +64,6 @@ export default function didProgramOrMemoryStructureChange(
 			return true;
 		}
 
-		if (compiledModule.initFunctionBody.length !== previousModule.initFunctionBody.length) {
-			return true;
-		}
-
 		const plannedModule = current.memoryPlan.modules[id]!;
 		const previousPlannedModule = previous.memoryPlan.modules[id]!;
 

--- a/packages/compiler/packages/language-spec/src/compiled.ts
+++ b/packages/compiler/packages/language-spec/src/compiled.ts
@@ -14,7 +14,6 @@ export type CompiledStackAnalysisLine = {
 /** Code generation output and metadata for a compiled executable module. */
 export interface CompiledModule {
 	index: number;
-	initFunctionBody: number[];
 	cycleFunction: number[];
 	id: string;
 	executionEntryName?: string;

--- a/packages/compiler/packages/stack-analyzer/src/analyzeStack.ts
+++ b/packages/compiler/packages/stack-analyzer/src/analyzeStack.ts
@@ -95,7 +95,6 @@ export interface StackAnalyzedFunction {
 export interface StackAnalysisProjectReport {
 	modules: Record<string, StackAnalyzedModule>;
 	functions: Record<string, StackAnalyzedFunction>;
-	usedFunctionIds: string[];
 }
 
 function toCompiledStackAnalysisLine(line: CompilerASTLine, facts: StackAnalysisLineFacts): CompiledStackAnalysisLine {
@@ -633,21 +632,21 @@ export function analyzeStack<
 		})
 	);
 	const modules = Object.fromEntries(input.ast.modules.map(ast => [ast.id, analyzeModule(input, ast)]));
-	const usedFunctionIds = new Set<string>();
+	const usedFunctionIdSet = new Set<string>();
 	for (const functionReport of Object.values(functionReports)) {
 		if (functionReport.exportName) {
-			usedFunctionIds.add(functionReport.functionId);
+			usedFunctionIdSet.add(functionReport.functionId);
 		}
 		for (const facts of functionReport.lineFacts) {
 			if (facts?.targetFunctionId) {
-				usedFunctionIds.add(facts.targetFunctionId);
+				usedFunctionIdSet.add(facts.targetFunctionId);
 			}
 		}
 	}
 	for (const moduleReport of Object.values(modules)) {
 		for (const facts of moduleReport.lineFacts) {
 			if (facts?.targetFunctionId) {
-				usedFunctionIds.add(facts.targetFunctionId);
+				usedFunctionIdSet.add(facts.targetFunctionId);
 			}
 		}
 	}
@@ -656,10 +655,10 @@ export function analyzeStack<
 			functionReport.functionId,
 			{
 				...functionReport,
-				...(usedFunctionIds.has(functionReport.functionId) ? { used: true } : {}),
+				...(usedFunctionIdSet.has(functionReport.functionId) ? { used: true } : {}),
 			},
 		])
 	);
 
-	return { modules, functions, usedFunctionIds: [...usedFunctionIds] };
+	return { modules, functions };
 }

--- a/packages/compiler/packages/stack-analyzer/tests/__snapshots__/analyzeStack.integration.test.ts.snap
+++ b/packages/compiler/packages/stack-analyzer/tests/__snapshots__/analyzeStack.integration.test.ts.snap
@@ -1109,8 +1109,5 @@ exports[`analyzeStack integration > analyzes a project-level module and function
       ],
     },
   },
-  "usedFunctionIds": [
-    "increment__int",
-  ],
 }
 `;

--- a/packages/compiler/packages/wasm-codegen/src/compileModule.ts
+++ b/packages/compiler/packages/wasm-codegen/src/compileModule.ts
@@ -106,7 +106,6 @@ export function compileModule(
 			}),
 			context.byteCode
 		),
-		initFunctionBody: [],
 		ast,
 		...(options.includeStackAnalysis ? { stackAnalysis: stackReport.stackAnalysis } : {}),
 		index,

--- a/packages/compiler/packages/wasm-codegen/src/emitWasmProgram.ts
+++ b/packages/compiler/packages/wasm-codegen/src/emitWasmProgram.ts
@@ -23,9 +23,7 @@ import {
 } from '@8f4e/compiler-wasm-utils';
 import type {
 	CompiledFunction,
-	CompiledFunctionLookup,
 	CompiledModule,
-	CompiledModuleLookup,
 	CompileOptions,
 	CompileResult,
 	CompilerCache,
@@ -44,14 +42,8 @@ import createInitialMemoryDataSegments from './initialMemoryDataSegments/createI
 /** Linkable compiler output consumed by the WebAssembly emitter. */
 export type WasmProgramInput = {
 	entryNames: string[];
-	importedFunctionCount: number;
-	builtInFunctionCount: number;
 	compiledModules: CompiledModule[];
-	compiledModulesMap: CompiledModuleLookup;
 	compiledFunctions: CompiledFunction[];
-	compiledFunctionsMap: CompiledFunctionLookup;
-	importedUserFunctions: CompiledFunction[];
-	definedFunctions: CompiledFunction[];
 	functionTypeRegistry: FunctionTypeRegistry;
 	memoryPlan: MemoryLayoutPlan;
 	memoryDefaultsByModuleId: Record<string, MemoryDefaults>;
@@ -101,14 +93,8 @@ export function emitWasmProgram(
 ): CompileResult {
 	const {
 		entryNames,
-		importedFunctionCount,
-		builtInFunctionCount,
 		compiledModules,
-		compiledModulesMap,
 		compiledFunctions,
-		compiledFunctionsMap,
-		importedUserFunctions,
-		definedFunctions,
 		functionTypeRegistry,
 		memoryPlan,
 		memoryDefaultsByModuleId,
@@ -128,6 +114,10 @@ export function emitWasmProgram(
 	const initialMemoryDataSegments = createInitialMemoryDataSegments(memoryPlan, memoryDefaultsByModuleId);
 	const cycleFunctions = compiledModules.map(({ cycleFunction }) => cycleFunction);
 	const functionSignatures = compiledModules.map(() => 0x00);
+	const importedUserFunctions = compiledFunctions.filter(func => func.import);
+	const definedFunctions = compiledFunctions.filter(func => !func.import);
+	const importedFunctionCount = importedUserFunctions.length;
+	const builtInFunctionCount = 1 + entryNames.length;
 	const uniqueUserFunctionTypes = functionTypeRegistry.types;
 	const userFunctionSignatureIndices = definedFunctions.map(func => func.typeIndex);
 	const userFunctionCount = definedFunctions.length;
@@ -208,8 +198,8 @@ export function emitWasmProgram(
 				? createDataSection(initialMemoryDataSegments.map(segment => createPassiveDataSegment(segment.bytes)))
 				: []),
 		]),
-		compiledModules: compiledModulesMap,
-		compiledFunctions: compiledFunctionsMap,
+		compiledModules: Object.fromEntries(compiledModules.map(module => [module.id, module])),
+		compiledFunctions: Object.fromEntries(compiledFunctions.map(func => [func.id, func])),
 		memoryPlan,
 		memoryDefaultsByModuleId,
 		pointerMetadataByModuleId,

--- a/packages/compiler/src/compileSubProgram.ts
+++ b/packages/compiler/src/compileSubProgram.ts
@@ -1,9 +1,7 @@
 import { ConstantResolverError, type ResolveConstantsProjectAST, resolveConstants } from '@8f4e/constant-resolver';
 import type {
 	CompiledFunction,
-	CompiledFunctionLookup,
 	CompiledModule,
-	CompiledModuleLookup,
 	CompileInput,
 	CompileOptions,
 	CompilerCache,
@@ -58,22 +56,10 @@ type CompilerSource = {
 export type CompiledSubProgram = {
 	/** Public entry names generated for this source program. */
 	entryNames: string[];
-	/** Number of imported user functions emitted before built-ins and defined functions. */
-	importedFunctionCount: number;
-	/** Number of built-in helper functions emitted before user-defined functions. */
-	builtInFunctionCount: number;
 	/** Compiled module bodies in source order. */
 	compiledModules: CompiledModule[];
-	/** Compiled module lookup keyed by module id. */
-	compiledModulesMap: CompiledModuleLookup;
 	/** Compiled user functions in source order. */
 	compiledFunctions: CompiledFunction[];
-	/** Compiled function lookup keyed by function id. */
-	compiledFunctionsMap: CompiledFunctionLookup;
-	/** User functions imported from the host environment. */
-	importedUserFunctions: CompiledFunction[];
-	/** User functions defined by the source program. */
-	definedFunctions: CompiledFunction[];
 	/** Function type table accumulated while compiling calls and definitions. */
 	functionTypeRegistry: FunctionTypeRegistry;
 	/** Project memory layout produced by the memory planner. */
@@ -411,10 +397,6 @@ export function compileSubProgram(
 			options
 		);
 	});
-	const importedUserFunctions = compiledFunctions.filter(func => func.import);
-	const definedFunctions = compiledFunctions.filter(func => !func.import);
-	const compiledFunctionsMap = Object.fromEntries(compiledFunctions.map(func => [func.id, func]));
-
 	const compiledModules = compileModules(
 		projectAst.modules,
 		{
@@ -433,18 +415,10 @@ export function compileSubProgram(
 		executionEntryName: moduleEntryNames[index],
 	}));
 
-	const compiledModulesMap = Object.fromEntries(compiledModules.map(module => [module.id, module]));
-
 	return {
 		entryNames,
-		importedFunctionCount,
-		builtInFunctionCount,
 		compiledModules,
-		compiledModulesMap,
 		compiledFunctions,
-		compiledFunctionsMap,
-		importedUserFunctions,
-		definedFunctions,
 		functionTypeRegistry,
 		memoryPlan,
 		memoryDefaultsByModuleId: memoryDefaultResolution.memoryDefaultsByModuleId,

--- a/packages/editor/packages/editor-state/src/features/code-blocks/shape/updateGraphicData.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/shape/updateGraphicData.test.ts
@@ -88,7 +88,6 @@ function createCompilerReports(memoryFixtures: Record<string, MemoryFixture> = {
 			filterA: {
 				id: 'filterA',
 				index: 0,
-				initFunctionBody: [],
 				cycleFunction: [],
 				ast,
 			},


### PR DESCRIPTION
## Summary
- remove duplicate compiler-to-codegen handoff fields for compiled module/function lookups and derived function groups/counts
- drop the always-empty `CompiledModule.initFunctionBody` field and its stale worker comparison
- remove redundant `usedFunctionIds` from the stack analyzer project report while keeping per-function `used` metadata
- update snapshots for the slimmer compiler output shapes

## Validation
- `npx nx run @8f4e/compiler:typecheck --output-style=stream`
- `npx nx run @8f4e/wasm-codegen:typecheck --output-style=stream`
- `npx nx run @8f4e/compiler-worker:typecheck --output-style=stream`
- `npx nx run @8f4e/editor-state:typecheck --output-style=stream`
- `npx nx run @8f4e/stack-analyzer:test --output-style=stream`
- `npx nx run @8f4e/cli:test --output-style=stream`
- `npx nx run @8f4e/compiler:test --output-style=stream`
- `npx nx run @8f4e/compiler-worker:test --output-style=stream`
- `npx nx run @8f4e/editor-state:test --output-style=stream`
- `npx nx run @8f4e/wasm-codegen:test --output-style=stream`

Note: Nx Cloud reported `ENOTFOUND` in this environment, but local validation passed.