### PR TITLE
feat(project-preparser): support explicit stdlib include exports

### DIFF
--- a/docs/todos/464-require-explicit-stdlib-include-exports.md
+++ b/docs/todos/464-require-explicit-stdlib-include-exports.md
@@ -1,0 +1,240 @@
+---
+title: 'TODO: Require explicit stdlib include exports'
+priority: Medium
+effort: 1-2d
+created: 2026-06-19
+issue: null
+status: Completed
+completed: 2026-06-19
+---
+
+# TODO: Require Explicit Stdlib Include Exports
+
+## Problem Description
+
+Standard-library include files currently expand into every function block they contain. The project preparser splits the
+resolved include source into function blocks and appends all of them to `CompileInput.functions`.
+
+That works while each include file is effectively one public function family, but it blocks a useful stdlib shape:
+
+- one or more public entry/helper functions exposed by the include;
+- private helper functions in the same stdlib file;
+- public functions calling private helpers without leaking those helper names into the project-global function namespace.
+
+Because compiler function names are global, unprefixed helper functions can collide with user functions or helpers from
+other include files. The current include behavior also has no way to distinguish public include symbols from
+implementation details.
+
+The project has not been released, so this can be implemented as a clean breaking change. Do not preserve compatibility
+with unmarked include files.
+
+## Proposed Solution
+
+Use `#export` inside included source files as an include-local public-symbol marker.
+
+The meaning of `#export` should be context-sensitive at the project-preparser boundary:
+
+- In normal project function blocks, `#export` keeps its existing meaning: export the function from the final WebAssembly
+  module.
+- In include source files, `#export` means: expose this function from the include into the project function namespace.
+
+During include expansion, the preparser should consume include-local `#export` lines and replace them with empty lines
+before compiler input is created. Replacing instead of deleting preserves block-relative line numbers for diagnostics.
+Like normal function exports, include-local `#export` may optionally provide an alias. A bare `#export` exposes the
+function under its source name; `#export someName` exposes the function under `someName`.
+
+Every include file must contain at least one include-local `#export`. If none are present, resolving that include should
+throw a `ProjectIncludeError`.
+
+Exported functions keep their public include names: either their original source names or their `#export` aliases.
+Non-exported functions are internal helpers and get deterministic include-id-derived prefixes. Calls inside the same
+include source should be rewritten when they target internal helpers.
+
+Repeated `include <id>` lines should be deduped by include id during project preparation. Including the same stdlib file
+twice should not create duplicate public signatures or duplicate generated internal helpers.
+
+Example include source:
+
+```8f4e
+function sine
+#export
+param float x
+call foldPhase
+call sineApprox
+functionEnd float
+
+function foldPhase
+param float x
+functionEnd float
+
+function sineApprox
+param float x
+functionEnd float
+```
+
+Compiler input should become equivalent to:
+
+```8f4e
+function sine
+
+param float x
+call __8f4e_std_math_trig_sine__foldPhase
+call __8f4e_std_math_trig_sine__sineApprox
+functionEnd float
+
+function __8f4e_std_math_trig_sine__foldPhase
+param float x
+functionEnd float
+
+function __8f4e_std_math_trig_sine__sineApprox
+param float x
+functionEnd float
+```
+
+## Design Decisions
+
+- Include-local `#export` is required. There is no basename fallback and no compatibility mode.
+- Include-local `#export` is a visibility marker, not a Wasm export directive.
+- Include-local `#export` lines are replaced with empty lines during include expansion.
+- Public include functions keep their original names unless `#export <alias>` provides an alias.
+- Internal include functions are renamed with a deterministic prefix derived from the include id.
+- Internal overload families keep one generated name per original source name, preserving overload grouping.
+- Export visibility is per concrete function block. Overload families may be split so some overloads are public and some
+  remain internal when the stdlib author chooses that shape deliberately.
+- Include-local `#export <alias>` should behave like the existing export directive's alias form, except it aliases the
+  function's public include name rather than creating a Wasm export.
+- Duplicate include declarations for the same include id are ignored after the first successful expansion.
+- Normal project functions keep the existing `#export` behavior and validation rules.
+
+## Anti-Patterns
+
+- Do not let stdlib `#export` lines pass through to the compiler as Wasm exports.
+- Do not preserve old behavior where every function in an include is public.
+- Do not infer public names from file basenames.
+- Do not add compatibility shims for unmarked include files.
+- Do not add include loading or stdlib-specific behavior to the compiler proper. Includes should still reduce to plain
+  function blocks before compiler input reaches semantic analysis and code generation.
+- Do not reject partially exported overload families just because other overloads with the same source name remain
+  internal.
+
+## Implementation Plan
+
+### Step 1: Extend Include Source Expansion
+
+- Update `packages/compiler/packages/project-preparser/src/functionIncludes.ts`.
+- Split include source into function blocks as today, preserving original line count.
+- Detect include-local `#export` lines inside each function block.
+- Replace each include-local `#export` line with an empty string before returning compiler input.
+- Throw `ProjectIncludeError` when an include file has zero exported function blocks.
+- Support the same optional alias shape as normal function exports: bare `#export` or `#export <alias>`.
+- Track expanded include ids and skip later duplicate declarations for the same include id.
+
+### Step 2: Prefix Internal Functions
+
+- Derive an identifier-safe prefix from the include id, for example `__8f4e_std_math_trig_sine__`.
+- Identify public names from function blocks containing include-local `#export`, using the alias when one is present and
+  the source name otherwise.
+- Identify internal source names from function blocks without include-local `#export`.
+- Rewrite internal function declaration names to their prefixed names.
+- Rewrite exported function declaration names to their public aliases when include-local `#export <alias>` is used.
+- Keep overloads with the same original internal name under the same prefixed name.
+
+### Step 3: Rewrite Internal Calls
+
+- Rewrite `call <name>` inside the included source when `<name>` is an internal function from the same include file.
+- Preserve calls to public include functions, project functions, imported functions, and built-in instructions unchanged.
+- Support normal call lines and inline call arguments by rewriting only the call target argument.
+- Keep line contents otherwise stable so syntax and semantic diagnostics stay useful.
+- For a source name with mixed public/internal overload visibility, keep rewriting source-based and conservative. The
+  preparser cannot infer which overload a `call <name>` targets from text alone. If the original call target is also a
+  public include name, do not silently rewrite it to the internal prefixed name. Prefer an explicit validation error for
+  ambiguous mixed-visibility call targets, or require aliases/distinct helper names to make the source rewrite
+  unambiguous.
+
+### Step 4: Update Stdlib Sources
+
+- Add bare `#export` markers to every currently public stdlib function block.
+- For overload families, mark every overload that should remain public.
+- Add or refactor helper functions only after the include rewrite behavior is tested.
+- Regenerate the stdlib manifest if the implementation changes manifest content. If manifest content remains file-id-only,
+  no manifest schema change is required.
+
+### Step 5: Update Tests and Documentation
+
+- Add project-preparser tests for:
+  - include files with one exported function and one internal helper;
+  - multiple exported functions from one include file;
+  - exported overload families;
+  - internal overload families;
+  - partially exported overload families;
+  - aliased include-local exports;
+  - calls from public functions to internal helpers;
+  - zero-export include files failing with `ProjectIncludeError`;
+  - ambiguous mixed-visibility call targets failing or requiring aliases;
+  - include-local `#export` lines becoming blank lines.
+- Update compiler/stdlib integration tests that include existing stdlib files.
+- Update `packages/compiler/docs/standard-library.md` to explain include-local exports.
+- Update `packages/compiler/packages/stdlib/README.md` to document the stdlib authoring rule.
+
+## Validation Checkpoints
+
+- `npx nx run @8f4e/project-preparser:test`
+- `npx nx run @8f4e/project-preparser:typecheck`
+- `npx nx run @8f4e/stdlib:generate-manifest`
+- `npx nx run @8f4e/stdlib:test`
+- `npx nx run compiler:test`
+- `npx nx run compiler:typecheck`
+- `npx nx run @8f4e/examples:test`
+
+## Success Criteria
+
+- [ ] Include files with no `#export` marker fail during include expansion.
+- [ ] Include-local `#export` markers expose functions to the project without creating Wasm exports.
+- [ ] Include-local `#export <alias>` exposes the function under the alias.
+- [ ] Include-local `#export` marker lines are replaced with empty lines, preserving line numbers.
+- [ ] Internal include helper declarations are prefixed deterministically.
+- [ ] Calls inside include files are rewritten when they target internal helpers.
+- [ ] Multiple public functions can be exposed from one include file.
+- [ ] Public and internal overload groups remain valid even when only some overloads are exported.
+- [ ] Ambiguous mixed-visibility call targets are rejected or require explicit aliases/distinct helper names.
+- [ ] Repeated include declarations for the same include id are deduped.
+- [ ] Existing stdlib includes compile after adding explicit `#export` markers.
+
+## Affected Components
+
+- `packages/compiler/packages/project-preparser/src/functionIncludes.ts` - include visibility detection, prefixing, call
+  rewriting, and include diagnostics.
+- `packages/compiler/packages/project-preparser/src/functionIncludes.test.ts` - unit coverage for include-local export
+  behavior.
+- `packages/compiler/packages/project-preparser/src/prepareCompilerInput.test.ts` - compiler-input behavior around include
+  expansion.
+- `packages/compiler/packages/stdlib/std/**/*.8f4e` - explicit `#export` markers for public stdlib functions.
+- `packages/compiler/docs/standard-library.md` - user-facing include and stdlib docs.
+- `packages/compiler/packages/stdlib/README.md` - stdlib authoring docs.
+- `packages/compiler/tests/stdlib` - integration coverage for compiled stdlib includes.
+
+## Risks & Considerations
+
+- **Context-sensitive directive meaning**: `#export` means Wasm export in project source but include-public symbol in
+  include source. Keep this context split contained inside the project-preparser.
+- **Diagnostics**: blanking include-local `#export` lines preserves line numbers, but generated helper names may appear in
+  diagnostics unless source metadata also records original and generated names.
+- **Overload visibility**: partial visibility for one source-name overload family is allowed, but text-only call rewriting
+  cannot disambiguate public and internal overloads with the same call target. Prefer explicit aliases or validation for
+  ambiguous internal calls.
+- **Call rewriting**: rewrite only call targets, not arbitrary identifiers, comments, locals, params, constants, or memory
+  names.
+- **Generated name stability**: derive prefixes from include ids so generated helper names are deterministic across CLI,
+  browser, editor, and VS Code include resolvers.
+
+## Related Items
+
+- **Related**: `docs/brainstorming_notes/048-project-preparser-compiler-input-pipeline.md`
+- **Related**: `docs/todos/452-add-reachability-based-function-pruning.md`
+
+## Notes
+
+- This TODO records the 2026-06-19 brainstorming decision to require explicit include-local `#export` markers.
+- The no-fallback rule is intentional because the project is unreleased.
+- The compiler should continue to receive only irreducible source blocks: entries/modules, constants, functions, and
+  prototypes. Include visibility is resolved before that boundary.

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -86,7 +86,7 @@ Active todo files are listed below.
 
 | ID | Title | Completed | Notes |
 | ---- | ----- | --------- | ----- |
-| 464 | Require explicit stdlib include exports | 2026-06-19 | Include-local `#export` now marks public stdlib functions, private helpers are prefixed, and `wrapPointer` exercises the private-helper path. |
+| 464 | Require explicit stdlib include exports | 2026-06-19 | Include-local `#export` now marks public stdlib functions, private helpers are prefixed, and `readInterpolated` exercises the private-helper path. |
 | 458 | Decouple module execution order from memory layout | 2026-06-18 | Memory layout now allocates modules alphabetically by id while execution order remains driven by entry/module source order. |
 | 460 | Fix cross-block constant cache dependencies | 2026-06-17 | Constant resolution now returns per-line facts beside source-shaped cached ASTs, and recompiling with a changed constants block re-resolves unchanged cached module ASTs correctly. |
 | 462 | Extract semantic reference resolver | 2026-06-17 | Semantic reference resolution now runs once in compileSubProgram and returns a report consumed by stack analysis and WASM codegen alongside unchanged ASTs. |

--- a/docs/todos/_index.md
+++ b/docs/todos/_index.md
@@ -86,6 +86,7 @@ Active todo files are listed below.
 
 | ID | Title | Completed | Notes |
 | ---- | ----- | --------- | ----- |
+| 464 | Require explicit stdlib include exports | 2026-06-19 | Include-local `#export` now marks public stdlib functions, private helpers are prefixed, and `wrapPointer` exercises the private-helper path. |
 | 458 | Decouple module execution order from memory layout | 2026-06-18 | Memory layout now allocates modules alphabetically by id while execution order remains driven by entry/module source order. |
 | 460 | Fix cross-block constant cache dependencies | 2026-06-17 | Constant resolution now returns per-line facts beside source-shaped cached ASTs, and recompiling with a changed constants block re-resolves unchanged cached module ASTs correctly. |
 | 462 | Extract semantic reference resolver | 2026-06-17 | Semantic reference resolution now runs once in compileSubProgram and returns a report consumed by stack analysis and WASM codegen alongside unchanged ASTs. |

--- a/packages/cli/tests/compileProjectModules.test.ts
+++ b/packages/cli/tests/compileProjectModules.test.ts
@@ -112,7 +112,7 @@ describe('compileProjectModules', () => {
 				compilerOptions: { startingMemoryWordAddress: 0 },
 				resolveInclude: includeId =>
 					includeId === 'std/test/includedOne'
-						? ['function includedOne', 'push 1', 'functionEnd int'].join('\n')
+						? ['function includedOne', '#export', 'push 1', 'functionEnd int'].join('\n')
 						: undefined,
 			}
 		);

--- a/packages/compiler/docs/standard-library.md
+++ b/packages/compiler/docs/standard-library.md
@@ -43,11 +43,15 @@ entryEnd
 ```
 
 Each `include` line accepts one standard library include id. An include id may provide multiple overloads of the
-same function name.
+same function name, or multiple public functions when the stdlib source marks them with include-local `#export`.
 
 Includes are resolved during project loading. The CLI loads the shipped standard library files from the installed
 package, while browser-based tools load those same files lazily. The compiler receives the included source as ordinary
 function blocks, so overload resolution, stack typing, and `call` behavior are the same as user-defined functions.
+
+Inside standard-library source files, `#export` marks functions that become public to the including project. The project
+preparser consumes those markers before compilation, so they do not create WebAssembly exports. Non-exported functions in
+an included source file are treated as private helpers and are renamed with an include-specific prefix.
 
 ## `std/stack/dup`
 

--- a/packages/compiler/packages/project-preparser/src/functionIncludes.test.ts
+++ b/packages/compiler/packages/project-preparser/src/functionIncludes.test.ts
@@ -7,24 +7,25 @@ import {
 } from './functionIncludes';
 
 describe('resolveFunctionIncludeSource', () => {
-	it('splits a resolved include source into function blocks with include metadata', () => {
+	it('splits exported include functions and prefixes internal helper functions', () => {
 		expect(
 			resolveFunctionIncludeSource(
 				'std/test/helpers',
 				[
 					'function first',
-					'param int value',
+					'#export',
+					'call helper',
 					'functionEnd int',
 					'',
-					'function second',
-					'param float value',
-					'functionEnd float',
+					'function helper',
+					'param int value',
+					'functionEnd int',
 					'',
 				].join('\n')
 			)
 		).toEqual([
 			{
-				code: ['function first', 'param int value', 'functionEnd int'],
+				code: ['function first', '', 'call __8f4e_std_test_helpers__helper', 'functionEnd int'],
 				source: {
 					kind: 'include',
 					includeId: 'std/test/helpers',
@@ -32,14 +33,93 @@ describe('resolveFunctionIncludeSource', () => {
 				},
 			},
 			{
-				code: ['function second', 'param float value', 'functionEnd float'],
+				code: ['function __8f4e_std_test_helpers__helper', 'param int value', 'functionEnd int'],
 				source: {
 					kind: 'include',
 					includeId: 'std/test/helpers',
-					symbolName: 'second',
+					symbolName: '__8f4e_std_test_helpers__helper',
 				},
 			},
 		]);
+	});
+
+	it('supports include-local export aliases', () => {
+		expect(
+			resolveFunctionIncludeSource(
+				'std/test/helpers',
+				['function internalName', '#export publicName', 'functionEnd'].join('\n')
+			)
+		).toEqual([
+			{
+				code: ['function publicName', '', 'functionEnd'],
+				source: {
+					kind: 'include',
+					includeId: 'std/test/helpers',
+					symbolName: 'publicName',
+				},
+			},
+		]);
+	});
+
+	it('allows partially exported overload families when calls are unambiguous', () => {
+		expect(
+			resolveFunctionIncludeSource(
+				'std/test/helpers',
+				[
+					'function convert',
+					'#export',
+					'param int value',
+					'functionEnd int',
+					'',
+					'function convert',
+					'param float value',
+					'functionEnd float',
+				].join('\n')
+			)
+		).toEqual([
+			{
+				code: ['function convert', '', 'param int value', 'functionEnd int'],
+				source: { kind: 'include', includeId: 'std/test/helpers', symbolName: 'convert' },
+			},
+			{
+				code: ['function __8f4e_std_test_helpers__convert', 'param float value', 'functionEnd float'],
+				source: {
+					kind: 'include',
+					includeId: 'std/test/helpers',
+					symbolName: '__8f4e_std_test_helpers__convert',
+				},
+			},
+		]);
+	});
+
+	it('throws when include source has no exported functions', () => {
+		expect(() =>
+			resolveFunctionIncludeSource('std/test/helpers', ['function helper', 'functionEnd int'].join('\n'))
+		).toThrow('include "std/test/helpers" must export at least one function');
+	});
+
+	it('throws when mixed public/internal overload calls cannot be rewritten unambiguously', () => {
+		expect(() =>
+			resolveFunctionIncludeSource(
+				'std/test/helpers',
+				[
+					'function caller',
+					'#export',
+					'push 1',
+					'call convert',
+					'functionEnd int',
+					'',
+					'function convert',
+					'#export',
+					'param int value',
+					'functionEnd int',
+					'',
+					'function convert',
+					'param float value',
+					'functionEnd float',
+				].join('\n')
+			)
+		).toThrow('call target "convert" is ambiguous');
 	});
 });
 
@@ -61,22 +141,44 @@ describe('resolveProjectIncludesAsync', () => {
 				],
 				async includeId => {
 					if (includeId === 'std/events/risingEdge') {
-						return ['function risingEdge', 'functionEnd int'].join('\n');
+						return ['function risingEdge', '#export', 'functionEnd int'].join('\n');
 					}
 					if (includeId === 'std/memory/wrapPointer') {
-						return ['function wrapPointer', 'functionEnd int*'].join('\n');
+						return ['function wrapPointer', '#export', 'functionEnd int*'].join('\n');
 					}
 					return undefined;
 				}
 			)
 		).resolves.toEqual([
 			{
-				code: ['function risingEdge', 'functionEnd int'],
+				code: ['function risingEdge', '', 'functionEnd int'],
 				source: { kind: 'include', includeId: 'std/events/risingEdge', symbolName: 'risingEdge' },
 			},
 			{
-				code: ['function wrapPointer', 'functionEnd int*'],
+				code: ['function wrapPointer', '', 'functionEnd int*'],
 				source: { kind: 'include', includeId: 'std/memory/wrapPointer', symbolName: 'wrapPointer' },
+			},
+		]);
+	});
+
+	it('dedupes repeated include declarations by include id', async () => {
+		await expect(
+			resolveProjectIncludesAsync(
+				[
+					{
+						id: 10,
+						code: ['includes', 'include std/events/risingEdge', 'include std/events/risingEdge', 'includesEnd'],
+					},
+				],
+				async includeId =>
+					includeId === 'std/events/risingEdge'
+						? ['function risingEdge', '#export', 'functionEnd int'].join('\n')
+						: undefined
+			)
+		).resolves.toEqual([
+			{
+				code: ['function risingEdge', '', 'functionEnd int'],
+				source: { kind: 'include', includeId: 'std/events/risingEdge', symbolName: 'risingEdge' },
 			},
 		]);
 	});

--- a/packages/compiler/packages/project-preparser/src/functionIncludes.ts
+++ b/packages/compiler/packages/project-preparser/src/functionIncludes.ts
@@ -17,8 +17,30 @@ export class ProjectIncludeError extends Error {
 	}
 }
 
+type FunctionIncludeBlock = {
+	code: string[];
+	startLineNumber: number;
+};
+
+type IncludeExport = {
+	lineIndex: number;
+	publicName: string;
+};
+
+type IncludeFunction = {
+	code: string[];
+	startLineNumber: number;
+	originalName: string;
+	finalName: string;
+	export?: IncludeExport;
+};
+
 function getFunctionName(line: string): string {
 	return line.trim().split(/\s+/)[1] ?? '';
+}
+
+function getIncludeFunctionPrefix(includeId: string): string {
+	return `__8f4e_${includeId.replace(/[^a-zA-Z0-9]+/g, '_')}__`;
 }
 
 function startsWithInstruction(line: string, instruction: string): boolean {
@@ -34,20 +56,20 @@ function normalizeSourceLines(source: string): string[] {
 	return lines[lines.length - 1] === '' ? lines.slice(0, -1) : lines;
 }
 
-function splitFunctionBlocks(lines: string[]): string[][] {
-	const blocks: string[][] = [];
-	let currentBlock: string[] | undefined;
+function splitFunctionBlocks(lines: string[]): FunctionIncludeBlock[] {
+	const blocks: FunctionIncludeBlock[] = [];
+	let currentBlock: FunctionIncludeBlock | undefined;
 
-	for (const line of lines) {
+	for (const [index, line] of lines.entries()) {
 		if (startsWithInstruction(line, 'function')) {
-			currentBlock = [line];
+			currentBlock = { code: [line], startLineNumber: index + 1 };
 			continue;
 		}
 
-		currentBlock?.push(line);
+		currentBlock?.code.push(line);
 
 		if (startsWithInstruction(line, 'functionEnd')) {
-			blocks.push(currentBlock ?? [line]);
+			blocks.push(currentBlock ?? { code: [line], startLineNumber: index + 1 });
 			currentBlock = undefined;
 		}
 	}
@@ -55,18 +77,156 @@ function splitFunctionBlocks(lines: string[]): string[][] {
 	return blocks;
 }
 
+function getIncludeExport(includeId: string, block: FunctionIncludeBlock): IncludeExport | undefined {
+	let includeExport: IncludeExport | undefined;
+
+	for (const [lineIndex, line] of block.code.entries()) {
+		if (!startsWithInstruction(line, '#export')) {
+			continue;
+		}
+
+		if (includeExport) {
+			throw new ProjectIncludeError(
+				`include "${includeId}" function can only declare one #export`,
+				block.startLineNumber + lineIndex
+			);
+		}
+
+		const [, publicName, ...extraArgs] = line.trim().split(/\s+/);
+		if (extraArgs.length > 0) {
+			throw new ProjectIncludeError(
+				`include "${includeId}" #export accepts at most one alias`,
+				block.startLineNumber + lineIndex
+			);
+		}
+
+		includeExport = {
+			lineIndex,
+			publicName: publicName ?? getFunctionName(block.code[0] ?? ''),
+		};
+	}
+
+	return includeExport;
+}
+
+function replaceInstructionFirstArgument(line: string, instruction: string, argument: string): string {
+	return line.replace(new RegExp(`^(\\s*${instruction}\\s+)\\S+`), `$1${argument}`);
+}
+
+function getLineFirstArgument(line: string): string {
+	return line.trim().split(/\s+/)[1] ?? '';
+}
+
+function createIncludeFunctions(includeId: string, blocks: FunctionIncludeBlock[]): IncludeFunction[] {
+	const prefix = getIncludeFunctionPrefix(includeId);
+	const functions = blocks.map(block => {
+		const originalName = getFunctionName(block.code[0] ?? '');
+		const includeExport = getIncludeExport(includeId, block);
+
+		return {
+			...block,
+			originalName,
+			finalName: includeExport?.publicName ?? `${prefix}${originalName}`,
+			...(includeExport ? { export: includeExport } : {}),
+		};
+	});
+
+	if (functions.every(func => !func.export)) {
+		throw new ProjectIncludeError(`include "${includeId}" must export at least one function`, 1);
+	}
+
+	return functions;
+}
+
+function createCallTargetRewriteMap(includeId: string, functions: IncludeFunction[]): Map<string, string> {
+	const finalNamesByOriginalName = new Map<string, Set<string>>();
+
+	for (const func of functions) {
+		const names = finalNamesByOriginalName.get(func.originalName) ?? new Set<string>();
+		names.add(func.finalName);
+		finalNamesByOriginalName.set(func.originalName, names);
+	}
+
+	const rewriteMap = new Map<string, string>();
+	const ambiguousNames = new Set<string>();
+
+	for (const [originalName, finalNames] of finalNamesByOriginalName) {
+		if (finalNames.size === 1) {
+			rewriteMap.set(originalName, [...finalNames][0]!);
+		} else {
+			ambiguousNames.add(originalName);
+		}
+	}
+
+	for (const func of functions) {
+		for (const [lineIndex, line] of func.code.entries()) {
+			if (!startsWithInstruction(line, 'call')) {
+				continue;
+			}
+			const targetName = getLineFirstArgument(line);
+			if (ambiguousNames.has(targetName)) {
+				throw new ProjectIncludeError(
+					`include "${includeId}" call target "${targetName}" is ambiguous because that function name expands to multiple public/internal include names`,
+					func.startLineNumber + lineIndex
+				);
+			}
+		}
+	}
+
+	return rewriteMap;
+}
+
+function rewriteIncludeFunctionCode(
+	func: IncludeFunction,
+	callTargetRewriteMap: ReadonlyMap<string, string>
+): string[] {
+	return func.code.map((line, lineIndex) => {
+		if (lineIndex === 0) {
+			return replaceInstructionFirstArgument(line, 'function', func.finalName);
+		}
+		if (func.export?.lineIndex === lineIndex) {
+			return '';
+		}
+		if (startsWithInstruction(line, 'call')) {
+			const targetName = getLineFirstArgument(line);
+			const rewrittenTargetName = callTargetRewriteMap.get(targetName);
+			if (rewrittenTargetName && rewrittenTargetName !== targetName) {
+				return replaceInstructionFirstArgument(line, 'call', rewrittenTargetName);
+			}
+		}
+		return line;
+	});
+}
+
 /**
  * Converts resolved include source text into function source blocks.
  */
 export function resolveFunctionIncludeSource(includeId: string, source: string): Module[] {
-	return splitFunctionBlocks(normalizeSourceLines(source)).map(code => ({
-		code,
+	const includeFunctions = createIncludeFunctions(includeId, splitFunctionBlocks(normalizeSourceLines(source)));
+	const callTargetRewriteMap = createCallTargetRewriteMap(includeId, includeFunctions);
+
+	return includeFunctions.map(func => ({
+		code: rewriteIncludeFunctionCode(func, callTargetRewriteMap),
 		source: {
 			kind: 'include' as const,
 			includeId,
-			symbolName: getFunctionName(code[0] ?? ''),
+			symbolName: func.finalName,
 		},
 	}));
+}
+
+function expandProjectInclude(
+	includedFunctionBlocks: Module[],
+	expandedIncludeIds: Set<string>,
+	includeId: string,
+	source: string
+): void {
+	if (expandedIncludeIds.has(includeId)) {
+		return;
+	}
+
+	includedFunctionBlocks.push(...resolveFunctionIncludeSource(includeId, source));
+	expandedIncludeIds.add(includeId);
 }
 
 export function collectProjectIncludeIdsFromBlock(block: Pick<ProjectBlock, 'code' | 'id'>) {
@@ -127,18 +287,23 @@ export function resolveProjectIncludes(
 	resolveInclude: ProjectIncludeResolver
 ): Module[] {
 	const includedFunctionBlocks: Module[] = [];
+	const expandedIncludeIds = new Set<string>();
 
 	for (const block of includeBlocks) {
 		if (block.disabled) {
 			continue;
 		}
 		for (const { includeId, lineNumber } of collectProjectIncludeIdsFromBlock(block)) {
+			if (expandedIncludeIds.has(includeId)) {
+				continue;
+			}
+
 			const source = resolveInclude(includeId);
 			if (source === undefined) {
 				throw new ProjectIncludeError(`unresolved include "${includeId}"`, lineNumber, block.id);
 			}
 
-			includedFunctionBlocks.push(...resolveFunctionIncludeSource(includeId, source));
+			expandProjectInclude(includedFunctionBlocks, expandedIncludeIds, includeId, source);
 		}
 	}
 

--- a/packages/compiler/packages/project-preparser/src/prepareCompilerInput.test.ts
+++ b/packages/compiler/packages/project-preparser/src/prepareCompilerInput.test.ts
@@ -12,12 +12,14 @@ const validPrototypeBlock = ['prototype oscillatorState', 'float phase', 'float 
 const validNoteBlock = ['note', '; @pos 2 3', 'remember to tune this later', 'noteEnd'];
 
 const includeSources: Record<string, string> = {
-	'std/events/risingEdge': ['function risingEdge', 'functionEnd int'].join('\n'),
+	'std/events/risingEdge': ['function risingEdge', '#export', 'functionEnd int'].join('\n'),
 	'std/memory/wrapPointer': [
 		'function wrapPointer',
+		'#export',
 		'functionEnd int*',
 		'',
 		'function wrapPointer',
+		'#export',
 		'functionEnd float*',
 	].join('\n'),
 };
@@ -77,15 +79,15 @@ describe('prepareCompilerInputFromProjectBlocksAsync', () => {
 
 		expect(input.functions).toEqual([
 			{
-				code: ['function risingEdge', 'functionEnd int'],
+				code: ['function risingEdge', '', 'functionEnd int'],
 				source: { kind: 'include', includeId: 'std/events/risingEdge', symbolName: 'risingEdge' },
 			},
 			{
-				code: ['function wrapPointer', 'functionEnd int*'],
+				code: ['function wrapPointer', '', 'functionEnd int*'],
 				source: { kind: 'include', includeId: 'std/memory/wrapPointer', symbolName: 'wrapPointer' },
 			},
 			{
-				code: ['function wrapPointer', 'functionEnd float*'],
+				code: ['function wrapPointer', '', 'functionEnd float*'],
 				source: { kind: 'include', includeId: 'std/memory/wrapPointer', symbolName: 'wrapPointer' },
 			},
 		]);
@@ -162,7 +164,7 @@ describe('prepareCompilerInputFromProjectSourceAsync', () => {
 		expect(input.entries.main).toEqual([{ code: validModuleBlock, projectBlockId: 8 }]);
 		expect(input.functions).toEqual([
 			{
-				code: ['function risingEdge', 'functionEnd int'],
+				code: ['function risingEdge', '', 'functionEnd int'],
 				source: { kind: 'include', includeId: 'std/events/risingEdge', symbolName: 'risingEdge' },
 			},
 		]);

--- a/packages/compiler/packages/project-preparser/tests/__snapshots__/projectPreparser.integration.test.ts.snap
+++ b/packages/compiler/packages/project-preparser/tests/__snapshots__/projectPreparser.integration.test.ts.snap
@@ -30,6 +30,7 @@ exports[`project-preparser integration > parses project source and prepares comp
       {
         "code": [
           "function risingEdge",
+          "",
           "functionEnd int",
         ],
         "source": {
@@ -41,6 +42,7 @@ exports[`project-preparser integration > parses project source and prepares comp
       {
         "code": [
           "function wrapPointer",
+          "",
           "functionEnd int*",
         ],
         "source": {
@@ -52,6 +54,7 @@ exports[`project-preparser integration > parses project source and prepares comp
       {
         "code": [
           "function wrapPointer",
+          "",
           "functionEnd float*",
         ],
         "source": {

--- a/packages/compiler/packages/project-preparser/tests/projectPreparser.integration.test.ts
+++ b/packages/compiler/packages/project-preparser/tests/projectPreparser.integration.test.ts
@@ -48,12 +48,14 @@ describe('project-preparser integration', () => {
 		].join('\n');
 		const resolveInclude: ProjectIncludeResolverAsync = includeId =>
 			({
-				'std/events/risingEdge': ['function risingEdge', 'functionEnd int'].join('\n'),
+				'std/events/risingEdge': ['function risingEdge', '#export', 'functionEnd int'].join('\n'),
 				'std/memory/wrapPointer': [
 					'function wrapPointer',
+					'#export',
 					'functionEnd int*',
 					'',
 					'function wrapPointer',
+					'#export',
 					'functionEnd float*',
 				].join('\n'),
 			})[includeId];

--- a/packages/compiler/packages/stdlib/README.md
+++ b/packages/compiler/packages/stdlib/README.md
@@ -18,6 +18,7 @@ This package owns:
 - Standard-library include source files.
 - Stable include ids such as `std/math/clamp` and `std/memory/loadAt`.
 - Keeping `manifest.json` in sync with `std/`.
+- Marking every public include function with `#export`.
 
 This package does not own:
 
@@ -26,3 +27,21 @@ This package does not own:
 - Runtime host behavior.
 
 Callers should use the manifest to discover available standard-library includes and load the exported source files through their own environment-specific resolver.
+
+## Include exports
+
+Stdlib source files must explicitly mark their public include functions with `#export`:
+
+```8f4e
+function clamp
+#export
+param int value
+param int minValue
+param int maxValue
+; ...
+functionEnd int
+```
+
+In stdlib include context, `#export` means "make this function available to the including project." It is consumed by
+the project preparser and does not create a WebAssembly export. Private helper functions should omit `#export`; the
+preparser prefixes those helper names when expanding the include.

--- a/packages/compiler/packages/stdlib/std/bitwise/extractBit.8f4e
+++ b/packages/compiler/packages/stdlib/std/bitwise/extractBit.8f4e
@@ -1,4 +1,5 @@
 function extractBit
+#export
 param int word
 param int bitIndex
 

--- a/packages/compiler/packages/stdlib/std/bitwise/extractByte.8f4e
+++ b/packages/compiler/packages/stdlib/std/bitwise/extractByte.8f4e
@@ -1,4 +1,5 @@
 function extractByte
+#export
 param int word
 param int byteIndex
 

--- a/packages/compiler/packages/stdlib/std/events/gateToTrigger.8f4e
+++ b/packages/compiler/packages/stdlib/std/events/gateToTrigger.8f4e
@@ -1,4 +1,5 @@
 function gateToTrigger
+#export
 #impure
 ; Returns a one-sample trigger
 ; when an int gate rises above
@@ -16,6 +17,7 @@ store
 functionEnd int
 
 function gateToTrigger
+#export
 #impure
 ; Returns a one-sample trigger
 ; when a float gate rises above

--- a/packages/compiler/packages/stdlib/std/events/hasChanged.8f4e
+++ b/packages/compiler/packages/stdlib/std/events/hasChanged.8f4e
@@ -1,4 +1,5 @@
 function hasChanged
+#export
 #impure
 param int currentValue
 param int* previousValue
@@ -13,6 +14,7 @@ store
 functionEnd int
 
 function hasChanged
+#export
 #impure
 param float currentValue
 param float* previousValue

--- a/packages/compiler/packages/stdlib/std/events/risingEdge.8f4e
+++ b/packages/compiler/packages/stdlib/std/events/risingEdge.8f4e
@@ -1,4 +1,5 @@
 function risingEdge
+#export
 #impure
 param int currentValue
 param int* previousValue
@@ -13,6 +14,7 @@ store
 functionEnd int
 
 function risingEdge
+#export
 #impure
 param float currentValue
 param float* previousValue

--- a/packages/compiler/packages/stdlib/std/events/triggerToGate.8f4e
+++ b/packages/compiler/packages/stdlib/std/events/triggerToGate.8f4e
@@ -1,4 +1,5 @@
 function triggerToGate
+#export
 #impure
 ; Converts an int trigger to a
 ; held gate by resetting the
@@ -33,6 +34,7 @@ ifEnd int
 functionEnd int
 
 function triggerToGate
+#export
 #impure
 ; Converts a float trigger to a
 ; held gate by resetting the

--- a/packages/compiler/packages/stdlib/std/math/clamp.8f4e
+++ b/packages/compiler/packages/stdlib/std/math/clamp.8f4e
@@ -1,4 +1,5 @@
 function clamp
+#export
 param int value
 param int minValue
 param int maxValue
@@ -12,6 +13,7 @@ min
 functionEnd int
 
 function clamp
+#export
 param float value
 param float minValue
 param float maxValue

--- a/packages/compiler/packages/stdlib/std/math/fract.8f4e
+++ b/packages/compiler/packages/stdlib/std/math/fract.8f4e
@@ -1,4 +1,5 @@
 function fract
+#export
 ; Returns the fractional part of
 ; a float by subtracting its
 ; integer-truncated value.

--- a/packages/compiler/packages/stdlib/std/math/lerp.8f4e
+++ b/packages/compiler/packages/stdlib/std/math/lerp.8f4e
@@ -1,4 +1,5 @@
 function lerp
+#export
 ; Linearly interpolates between
 ; start and end by amount.
 param float start

--- a/packages/compiler/packages/stdlib/std/math/normalize.8f4e
+++ b/packages/compiler/packages/stdlib/std/math/normalize.8f4e
@@ -1,4 +1,5 @@
 function normalize
+#export
 #impure
 ; Loads a signed int8 value and
 ; maps it to a clamped -1..1
@@ -20,6 +21,7 @@ min
 functionEnd float
 
 function normalize
+#export
 #impure
 ; Loads an unsigned int8 value
 ; and maps it to a clamped
@@ -41,6 +43,7 @@ min
 functionEnd float
 
 function normalize
+#export
 #impure
 ; Loads a signed int16 value
 ; and maps it to a clamped
@@ -62,6 +65,7 @@ min
 functionEnd float
 
 function normalize
+#export
 #impure
 ; Loads an unsigned int16 value
 ; and maps it to a clamped
@@ -83,6 +87,7 @@ min
 functionEnd float
 
 function normalize
+#export
 #impure
 ; Loads a signed int value and
 ; maps it to a clamped -1..1

--- a/packages/compiler/packages/stdlib/std/math/pow2.8f4e
+++ b/packages/compiler/packages/stdlib/std/math/pow2.8f4e
@@ -1,4 +1,5 @@
 function pow2
+#export
 param int exponent
 
 push 1

--- a/packages/compiler/packages/stdlib/std/math/smoothstep.8f4e
+++ b/packages/compiler/packages/stdlib/std/math/smoothstep.8f4e
@@ -1,4 +1,5 @@
 function smoothstep
+#export
 ; Smoothly maps amount in
 ; 0..1 to an eased 0..1
 ; curve.

--- a/packages/compiler/packages/stdlib/std/math/trig/advancePhase.8f4e
+++ b/packages/compiler/packages/stdlib/std/math/trig/advancePhase.8f4e
@@ -1,4 +1,5 @@
 function advancePhase
+#export
 #impure
 ; Advances a phase by one sample
 ; and wraps from PI to -PI.

--- a/packages/compiler/packages/stdlib/std/math/trig/cosine.8f4e
+++ b/packages/compiler/packages/stdlib/std/math/trig/cosine.8f4e
@@ -1,4 +1,5 @@
 function cosine
+#export
 ; Polynomial approximation
 ; of the cosine function with
 ; Taylor series (6th order).

--- a/packages/compiler/packages/stdlib/std/math/trig/saw.8f4e
+++ b/packages/compiler/packages/stdlib/std/math/trig/saw.8f4e
@@ -1,4 +1,5 @@
 function saw
+#export
 ; Sawtooth function for
 ; the input range [-PI, PI].
 ; Output range: [-1, 1].

--- a/packages/compiler/packages/stdlib/std/math/trig/sine.8f4e
+++ b/packages/compiler/packages/stdlib/std/math/trig/sine.8f4e
@@ -1,4 +1,5 @@
 function sine
+#export
 ; Polynomial approximation
 ; of the sine function with
 ; Taylor series (7th order).

--- a/packages/compiler/packages/stdlib/std/math/trig/triangle.8f4e
+++ b/packages/compiler/packages/stdlib/std/math/trig/triangle.8f4e
@@ -1,4 +1,5 @@
 function triangle
+#export
 ; Triangle function for
 ; the input range [-PI, PI].
 ; Output range: [-1, 1].

--- a/packages/compiler/packages/stdlib/std/memory/advancePointer.8f4e
+++ b/packages/compiler/packages/stdlib/std/memory/advancePointer.8f4e
@@ -1,4 +1,5 @@
 function advancePointer
+#export
 #impure
 ; Advances an int pointer by
 ; one element and wraps it
@@ -35,6 +36,7 @@ store
 functionEnd
 
 function advancePointer
+#export
 #impure
 ; Advances a float pointer by
 ; one element and wraps it

--- a/packages/compiler/packages/stdlib/std/memory/copy.8f4e
+++ b/packages/compiler/packages/stdlib/std/memory/copy.8f4e
@@ -1,4 +1,5 @@
 function copy
+#export
 #impure
 ; Copies the value pointed to
 ; by source into dest.
@@ -12,6 +13,7 @@ store
 functionEnd
 
 function copy
+#export
 #impure
 ; Copies the value pointed to
 ; by source into dest.

--- a/packages/compiler/packages/stdlib/std/memory/decrementPointer.8f4e
+++ b/packages/compiler/packages/stdlib/std/memory/decrementPointer.8f4e
@@ -1,4 +1,5 @@
 function decrementPointer
+#export
 #impure
 ; Decrements an int pointer by
 ; one element and wraps it
@@ -35,6 +36,7 @@ store
 functionEnd
 
 function decrementPointer
+#export
 #impure
 ; Decrements a float pointer by
 ; one element and wraps it

--- a/packages/compiler/packages/stdlib/std/memory/loadAt.8f4e
+++ b/packages/compiler/packages/stdlib/std/memory/loadAt.8f4e
@@ -1,4 +1,5 @@
 function loadAt
+#export
 #impure
 param int* buffer
 param int index

--- a/packages/compiler/packages/stdlib/std/memory/nearestValue.8f4e
+++ b/packages/compiler/packages/stdlib/std/memory/nearestValue.8f4e
@@ -1,4 +1,5 @@
 function nearestValue
+#export
 #impure
 ; Returns the int buffer value
 ; nearest to value. Ties keep the
@@ -75,6 +76,7 @@ ifEnd int
 functionEnd int
 
 function nearestValue
+#export
 #impure
 ; Returns the float buffer value
 ; nearest to value. Ties keep the

--- a/packages/compiler/packages/stdlib/std/memory/readInterpolated.8f4e
+++ b/packages/compiler/packages/stdlib/std/memory/readInterpolated.8f4e
@@ -1,4 +1,5 @@
 function readInterpolated
+#export
 #impure
 ; Reads an interpolated float
 ; value from a circular int
@@ -64,6 +65,7 @@ add
 functionEnd float
 
 function readInterpolated
+#export
 #impure
 ; Reads an interpolated float
 ; value from a circular int16
@@ -129,6 +131,7 @@ add
 functionEnd float
 
 function readInterpolated
+#export
 #impure
 ; Reads an interpolated float
 ; value from a circular float

--- a/packages/compiler/packages/stdlib/std/memory/readInterpolated.8f4e
+++ b/packages/compiler/packages/stdlib/std/memory/readInterpolated.8f4e
@@ -18,38 +18,20 @@ push sizeof(*buffer)
 mul
 localSet byteLength
 
-push buffer
 push pointer
 push buffer
-sub
 push byteLength
-ensureNonZero
-remainder
-push byteLength
-add
-push byteLength
-ensureNonZero
-remainder
-add
+call wrapReadAddress
 load
 castToFloat
 localSet first
 
-push buffer
 push pointer
 push sizeof(*buffer)
 add
 push buffer
-sub
 push byteLength
-ensureNonZero
-remainder
-push byteLength
-add
-push byteLength
-ensureNonZero
-remainder
-add
+call wrapReadAddress
 load
 castToFloat
 localSet second
@@ -84,38 +66,20 @@ push sizeof(*buffer)
 mul
 localSet byteLength
 
-push buffer
 push pointer
 push buffer
-sub
 push byteLength
-ensureNonZero
-remainder
-push byteLength
-add
-push byteLength
-ensureNonZero
-remainder
-add
+call wrapReadAddress
 load16s
 castToFloat
 localSet first
 
-push buffer
 push pointer
 push sizeof(*buffer)
 add
 push buffer
-sub
 push byteLength
-ensureNonZero
-remainder
-push byteLength
-add
-push byteLength
-ensureNonZero
-remainder
-add
+call wrapReadAddress
 load16s
 castToFloat
 localSet second
@@ -150,37 +114,19 @@ push sizeof(*buffer)
 mul
 localSet byteLength
 
-push buffer
 push pointer
 push buffer
-sub
 push byteLength
-ensureNonZero
-remainder
-push byteLength
-add
-push byteLength
-ensureNonZero
-remainder
-add
+call wrapReadAddress
 loadFloat
 localSet first
 
-push buffer
 push pointer
 push sizeof(*buffer)
 add
 push buffer
-sub
 push byteLength
-ensureNonZero
-remainder
-push byteLength
-add
-push byteLength
-ensureNonZero
-remainder
-add
+call wrapReadAddress
 loadFloat
 localSet second
 
@@ -193,3 +139,78 @@ mul
 add
 
 functionEnd float
+
+function wrapReadAddress
+; Wraps an int-buffer byte
+; address into the circular
+; buffer range used by
+; readInterpolated.
+param int pointer
+param int* buffer
+param int byteLength
+
+push buffer
+push pointer
+push buffer
+sub
+push byteLength
+ensureNonZero
+remainder
+push byteLength
+add
+push byteLength
+ensureNonZero
+remainder
+add
+
+functionEnd int*
+
+function wrapReadAddress
+; Wraps an int16-buffer byte
+; address into the circular
+; buffer range used by
+; readInterpolated.
+param int pointer
+param int16* buffer
+param int byteLength
+
+push buffer
+push pointer
+push buffer
+sub
+push byteLength
+ensureNonZero
+remainder
+push byteLength
+add
+push byteLength
+ensureNonZero
+remainder
+add
+
+functionEnd int16*
+
+function wrapReadAddress
+; Wraps a float-buffer byte
+; address into the circular
+; buffer range used by
+; readInterpolated.
+param int pointer
+param float* buffer
+param int byteLength
+
+push buffer
+push pointer
+push buffer
+sub
+push byteLength
+ensureNonZero
+remainder
+push byteLength
+add
+push byteLength
+ensureNonZero
+remainder
+add
+
+functionEnd float*

--- a/packages/compiler/packages/stdlib/std/memory/storeAt.8f4e
+++ b/packages/compiler/packages/stdlib/std/memory/storeAt.8f4e
@@ -1,4 +1,5 @@
 function storeAt
+#export
 #impure
 param int* buffer
 param int index

--- a/packages/compiler/packages/stdlib/std/memory/wrapPointer.8f4e
+++ b/packages/compiler/packages/stdlib/std/memory/wrapPointer.8f4e
@@ -7,36 +7,6 @@ param int pointer
 param int* buffer
 param int itemCount
 
-push pointer
-push buffer
-push itemCount
-call wrapPointerAddress
-
-functionEnd int*
-
-function wrapPointer
-#export
-; Bidirectionally wraps a float
-; byte address into a circular
-; float buffer.
-param int pointer
-param float* buffer
-param int itemCount
-
-push pointer
-push buffer
-push itemCount
-call wrapPointerAddress
-
-functionEnd float*
-
-function wrapPointerAddress
-; Private int-buffer wrapping
-; helper used by wrapPointer.
-param int pointer
-param int* buffer
-param int itemCount
-
 local int byteLength
 
 push itemCount
@@ -60,9 +30,11 @@ add
 
 functionEnd int*
 
-function wrapPointerAddress
-; Private float-buffer wrapping
-; helper used by wrapPointer.
+function wrapPointer
+#export
+; Bidirectionally wraps a float
+; byte address into a circular
+; float buffer.
 param int pointer
 param float* buffer
 param int itemCount

--- a/packages/compiler/packages/stdlib/std/memory/wrapPointer.8f4e
+++ b/packages/compiler/packages/stdlib/std/memory/wrapPointer.8f4e
@@ -1,7 +1,38 @@
 function wrapPointer
+#export
 ; Bidirectionally wraps an int
 ; byte address into a circular
 ; int buffer.
+param int pointer
+param int* buffer
+param int itemCount
+
+push pointer
+push buffer
+push itemCount
+call wrapPointerAddress
+
+functionEnd int*
+
+function wrapPointer
+#export
+; Bidirectionally wraps a float
+; byte address into a circular
+; float buffer.
+param int pointer
+param float* buffer
+param int itemCount
+
+push pointer
+push buffer
+push itemCount
+call wrapPointerAddress
+
+functionEnd float*
+
+function wrapPointerAddress
+; Private int-buffer wrapping
+; helper used by wrapPointer.
 param int pointer
 param int* buffer
 param int itemCount
@@ -29,10 +60,9 @@ add
 
 functionEnd int*
 
-function wrapPointer
-; Bidirectionally wraps a float
-; byte address into a circular
-; float buffer.
+function wrapPointerAddress
+; Private float-buffer wrapping
+; helper used by wrapPointer.
 param int pointer
 param float* buffer
 param int itemCount

--- a/packages/compiler/packages/stdlib/std/random/lcg.8f4e
+++ b/packages/compiler/packages/stdlib/std/random/lcg.8f4e
@@ -1,4 +1,5 @@
 function lcg
+#export
 #impure
 ; Advances a 16-bit linear
 ; congruential generator seed

--- a/packages/compiler/packages/stdlib/std/random/xorshift.8f4e
+++ b/packages/compiler/packages/stdlib/std/random/xorshift.8f4e
@@ -1,4 +1,5 @@
 function xorshift
+#export
 #impure
 ; Advances a signed 32-bit
 ; XORShift seed and returns the

--- a/packages/compiler/packages/stdlib/std/stack/dup.8f4e
+++ b/packages/compiler/packages/stdlib/std/stack/dup.8f4e
@@ -1,4 +1,5 @@
 function dup
+#export
 param int value
 
 push value
@@ -7,6 +8,7 @@ push value
 functionEnd int int
 
 function dup
+#export
 param float value
 
 push value

--- a/packages/compiler/packages/stdlib/std/stack/swap.8f4e
+++ b/packages/compiler/packages/stdlib/std/stack/swap.8f4e
@@ -1,4 +1,5 @@
 function swap
+#export
 param int first
 param int second
 
@@ -8,6 +9,7 @@ push first
 functionEnd int int
 
 function swap
+#export
 param int first
 param float second
 
@@ -17,6 +19,7 @@ push first
 functionEnd float int
 
 function swap
+#export
 param float first
 param int second
 
@@ -26,6 +29,7 @@ push first
 functionEnd int float
 
 function swap
+#export
 param float first
 param float second
 

--- a/packages/compiler/tests/__snapshots__/stdlib/read-interpolated-float.test.8f4e.compile-result.snap
+++ b/packages/compiler/tests/__snapshots__/stdlib/read-interpolated-float.test.8f4e.compile-result.snap
@@ -1,5 +1,524 @@
 {
   "functionAst": {
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__float_p__int": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float*",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float*",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+      "type": "function",
+    },
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int16_p__int": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int16*",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int16*",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+      "type": "function",
+    },
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int_p__int": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int*",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int*",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+      "type": "function",
+    },
     "readInterpolated__int__float_p__int__float": {
       "lines": [
         {
@@ -182,17 +701,6 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
               "value": "pointer",
             },
           ],
@@ -210,10 +718,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -225,50 +729,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -284,17 +753,6 @@
             },
           ],
           "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
         },
         {
           "arguments": [
@@ -336,10 +794,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -351,50 +805,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -664,17 +1083,6 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
               "value": "pointer",
             },
           ],
@@ -692,10 +1100,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -707,50 +1111,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -770,17 +1139,6 @@
             },
           ],
           "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
         },
         {
           "arguments": [
@@ -822,10 +1180,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -837,50 +1191,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -1154,17 +1473,6 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
               "value": "pointer",
             },
           ],
@@ -1182,10 +1490,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -1197,50 +1501,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -1260,17 +1529,6 @@
             },
           ],
           "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
         },
         {
           "arguments": [
@@ -1312,10 +1570,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -1327,50 +1581,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -1464,6 +1683,45 @@
     },
   },
   "functionOverview": {
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__float_p__int": {
+      "id": "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__float_p__int",
+      "signature": {
+        "parameters": [
+          "int",
+          "float*",
+          "int",
+        ],
+        "returns": [
+          "float*",
+        ],
+      },
+    },
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int16_p__int": {
+      "id": "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int16_p__int",
+      "signature": {
+        "parameters": [
+          "int",
+          "int16*",
+          "int",
+        ],
+        "returns": [
+          "int16*",
+        ],
+      },
+    },
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int_p__int": {
+      "id": "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int_p__int",
+      "signature": {
+        "parameters": [
+          "int",
+          "int*",
+          "int",
+        ],
+        "returns": [
+          "int*",
+        ],
+      },
+    },
     "readInterpolated__int__float_p__int__float": {
       "id": "readInterpolated__int__float_p__int__float",
       "signature": {
@@ -1882,6 +2140,9 @@
   },
   "overview": {
     "compiledFunctions": [
+      "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__float_p__int",
+      "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int_p__int",
+      "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int16_p__int",
       "readInterpolated__int__float_p__int__float",
       "readInterpolated__int__int_p__int__float",
       "readInterpolated__int__int16_p__int__float",

--- a/packages/compiler/tests/__snapshots__/stdlib/read-interpolated-int.test.8f4e.compile-result.snap
+++ b/packages/compiler/tests/__snapshots__/stdlib/read-interpolated-int.test.8f4e.compile-result.snap
@@ -1,5 +1,524 @@
 {
   "functionAst": {
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__float_p__int": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float*",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float*",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+      "type": "function",
+    },
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int16_p__int": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int16*",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int16*",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+      "type": "function",
+    },
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int_p__int": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int*",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int*",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+      "type": "function",
+    },
     "readInterpolated__int__float_p__int__float": {
       "lines": [
         {
@@ -182,17 +701,6 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
               "value": "pointer",
             },
           ],
@@ -210,10 +718,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -225,50 +729,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -284,17 +753,6 @@
             },
           ],
           "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
         },
         {
           "arguments": [
@@ -336,10 +794,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -351,50 +805,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -664,17 +1083,6 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
               "value": "pointer",
             },
           ],
@@ -692,10 +1100,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -707,50 +1111,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -770,17 +1139,6 @@
             },
           ],
           "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
         },
         {
           "arguments": [
@@ -822,10 +1180,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -837,50 +1191,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -1154,17 +1473,6 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
               "value": "pointer",
             },
           ],
@@ -1182,10 +1490,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -1197,50 +1501,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -1260,17 +1529,6 @@
             },
           ],
           "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
         },
         {
           "arguments": [
@@ -1312,10 +1570,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -1327,50 +1581,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -1464,6 +1683,45 @@
     },
   },
   "functionOverview": {
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__float_p__int": {
+      "id": "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__float_p__int",
+      "signature": {
+        "parameters": [
+          "int",
+          "float*",
+          "int",
+        ],
+        "returns": [
+          "float*",
+        ],
+      },
+    },
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int16_p__int": {
+      "id": "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int16_p__int",
+      "signature": {
+        "parameters": [
+          "int",
+          "int16*",
+          "int",
+        ],
+        "returns": [
+          "int16*",
+        ],
+      },
+    },
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int_p__int": {
+      "id": "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int_p__int",
+      "signature": {
+        "parameters": [
+          "int",
+          "int*",
+          "int",
+        ],
+        "returns": [
+          "int*",
+        ],
+      },
+    },
     "readInterpolated__int__float_p__int__float": {
       "id": "readInterpolated__int__float_p__int__float",
       "signature": {
@@ -1882,6 +2140,9 @@
   },
   "overview": {
     "compiledFunctions": [
+      "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__float_p__int",
+      "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int_p__int",
+      "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int16_p__int",
       "readInterpolated__int__float_p__int__float",
       "readInterpolated__int__int_p__int__float",
       "readInterpolated__int__int16_p__int__float",

--- a/packages/compiler/tests/__snapshots__/stdlib/read-interpolated-int16.test.8f4e.compile-result.snap
+++ b/packages/compiler/tests/__snapshots__/stdlib/read-interpolated-int16.test.8f4e.compile-result.snap
@@ -1,5 +1,524 @@
 {
   "functionAst": {
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__float_p__int": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float*",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float*",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+      "type": "function",
+    },
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int16_p__int": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int16*",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int16*",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+      "type": "function",
+    },
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int_p__int": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int*",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int*",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
+      "type": "function",
+    },
     "readInterpolated__int__float_p__int__float": {
       "lines": [
         {
@@ -182,17 +701,6 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
               "value": "pointer",
             },
           ],
@@ -210,10 +718,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -225,50 +729,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -284,17 +753,6 @@
             },
           ],
           "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
         },
         {
           "arguments": [
@@ -336,10 +794,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -351,50 +805,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -664,17 +1083,6 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
               "value": "pointer",
             },
           ],
@@ -692,10 +1100,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -707,50 +1111,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -770,17 +1139,6 @@
             },
           ],
           "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
         },
         {
           "arguments": [
@@ -822,10 +1180,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -837,50 +1191,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -1154,17 +1473,6 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
               "value": "pointer",
             },
           ],
@@ -1182,10 +1490,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -1197,50 +1501,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -1260,17 +1529,6 @@
             },
           ],
           "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
         },
         {
           "arguments": [
@@ -1312,10 +1570,6 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
@@ -1327,50 +1581,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
           "arguments": [
             {
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_readInterpolated__wrapReadAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [],
@@ -1464,6 +1683,45 @@
     },
   },
   "functionOverview": {
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__float_p__int": {
+      "id": "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__float_p__int",
+      "signature": {
+        "parameters": [
+          "int",
+          "float*",
+          "int",
+        ],
+        "returns": [
+          "float*",
+        ],
+      },
+    },
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int16_p__int": {
+      "id": "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int16_p__int",
+      "signature": {
+        "parameters": [
+          "int",
+          "int16*",
+          "int",
+        ],
+        "returns": [
+          "int16*",
+        ],
+      },
+    },
+    "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int_p__int": {
+      "id": "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int_p__int",
+      "signature": {
+        "parameters": [
+          "int",
+          "int*",
+          "int",
+        ],
+        "returns": [
+          "int*",
+        ],
+      },
+    },
     "readInterpolated__int__float_p__int__float": {
       "id": "readInterpolated__int__float_p__int__float",
       "signature": {
@@ -1894,6 +2152,9 @@
   },
   "overview": {
     "compiledFunctions": [
+      "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__float_p__int",
+      "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int_p__int",
+      "__8f4e_std_memory_readInterpolated__wrapReadAddress__int__int16_p__int",
       "readInterpolated__int__float_p__int__float",
       "readInterpolated__int__int_p__int__float",
       "readInterpolated__int__int16_p__int__float",

--- a/packages/compiler/tests/__snapshots__/stdlib/wrap-pointer-float.test.8f4e.compile-result.snap
+++ b/packages/compiler/tests/__snapshots__/stdlib/wrap-pointer-float.test.8f4e.compile-result.snap
@@ -1,6 +1,6 @@
 {
   "functionAst": {
-    "wrapPointer__int__float_p__int": {
+    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int": {
       "lines": [
         {
           "arguments": [
@@ -8,7 +8,7 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "wrapPointer",
+              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
             },
           ],
           "instruction": "function",
@@ -213,6 +213,358 @@
         {
           "arguments": [],
           "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float*",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
+      "type": "function",
+    },
+    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int*",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "itemCount",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "local",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "itemCount",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "isPointee": true,
+              "referenceKind": "pointee-element-word-size",
+              "scope": "local",
+              "targetMemoryId": "buffer",
+              "type": "identifier",
+              "value": "sizeof(*buffer)",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "mul",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "localSet",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int*",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
+      "type": "function",
+    },
+    "wrapPointer__int__float_p__int": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "wrapPointer",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float*",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "itemCount",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "itemCount",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
+            },
+          ],
+          "instruction": "call",
         },
         {
           "arguments": [
@@ -299,73 +651,6 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "int",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "local",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "itemCount",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "isPointee": true,
-              "referenceKind": "pointee-element-word-size",
-              "scope": "local",
-              "targetMemoryId": "buffer",
-              "type": "identifier",
-              "value": "sizeof(*buffer)",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "mul",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
               "value": "pointer",
             },
           ],
@@ -383,8 +668,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "itemCount",
+            },
+          ],
+          "instruction": "push",
         },
         {
           "arguments": [
@@ -392,56 +684,10 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [
@@ -460,6 +706,32 @@
     },
   },
   "functionOverview": {
+    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int": {
+      "id": "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int",
+      "signature": {
+        "parameters": [
+          "int",
+          "float*",
+          "int",
+        ],
+        "returns": [
+          "float*",
+        ],
+      },
+    },
+    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int": {
+      "id": "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int",
+      "signature": {
+        "parameters": [
+          "int",
+          "int*",
+          "int",
+        ],
+        "returns": [
+          "int*",
+        ],
+      },
+    },
     "wrapPointer__int__float_p__int": {
       "id": "wrapPointer__int__float_p__int",
       "signature": {
@@ -885,6 +1157,8 @@
   },
   "overview": {
     "compiledFunctions": [
+      "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int",
+      "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int",
       "wrapPointer__int__float_p__int",
       "wrapPointer__int__int_p__int",
     ],

--- a/packages/compiler/tests/__snapshots__/stdlib/wrap-pointer-float.test.8f4e.compile-result.snap
+++ b/packages/compiler/tests/__snapshots__/stdlib/wrap-pointer-float.test.8f4e.compile-result.snap
@@ -1,463 +1,5 @@
 {
   "functionAst": {
-    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int": {
-      "lines": [
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
-            },
-          ],
-          "instruction": "function",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "pointer",
-            },
-          ],
-          "instruction": "param",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "float*",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "param",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "itemCount",
-            },
-          ],
-          "instruction": "param",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "local",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "itemCount",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "isPointee": true,
-              "referenceKind": "pointee-element-word-size",
-              "scope": "local",
-              "targetMemoryId": "buffer",
-              "type": "identifier",
-              "value": "sizeof(*buffer)",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "mul",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "pointer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "float*",
-            },
-          ],
-          "instruction": "functionEnd",
-        },
-      ],
-      "name": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
-      "type": "function",
-    },
-    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int": {
-      "lines": [
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
-            },
-          ],
-          "instruction": "function",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "pointer",
-            },
-          ],
-          "instruction": "param",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int*",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "param",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "itemCount",
-            },
-          ],
-          "instruction": "param",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "local",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "itemCount",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "isPointee": true,
-              "referenceKind": "pointee-element-word-size",
-              "scope": "local",
-              "targetMemoryId": "buffer",
-              "type": "identifier",
-              "value": "sizeof(*buffer)",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "mul",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "pointer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int*",
-            },
-          ],
-          "instruction": "functionEnd",
-        },
-      ],
-      "name": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
-      "type": "function",
-    },
     "wrapPointer__int__float_p__int": {
       "lines": [
         {
@@ -528,10 +70,55 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "pointer",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "local",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "itemCount",
             },
           ],
           "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "isPointee": true,
+              "referenceKind": "pointee-element-word-size",
+              "scope": "local",
+              "targetMemoryId": "buffer",
+              "type": "identifier",
+              "value": "sizeof(*buffer)",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "mul",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "localSet",
         },
         {
           "arguments": [
@@ -550,7 +137,7 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "itemCount",
+              "value": "pointer",
             },
           ],
           "instruction": "push",
@@ -561,10 +148,71 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
+              "value": "buffer",
             },
           ],
-          "instruction": "call",
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
         },
         {
           "arguments": [
@@ -651,10 +299,55 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "pointer",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "local",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "itemCount",
             },
           ],
           "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "isPointee": true,
+              "referenceKind": "pointee-element-word-size",
+              "scope": "local",
+              "targetMemoryId": "buffer",
+              "type": "identifier",
+              "value": "sizeof(*buffer)",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "mul",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "localSet",
         },
         {
           "arguments": [
@@ -673,7 +366,7 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "itemCount",
+              "value": "pointer",
             },
           ],
           "instruction": "push",
@@ -684,10 +377,71 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
+              "value": "buffer",
             },
           ],
-          "instruction": "call",
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
         },
         {
           "arguments": [
@@ -706,32 +460,6 @@
     },
   },
   "functionOverview": {
-    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int": {
-      "id": "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int",
-      "signature": {
-        "parameters": [
-          "int",
-          "float*",
-          "int",
-        ],
-        "returns": [
-          "float*",
-        ],
-      },
-    },
-    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int": {
-      "id": "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int",
-      "signature": {
-        "parameters": [
-          "int",
-          "int*",
-          "int",
-        ],
-        "returns": [
-          "int*",
-        ],
-      },
-    },
     "wrapPointer__int__float_p__int": {
       "id": "wrapPointer__int__float_p__int",
       "signature": {
@@ -1157,8 +885,6 @@
   },
   "overview": {
     "compiledFunctions": [
-      "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int",
-      "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int",
       "wrapPointer__int__float_p__int",
       "wrapPointer__int__int_p__int",
     ],

--- a/packages/compiler/tests/__snapshots__/stdlib/wrap-pointer-int.test.8f4e.compile-result.snap
+++ b/packages/compiler/tests/__snapshots__/stdlib/wrap-pointer-int.test.8f4e.compile-result.snap
@@ -1,6 +1,6 @@
 {
   "functionAst": {
-    "wrapPointer__int__float_p__int": {
+    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int": {
       "lines": [
         {
           "arguments": [
@@ -8,7 +8,7 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "wrapPointer",
+              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
             },
           ],
           "instruction": "function",
@@ -213,6 +213,358 @@
         {
           "arguments": [],
           "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float*",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
+      "type": "function",
+    },
+    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int*",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "itemCount",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "local",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "itemCount",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "isPointee": true,
+              "referenceKind": "pointee-element-word-size",
+              "scope": "local",
+              "targetMemoryId": "buffer",
+              "type": "identifier",
+              "value": "sizeof(*buffer)",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "mul",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "localSet",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int*",
+            },
+          ],
+          "instruction": "functionEnd",
+        },
+      ],
+      "name": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
+      "type": "function",
+    },
+    "wrapPointer__int__float_p__int": {
+      "lines": [
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "wrapPointer",
+            },
+          ],
+          "instruction": "function",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "float*",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "itemCount",
+            },
+          ],
+          "instruction": "param",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "pointer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "buffer",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "itemCount",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
+            },
+          ],
+          "instruction": "call",
         },
         {
           "arguments": [
@@ -299,73 +651,6 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "int",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "local",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "itemCount",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "isPointee": true,
-              "referenceKind": "pointee-element-word-size",
-              "scope": "local",
-              "targetMemoryId": "buffer",
-              "type": "identifier",
-              "value": "sizeof(*buffer)",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "mul",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
               "value": "pointer",
             },
           ],
@@ -383,8 +668,15 @@
           "instruction": "push",
         },
         {
-          "arguments": [],
-          "instruction": "sub",
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "itemCount",
+            },
+          ],
+          "instruction": "push",
         },
         {
           "arguments": [
@@ -392,56 +684,10 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "byteLength",
+              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
             },
           ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
+          "instruction": "call",
         },
         {
           "arguments": [
@@ -460,6 +706,32 @@
     },
   },
   "functionOverview": {
+    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int": {
+      "id": "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int",
+      "signature": {
+        "parameters": [
+          "int",
+          "float*",
+          "int",
+        ],
+        "returns": [
+          "float*",
+        ],
+      },
+    },
+    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int": {
+      "id": "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int",
+      "signature": {
+        "parameters": [
+          "int",
+          "int*",
+          "int",
+        ],
+        "returns": [
+          "int*",
+        ],
+      },
+    },
     "wrapPointer__int__float_p__int": {
       "id": "wrapPointer__int__float_p__int",
       "signature": {
@@ -885,6 +1157,8 @@
   },
   "overview": {
     "compiledFunctions": [
+      "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int",
+      "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int",
       "wrapPointer__int__float_p__int",
       "wrapPointer__int__int_p__int",
     ],

--- a/packages/compiler/tests/__snapshots__/stdlib/wrap-pointer-int.test.8f4e.compile-result.snap
+++ b/packages/compiler/tests/__snapshots__/stdlib/wrap-pointer-int.test.8f4e.compile-result.snap
@@ -1,463 +1,5 @@
 {
   "functionAst": {
-    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int": {
-      "lines": [
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
-            },
-          ],
-          "instruction": "function",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "pointer",
-            },
-          ],
-          "instruction": "param",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "float*",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "param",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "itemCount",
-            },
-          ],
-          "instruction": "param",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "local",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "itemCount",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "isPointee": true,
-              "referenceKind": "pointee-element-word-size",
-              "scope": "local",
-              "targetMemoryId": "buffer",
-              "type": "identifier",
-              "value": "sizeof(*buffer)",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "mul",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "pointer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "float*",
-            },
-          ],
-          "instruction": "functionEnd",
-        },
-      ],
-      "name": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
-      "type": "function",
-    },
-    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int": {
-      "lines": [
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
-            },
-          ],
-          "instruction": "function",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "pointer",
-            },
-          ],
-          "instruction": "param",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int*",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "param",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "itemCount",
-            },
-          ],
-          "instruction": "param",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int",
-            },
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "local",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "itemCount",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "isPointee": true,
-              "referenceKind": "pointee-element-word-size",
-              "scope": "local",
-              "targetMemoryId": "buffer",
-              "type": "identifier",
-              "value": "sizeof(*buffer)",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "mul",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "localSet",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "pointer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "buffer",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "sub",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "byteLength",
-            },
-          ],
-          "instruction": "push",
-        },
-        {
-          "arguments": [],
-          "instruction": "ensureNonZero",
-        },
-        {
-          "arguments": [],
-          "instruction": "remainder",
-        },
-        {
-          "arguments": [],
-          "instruction": "add",
-        },
-        {
-          "arguments": [
-            {
-              "referenceKind": "plain",
-              "scope": "local",
-              "type": "identifier",
-              "value": "int*",
-            },
-          ],
-          "instruction": "functionEnd",
-        },
-      ],
-      "name": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
-      "type": "function",
-    },
     "wrapPointer__int__float_p__int": {
       "lines": [
         {
@@ -528,10 +70,55 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "pointer",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "local",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "itemCount",
             },
           ],
           "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "isPointee": true,
+              "referenceKind": "pointee-element-word-size",
+              "scope": "local",
+              "targetMemoryId": "buffer",
+              "type": "identifier",
+              "value": "sizeof(*buffer)",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "mul",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "localSet",
         },
         {
           "arguments": [
@@ -550,7 +137,7 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "itemCount",
+              "value": "pointer",
             },
           ],
           "instruction": "push",
@@ -561,10 +148,71 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
+              "value": "buffer",
             },
           ],
-          "instruction": "call",
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
         },
         {
           "arguments": [
@@ -651,10 +299,55 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "pointer",
+              "value": "int",
+            },
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "local",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "itemCount",
             },
           ],
           "instruction": "push",
+        },
+        {
+          "arguments": [
+            {
+              "isPointee": true,
+              "referenceKind": "pointee-element-word-size",
+              "scope": "local",
+              "targetMemoryId": "buffer",
+              "type": "identifier",
+              "value": "sizeof(*buffer)",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "mul",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "localSet",
         },
         {
           "arguments": [
@@ -673,7 +366,7 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "itemCount",
+              "value": "pointer",
             },
           ],
           "instruction": "push",
@@ -684,10 +377,71 @@
               "referenceKind": "plain",
               "scope": "local",
               "type": "identifier",
-              "value": "__8f4e_std_memory_wrapPointer__wrapPointerAddress",
+              "value": "buffer",
             },
           ],
-          "instruction": "call",
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "sub",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
+        },
+        {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "byteLength",
+            },
+          ],
+          "instruction": "push",
+        },
+        {
+          "arguments": [],
+          "instruction": "ensureNonZero",
+        },
+        {
+          "arguments": [],
+          "instruction": "remainder",
+        },
+        {
+          "arguments": [],
+          "instruction": "add",
         },
         {
           "arguments": [
@@ -706,32 +460,6 @@
     },
   },
   "functionOverview": {
-    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int": {
-      "id": "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int",
-      "signature": {
-        "parameters": [
-          "int",
-          "float*",
-          "int",
-        ],
-        "returns": [
-          "float*",
-        ],
-      },
-    },
-    "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int": {
-      "id": "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int",
-      "signature": {
-        "parameters": [
-          "int",
-          "int*",
-          "int",
-        ],
-        "returns": [
-          "int*",
-        ],
-      },
-    },
     "wrapPointer__int__float_p__int": {
       "id": "wrapPointer__int__float_p__int",
       "signature": {
@@ -1157,8 +885,6 @@
   },
   "overview": {
     "compiledFunctions": [
-      "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__float_p__int",
-      "__8f4e_std_memory_wrapPointer__wrapPointerAddress__int__int_p__int",
       "wrapPointer__int__float_p__int",
       "wrapPointer__int__int_p__int",
     ],

--- a/packages/editor/packages/editor-state/src/features/program-compiler/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/effect.test.ts
@@ -238,12 +238,18 @@ describe('program compiler effect', () => {
 		});
 		mockState.callbacks.resolveInclude = vi.fn(async includeId => {
 			if (includeId === 'std/events/risingEdge') {
-				return ['function risingEdge', 'functionEnd int'].join('\n');
+				return ['function risingEdge', '#export', 'functionEnd int'].join('\n');
 			}
 			if (includeId === 'std/memory/wrapPointer') {
-				return ['function wrapPointer', 'functionEnd int*', '', 'function wrapPointer', 'functionEnd float*'].join(
-					'\n'
-				);
+				return [
+					'function wrapPointer',
+					'#export',
+					'functionEnd int*',
+					'',
+					'function wrapPointer',
+					'#export',
+					'functionEnd float*',
+				].join('\n');
 			}
 			return undefined;
 		});
@@ -268,15 +274,15 @@ describe('program compiler effect', () => {
 			expect.objectContaining({
 				functions: expect.arrayContaining([
 					expect.objectContaining({
-						code: ['function risingEdge', 'functionEnd int'],
+						code: ['function risingEdge', '', 'functionEnd int'],
 						source: { kind: 'include', includeId: 'std/events/risingEdge', symbolName: 'risingEdge' },
 					}),
 					expect.objectContaining({
-						code: ['function wrapPointer', 'functionEnd int*'],
+						code: ['function wrapPointer', '', 'functionEnd int*'],
 						source: { kind: 'include', includeId: 'std/memory/wrapPointer', symbolName: 'wrapPointer' },
 					}),
 					expect.objectContaining({
-						code: ['function wrapPointer', 'functionEnd float*'],
+						code: ['function wrapPointer', '', 'functionEnd float*'],
 						source: { kind: 'include', includeId: 'std/memory/wrapPointer', symbolName: 'wrapPointer' },
 					}),
 				]),


### PR DESCRIPTION
## Summary
- add include-local `#export` handling during project include expansion
- prefix private stdlib helper functions and rewrite internal `call` targets
- require at least one stdlib include export and update stdlib sources accordingly
- keep `wrapPointer` as a direct implementation and extract repeated circular-address wrapping inside `readInterpolated` as private `wrapReadAddress` overloads

## Rationale
Stdlib include files need to expose public entry functions while keeping implementation helpers out of the global project function namespace. Consuming include-local `#export` in the project preparser lets stdlib authors mark the intended public surface without leaking Wasm exports.

The private-helper example now lives in `readInterpolated`, where the wrapped-address calculation is reused for both samples in each overload while the public function still owns the interpolation behavior.

## Validation
- `npx nx run @8f4e/project-preparser:test`
- `npx nx run compiler:test`
- `npx nx run compiler:typecheck`
- `npx nx run cli:test`
- `npx nx run @8f4e/examples:test` (`No tests found`)
- `npx nx run @8f4e/editor-state:test`
- focused fixture run: `npx nx run compiler:test -- --run tests/fixturePrograms.test.ts --testNamePattern 'wrap-pointer|read-interpolated'`
- focused CI fix run: `npx nx run @8f4e/editor-state:test -- --run src/features/program-compiler/effect.test.ts --testNamePattern 'resolves functions from the current includes block before compiling'`
- `git diff --check`