### PR TITLE
fix(examples): use project compiler API in coverage logger

### DIFF
--- a/scripts/log-compiler-coverage-counts.mjs
+++ b/scripts/log-compiler-coverage-counts.mjs
@@ -103,20 +103,14 @@ async function main() {
 			detailed: true,
 		});
 
-		const [{ default: compile }, { prepareCompilerInputFromProjectSourceAsync }] = await Promise.all([
-			import('@8f4e/compiler'),
-			import('@8f4e/project-preparser'),
-		]);
+		const { compileProject, parseProjectSource } = await import('@8f4e/compiler');
 
 		const parsedCases = [];
 		for (const benchmarkCase of benchmarkCases) {
 			const rawProject = await fs.readFile(benchmarkCase.filePath, 'utf8');
-			const compilerInput = await prepareCompilerInputFromProjectSourceAsync(rawProject, {
-				resolveInclude: resolveStdlibInclude,
-			});
 			parsedCases.push({
 				...benchmarkCase,
-				compilerInput,
+				project: parseProjectSource(rawProject),
 			});
 		}
 
@@ -142,7 +136,10 @@ async function main() {
 				continue;
 			}
 
-			compile(benchmarkCase.compilerInput, compilerOptions);
+			await compileProject(benchmarkCase.project, {
+				...compilerOptions,
+				resolveInclude: resolveStdlibInclude,
+			});
 			const { result: coverageResult } = await session.post('Profiler.takePreciseCoverage');
 			const coverage = summarizeCoverage(coverageResult);
 			assertCoverageMatched(coverage, benchmarkCase);


### PR DESCRIPTION
Summary
- replace the removed compiler-input preparation helper with parseProjectSource
- replace the removed compiler default export with compileProject
- pass the standard-library include resolver through compileProject

Rationale
The release coverage logger was the remaining consumer of the pre-ProjectObjectModel compiler API, causing the release job to fail after PR #880 merged.

Test notes
- npx biome check scripts/log-compiler-coverage-counts.mjs
- npx nx run @8f4e/examples:log-compiler-coverage-counts
- compiled the sineGenerator benchmark through parseProjectSource and compileProject (499 bytes)