### PR TITLE
feat(editor): represent project groups as nested slices

### DIFF
--- a/docs/todos/477-establish-project-object-model.md
+++ b/docs/todos/477-establish-project-object-model.md
@@ -74,6 +74,12 @@ modules, functions, constants, prototypes, includes, notes, unknown blocks, and 
 The initial group refactor does not recursively compile these models: `compileProject` continues to compile only the
 root model until whole-program sub-program composition is implemented separately.
 
+The editor mirrors this recursive ownership without introducing another project schema. A project group is represented
+by the same `CodeBlockGraphicData` used for other visible blocks, with `nestedProjectCodeBlocks` pointing to the child
+project's code-block array. `rootCodeBlocks` owns the recursive editor tree, while the existing `codeBlocks` field points
+directly to the one project slice currently rendered. Project-owned arrays keep stable identity and editor operations
+replace their contents in place; loading a project rebuilds the tree and resets the rendered pointer to the root.
+
 Make both project input paths converge on that contract:
 
 ```text
@@ -202,6 +208,8 @@ object model.
 - [x] Module order is preserved per entry, while functions, constants, and prototypes are compiled as hoisted blocks.
 - [x] Groups recursively own complete `ProjectObjectModel` values instead of referencing root blocks by id.
 - [x] Root compilation remains unchanged and does not yet compile recursively owned groups.
+- [x] The editor mirrors group ownership with recursively nested code-block arrays and renders only the root slice until
+  group navigation is implemented.
 - [x] Compiler stages consume the canonical typed collections directly; `SubProgramSource` and whole-project
   preparation are removed.
 - [x] Bare project-block arrays and duplicate editor/preparser project contracts are removed from public APIs.
@@ -230,7 +238,8 @@ object model.
 - **Module order**: Only module order is semantically significant. The implementation must preserve order within each
   entry without inventing global ordering requirements for hoisted blocks.
 - **Group behavior**: Nested projects own their blocks structurally. The compiler intentionally ignores nested groups
-  for now so future recursive compilation cannot accidentally compile them twice.
+  for now so future recursive compilation cannot accidentally compile them twice. Editor project-slice arrays retain
+  stable identity so direct root/current pointers cannot be invalidated by add, delete, paste, or reorder operations.
 - **Editor metadata ownership**: Grid position, selection, cursor, rendering caches, and transient creation state must
   not leak into the compiler-owned model merely because the editor currently stores them beside source blocks.
 - **Diagnostic mapping**: Changes to block identity must preserve reliable mapping from compiler diagnostics back to

--- a/docs/todos/477-establish-project-object-model.md
+++ b/docs/todos/477-establish-project-object-model.md
@@ -208,8 +208,8 @@ object model.
 - [x] Module order is preserved per entry, while functions, constants, and prototypes are compiled as hoisted blocks.
 - [x] Groups recursively own complete `ProjectObjectModel` values instead of referencing root blocks by id.
 - [x] Root compilation remains unchanged and does not yet compile recursively owned groups.
-- [x] The editor mirrors group ownership with recursively nested code-block arrays and renders only the root slice until
-  group navigation is implemented.
+- [x] The editor mirrors group ownership with recursively nested code-block arrays, initially renders the root slice,
+  and can move into child slices or back to their parent from context menus.
 - [x] Compiler stages consume the canonical typed collections directly; `SubProgramSource` and whole-project
   preparation are removed.
 - [x] Bare project-block arrays and duplicate editor/preparser project contracts are removed from public APIs.

--- a/packages/editor/packages/editor-state-testing/src/index.ts
+++ b/packages/editor/packages/editor-state-testing/src/index.ts
@@ -125,6 +125,7 @@ export function createMockEventDispatcher(): EventDispatcher {
 export function createMockState(overrides: DeepPartial<State> = {}): State {
 	const mockRuntimeFactory = () => () => {};
 	const workerRuntimeDefaults = { sampleRate: 50 } as const;
+	const rootCodeBlocks: CodeBlockGraphicData[] = [];
 
 	const defaults: State = {
 		compiler: {
@@ -153,7 +154,8 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			},
 		},
 		codeBlockRendering: {
-			codeBlocks: [],
+			rootCodeBlocks,
+			codeBlocks: rootCodeBlocks,
 			entryOutlines: [],
 			viewportAnchoredCodeBlocks: [],
 			nextCodeBlockCreationIndex: 0,

--- a/packages/editor/packages/editor-state-types/src/features/code-blocks/types.ts
+++ b/packages/editor/packages/editor-state-types/src/features/code-blocks/types.ts
@@ -355,12 +355,10 @@ export interface CodeBlockGraphicData {
 	 * This is separate from the visual `; @group` directive.
 	 */
 	entry?: string;
-	/** Nested project ownership retained while editing recursively structured projects. */
-	subProgramPath?: Array<{
-		id?: string;
-		name?: string;
-		entry?: string;
-	}>;
+	/** Stable project-model identity retained by a project-group block. */
+	projectGroupId?: string;
+	/** Child project slice owned by a project-group block. Its array identity remains stable while editing. */
+	nestedProjectCodeBlocks?: CodeBlockGraphicData[];
 	/**
 	 * When true, the block is excluded from compilation and rendered with a transparent background.
 	 * Defaults to false.
@@ -435,6 +433,9 @@ export interface CodeBlockEntryOutline {
  */
 export type CodeBlockRendering = {
 	outputsByWordAddress: Map<number, Output>;
+	/** Recursive project-tree root. Project-owned array identities remain stable while editing. */
+	rootCodeBlocks: CodeBlockGraphicData[];
+	/** Direct pointer to the project slice currently rendered by the editor. */
 	codeBlocks: CodeBlockGraphicData[];
 	/**
 	 * Derived outline corners for execution entries that contain multiple module blocks.

--- a/packages/editor/packages/editor-state/src/features/browser-local-notes/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/browser-local-notes/effect.ts
@@ -2,6 +2,7 @@ import type { CodeBlockGraphicData, EventDispatcher, State } from '@8f4e/editor-
 import type { StateManager } from '@8f4e/state-manager';
 import upsertPos from '../code-blocks/features/directives/pos/upsert';
 import { deriveDirectiveState } from '../code-blocks/features/directives/registry';
+import replaceCodeBlocksInPlace from '../code-blocks/replaceCodeBlocksInPlace';
 import getBlockType from '../code-blocks/utils/codeParsers/getBlockType';
 import { createCodeBlockGraphicData } from '../code-blocks/utils/createCodeBlockGraphicData';
 import {
@@ -98,7 +99,8 @@ export default function browserLocalNotes(store: StateManager<State>, events: Ev
 
 			state.codeBlockRendering.nextCodeBlockCreationIndex = creationIndex;
 			browserLocalNotesLoaded = true;
-			store.set('codeBlockRendering.codeBlocks', nextCodeBlocks);
+			replaceCodeBlocksInPlace(state.codeBlockRendering.codeBlocks, nextCodeBlocks);
+			store.set('codeBlockRendering.codeBlocks', state.codeBlockRendering.codeBlocks);
 			saveBrowserLocalNotes();
 		} catch (err) {
 			console.warn('Failed to load browser-local notes from storage:', err);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/README.md
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/README.md
@@ -66,6 +66,9 @@ Project-group blocks use the same `CodeBlockGraphicData` representation as other
 `nestedProjectCodeBlocks` field points to the child project slice. Project-owned arrays keep stable identity; add,
 delete, paste, and reorder operations replace their contents in place so the root tree and rendered-slice pointer do
 not diverge. Loading a project rebuilds the recursive tree and resets `codeBlocks` to `rootCodeBlocks`.
+Project-group blocks expose an **Open group** context-menu action that points `codeBlocks` directly at their child
+slice. Nested-slice context menus expose **Go back**, which finds the immediate parent through those stable array
+references.
 
 ## Integration Points
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/README.md
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/README.md
@@ -57,9 +57,15 @@ This feature contains several subfeatures under `features/` that handle specific
 
 ### State Touched
 
-- `state.codeBlockRendering.codeBlocks` - Array of all code blocks with their visual and code data
+- `state.codeBlockRendering.rootCodeBlocks` - Recursive root tree of project-owned code-block arrays
+- `state.codeBlockRendering.codeBlocks` - Direct pointer to the project slice currently rendered
 - `state.codeBlockRendering.selectedCodeBlock` - Currently selected block reference
 - Block-specific properties: position, size, color, blockType, code, cursor, widgets (inputs/outputs/buttons/switches)
+
+Project-group blocks use the same `CodeBlockGraphicData` representation as other blocks. Their optional
+`nestedProjectCodeBlocks` field points to the child project slice. Project-owned arrays keep stable identity; add,
+delete, paste, and reorder operations replace their contents in place so the root tree and rendered-slice pointer do
+not diverge. Loading a project rebuilds the recursive tree and resets `codeBlocks` to `rootCodeBlocks`.
 
 ## Integration Points
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/effect.test.ts
@@ -165,10 +165,11 @@ describe('code block rendering home directive', () => {
 		expect(renderedIncludes?.code).toEqual(includesBlock);
 	});
 
-	it('renders blocks from recursively owned sub-programs with their ownership path', () => {
+	it('renders root blocks and project-group blocks while retaining nested slices', () => {
 		const state = createMockState({
 			initialProjectState: {
 				...EMPTY_DEFAULT_PROJECT,
+				modules: [{ id: 0, entry: 'main', code: ['module root', 'moduleEnd'] }],
 				groups: [
 					{
 						...EMPTY_DEFAULT_PROJECT,
@@ -187,10 +188,53 @@ describe('code block rendering home directive', () => {
 		codeBlockRenderingEffect(store, events);
 		store.set('initialProjectState', state.initialProjectState);
 
-		expect(state.codeBlockRendering.codeBlocks).toHaveLength(1);
-		expect(state.codeBlockRendering.codeBlocks[0].subProgramPath).toEqual([
-			{ id: 'audio', name: 'Audio', entry: 'main' },
-		]);
+		expect(state.codeBlockRendering.codeBlocks).toBe(state.codeBlockRendering.rootCodeBlocks);
+		expect(state.codeBlockRendering.codeBlocks).toHaveLength(2);
+		expect(state.codeBlockRendering.codeBlocks.map(block => block.name)).toEqual(['root', 'Audio']);
+		const groupBlock = state.codeBlockRendering.codeBlocks[1];
+		expect(groupBlock.projectGroupId).toBe('audio');
+		expect(groupBlock.nestedProjectCodeBlocks).toHaveLength(1);
+		expect(groupBlock.nestedProjectCodeBlocks?.[0]).toMatchObject({
+			name: 'voice',
+			entry: 'main',
+			code: ['module voice', 'moduleEnd'],
+		});
+		expect(state.codeBlockRendering.codeBlocks.some(block => block.name === 'voice')).toBe(false);
+	});
+
+	it('resets the rendered slice pointer to the new root when a project reloads', () => {
+		const state = createMockState({
+			initialProjectState: {
+				...EMPTY_DEFAULT_PROJECT,
+				groups: [
+					{
+						...EMPTY_DEFAULT_PROJECT,
+						name: 'Audio',
+						entry: 'main',
+						modules: [{ id: 1, entry: 'main', code: ['module voice', 'moduleEnd'] }],
+					},
+				],
+			},
+			spriteLookups: createSpriteLookups(),
+		});
+		const store = createStateManager(state);
+		const events = createMockEventDispatcherWithVitest();
+
+		codeBlockRenderingEffect(store, events);
+		store.set('initialProjectState', state.initialProjectState);
+		const firstRoot = state.codeBlockRendering.rootCodeBlocks;
+		const nestedSlice = firstRoot[0].nestedProjectCodeBlocks;
+		expect(nestedSlice).toBeDefined();
+		store.set('codeBlockRendering.codeBlocks', nestedSlice!);
+
+		store.set('initialProjectState', {
+			...EMPTY_DEFAULT_PROJECT,
+			modules: [{ id: 2, entry: 'main', code: ['module replacement', 'moduleEnd'] }],
+		});
+
+		expect(state.codeBlockRendering.rootCodeBlocks).not.toBe(firstRoot);
+		expect(state.codeBlockRendering.codeBlocks).toBe(state.codeBlockRendering.rootCodeBlocks);
+		expect(state.codeBlockRendering.codeBlocks.map(block => block.name)).toEqual(['replacement']);
 	});
 
 	it('centers the initial viewport using the home alignment hint', () => {

--- a/packages/editor/packages/editor-state/src/features/code-blocks/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/effect.ts
@@ -202,32 +202,32 @@ export default function codeBlockRendering(store: StateManager<State>, events: E
 		type ClassifiedProjectBlock = ProjectBlock & {
 			blockType: CodeBlockGraphicData['blockType'];
 			entry?: string;
-			subProgramPath?: CodeBlockGraphicData['subProgramPath'];
 		};
-		const collectClassifiedBlocks = (
-			currentProject: ProjectObjectModel,
-			subProgramPath: NonNullable<CodeBlockGraphicData['subProgramPath']> = []
-		): ClassifiedProjectBlock[] => {
-			const pathFields = subProgramPath.length > 0 ? { subProgramPath } : {};
+		const collectProjectBlocks = (currentProject: ProjectObjectModel): ClassifiedProjectBlock[] => {
 			return [
-				...currentProject.modules.map(block => ({ ...block, ...pathFields, blockType: 'module' as const })),
-				...currentProject.functions.map(block => ({ ...block, ...pathFields, blockType: 'function' as const })),
-				...currentProject.constants.map(block => ({ ...block, ...pathFields, blockType: 'constants' as const })),
-				...currentProject.prototypes.map(block => ({ ...block, ...pathFields, blockType: 'prototype' as const })),
-				...currentProject.includes.map(block => ({ ...block, ...pathFields, blockType: 'includes' as const })),
-				...currentProject.notes.map(block => ({ ...block, ...pathFields, blockType: 'note' as const })),
-				...currentProject.unknown.map(block => ({ ...block, ...pathFields, blockType: 'unknown' as const })),
-				...currentProject.groups.flatMap(group =>
-					collectClassifiedBlocks(group, [...subProgramPath, { id: group.id, name: group.name, entry: group.entry }])
-				),
+				...currentProject.modules.map(block => ({ ...block, blockType: 'module' as const })),
+				...currentProject.functions.map(block => ({ ...block, blockType: 'function' as const })),
+				...currentProject.constants.map(block => ({ ...block, blockType: 'constants' as const })),
+				...currentProject.prototypes.map(block => ({ ...block, blockType: 'prototype' as const })),
+				...currentProject.includes.map(block => ({ ...block, blockType: 'includes' as const })),
+				...currentProject.notes.map(block => ({ ...block, blockType: 'note' as const })),
+				...currentProject.unknown.map(block => ({ ...block, blockType: 'unknown' as const })),
 			];
 		};
-		const classifiedBlocks = collectClassifiedBlocks(project);
-		state.codeBlockRendering.nextCodeBlockCreationIndex = Math.max(-1, ...classifiedBlocks.map(block => block.id)) + 1;
+		const getHighestProjectBlockId = (currentProject: ProjectObjectModel): number =>
+			Math.max(
+				-1,
+				...collectProjectBlocks(currentProject).map(block => block.id),
+				...currentProject.groups.map(getHighestProjectBlockId)
+			);
+		let nextCodeBlockCreationIndex = getHighestProjectBlockId(project) + 1;
 		store.set('codeBlockRendering.selectedCodeBlock', undefined);
 		store.set('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', undefined);
 
-		const codeBlocks = classifiedBlocks.map(codeBlock => {
+		const createGraphicCodeBlock = (
+			codeBlock: ClassifiedProjectBlock,
+			overrides: Partial<CodeBlockGraphicData> = {}
+		): CodeBlockGraphicData => {
 			// Parse @pos directive from code, default to (0,0) if missing or invalid
 			const blockParsedDirectives = parseBlockDirectives(codeBlock.code);
 			const posResult = parsePos(blockParsedDirectives);
@@ -255,7 +255,6 @@ export default function codeBlockRendering(store: StateManager<State>, events: E
 				creationIndex: codeBlock.id,
 				blockType: codeBlock.blockType,
 				entry: codeBlock.entry,
-				subProgramPath: codeBlock.subProgramPath,
 				disabled: codeBlock.disabled ?? directiveState.blockState.disabled,
 				hidden: directiveState.blockState.hidden,
 				isHome: directiveState.blockState.isHome,
@@ -264,16 +263,47 @@ export default function codeBlockRendering(store: StateManager<State>, events: E
 				alwaysOnTop: directiveState.blockState.alwaysOnTop ?? false,
 				viewportAnchor: directiveState.blockState.viewportAnchor,
 				parsedDirectives: blockParsedDirectives,
+				...overrides,
 			});
-		});
+		};
+		const createProjectCodeBlockSlice = (currentProject: ProjectObjectModel): CodeBlockGraphicData[] => {
+			const codeBlocks = collectProjectBlocks(currentProject).map(codeBlock => createGraphicCodeBlock(codeBlock));
+			const groupBlocks = currentProject.groups.map((group, groupIndex) => {
+				const groupName = group.name ?? `group${groupIndex + 1}`;
+				const gridX = groupIndex * 24;
+				const gridY = -6;
+				const creationIndex = nextCodeBlockCreationIndex;
+				nextCodeBlockCreationIndex += 1;
+				return createGraphicCodeBlock(
+					{
+						id: creationIndex,
+						code: [`group ${groupName}`, `; @pos ${gridX} ${gridY}`, 'groupEnd'],
+						blockType: 'unknown',
+						entry: group.entry,
+					},
+					{
+						name: groupName,
+						...(group.id ? { projectGroupId: group.id } : {}),
+						nestedProjectCodeBlocks: createProjectCodeBlockSlice(group),
+					}
+				);
+			});
+			const projectCodeBlocks = [...codeBlocks, ...groupBlocks];
 
-		// Stable-sort to maintain the partition: normal blocks first, always-on-top last.
-		const partitionedCodeBlocks = [...codeBlocks.filter(b => !b.alwaysOnTop), ...codeBlocks.filter(b => b.alwaysOnTop)];
+			// Stable-sort to maintain the partition: normal blocks first, always-on-top last.
+			return [
+				...projectCodeBlocks.filter(block => !block.alwaysOnTop),
+				...projectCodeBlocks.filter(block => block.alwaysOnTop),
+			];
+		};
+		const rootCodeBlocks = createProjectCodeBlockSlice(project);
+		state.codeBlockRendering.nextCodeBlockCreationIndex = nextCodeBlockCreationIndex;
 
-		store.set('codeBlockRendering.codeBlocks', partitionedCodeBlocks);
+		store.set('codeBlockRendering.rootCodeBlocks', rootCodeBlocks);
+		store.set('codeBlockRendering.codeBlocks', rootCodeBlocks);
 
 		// Center viewport on first @home block, or default to (0,0)
-		const homeBlock = codeBlocks.find(block => block.isHome);
+		const homeBlock = rootCodeBlocks.find(block => block.isHome);
 		if (homeBlock) {
 			store.set('codeBlockRendering.selectedCodeBlock', homeBlock);
 			const { x, y } = centerViewportOnCodeBlock(state.viewport, homeBlock, {

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.ts
@@ -3,6 +3,7 @@ import type { CompilerSourceBlockType, DocumentBlockType } from '@8f4e/language-
 import { documentBlockInstructionByType } from '@8f4e/language-spec';
 import type { StateManager } from '@8f4e/state-manager';
 import { instructionParser } from '@8f4e/tokenizer';
+import replaceCodeBlocksInPlace from '../../replaceCodeBlocksInPlace';
 import getBlockType from '../../utils/codeParsers/getBlockType';
 import { createCodeBlockGraphicData } from '../../utils/createCodeBlockGraphicData';
 import getCodeBlockNameFromSource from '../../utils/getCodeBlockNameFromSource';
@@ -246,7 +247,8 @@ export default function codeBlockCreator(store: StateManager<State>, events: Eve
 		const existingBlocks = state.codeBlockRendering.codeBlocks;
 		const normalBlocks = existingBlocks.filter(b => !b.alwaysOnTop);
 		const topBlocks = existingBlocks.filter(b => b.alwaysOnTop);
-		store.set('codeBlockRendering.codeBlocks', [...normalBlocks, codeBlock, ...topBlocks]);
+		replaceCodeBlocksInPlace(existingBlocks, [...normalBlocks, codeBlock, ...topBlocks]);
+		store.set('codeBlockRendering.codeBlocks', existingBlocks);
 	}
 
 	function onDeleteCodeBlock({ codeBlock }: { codeBlock: CodeBlockGraphicData }): void {
@@ -254,10 +256,12 @@ export default function codeBlockCreator(store: StateManager<State>, events: Eve
 			return;
 		}
 
-		store.set(
-			'codeBlockRendering.codeBlocks',
-			state.codeBlockRendering.codeBlocks.filter(block => block !== codeBlock)
+		const codeBlocks = state.codeBlockRendering.codeBlocks;
+		replaceCodeBlocksInPlace(
+			codeBlocks,
+			codeBlocks.filter(block => block !== codeBlock)
 		);
+		store.set('codeBlockRendering.codeBlocks', codeBlocks);
 	}
 
 	function onCopyCodeBlock({ codeBlock }: { codeBlock: CodeBlockGraphicData }): void {

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/pasteMultipleBlocks.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/pasteMultipleBlocks.ts
@@ -1,5 +1,6 @@
 import type { CodeBlockGraphicData, State } from '@8f4e/editor-state-types';
 import type { StateManager } from '@8f4e/state-manager';
+import replaceCodeBlocksInPlace from '../../replaceCodeBlocksInPlace';
 import getBlockType from '../../utils/codeParsers/getBlockType';
 import { createCodeBlockGraphicData } from '../../utils/createCodeBlockGraphicData';
 import getCodeBlockNameFromSource from '../../utils/getCodeBlockNameFromSource';
@@ -222,5 +223,6 @@ export function pasteMultipleBlocks(
 	];
 
 	// Trigger single store update with all new blocks
-	store.set('codeBlockRendering.codeBlocks', sorted);
+	replaceCodeBlocksInPlace(state.codeBlockRendering.codeBlocks, sorted);
+	store.set('codeBlockRendering.codeBlocks', state.codeBlockRendering.codeBlocks);
 }

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockDragger/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockDragger/effect.ts
@@ -1,5 +1,6 @@
 import type { CodeBlockGraphicData, EventDispatcher, InternalMouseEvent, State } from '@8f4e/editor-state-types';
 import type { StateManager } from '@8f4e/state-manager';
+import replaceCodeBlocksInPlace from '../../replaceCodeBlocksInPlace';
 import findCodeBlockAtViewportCoordinates from '../../utils/finders/findCodeBlockAtViewportCoordinates';
 import upsertPos from '../directives/pos/upsert';
 import { worldPositionToAnchoredPos } from '../directives/viewport/resolve';
@@ -81,11 +82,11 @@ export default function codeBlockDragger(store: StateManager<State>, events: Eve
 		// Always-on-top blocks move to the end of the always-on-top segment (end of array).
 		const allOthers = state.codeBlockRendering.codeBlocks.filter(block => block !== draggedCodeBlock);
 		if (draggedCodeBlock.alwaysOnTop) {
-			state.codeBlockRendering.codeBlocks = [...allOthers, draggedCodeBlock];
+			replaceCodeBlocksInPlace(state.codeBlockRendering.codeBlocks, [...allOthers, draggedCodeBlock]);
 		} else {
 			const normalOthers = allOthers.filter(block => !block.alwaysOnTop);
 			const topBlocks = allOthers.filter(block => block.alwaysOnTop);
-			state.codeBlockRendering.codeBlocks = [...normalOthers, draggedCodeBlock, ...topBlocks];
+			replaceCodeBlocksInPlace(state.codeBlockRendering.codeBlocks, [...normalOthers, draggedCodeBlock, ...topBlocks]);
 		}
 	}
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/group/deleter/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/group/deleter/effect.ts
@@ -1,6 +1,7 @@
 import type { CodeBlockGraphicData, EventDispatcher, State } from '@8f4e/editor-state-types';
 
 import type { StateManager } from '@8f4e/state-manager';
+import replaceCodeBlocksInPlace from '../../../replaceCodeBlocksInPlace';
 import { getGroupBlocks } from '../getGroupBlocks';
 
 /**
@@ -57,7 +58,8 @@ export default function groupDeleter(store: StateManager<State>, events: EventDi
 		}
 
 		// Update the code blocks array
-		store.set('codeBlockRendering.codeBlocks', remainingBlocks);
+		replaceCodeBlocksInPlace(state.codeBlockRendering.codeBlocks, remainingBlocks);
+		store.set('codeBlockRendering.codeBlocks', state.codeBlockRendering.codeBlocks);
 	}
 
 	events.on('deleteGroup', onDeleteGroup);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/projectGroupNavigation/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/projectGroupNavigation/effect.test.ts
@@ -1,0 +1,116 @@
+import type { State } from '@8f4e/editor-state-types';
+import createStateManager from '@8f4e/state-manager';
+import { describe, expect, it, type MockInstance } from 'vitest';
+import { createMockCodeBlock, createMockState } from '~/pureHelpers/testingUtils/testUtils';
+import { createMockEventDispatcherWithVitest } from '~/pureHelpers/testingUtils/vitestTestUtils';
+import projectGroupNavigation from './effect';
+
+describe('projectGroupNavigation', () => {
+	it('opens a project group by pointing the rendered slice at its nested blocks', () => {
+		const nestedProjectCodeBlocks = [createMockCodeBlock({ name: 'nested' })];
+		const groupBlock = createMockCodeBlock({ nestedProjectCodeBlocks });
+		const rootCodeBlocks = [groupBlock];
+		const state = createMockState({
+			codeBlockRendering: {
+				rootCodeBlocks,
+				codeBlocks: rootCodeBlocks,
+				selectedCodeBlock: groupBlock,
+				selectedCodeBlockForProgrammaticEdit: groupBlock,
+				selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger: groupBlock,
+				draggedCodeBlock: groupBlock,
+			},
+			viewport: { x: 64, y: 96 },
+		});
+		const store = createStateManager(state as State);
+		const events = createMockEventDispatcherWithVitest();
+
+		projectGroupNavigation(store, events);
+		const openGroup = (events.on as unknown as MockInstance).mock.calls.find(
+			call => call[0] === 'openProjectGroup'
+		)?.[1];
+		openGroup({ codeBlock: groupBlock });
+
+		expect(state.codeBlockRendering.rootCodeBlocks).toBe(rootCodeBlocks);
+		expect(state.codeBlockRendering.codeBlocks).toBe(nestedProjectCodeBlocks);
+		expect(state.codeBlockRendering.selectedCodeBlock).toBeUndefined();
+		expect(state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit).toBeUndefined();
+		expect(state.codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger).toBeUndefined();
+		expect(state.codeBlockRendering.draggedCodeBlock).toBeUndefined();
+		expect(state.viewport.x).toBe(0);
+		expect(state.viewport.y).toBe(0);
+	});
+
+	it('opens empty project groups', () => {
+		const nestedProjectCodeBlocks: [] = [];
+		const groupBlock = createMockCodeBlock({ nestedProjectCodeBlocks });
+		const state = createMockState();
+		const store = createStateManager(state as State);
+		const events = createMockEventDispatcherWithVitest();
+
+		projectGroupNavigation(store, events);
+		const openGroup = (events.on as unknown as MockInstance).mock.calls.find(
+			call => call[0] === 'openProjectGroup'
+		)?.[1];
+		openGroup({ codeBlock: groupBlock });
+
+		expect(state.codeBlockRendering.codeBlocks).toBe(nestedProjectCodeBlocks);
+	});
+
+	it('returns to the immediate parent slice one level at a time', () => {
+		const deepestSlice = [createMockCodeBlock({ name: 'deepest' })];
+		const nestedGroup = createMockCodeBlock({ nestedProjectCodeBlocks: deepestSlice });
+		const firstLevelSlice = [nestedGroup];
+		const rootGroup = createMockCodeBlock({ nestedProjectCodeBlocks: firstLevelSlice });
+		const rootCodeBlocks = [rootGroup];
+		const state = createMockState({
+			codeBlockRendering: {
+				rootCodeBlocks,
+				codeBlocks: deepestSlice,
+			},
+		});
+		const store = createStateManager(state as State);
+		const events = createMockEventDispatcherWithVitest();
+
+		projectGroupNavigation(store, events);
+		const goBack = (events.on as unknown as MockInstance).mock.calls.find(
+			call => call[0] === 'goToParentProjectGroup'
+		)?.[1];
+		goBack();
+
+		expect(state.codeBlockRendering.codeBlocks).toBe(firstLevelSlice);
+
+		goBack();
+
+		expect(state.codeBlockRendering.codeBlocks).toBe(rootCodeBlocks);
+	});
+
+	it('keeps the root slice active when there is no parent', () => {
+		const state = createMockState();
+		const rootCodeBlocks = state.codeBlockRendering.rootCodeBlocks;
+		const store = createStateManager(state as State);
+		const events = createMockEventDispatcherWithVitest();
+
+		projectGroupNavigation(store, events);
+		const goBack = (events.on as unknown as MockInstance).mock.calls.find(
+			call => call[0] === 'goToParentProjectGroup'
+		)?.[1];
+		goBack();
+
+		expect(state.codeBlockRendering.codeBlocks).toBe(rootCodeBlocks);
+	});
+
+	it('ignores ordinary code blocks when opening a group', () => {
+		const state = createMockState();
+		const originalSlice = state.codeBlockRendering.codeBlocks;
+		const store = createStateManager(state as State);
+		const events = createMockEventDispatcherWithVitest();
+
+		projectGroupNavigation(store, events);
+		const openGroup = (events.on as unknown as MockInstance).mock.calls.find(
+			call => call[0] === 'openProjectGroup'
+		)?.[1];
+		openGroup({ codeBlock: createMockCodeBlock() });
+
+		expect(state.codeBlockRendering.codeBlocks).toBe(originalSlice);
+	});
+});

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/projectGroupNavigation/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/projectGroupNavigation/effect.ts
@@ -1,0 +1,72 @@
+import type { CodeBlockGraphicData, EventDispatcher, State } from '@8f4e/editor-state-types';
+import type { StateManager } from '@8f4e/state-manager';
+import centerViewportOnCodeBlock from '../../../viewport/centerViewportOnCodeBlock';
+import updateViewport from '../../../viewport/updateViewport';
+
+export interface OpenProjectGroupEvent {
+	codeBlock: CodeBlockGraphicData;
+}
+
+export function findParentProjectSlice(
+	rootCodeBlocks: CodeBlockGraphicData[],
+	currentCodeBlocks: CodeBlockGraphicData[]
+): CodeBlockGraphicData[] | undefined {
+	for (const codeBlock of rootCodeBlocks) {
+		const nestedProjectCodeBlocks = codeBlock.nestedProjectCodeBlocks;
+		if (nestedProjectCodeBlocks === undefined) {
+			continue;
+		}
+
+		if (nestedProjectCodeBlocks === currentCodeBlocks) {
+			return rootCodeBlocks;
+		}
+
+		const parentCodeBlocks = findParentProjectSlice(nestedProjectCodeBlocks, currentCodeBlocks);
+		if (parentCodeBlocks) {
+			return parentCodeBlocks;
+		}
+	}
+}
+
+/** Moves the editor's rendered-slice pointer through the recursive project tree. */
+export default function projectGroupNavigation(store: StateManager<State>, events: EventDispatcher): void {
+	const state = store.getState();
+
+	function showProjectSlice(codeBlocks: CodeBlockGraphicData[]): void {
+		store.set('codeBlockRendering.selectedCodeBlock', undefined);
+		store.set('codeBlockRendering.selectedCodeBlockForProgrammaticEdit', undefined);
+		store.set('codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger', undefined);
+		state.codeBlockRendering.draggedCodeBlock = undefined;
+		store.set('codeBlockRendering.codeBlocks', codeBlocks);
+
+		const homeBlock = codeBlocks.find(block => block.isHome);
+		if (homeBlock) {
+			const { x, y } = centerViewportOnCodeBlock(state.viewport, homeBlock, {
+				alignment: homeBlock.homeAlignment,
+			});
+			updateViewport(state, x, y, events);
+			return;
+		}
+
+		updateViewport(state, 0, 0, events);
+	}
+
+	function onOpenProjectGroup({ codeBlock }: OpenProjectGroupEvent): void {
+		if (codeBlock.nestedProjectCodeBlocks !== undefined) {
+			showProjectSlice(codeBlock.nestedProjectCodeBlocks);
+		}
+	}
+
+	function onGoToParentProjectGroup(): void {
+		const parentCodeBlocks = findParentProjectSlice(
+			state.codeBlockRendering.rootCodeBlocks,
+			state.codeBlockRendering.codeBlocks
+		);
+		if (parentCodeBlocks) {
+			showProjectSlice(parentCodeBlocks);
+		}
+	}
+
+	events.on<OpenProjectGroupEvent>('openProjectGroup', onOpenProjectGroup);
+	events.on('goToParentProjectGroup', onGoToParentProjectGroup);
+}

--- a/packages/editor/packages/editor-state/src/features/code-blocks/replaceCodeBlocksInPlace.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/replaceCodeBlocksInPlace.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { createMockCodeBlock } from '~/pureHelpers/testingUtils/testUtils';
+import replaceCodeBlocksInPlace from './replaceCodeBlocksInPlace';
+
+describe('replaceCodeBlocksInPlace', () => {
+	it('preserves the project slice identity while replacing its contents', () => {
+		const originalBlock = createMockCodeBlock({ name: 'original' });
+		const replacementBlock = createMockCodeBlock({ name: 'replacement' });
+		const projectSlice = [originalBlock];
+		const renderedSlice = projectSlice;
+
+		replaceCodeBlocksInPlace(renderedSlice, [replacementBlock]);
+
+		expect(renderedSlice).toBe(projectSlice);
+		expect(projectSlice).toEqual([replacementBlock]);
+	});
+});

--- a/packages/editor/packages/editor-state/src/features/code-blocks/replaceCodeBlocksInPlace.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/replaceCodeBlocksInPlace.ts
@@ -1,0 +1,9 @@
+import type { CodeBlockGraphicData } from '@8f4e/editor-state-types';
+
+/** Replaces a project slice without changing the array identity referenced by its owner. */
+export default function replaceCodeBlocksInPlace(
+	codeBlocks: CodeBlockGraphicData[],
+	replacement: readonly CodeBlockGraphicData[]
+): void {
+	codeBlocks.splice(0, codeBlocks.length, ...replacement);
+}

--- a/packages/editor/packages/editor-state/src/features/code-blocks/utils/getCodeBlockNameFromSource.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/utils/getCodeBlockNameFromSource.test.ts
@@ -18,6 +18,10 @@ describe('getCodeBlockNameFromSource', () => {
 		expect(getCodeBlockNameFromSource(['prototype oscillatorState', '', 'prototypeEnd'])).toBe('oscillatorState');
 	});
 
+	it('returns raw project-group names for group blocks', () => {
+		expect(getCodeBlockNameFromSource(['group audio', '', 'groupEnd'])).toBe('audio');
+	});
+
 	it('returns empty string for note blocks', () => {
 		expect(getCodeBlockNameFromSource(['note', '', 'noteEnd'])).toBe('');
 		expect(getCodeBlockNameFromSource(['note fragmentShaderPostprocess', '', 'noteEnd'])).toBe('');

--- a/packages/editor/packages/editor-state/src/features/code-blocks/utils/getCodeBlockNameFromSource.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/utils/getCodeBlockNameFromSource.ts
@@ -6,6 +6,7 @@ const namedBlockStarts: ReadonlySet<string> = new Set([
 	documentBlockInstructionByType.function.start,
 	documentBlockInstructionByType.constants.start,
 	documentBlockInstructionByType.prototype.start,
+	'group',
 ]);
 
 /**

--- a/packages/editor/packages/editor-state/src/features/menu/menus/index.ts
+++ b/packages/editor/packages/editor-state/src/features/menu/menus/index.ts
@@ -1,5 +1,5 @@
 export { favoritesMenu } from './favoritesMenu';
 export { mainMenu } from './mainMenu';
 export { moduleCategoriesMenu } from './moduleCategoriesMenu';
-export { moduleMenu, type OpenGroupEvent } from './moduleMenu';
+export { moduleMenu } from './moduleMenu';
 export { projectMenu } from './projectMenu';

--- a/packages/editor/packages/editor-state/src/features/menu/menus/mainMenu.ts
+++ b/packages/editor/packages/editor-state/src/features/menu/menus/mainMenu.ts
@@ -1,6 +1,9 @@
 import type { MenuGenerator } from '@8f4e/editor-state-types';
 
 export const mainMenu: MenuGenerator = state => [
+	...(state.codeBlockRendering.codeBlocks !== state.codeBlockRendering.rootCodeBlocks
+		? [{ title: 'Go back', action: 'goToParentProjectGroup', close: true }, { divider: true }]
+		: []),
 	...(state.featureFlags.editing
 		? [
 				{

--- a/packages/editor/packages/editor-state/src/features/menu/menus/moduleMenu.test.ts
+++ b/packages/editor/packages/editor-state/src/features/menu/menus/moduleMenu.test.ts
@@ -3,6 +3,60 @@ import { createMockCodeBlock, createMockState } from '~/pureHelpers/testingUtils
 import { moduleMenu } from './moduleMenu';
 
 describe('module menu', () => {
+	it('adds an open action for project-group blocks', async () => {
+		const codeBlock = createMockCodeBlock({
+			name: 'Audio',
+			nestedProjectCodeBlocks: [],
+		});
+		const state = createMockState({
+			codeBlockRendering: {
+				selectedCodeBlock: codeBlock,
+			},
+		});
+
+		const items = await moduleMenu(state);
+
+		expect(items.find(candidate => candidate.action === 'openProjectGroup')).toEqual({
+			title: 'Open group',
+			action: 'openProjectGroup',
+			payload: { codeBlock },
+			close: true,
+		});
+	});
+
+	it('does not add the project-group action to ordinary blocks', async () => {
+		const codeBlock = createMockCodeBlock();
+		const state = createMockState({
+			codeBlockRendering: {
+				selectedCodeBlock: codeBlock,
+			},
+		});
+
+		const items = await moduleMenu(state);
+
+		expect(items.some(candidate => candidate.action === 'openProjectGroup')).toBe(false);
+	});
+
+	it('adds a go-back action when rendering a nested project slice', async () => {
+		const rootCodeBlocks = [createMockCodeBlock()];
+		const nestedProjectCodeBlocks = [createMockCodeBlock()];
+		const state = createMockState({
+			codeBlockRendering: {
+				rootCodeBlocks,
+				codeBlocks: nestedProjectCodeBlocks,
+				selectedCodeBlock: nestedProjectCodeBlocks[0],
+			},
+		});
+
+		const items = await moduleMenu(state);
+
+		expect(items.find(candidate => candidate.action === 'goToParentProjectGroup')).toEqual({
+			title: 'Go back',
+			action: 'goToParentProjectGroup',
+			close: true,
+		});
+	});
+
 	it('adds an action for saving slider values to code when a selected block has sliders', async () => {
 		const codeBlock = createMockCodeBlock({
 			blockType: 'module',

--- a/packages/editor/packages/editor-state/src/features/menu/menus/moduleMenu.ts
+++ b/packages/editor/packages/editor-state/src/features/menu/menus/moduleMenu.ts
@@ -8,15 +8,15 @@ const functionBlockType = documentBlockInstructionByType.function.type;
 const moduleBlockType = documentBlockInstructionByType.module.type;
 const noteBlockType = documentBlockInstructionByType.note.type;
 
-export interface OpenGroupEvent {
-	codeBlock: CodeBlockGraphicData;
-}
-
 export const moduleMenu: MenuGenerator = state => {
-	const blockType = state.codeBlockRendering.selectedCodeBlock?.blockType;
+	const selectedCodeBlock = state.codeBlockRendering.selectedCodeBlock;
+	const blockType = selectedCodeBlock?.blockType;
+	const isProjectGroup = selectedCodeBlock?.nestedProjectCodeBlocks !== undefined;
 	let blockLabel = 'module';
 
-	if (blockType === functionBlockType) {
+	if (isProjectGroup) {
+		blockLabel = 'group';
+	} else if (blockType === functionBlockType) {
 		blockLabel = 'function';
 	} else if (blockType === noteBlockType) {
 		blockLabel = 'note';
@@ -59,6 +59,19 @@ export const moduleMenu: MenuGenerator = state => {
 	}
 
 	return [
+		...(state.codeBlockRendering.codeBlocks !== state.codeBlockRendering.rootCodeBlocks
+			? [{ title: 'Go back', action: 'goToParentProjectGroup', close: true }]
+			: []),
+		...(isProjectGroup
+			? [
+					{
+						title: 'Open group',
+						action: 'openProjectGroup',
+						payload: { codeBlock: selectedCodeBlock },
+						close: true,
+					},
+				]
+			: []),
 		...(state.featureFlags.editing
 			? [
 					{

--- a/packages/editor/packages/editor-state/src/features/program-compiler/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/program-compiler/effect.ts
@@ -45,7 +45,7 @@ export default function compiler(store: StateManager<State>) {
 				includeStackAnalysis: state.featureFlags.codeLineSelection,
 			};
 			const project = convertGraphicDataToProjectStructure(
-				state.codeBlockRendering.codeBlocks,
+				state.codeBlockRendering.rootCodeBlocks,
 				state.initialProjectState
 			);
 			const result = await state.callbacks.compileCode(project, {

--- a/packages/editor/packages/editor-state/src/features/project-export/README.md
+++ b/packages/editor/packages/editor-state/src/features/project-export/README.md
@@ -33,7 +33,7 @@ WASM export is separate from project serialization and writes compiled binary mo
 ## State Sources
 
 Serializes from:
-- `state.codeBlockRendering.codeBlocks` - Code block data
+- `state.codeBlockRendering.rootCodeBlocks` - Recursive root code-block tree
 
 ## Integration Points
 
@@ -61,9 +61,10 @@ interface ProjectObjectModel {
 ```
 
 Collection membership defines block type. The adapter uses the editor's already-known block type and does not make the
-compiler rediscover it from source text. Nested group blocks retain a runtime sub-program path so editor state can be
-converted back into the same recursively owned project structure. Compilation currently consumes only the root
-project; recursive sub-program composition is intentionally deferred.
+compiler rediscover it from source text. Project groups are rendered as ordinary `CodeBlockGraphicData` values whose
+optional `nestedProjectCodeBlocks` field owns the child project slice. Export recursively traverses that tree from
+`rootCodeBlocks`, regardless of which slice `codeBlocks` currently points to. Compilation currently consumes only the
+root project; recursive sub-program composition is intentionally deferred.
 
 ## References
 

--- a/packages/editor/packages/editor-state/src/features/project-export/__tests__/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/__tests__/effect.test.ts
@@ -198,13 +198,15 @@ describe('projectExport', () => {
 			const mockGetStorageQuota = vi.fn().mockResolvedValue({ usedBytes: 1024, totalBytes: 10240 });
 			mockState.callbacks.saveSession = mockSaveSession;
 			mockState.callbacks.getStorageQuota = mockGetStorageQuota;
-			mockState.codeBlockRendering.codeBlocks = [
+			const rootCodeBlocks = [
 				createMockCodeBlock({
 					blockType: 'module',
 					code: ['module other', 'moduleEnd'],
 					entry: 'entry1',
 				}),
 			];
+			mockState.codeBlockRendering.rootCodeBlocks = rootCodeBlocks;
+			mockState.codeBlockRendering.codeBlocks = rootCodeBlocks;
 
 			projectExport(store, mockEvents);
 

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeCodeBlocks.test.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeCodeBlocks.test.ts
@@ -120,16 +120,28 @@ describe('convertGraphicDataToProjectStructure', () => {
 		]);
 	});
 
-	it('reconstructs recursively owned projects from runtime sub-program paths', () => {
+	it('reconstructs recursively owned projects from nested project code-block slices', () => {
 		const result = convertGraphicDataToProjectStructure([
 			createMockCodeBlock({
-				creationIndex: 1,
-				blockType: 'module',
+				name: 'Audio',
 				entry: 'main',
-				code: ['module voice', 'moduleEnd'],
-				subProgramPath: [
-					{ id: 'audio', name: 'Audio', entry: 'main' },
-					{ id: 'oscillator', name: 'Oscillator', entry: 'main' },
+				projectGroupId: 'audio',
+				code: ['group Audio', 'groupEnd'],
+				nestedProjectCodeBlocks: [
+					createMockCodeBlock({
+						name: 'Oscillator',
+						entry: 'main',
+						projectGroupId: 'oscillator',
+						code: ['group Oscillator', 'groupEnd'],
+						nestedProjectCodeBlocks: [
+							createMockCodeBlock({
+								creationIndex: 1,
+								blockType: 'module',
+								entry: 'main',
+								code: ['module voice', 'moduleEnd'],
+							}),
+						],
+					}),
 				],
 			}),
 		]);
@@ -149,33 +161,32 @@ describe('convertGraphicDataToProjectStructure', () => {
 		});
 	});
 
-	it('preserves empty nested projects from the loaded project structure', () => {
-		const projectStructure = {
-			modules: [],
-			functions: [],
-			constants: [],
-			prototypes: [],
-			includes: [],
-			notes: [],
-			unknown: [],
-			groups: [
-				{
-					id: 'empty',
-					name: 'Empty',
-					entry: 'main',
-					modules: [],
-					functions: [],
-					constants: [],
-					prototypes: [],
-					includes: [],
-					notes: [],
-					unknown: [],
-					groups: [],
-				},
-			],
-		};
+	it('preserves empty nested projects represented by project-group blocks', () => {
+		const result = convertGraphicDataToProjectStructure([
+			createMockCodeBlock({
+				name: 'Empty',
+				entry: 'main',
+				projectGroupId: 'empty',
+				code: ['group Empty', 'groupEnd'],
+				nestedProjectCodeBlocks: [],
+			}),
+		]);
 
-		expect(convertGraphicDataToProjectStructure([], projectStructure).groups).toEqual(projectStructure.groups);
+		expect(result.groups).toEqual([
+			{
+				id: 'empty',
+				name: 'Empty',
+				entry: 'main',
+				modules: [],
+				functions: [],
+				constants: [],
+				prototypes: [],
+				includes: [],
+				notes: [],
+				unknown: [],
+				groups: [],
+			},
+		]);
 	});
 
 	it('rejects module blocks without an entry', () => {

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeCodeBlocks.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeCodeBlocks.ts
@@ -17,48 +17,36 @@ function createEmptyProject(metadata: Pick<ProjectObjectModel, 'id' | 'name' | '
 	};
 }
 
-function cloneProjectStructure(project: ProjectObjectModel): ProjectObjectModel {
-	return {
-		...createEmptyProject({
-			...(project.id ? { id: project.id } : {}),
-			...(project.name ? { name: project.name } : {}),
-			...(project.entry ? { entry: project.entry } : {}),
-		}),
-		groups: project.groups.map(cloneProjectStructure),
-	};
-}
-
-function getProjectForPath(
-	rootProject: ProjectObjectModel,
-	subProgramPath: CodeBlockGraphicData['subProgramPath']
-): ProjectObjectModel {
-	let project = rootProject;
-	for (const segment of subProgramPath ?? []) {
-		let group = project.groups.find(candidate =>
-			segment.id ? candidate.id === segment.id : candidate.name === segment.name && candidate.entry === segment.entry
-		);
-		if (!group) {
-			group = createEmptyProject({
-				...(segment.id ? { id: segment.id } : {}),
-				...(segment.name ? { name: segment.name } : {}),
-				...(segment.entry ? { entry: segment.entry } : {}),
-			});
-			project.groups.push(group);
-		}
-		project = group;
-	}
-	return project;
-}
-
 /** Converts editor-owned live blocks directly into the canonical project collections. */
 export default function convertGraphicDataToProjectStructure(
 	codeBlocks: CodeBlockGraphicData[],
 	projectStructure?: ProjectObjectModel
 ): ProjectObjectModel {
-	const project = projectStructure ? cloneProjectStructure(projectStructure) : createEmptyProject();
+	const project = createEmptyProject(
+		projectStructure
+			? {
+					...(projectStructure.id ? { id: projectStructure.id } : {}),
+					...(projectStructure.name ? { name: projectStructure.name } : {}),
+					...(projectStructure.entry ? { entry: projectStructure.entry } : {}),
+				}
+			: {}
+	);
 
 	for (const codeBlock of sortCodeBlocksByGridPosition(codeBlocks.filter(block => !isBrowserLocalNoteBlock(block)))) {
-		const owningProject = getProjectForPath(project, codeBlock.subProgramPath);
+		if (codeBlock.nestedProjectCodeBlocks !== undefined) {
+			project.groups.push(
+				convertGraphicDataToProjectStructure(
+					codeBlock.nestedProjectCodeBlocks,
+					createEmptyProject({
+						...(codeBlock.projectGroupId ? { id: codeBlock.projectGroupId } : {}),
+						name: codeBlock.name,
+						...(codeBlock.entry ? { entry: codeBlock.entry } : {}),
+					})
+				)
+			);
+			continue;
+		}
+
 		const block: ProjectBlock = {
 			id: codeBlock.creationIndex,
 			code: codeBlock.code,
@@ -67,19 +55,19 @@ export default function convertGraphicDataToProjectStructure(
 
 		if (codeBlock.blockType === 'module') {
 			if (!codeBlock.entry) throw new Error(`Module code block "${codeBlock.name}" is missing an entry`);
-			owningProject.modules.push({ ...block, entry: codeBlock.entry });
+			project.modules.push({ ...block, entry: codeBlock.entry });
 		} else if (codeBlock.blockType === 'function') {
-			owningProject.functions.push(block);
+			project.functions.push(block);
 		} else if (codeBlock.blockType === 'constants') {
-			owningProject.constants.push(block);
+			project.constants.push(block);
 		} else if (codeBlock.blockType === 'prototype') {
-			owningProject.prototypes.push(block);
+			project.prototypes.push(block);
 		} else if (codeBlock.blockType === 'includes') {
-			owningProject.includes.push(block);
+			project.includes.push(block);
 		} else if (codeBlock.blockType === 'note') {
-			owningProject.notes.push(block);
+			project.notes.push(block);
 		} else {
-			owningProject.unknown.push(block);
+			project.unknown.push(block);
 		}
 	}
 

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeToProject.test.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeToProject.test.ts
@@ -4,16 +4,18 @@ import serializeToProject from './serializeToProject';
 
 describe('serializeToProject', () => {
 	it('serializes basic project state without compiled data', () => {
+		const rootCodeBlocks = [
+			createMockCodeBlock({
+				name: 'block-1',
+				code: ['10 example'],
+				x: 20,
+				y: 30,
+			}),
+		];
 		const state = createMockState({
 			codeBlockRendering: {
-				codeBlocks: [
-					createMockCodeBlock({
-						name: 'block-1',
-						code: ['10 example'],
-						x: 20,
-						y: 30,
-					}),
-				],
+				rootCodeBlocks,
+				codeBlocks: rootCodeBlocks,
 			},
 			binaryAssets: [],
 			viewport: {
@@ -30,17 +32,19 @@ describe('serializeToProject', () => {
 	});
 
 	it('derives serialized project data from current code blocks', () => {
+		const rootCodeBlocks = [
+			createMockCodeBlock({
+				name: 'includes',
+				blockType: 'includes',
+				code: ['includes', 'include std/current', 'includesEnd'],
+				x: 0,
+				y: 0,
+			}),
+		];
 		const state = createMockState({
 			codeBlockRendering: {
-				codeBlocks: [
-					createMockCodeBlock({
-						name: 'includes',
-						blockType: 'includes',
-						code: ['includes', 'include std/current', 'includesEnd'],
-						x: 0,
-						y: 0,
-					}),
-				],
+				rootCodeBlocks,
+				codeBlocks: rootCodeBlocks,
 			},
 		});
 
@@ -58,5 +62,43 @@ describe('serializeToProject', () => {
 			unknown: [],
 			groups: [],
 		});
+	});
+
+	it('serializes the recursive root tree instead of only the rendered nested slice', () => {
+		const nestedProjectCodeBlocks = [
+			createMockCodeBlock({
+				name: 'voice',
+				blockType: 'module',
+				entry: 'main',
+				creationIndex: 2,
+				code: ['module voice', 'moduleEnd'],
+			}),
+		];
+		const rootCodeBlocks = [
+			createMockCodeBlock({
+				name: 'root',
+				blockType: 'module',
+				entry: 'main',
+				creationIndex: 1,
+				code: ['module root', 'moduleEnd'],
+			}),
+			createMockCodeBlock({
+				name: 'Audio',
+				entry: 'main',
+				code: ['group Audio', 'groupEnd'],
+				nestedProjectCodeBlocks,
+			}),
+		];
+		const state = createMockState({
+			codeBlockRendering: {
+				rootCodeBlocks,
+				codeBlocks: nestedProjectCodeBlocks,
+			},
+		});
+
+		const project = serializeToProject(state);
+
+		expect(project.modules.map(block => block.code[0])).toEqual(['module root']);
+		expect(project.groups[0].modules.map(block => block.code[0])).toEqual(['module voice']);
 	});
 });

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeToProject.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeToProject.ts
@@ -9,5 +9,5 @@ import convertGraphicDataToProjectStructure from './serializeCodeBlocks';
  */
 export default function serializeToProject(state: State): ProjectObjectModel {
 	const { codeBlockRendering } = state;
-	return convertGraphicDataToProjectStructure(codeBlockRendering.codeBlocks, state.initialProjectState);
+	return convertGraphicDataToProjectStructure(codeBlockRendering.rootCodeBlocks, state.initialProjectState);
 }

--- a/packages/editor/packages/editor-state/src/index.ts
+++ b/packages/editor/packages/editor-state/src/index.ts
@@ -25,6 +25,7 @@ import groupSkipExecutionToggler from './features/code-blocks/features/group/ski
 import groupUngroupper from './features/code-blocks/features/group/ungroupper/effect';
 import memoryConnectionRemover from './features/code-blocks/features/memoryConnectionRemover/effect';
 import parsedDirectivesUpdater from './features/code-blocks/features/parsedDirectivesUpdater/effect';
+import projectGroupNavigation from './features/code-blocks/features/projectGroupNavigation/effect';
 import skipExecutionToggler from './features/code-blocks/features/skipExecutionToggler/effect';
 import sliderDefaultSaver from './features/code-blocks/features/sliderDefaultSaver/effect';
 import codeEditing from './features/code-editing/effect';
@@ -105,6 +106,7 @@ export default function init(events: EventDispatcher, options: Options): StateMa
 	groupRemover(store, events);
 	groupUngroupper(store, events);
 	groupDeleter(store, events);
+	projectGroupNavigation(store, events);
 	parsedDirectivesUpdater(store);
 	autoEnvConstants(store); // Must run after codeBlockCreator to ensure env block is created
 	blockTypeUpdater(store); // Must run before compiler to classify blocks first

--- a/packages/editor/packages/editor-state/src/pureHelpers/state/createDefaultState.ts
+++ b/packages/editor/packages/editor-state/src/pureHelpers/state/createDefaultState.ts
@@ -1,6 +1,9 @@
+import type { CodeBlockGraphicData } from '@8f4e/editor-state-types';
 import { defaultFeatureFlags } from './featureFlags';
 
 export default function createDefaultState() {
+	const rootCodeBlocks: CodeBlockGraphicData[] = [];
+
 	return {
 		compiler: {
 			isCompiling: false,
@@ -14,7 +17,8 @@ export default function createDefaultState() {
 			pointerMetadataByModuleId: {},
 		},
 		codeBlockRendering: {
-			codeBlocks: [],
+			rootCodeBlocks,
+			codeBlocks: rootCodeBlocks,
 			entryOutlines: [],
 			viewportAnchoredCodeBlocks: [],
 			nextCodeBlockCreationIndex: 0,

--- a/packages/editor/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
+++ b/packages/editor/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
@@ -246,6 +246,7 @@ export function createMockEventDispatcher(): EventDispatcher {
 export function createMockState(overrides: DeepPartial<State> = {}): State {
 	const mockRuntimeFactory = () => () => {};
 	const workerRuntimeDefaults = { sampleRate: 50 } as const;
+	const rootCodeBlocks: CodeBlockGraphicData[] = [];
 
 	const defaults: State = {
 		compiler: {
@@ -274,7 +275,8 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			},
 		},
 		codeBlockRendering: {
-			codeBlocks: [],
+			rootCodeBlocks,
+			codeBlocks: rootCodeBlocks,
 			entryOutlines: [],
 			viewportAnchoredCodeBlocks: [],
 			nextCodeBlockCreationIndex: 0,

--- a/packages/editor/packages/editor-state/tests/menu/mainMenu.test.ts
+++ b/packages/editor/packages/editor-state/tests/menu/mainMenu.test.ts
@@ -4,6 +4,33 @@ import { mainMenu } from '../../src/features/menu/menus';
 import { createMockState } from '../../src/pureHelpers/testingUtils/testUtils';
 
 describe('menus - go home entry', () => {
+	it('adds a go-back action when rendering a nested project slice', () => {
+		const rootCodeBlocks = [];
+		const nestedProjectCodeBlocks = [];
+		const mockState = createMockState({
+			codeBlockRendering: {
+				rootCodeBlocks,
+				codeBlocks: nestedProjectCodeBlocks,
+			},
+		});
+
+		const menu = mainMenu(mockState as State);
+
+		expect(menu.find(item => item.action === 'goToParentProjectGroup')).toEqual({
+			title: 'Go back',
+			action: 'goToParentProjectGroup',
+			close: true,
+		});
+	});
+
+	it('does not add a go-back action at the project root', () => {
+		const mockState = createMockState();
+
+		const menu = mainMenu(mockState as State);
+
+		expect(menu.some(item => item.action === 'goToParentProjectGroup')).toBe(false);
+	});
+
 	it('places "Go @home" directly above "Jump to..."', () => {
 		const mockState = createMockState({
 			editorMode: 'edit',


### PR DESCRIPTION
## Summary

- mirror recursively owned `ProjectObjectModel.groups` in editor state using nested code-block slices
- render one active project slice while retaining a separate recursive root pointer
- preserve slice identity by mutating add, delete, paste, reorder, and local-note updates in place
- navigate into groups and back to their immediate parent through block and background context menus
- serialize and live-compile from the recursive root while keeping compiler behavior root-only

## Rationale

The editor previously flattened nested project groups into one visible block collection. Keeping the same recursive ownership in editor memory makes group blocks visible at their parent level and provides direct child-slice navigation without introducing another project schema.

## Current scope

- project reload resets the rendered slice to the root
- **Open group** switches directly to the selected group child slice
- **Go back** resolves and opens the immediate parent slice
- group graphic positions are generated deterministically because they are not yet persisted in the project object model

## Tests

- `npx nx run @8f4e/editor-state:test`
- `npx nx run @8f4e/editor-state:typecheck`
- `npx nx run app:build`