### PR TITLE
Fix binary asset loading dialog

### DIFF
--- a/packages/editor/packages/editor-state/src/features/binary-assets/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/binary-assets/effect.test.ts
@@ -45,7 +45,7 @@ describe('binary asset loading dialog effect', () => {
 		expect(events.dispatch).toHaveBeenCalledWith('addDialog', {
 			id: 'binary-assets-loading',
 			title: 'Loading assets',
-			text: 'Loading binary assets (1/2).',
+			text: 'Loading binary assets...',
 			buttons: [],
 		});
 	});
@@ -65,7 +65,7 @@ describe('binary asset loading dialog effect', () => {
 		expect(events.dispatch).toHaveBeenLastCalledWith('addDialog', {
 			id: 'binary-assets-loading',
 			title: 'Loading assets',
-			text: 'Loading binary assets (0/2).',
+			text: 'Loading binary assets...',
 			buttons: [],
 		});
 

--- a/packages/editor/packages/editor-state/src/features/binary-assets/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/binary-assets/effect.test.ts
@@ -1,0 +1,79 @@
+import type { EventDispatcher, State } from '@8f4e/editor-state-types';
+import createStateManager from '@8f4e/state-manager';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockState } from '~/pureHelpers/testingUtils/testUtils';
+import binaryAssetLoadingDialog from './effect';
+
+function createEvents(): EventDispatcher {
+	return {
+		on: vi.fn(),
+		off: vi.fn(),
+		dispatch: vi.fn(),
+	};
+}
+
+function createBinaryAsset(overrides: Partial<State['binaryAssets'][number]> = {}): State['binaryAssets'][number] {
+	return {
+		id: 'asset',
+		url: 'https://example.com/asset.bin',
+		memoryId: 'samples:buffer',
+		loadedIntoMemory: false,
+		...overrides,
+	};
+}
+
+describe('binary asset loading dialog effect', () => {
+	it('does not dispatch a dialog when there are no binary assets', () => {
+		const state = createMockState({ binaryAssets: [] });
+		const store = createStateManager(state);
+		const events = createEvents();
+
+		binaryAssetLoadingDialog(store, events);
+
+		expect(events.dispatch).not.toHaveBeenCalled();
+	});
+
+	it('adds a loading dialog while assets are pending', () => {
+		const state = createMockState({
+			binaryAssets: [createBinaryAsset(), createBinaryAsset({ id: 'loaded', loadedIntoMemory: true })],
+		});
+		const store = createStateManager(state);
+		const events = createEvents();
+
+		binaryAssetLoadingDialog(store, events);
+
+		expect(events.dispatch).toHaveBeenCalledWith('addDialog', {
+			id: 'binary-assets-loading',
+			title: 'Loading assets',
+			text: 'Loading binary assets (1/2).',
+			buttons: [],
+		});
+	});
+
+	it('updates and removes the loading dialog as assets load', () => {
+		const state = createMockState({ binaryAssets: [] });
+		const store = createStateManager(state);
+		const events = createEvents();
+
+		binaryAssetLoadingDialog(store, events);
+
+		store.set('binaryAssets', [
+			createBinaryAsset(),
+			createBinaryAsset({ id: 'second', url: 'https://example.com/b.bin' }),
+		]);
+
+		expect(events.dispatch).toHaveBeenLastCalledWith('addDialog', {
+			id: 'binary-assets-loading',
+			title: 'Loading assets',
+			text: 'Loading binary assets (0/2).',
+			buttons: [],
+		});
+
+		store.set('binaryAssets', [
+			createBinaryAsset({ loadedIntoMemory: true }),
+			createBinaryAsset({ id: 'second', url: 'https://example.com/b.bin', loadedIntoMemory: true }),
+		]);
+
+		expect(events.dispatch).toHaveBeenLastCalledWith('removeDialog', { id: 'binary-assets-loading' });
+	});
+});

--- a/packages/editor/packages/editor-state/src/features/binary-assets/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/binary-assets/effect.ts
@@ -1,0 +1,46 @@
+import type { DialogContent, EventDispatcher, State } from '@8f4e/editor-state-types';
+import type { StateManager } from '@8f4e/state-manager';
+
+const BINARY_ASSET_LOADING_DIALOG_ID = 'binary-assets-loading';
+
+function createBinaryAssetLoadingDialog(state: State): DialogContent | undefined {
+	const totalAssetCount = state.binaryAssets.length;
+	if (totalAssetCount === 0) {
+		return undefined;
+	}
+
+	const loadedAssetCount = state.binaryAssets.filter(asset => asset.loadedIntoMemory).length;
+	if (loadedAssetCount === totalAssetCount) {
+		return undefined;
+	}
+
+	return {
+		id: BINARY_ASSET_LOADING_DIALOG_ID,
+		title: 'Loading assets',
+		text: `Loading binary assets (${loadedAssetCount}/${totalAssetCount}).`,
+		buttons: [],
+	};
+}
+
+export default function binaryAssetLoadingDialog(store: StateManager<State>, events: EventDispatcher): void {
+	let loadingDialogVisible = store.getState().dialogStack.some(dialog => dialog.id === BINARY_ASSET_LOADING_DIALOG_ID);
+
+	function syncBinaryAssetLoadingDialog(): void {
+		const dialog = createBinaryAssetLoadingDialog(store.getState());
+
+		if (dialog) {
+			loadingDialogVisible = true;
+			events.dispatch('addDialog', dialog);
+			return;
+		}
+
+		if (loadingDialogVisible) {
+			loadingDialogVisible = false;
+			events.dispatch('removeDialog', { id: BINARY_ASSET_LOADING_DIALOG_ID });
+		}
+	}
+
+	store.subscribe('binaryAssets', syncBinaryAssetLoadingDialog);
+
+	syncBinaryAssetLoadingDialog();
+}

--- a/packages/editor/packages/editor-state/src/features/binary-assets/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/binary-assets/effect.ts
@@ -4,20 +4,19 @@ import type { StateManager } from '@8f4e/state-manager';
 const BINARY_ASSET_LOADING_DIALOG_ID = 'binary-assets-loading';
 
 function createBinaryAssetLoadingDialog(state: State): DialogContent | undefined {
-	const totalAssetCount = state.binaryAssets.length;
-	if (totalAssetCount === 0) {
+	if (state.binaryAssets.length === 0) {
 		return undefined;
 	}
 
-	const loadedAssetCount = state.binaryAssets.filter(asset => asset.loadedIntoMemory).length;
-	if (loadedAssetCount === totalAssetCount) {
+	const hasPendingAssets = state.binaryAssets.some(asset => !asset.loadedIntoMemory);
+	if (!hasPendingAssets) {
 		return undefined;
 	}
 
 	return {
 		id: BINARY_ASSET_LOADING_DIALOG_ID,
 		title: 'Loading assets',
-		text: `Loading binary assets (${loadedAssetCount}/${totalAssetCount}).`,
+		text: 'Loading binary assets...',
 		buttons: [],
 	};
 }

--- a/packages/editor/packages/editor-state/src/index.ts
+++ b/packages/editor/packages/editor-state/src/index.ts
@@ -1,5 +1,6 @@
 import type { EventDispatcher, Options, State } from '@8f4e/editor-state-types';
 import createStateManager, { type StateManager } from '@8f4e/state-manager';
+import binaryAssetLoadingDialog from './features/binary-assets/effect';
 import browserLocalNotes from './features/browser-local-notes/effect';
 import canvasScreenshot from './features/canvas-screenshot/effect';
 import codeBlockRendering from './features/code-blocks/effect';
@@ -78,6 +79,7 @@ export default function init(events: EventDispatcher, options: Options): StateMa
 	projectExport(store, events);
 	canvasScreenshot(store, events);
 	dialog(store, events);
+	binaryAssetLoadingDialog(store, events);
 
 	runtime(store, events);
 	editorMode(store, events);

--- a/packages/editor/src/editorEnvironmentPlugins/binaryAssets/configSync.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/binaryAssets/configSync.ts
@@ -30,7 +30,15 @@ export default function createBinaryAssetConfigSync({
 		const generation = ++fetchGeneration;
 		setErrors([]);
 
-		store.set('binaryAssets', []);
+		store.set(
+			'binaryAssets',
+			loadRequests.map(asset => ({
+				id: asset.id,
+				url: asset.url,
+				memoryId: asset.memoryId,
+				loadedIntoMemory: false,
+			}))
+		);
 
 		if (loadRequests.length === 0) {
 			return;

--- a/packages/editor/src/editorEnvironmentPlugins/binaryAssets/memoryLoader.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/binaryAssets/memoryLoader.ts
@@ -24,6 +24,10 @@ function resolveBinaryAssetTarget(
 	};
 }
 
+function getBinaryAssetKey(asset: BinaryAsset): string {
+	return `${asset.id ?? ''}\u0000${asset.url}\u0000${asset.memoryId ?? ''}`;
+}
+
 export default function createBinaryAssetMemoryLoader({
 	store,
 	memoryViews,
@@ -34,13 +38,14 @@ export default function createBinaryAssetMemoryLoader({
 	assetStore: Map<string, ArrayBuffer>;
 }): () => void {
 	async function loadBinaryFilesIntoMemory(assets: BinaryAsset[]): Promise<void> {
-		const state = store.getState();
+		const loadedAssets = new Map<string, BinaryAsset>();
 
 		for (const asset of assets) {
 			if (!asset.memoryId || asset.assetByteLength === undefined) {
 				continue;
 			}
 
+			const state = store.getState();
 			const resolved = resolveBinaryAssetTarget(state, asset.memoryId);
 			if (!resolved) {
 				console.warn('Unable to resolve memory target:', asset.memoryId);
@@ -48,13 +53,41 @@ export default function createBinaryAssetMemoryLoader({
 			}
 
 			try {
-				asset.byteAddress = resolved.byteAddress;
-				asset.memoryByteLength = resolved.memoryByteLength;
-				await loadBinaryAssetIntoMemory(asset, assetStore, memoryViews);
-				asset.loadedIntoMemory = true;
+				const loadedAsset = {
+					...asset,
+					byteAddress: resolved.byteAddress,
+					memoryByteLength: resolved.memoryByteLength,
+					loadedIntoMemory: true,
+				};
+				await loadBinaryAssetIntoMemory(loadedAsset, assetStore, memoryViews);
+				loadedAssets.set(getBinaryAssetKey(asset), loadedAsset);
 			} catch (error) {
 				console.error('Failed to load binary asset into memory:', asset.url, error);
 			}
+		}
+
+		if (loadedAssets.size === 0) {
+			return;
+		}
+
+		let changed = false;
+		const nextAssets = store.getState().binaryAssets.map(asset => {
+			const loadedAsset = loadedAssets.get(getBinaryAssetKey(asset));
+			if (!loadedAsset) {
+				return asset;
+			}
+
+			changed = true;
+			return {
+				...asset,
+				byteAddress: loadedAsset.byteAddress,
+				memoryByteLength: loadedAsset.memoryByteLength,
+				loadedIntoMemory: true,
+			};
+		});
+
+		if (changed) {
+			store.set('binaryAssets', nextAssets);
 		}
 	}
 

--- a/packages/editor/src/editorEnvironmentPlugins/binaryAssets/plugin.test.ts
+++ b/packages/editor/src/editorEnvironmentPlugins/binaryAssets/plugin.test.ts
@@ -259,7 +259,14 @@ describe('binary assets plugin', () => {
 			},
 		} as State['editorConfig']['bin']);
 
-		expect(store.getState().binaryAssets).toEqual([]);
+		expect(store.getState().binaryAssets).toEqual([
+			{
+				id: 'amen',
+				url: 'https://example.com/pneumatic/sample_1.pcm',
+				memoryId: 'samples:buffer',
+				loadedIntoMemory: false,
+			},
+		]);
 
 		resolveFetch([
 			{
@@ -299,7 +306,14 @@ describe('binary assets plugin', () => {
 			setErrors: vi.fn(),
 			services,
 		});
-		expect(store.getState().binaryAssets).toEqual([]);
+		expect(store.getState().binaryAssets).toEqual([
+			{
+				id: 'amen',
+				url: 'https://example.com/pneumatic/sample_1.pcm',
+				memoryId: 'samples:buffer',
+				loadedIntoMemory: false,
+			},
+		]);
 
 		store.set('codeBlockRendering.codeBlocks', [
 			...store.getState().codeBlockRendering.codeBlocks,
@@ -309,7 +323,14 @@ describe('binary assets plugin', () => {
 				code: ['constants env', 'constantsEnd'],
 			},
 		] as State['codeBlockRendering']['codeBlocks']);
-		expect(store.getState().binaryAssets).toEqual([]);
+		expect(store.getState().binaryAssets).toEqual([
+			{
+				id: 'amen',
+				url: 'https://example.com/pneumatic/sample_1.pcm',
+				memoryId: 'samples:buffer',
+				loadedIntoMemory: false,
+			},
+		]);
 
 		resolveFetch([
 			{


### PR DESCRIPTION
## Summary
- publish binary asset rows as pending before fetches complete
- republish asset rows as loaded after they are copied into memory
- show an indeterminate loading dialog while any binary assets are pending

## Rationale
Heavy projects with binary assets previously looked idle while assets loaded. The editor now has a simple pending/loaded signal and a dialog derived from that state without introducing per-asset progress updates that could churn compilation.

## Validation
- npx nx run @8f4e/editor:test
- npx nx run @8f4e/editor:typecheck
- npx nx run @8f4e/editor-state:test
- npx nx run @8f4e/editor-state:typecheck
- npx nx run @8f4e/editor-state:build
