### PR TITLE
feat(compiler): compose nested project groups

### DIFF
--- a/docs/todos/477-establish-project-object-model.md
+++ b/docs/todos/477-establish-project-object-model.md
@@ -71,8 +71,9 @@ blocks remain available to editors without entering compilation.
 Groups use the same object model recursively rather than referencing root-owned blocks by id. A nested model owns its
 modules, functions, constants, prototypes, includes, notes, unknown blocks, and further groups. Optional `id` and
 `name` fields provide stable and display identity, while optional `entry` retains the textual entry containing a group.
-The initial group refactor does not recursively compile these models: `compileProject` continues to compile only the
-root model until whole-program sub-program composition is implemented separately.
+The initial group refactor compiled only the root model. The follow-up compiler composition work now recursively parses
+and isolates these models before flattening them into one globally planned program; it does not merge independently
+compiled WebAssembly artifacts.
 
 The editor mirrors this recursive ownership without introducing another project schema. A project group is represented
 by the same `CodeBlockGraphicData` used for other visible blocks, with `nestedProjectCodeBlocks` pointing to the child
@@ -207,7 +208,8 @@ object model.
   type field.
 - [x] Module order is preserved per entry, while functions, constants, and prototypes are compiled as hoisted blocks.
 - [x] Groups recursively own complete `ProjectObjectModel` values instead of referencing root blocks by id.
-- [x] Root compilation remains unchanged and does not yet compile recursively owned groups.
+- [x] The initial object-model refactor left recursive compilation out of scope; follow-up composition now compiles all
+  recursively owned groups before one global allocation and code-generation pass.
 - [x] The editor mirrors group ownership with recursively nested code-block arrays, initially renders the root slice,
   and can move into child slices or back to their parent from context menus.
 - [x] Compiler stages consume the canonical typed collections directly; `SubProgramSource` and whole-project
@@ -237,9 +239,10 @@ object model.
   its stable id and module entry where applicable.
 - **Module order**: Only module order is semantically significant. The implementation must preserve order within each
   entry without inventing global ordering requirements for hoisted blocks.
-- **Group behavior**: Nested projects own their blocks structurally. The compiler intentionally ignores nested groups
-  for now so future recursive compilation cannot accidentally compile them twice. Editor project-slice arrays retain
-  stable identity so direct root/current pointers cannot be invalidated by add, delete, paste, or reorder operations.
+- **Group behavior**: Nested projects own their blocks structurally. The compiler composer visits every owned project
+  exactly once, isolates nested symbols, and places child modules before parent modules. Editor project-slice arrays
+  retain stable identity so direct root/current pointers cannot be invalidated by add, delete, paste, or reorder
+  operations.
 - **Editor metadata ownership**: Grid position, selection, cursor, rendering caches, and transient creation state must
   not leak into the compiler-owned model merely because the editor currently stores them beside source blocks.
 - **Diagnostic mapping**: Changes to block identity must preserve reliable mapping from compiler diagnostics back to

--- a/package-lock.json
+++ b/package-lock.json
@@ -111,6 +111,10 @@
       "resolved": "packages/metrics-dashboard",
       "link": true
     },
+    "node_modules/@8f4e/program-composer": {
+      "resolved": "packages/compiler/packages/program-composer",
+      "link": true
+    },
     "node_modules/@8f4e/project-preparser": {
       "resolved": "packages/compiler/packages/project-preparser",
       "link": true
@@ -10176,6 +10180,7 @@
       "license": "MIT",
       "dependencies": {
         "@8f4e/language-spec": "*",
+        "@8f4e/program-composer": "*",
         "@8f4e/project-preparser": "*",
         "@8f4e/sub-program": "*",
         "@8f4e/wasm-codegen": "*"
@@ -10217,6 +10222,19 @@
         "@types/node": "24.13.2"
       }
     },
+    "packages/compiler/packages/program-composer": {
+      "name": "@8f4e/program-composer",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@8f4e/language-spec": "*",
+        "@8f4e/tokenizer": "*"
+      },
+      "devDependencies": {
+        "@8f4e/project-preparser": "*",
+        "@types/node": "24.13.2"
+      }
+    },
     "packages/compiler/packages/project-preparser": {
       "name": "@8f4e/project-preparser",
       "version": "2.0.1",
@@ -10243,9 +10261,9 @@
         "@8f4e/memory-default-resolver": "*",
         "@8f4e/memory-planner": "*",
         "@8f4e/memory-reference-resolver": "*",
+        "@8f4e/program-composer": "*",
         "@8f4e/semantic-reference-resolver": "*",
         "@8f4e/stack-analyzer": "*",
-        "@8f4e/tokenizer": "*",
         "@8f4e/wasm-codegen": "*"
       },
       "devDependencies": {

--- a/packages/compiler/AGENTS.md
+++ b/packages/compiler/AGENTS.md
@@ -6,16 +6,20 @@
 - Compiles custom assembly language into WebAssembly bytecode.
 - Supports modules (stateful, with memory) and pure functions (stateless, stack-only).
 - Shared language contracts live in the nested standalone subpackage `@8f4e/language-spec` (`packages/compiler/packages/language-spec`).
-- Closed-unit compilation lives in `@8f4e/sub-program` (`packages/compiler/packages/sub-program`); its exclusively owned passes live under that package's `packages/` directory.
+- Recursive project traversal, AST parsing, symbol isolation, and deterministic flattening live in
+  `@8f4e/program-composer` (`packages/compiler/packages/program-composer`).
+- Global semantic analysis, allocation, and code generation live in `@8f4e/sub-program`
+  (`packages/compiler/packages/sub-program`); its exclusively owned passes live under that package's `packages/`
+  directory.
 - Include-only source resolution lives in the nested standalone subpackage `@8f4e/include-resolver` (`packages/compiler/packages/include-resolver`).
 - Syntax parsing lives in the sub-program-owned package `@8f4e/tokenizer` (`packages/compiler/packages/sub-program/packages/tokenizer`).
 - Project preparsing lives in the nested standalone subpackage `@8f4e/project-preparser` (`packages/compiler/packages/project-preparser`).
 - `@8f4e/language-spec` solely owns `ProjectObjectModel`. The public compiler project API is
   `parseProjectSource(text)` plus asynchronous `compileProject(project, options)`; internal stages must not require
   callers to prepare a parallel whole-project input.
-- `ProjectObjectModel.groups` recursively owns nested `ProjectObjectModel` values. `compileProject` currently compiles
-  only the root model; keep recursive sub-program composition and linking deferred until that work is implemented
-  explicitly.
+- `ProjectObjectModel.groups` recursively owns nested `ProjectObjectModel` values. `compileProject` composes all groups
+  before global allocation and code generation. Nested symbols are compiler-qualified and child modules execute before
+  their parent modules for the same entry.
 - WebAssembly body generation and final binary emission live in `@8f4e/wasm-codegen` (`packages/compiler/packages/wasm-codegen`).
 - Standard library sources live in the nested source package `@8f4e/stdlib` (`packages/compiler/packages/stdlib`).
 

--- a/packages/compiler/README.md
+++ b/packages/compiler/README.md
@@ -12,7 +12,10 @@ editor state ---------------------/         |
                                       compileProject
                                              |
                                              v
-  private compiler stages
+  program-composer (recursive traversal, parsing, symbol isolation, child-first module order)
+                                             |
+                                             v
+  private global compiler stages
   -> WebAssembly emission
   -> CompileResult
 ```
@@ -26,11 +29,16 @@ the text representation without invoking a second block-classification or whole-
 filtering `modules` by `entry` preserves the execution order for that entry. Hoisted declarations do not share a global
 order with modules or with each other.
 
+Nested `groups` are composed before semantic allocation and code generation. The composer qualifies nested module,
+function, constant-namespace, and prototype names so sibling groups may reuse source-level names safely. It then hands
+one flattened validated-AST program to the compiler, allowing memory addresses, function indexes, type indexes, and
+entries to be planned once. Child modules execute before parent modules for the same entry.
+
 ## Compiler Passes
 
 ```text
-                       8f4e Sub-program Pipeline
-                       =========================
+                       8f4e Composed Program Pipeline
+                       ==============================
 
   source modules       source functions       constants/prototypes
        |                     |                       |
@@ -54,7 +62,7 @@ order with modules or with each other.
                                 v
                   +-----------------------------+
                   |  3. Input-order contract    |
-                  |  caller-provided order      |
+                  |  composer-provided order    |
                   |                             |
                   |  module execution and       |
                   |  memory layout preserve     |
@@ -90,7 +98,7 @@ order with modules or with each other.
                   |  resolveSemanticReferences()|
                   |                             |
                   |  resolve value refs once    |
-                  |  for the whole sub-program  |
+                  |  for the composed program   |
                   +-----------------------------+
                                 |
                                 v

--- a/packages/compiler/packages/include-resolver/tests/__snapshots__/resolveIncludeSourceTree.integration.test.ts.snap
+++ b/packages/compiler/packages/include-resolver/tests/__snapshots__/resolveIncludeSourceTree.integration.test.ts.snap
@@ -35,7 +35,7 @@ include std/events/risingEdge
 includesEnd
 
 constants shared
-const int tableSize 16
+const TABLE_SIZE 16
 constantsEnd
 
 entry main

--- a/packages/compiler/packages/include-resolver/tests/resolveIncludeSourceTree.integration.test.ts
+++ b/packages/compiler/packages/include-resolver/tests/resolveIncludeSourceTree.integration.test.ts
@@ -14,7 +14,7 @@ describe('resolveIncludeSourceTree integration', () => {
 			'includesEnd',
 			'',
 			'constants shared',
-			'const int tableSize 16',
+			'const TABLE_SIZE 16',
 			'constantsEnd',
 			'',
 			'entry main',

--- a/packages/compiler/packages/program-composer/AGENTS.md
+++ b/packages/compiler/packages/program-composer/AGENTS.md
@@ -1,0 +1,23 @@
+# Program Composer Package Guidelines
+
+This file extends the root and `packages/compiler/AGENTS.md` guidance for
+`packages/compiler/packages/program-composer`.
+
+## Package Scope
+
+- Package name: `@8f4e/program-composer`.
+- Own recursive `ProjectObjectModel` traversal, per-project cache namespaces, internal symbol qualification, and
+  deterministic module execution order.
+- Produce one composed validated-AST program for the compiler's global semantic, allocation, and code-generation pass.
+- Keep the canonical source object model in `@8f4e/language-spec`; do not introduce another source representation.
+- Keep memory planning, function/type indexing, semantic resolution, and WebAssembly emission outside this package.
+- Nested projects are isolated namespaces. Their modules run before their parent project's modules for the same entry.
+- Keep source-shaped integration fixtures and their file snapshots under `tests/`; keep `src/` limited to package code.
+
+## Commands
+
+- From the repository root, prefer Nx:
+  - `npx nx run @8f4e/program-composer:build`
+  - `npx nx run @8f4e/program-composer:typecheck`
+  - `npx nx run @8f4e/program-composer:test`
+  - `npx nx run @8f4e/program-composer:lint`

--- a/packages/compiler/packages/program-composer/README.md
+++ b/packages/compiler/packages/program-composer/README.md
@@ -1,0 +1,6 @@
+# @8f4e/program-composer
+
+Private compiler stage that parses recursive `ProjectObjectModel` trees, isolates group symbols, and produces one
+ordered AST program for global allocation and code generation.
+
+This package is internal to `@8f4e/compiler` and is not a second project object model or a public compilation API.

--- a/packages/compiler/packages/program-composer/package.json
+++ b/packages/compiler/packages/program-composer/package.json
@@ -1,13 +1,11 @@
 {
-  "name": "@8f4e/compiler",
-  "version": "5.0.0",
+  "name": "@8f4e/program-composer",
+  "version": "0.1.0",
   "private": true,
-  "description": "8f4e compiler package",
+  "description": "Recursive project composition for the 8f4e compiler",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
   "exports": {
-    ".": {
+    "./internal": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }
@@ -25,13 +23,10 @@
   "homepage": "https://github.com/andorthehood/8f4e#readme",
   "dependencies": {
     "@8f4e/language-spec": "*",
-    "@8f4e/program-composer": "*",
-    "@8f4e/project-preparser": "*",
-    "@8f4e/sub-program": "*",
-    "@8f4e/wasm-codegen": "*"
+    "@8f4e/tokenizer": "*"
   },
   "devDependencies": {
-    "@8f4e/stdlib": "*",
+    "@8f4e/project-preparser": "*",
     "@types/node": "24.13.2"
   }
 }

--- a/packages/compiler/packages/program-composer/project.json
+++ b/packages/compiler/packages/program-composer/project.json
@@ -1,0 +1,47 @@
+{
+  "name": "@8f4e/program-composer",
+  "sourceRoot": "packages/compiler/packages/program-composer/src",
+  "projectType": "library",
+  "targets": {
+    "build": {
+      "executor": "nx:run-commands",
+      "outputs": ["{projectRoot}/dist"],
+      "dependsOn": ["^build"],
+      "options": {
+        "command": "rm -rf dist && tsc --emitDeclarationOnly && vite build",
+        "cwd": "{projectRoot}"
+      }
+    },
+    "lint": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "biome check --write packages/compiler/packages/program-composer/src",
+        "cwd": "{workspaceRoot}"
+      }
+    },
+    "dev": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "rm -rf dist && concurrently -k -n types,bundle \"tsc --emitDeclarationOnly --watch\" \"vite build --watch\"",
+        "cwd": "{projectRoot}"
+      }
+    },
+    "test": {
+      "executor": "@nx/vitest:test",
+      "outputs": ["{workspaceRoot}/coverage/@8f4e/program-composer"],
+      "dependsOn": ["^build"],
+      "options": {
+        "config": "{projectRoot}/vitest.config.ts",
+        "reportsDirectory": "{workspaceRoot}/coverage/@8f4e/program-composer"
+      }
+    },
+    "typecheck": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "tsc --noEmit",
+        "cwd": "{projectRoot}"
+      }
+    }
+  },
+  "tags": ["type:library", "scope:core"]
+}

--- a/packages/compiler/packages/program-composer/src/compilerSource.ts
+++ b/packages/compiler/packages/program-composer/src/compilerSource.ts
@@ -1,0 +1,59 @@
+import type { CompilerCache, ProjectBlock, SourceMetadata, ValidatedAST } from '@8f4e/language-spec';
+import { compileToAST, SyntaxRulesError } from '@8f4e/tokenizer';
+import type { CompilerDerivedSource, ProjectUnitKey } from './types';
+
+type CompilerSource = {
+	code: string[];
+	cacheKey: string;
+	projectBlockId?: number;
+	source?: SourceMetadata;
+};
+
+function attachSourceMetadataToSyntaxError(source: CompilerSource, error: unknown): unknown {
+	if (!(error instanceof SyntaxRulesError) || (source.projectBlockId === undefined && source.source === undefined)) {
+		return error;
+	}
+
+	error.context = {
+		...error.context,
+		...(source.projectBlockId !== undefined ? { projectBlockId: source.projectBlockId } : {}),
+		...(source.source !== undefined ? { source: source.source } : {}),
+	};
+	return error;
+}
+
+function attachSourceMetadataToAst<TAst extends ValidatedAST>(ast: TAst, source: CompilerSource): TAst {
+	if (source.projectBlockId === undefined && source.source === undefined) {
+		return ast;
+	}
+
+	return {
+		...ast,
+		...(source.projectBlockId !== undefined ? { projectBlockId: source.projectBlockId } : {}),
+		...(source.source !== undefined ? { source: source.source } : {}),
+	} as TAst;
+}
+
+/** Parses one compiler source block and attaches its project diagnostic metadata. */
+export function compileSourceToAST<TAst extends ValidatedAST>(source: CompilerSource, cache: CompilerCache): TAst {
+	try {
+		const ast = compileToAST(source.code, cache.ast, source.cacheKey) as TAst;
+		return attachSourceMetadataToAst(ast, source);
+	} catch (error) {
+		throw attachSourceMetadataToSyntaxError(source, error);
+	}
+}
+
+/** Creates a source block with a cache key scoped to its owning recursive project unit. */
+export function createCompilerSource(
+	source: CompilerDerivedSource | ProjectBlock,
+	unitKey: ProjectUnitKey,
+	blockKey: string
+): CompilerSource {
+	return {
+		code: source.code,
+		cacheKey: `${unitKey}:${blockKey}`,
+		...('id' in source ? { projectBlockId: source.id } : { projectBlockId: source.projectBlockId }),
+		...('source' in source ? { source: source.source } : {}),
+	};
+}

--- a/packages/compiler/packages/program-composer/src/composeProgram.ts
+++ b/packages/compiler/packages/program-composer/src/composeProgram.ts
@@ -1,0 +1,115 @@
+import type {
+	CompilerCache,
+	ProjectObjectModel,
+	ValidatedAST,
+	ValidatedConstantsAST,
+	ValidatedFunctionAST,
+	ValidatedModuleAST,
+	ValidatedPrototypeAST,
+} from '@8f4e/language-spec';
+import { compileSourceToAST, createCompilerSource } from './compilerSource';
+import { createCompilerCache } from './createCompilerCache';
+import { createUnitSymbolPrefix, getChildProjectUnitKey, ROOT_PROJECT_UNIT_KEY } from './projectUnitKey';
+import { qualifyAst } from './qualifyAst';
+import type { ComposedProgram, IncludedFunctionsByProjectUnit, ProjectUnitKey } from './types';
+
+function appendUnit(
+	project: ProjectObjectModel,
+	unitKey: ProjectUnitKey,
+	program: ComposedProgram,
+	includedFunctionsByUnit: IncludedFunctionsByProjectUnit
+): void {
+	project.groups.forEach((group, index) => {
+		appendUnit(group, getChildProjectUnitKey(unitKey, group, index), program, includedFunctionsByUnit);
+	});
+
+	const prefix = unitKey === ROOT_PROJECT_UNIT_KEY ? undefined : createUnitSymbolPrefix(unitKey);
+	const qualify = <TAst extends ValidatedAST>(ast: TAst): TAst => (prefix ? qualifyAst(ast, prefix) : ast);
+	const prototypes = project.prototypes.filter(block => !block.disabled);
+	const modules = project.modules.filter(block => !block.disabled);
+	const constants = project.constants.filter(block => !block.disabled);
+	const functions = project.functions.filter(block => !block.disabled);
+	const includedFunctions = includedFunctionsByUnit.get(unitKey) ?? [];
+
+	program.ast.prototypes.push(
+		...prototypes.map((prototype, index) =>
+			qualify(
+				compileSourceToAST<ValidatedPrototypeAST>(
+					createCompilerSource(prototype, unitKey, `prototype:${index}`),
+					program.cache
+				)
+			)
+		)
+	);
+	program.ast.constants.push(
+		...constants.map((constantsBlock, index) =>
+			qualify(
+				compileSourceToAST<ValidatedConstantsAST>(
+					createCompilerSource(constantsBlock, unitKey, `constants:${index}`),
+					program.cache
+				)
+			)
+		)
+	);
+	program.ast.functions.push(
+		...functions.map((func, index) =>
+			qualify(
+				compileSourceToAST<ValidatedFunctionAST>(
+					createCompilerSource(func, unitKey, `function:${index}`),
+					program.cache
+				)
+			)
+		),
+		...includedFunctions.map((func, index) =>
+			qualify(
+				compileSourceToAST<ValidatedFunctionAST>(
+					createCompilerSource(func, unitKey, `include:function:${index}`),
+					program.cache
+				)
+			)
+		)
+	);
+
+	const moduleIndexByEntry = new Map<string, number>();
+	for (const module of modules) {
+		const index = moduleIndexByEntry.get(module.entry) ?? 0;
+		moduleIndexByEntry.set(module.entry, index + 1);
+		program.ast.modules.push(
+			qualify(
+				compileSourceToAST<ValidatedModuleAST>(
+					createCompilerSource(module, unitKey, `entry:${module.entry}:module:${index}`),
+					program.cache
+				)
+			)
+		);
+		program.moduleEntryNames.push(module.entry);
+		if (!program.entryNames.includes(module.entry)) {
+			program.entryNames.push(module.entry);
+		}
+	}
+}
+
+/**
+ * Parses and composes a recursive project tree into one globally planned compiler program.
+ * Child modules are appended before parent modules, while functions, constants, and prototypes remain hoisted.
+ */
+export function composeProgram(
+	project: ProjectObjectModel,
+	cache: CompilerCache = createCompilerCache(),
+	includedFunctionsByUnit: IncludedFunctionsByProjectUnit = new Map()
+): ComposedProgram {
+	const program: ComposedProgram = {
+		entryNames: ['main'],
+		moduleEntryNames: [],
+		ast: {
+			prototypes: [],
+			modules: [],
+			constants: [],
+			functions: [],
+		},
+		cache,
+	};
+
+	appendUnit(project, ROOT_PROJECT_UNIT_KEY, program, includedFunctionsByUnit);
+	return program;
+}

--- a/packages/compiler/packages/program-composer/src/createCompilerCache.ts
+++ b/packages/compiler/packages/program-composer/src/createCompilerCache.ts
@@ -1,0 +1,9 @@
+import type { CompilerCache, ValidatedAST } from '@8f4e/language-spec';
+import { createASTCache } from '@8f4e/tokenizer';
+
+/** Creates the compiler cache shared by parsing and later compilation stages. */
+export function createCompilerCache(): CompilerCache {
+	return {
+		ast: createASTCache<ValidatedAST>(),
+	};
+}

--- a/packages/compiler/packages/program-composer/src/index.ts
+++ b/packages/compiler/packages/program-composer/src/index.ts
@@ -1,0 +1,9 @@
+export { composeProgram } from './composeProgram';
+export { createCompilerCache } from './createCompilerCache';
+export { getChildProjectUnitKey, ROOT_PROJECT_UNIT_KEY } from './projectUnitKey';
+export type {
+	CompilerDerivedSource,
+	ComposedProgram,
+	IncludedFunctionsByProjectUnit,
+	ProjectUnitKey,
+} from './types';

--- a/packages/compiler/packages/program-composer/src/projectUnitKey.ts
+++ b/packages/compiler/packages/program-composer/src/projectUnitKey.ts
@@ -1,0 +1,23 @@
+import type { ProjectObjectModel } from '@8f4e/language-spec';
+import type { ProjectUnitKey } from './types';
+
+export const ROOT_PROJECT_UNIT_KEY: ProjectUnitKey = 'root';
+
+/** Returns the deterministic traversal key for a nested project. */
+export function getChildProjectUnitKey(
+	parentKey: ProjectUnitKey,
+	group: ProjectObjectModel,
+	groupIndex: number
+): ProjectUnitKey {
+	const identity = group.id === undefined ? String(groupIndex) : `id:${encodeURIComponent(group.id)}`;
+	return `${parentKey}/groups/${identity}`;
+}
+
+/** Creates the compiler-owned symbol prefix for a nested project unit. */
+export function createUnitSymbolPrefix(unitKey: ProjectUnitKey): string {
+	const path = unitKey
+		.slice(ROOT_PROJECT_UNIT_KEY.length)
+		.replaceAll('/groups/', '$')
+		.replace(/[^a-zA-Z0-9_$]+/g, '$');
+	return `__8f4e$group$${path}__`;
+}

--- a/packages/compiler/packages/program-composer/src/qualifyAst.ts
+++ b/packages/compiler/packages/program-composer/src/qualifyAst.ts
@@ -1,0 +1,147 @@
+import type { Argument, ArgumentIdentifier, CompilerASTLine, ValidatedAST } from '@8f4e/language-spec';
+import { ArgumentType } from '@8f4e/language-spec';
+
+function qualifySymbol(prefix: string, symbol: string): string {
+	return `${prefix}${symbol}`;
+}
+
+function qualifyIntermoduleIdentifier(argument: ArgumentIdentifier, prefix: string): ArgumentIdentifier {
+	if (argument.scope !== 'intermodule' || argument.targetModuleId === 'this') {
+		return argument;
+	}
+
+	const targetModuleId = qualifySymbol(prefix, argument.targetModuleId);
+	return {
+		...argument,
+		value: argument.value.replace(argument.targetModuleId, targetModuleId),
+		targetModuleId,
+	};
+}
+
+function qualifyArgument(argument: Argument, prefix: string): Argument {
+	if (argument.type === ArgumentType.IDENTIFIER) {
+		return qualifyIntermoduleIdentifier(argument, prefix);
+	}
+	if (argument.type === ArgumentType.COMPILE_TIME_EXPRESSION) {
+		return {
+			...argument,
+			left:
+				argument.left.type === ArgumentType.IDENTIFIER
+					? qualifyIntermoduleIdentifier(argument.left, prefix)
+					: argument.left,
+			right:
+				argument.right.type === ArgumentType.IDENTIFIER
+					? qualifyIntermoduleIdentifier(argument.right, prefix)
+					: argument.right,
+		};
+	}
+	return argument;
+}
+
+const FIRST_ARGUMENT_SYMBOL_INSTRUCTIONS = new Set([
+	'module',
+	'function',
+	'constants',
+	'prototype',
+	'call',
+	'use',
+	'shape',
+	'paramShape',
+	'pushShape',
+]);
+
+function qualifyLine(line: CompilerASTLine, prefix: string): CompilerASTLine {
+	const argumentsWithQualifiedModules = line.arguments.map(argument => qualifyArgument(argument, prefix));
+	if (FIRST_ARGUMENT_SYMBOL_INSTRUCTIONS.has(line.instruction)) {
+		const firstArgument = argumentsWithQualifiedModules[0] as ArgumentIdentifier;
+		argumentsWithQualifiedModules[0] = {
+			...firstArgument,
+			value: qualifySymbol(prefix, firstArgument.value),
+		};
+	}
+
+	return {
+		...line,
+		arguments: argumentsWithQualifiedModules,
+	} as CompilerASTLine;
+}
+
+function rebasePairedBlockIndexes(line: CompilerASTLine, removedLineIndex: number | undefined): CompilerASTLine {
+	if (removedLineIndex === undefined) {
+		return line;
+	}
+	const rebase = (index: number) => (index > removedLineIndex ? index - 1 : index);
+	if (line.instruction === 'if') {
+		const ifBlock = line.ifBlock!;
+		return { ...line, ifBlock: { ...ifBlock, matchingIfEndIndex: rebase(ifBlock.matchingIfEndIndex) } };
+	}
+	if (line.instruction === 'ifEnd') {
+		const ifEndBlock = line.ifEndBlock!;
+		return { ...line, ifEndBlock: { ...ifEndBlock, matchingIfIndex: rebase(ifEndBlock.matchingIfIndex) } };
+	}
+	if (line.instruction === 'block') {
+		const blockBlock = line.blockBlock!;
+		return {
+			...line,
+			blockBlock: { ...blockBlock, matchingBlockEndIndex: rebase(blockBlock.matchingBlockEndIndex) },
+		};
+	}
+	if (line.instruction === 'blockEnd') {
+		const blockEndBlock = line.blockEndBlock!;
+		return {
+			...line,
+			blockEndBlock: { ...blockEndBlock, matchingBlockIndex: rebase(blockEndBlock.matchingBlockIndex) },
+		};
+	}
+	return line;
+}
+
+/** Qualifies all project-unit-owned symbols and removes nested host exports from one validated AST. */
+export function qualifyAst<TAst extends ValidatedAST>(ast: TAst, prefix: string): TAst {
+	const removedLineIndex = ast.type === 'function' && ast.exportLine ? ast.lines.indexOf(ast.exportLine) : undefined;
+	const qualifiedLineByOriginal = new Map<CompilerASTLine, CompilerASTLine>();
+	const lines = ast.lines.flatMap((line, index) => {
+		if (index === removedLineIndex) {
+			return [];
+		}
+		const qualifiedLine = rebasePairedBlockIndexes(qualifyLine(line, prefix), removedLineIndex);
+		qualifiedLineByOriginal.set(line, qualifiedLine);
+		return [qualifiedLine];
+	});
+	const getQualifiedLine = <TLine extends CompilerASTLine>(line: TLine): TLine =>
+		qualifiedLineByOriginal.get(line) as TLine;
+
+	switch (ast.type) {
+		case 'module':
+			return {
+				...ast,
+				id: qualifySymbol(prefix, ast.id),
+				lines,
+				moduleLine: getQualifiedLine(ast.moduleLine),
+			} as TAst;
+		case 'constants':
+			return {
+				...ast,
+				id: qualifySymbol(prefix, ast.id),
+				lines,
+				constantsLine: getQualifiedLine(ast.constantsLine),
+			} as TAst;
+		case 'prototype':
+			return {
+				...ast,
+				id: qualifySymbol(prefix, ast.id),
+				lines,
+				prototypeLine: getQualifiedLine(ast.prototypeLine),
+			} as TAst;
+		case 'function':
+			return {
+				...ast,
+				name: qualifySymbol(prefix, ast.name),
+				lines,
+				functionLine: getQualifiedLine(ast.functionLine),
+				functionEndLine: getQualifiedLine(ast.functionEndLine),
+				exportLine: undefined,
+				...(ast.importLine ? { importLine: getQualifiedLine(ast.importLine) } : {}),
+			} as TAst;
+	}
+}

--- a/packages/compiler/packages/program-composer/src/types.ts
+++ b/packages/compiler/packages/program-composer/src/types.ts
@@ -1,0 +1,34 @@
+import type {
+	CompilerCache,
+	SourceMetadata,
+	ValidatedConstantsAST,
+	ValidatedFunctionAST,
+	ValidatedModuleAST,
+	ValidatedPrototypeAST,
+} from '@8f4e/language-spec';
+
+/** Stable traversal key for one project in a recursive object-model tree. */
+export type ProjectUnitKey = string;
+
+/** Function source produced by resolving a project's include blocks. */
+export type CompilerDerivedSource = {
+	code: string[];
+	projectBlockId?: number;
+	source?: SourceMetadata;
+};
+
+/** Include expansions keyed by the recursive project unit that owns them. */
+export type IncludedFunctionsByProjectUnit = ReadonlyMap<ProjectUnitKey, readonly CompilerDerivedSource[]>;
+
+/** One globally planned AST assembled from a recursive project tree. */
+export interface ComposedProgram {
+	entryNames: string[];
+	moduleEntryNames: string[];
+	ast: {
+		prototypes: ValidatedPrototypeAST[];
+		modules: ValidatedModuleAST[];
+		constants: ValidatedConstantsAST[];
+		functions: ValidatedFunctionAST[];
+	};
+	cache: CompilerCache;
+}

--- a/packages/compiler/packages/program-composer/tests/__snapshots__/cache-namespaces.8f4e.program.snap
+++ b/packages/compiler/packages/program-composer/tests/__snapshots__/cache-namespaces.8f4e.program.snap
@@ -1,0 +1,98 @@
+{
+  "ast": {
+    "constants": [],
+    "functions": [],
+    "modules": [
+      {
+        "id": "__8f4e$group$$0__same",
+        "lines": [
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "__8f4e$group$$0__same",
+              },
+            ],
+            "instruction": "module",
+            "lineNumber": 0,
+          },
+          {
+            "arguments": [],
+            "instruction": "moduleEnd",
+            "lineNumber": 1,
+          },
+        ],
+        "moduleLine": {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e$group$$0__same",
+            },
+          ],
+          "instruction": "module",
+          "lineNumber": 0,
+        },
+        "projectBlockId": 8,
+        "type": "module",
+      },
+      {
+        "id": "same",
+        "lines": [
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "same",
+              },
+            ],
+            "instruction": "module",
+            "lineNumber": 0,
+          },
+          {
+            "arguments": [],
+            "instruction": "moduleEnd",
+            "lineNumber": 1,
+          },
+        ],
+        "moduleLine": {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "same",
+            },
+          ],
+          "instruction": "module",
+          "lineNumber": 0,
+        },
+        "projectBlockId": 4,
+        "type": "module",
+      },
+    ],
+    "prototypes": [],
+  },
+  "cache": {
+    "keys": [
+      "root/groups/0:entry:main:module:0",
+      "root:entry:main:module:0",
+    ],
+    "stats": {
+      "hits": 2,
+      "misses": 2,
+    },
+  },
+  "entryNames": [
+    "main",
+  ],
+  "moduleEntryNames": [
+    "main",
+    "main",
+  ],
+}

--- a/packages/compiler/packages/program-composer/tests/__snapshots__/intermodule-references.8f4e.program.snap
+++ b/packages/compiler/packages/program-composer/tests/__snapshots__/intermodule-references.8f4e.program.snap
@@ -1,0 +1,130 @@
+{
+  "ast": {
+    "constants": [],
+    "functions": [],
+    "modules": [
+      {
+        "id": "__8f4e$group$$0__source",
+        "lines": [
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "__8f4e$group$$0__source",
+              },
+            ],
+            "instruction": "module",
+            "lineNumber": 0,
+          },
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "value",
+              },
+            ],
+            "instruction": "int",
+            "lineNumber": 1,
+          },
+          {
+            "arguments": [],
+            "instruction": "moduleEnd",
+            "lineNumber": 2,
+          },
+        ],
+        "moduleLine": {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e$group$$0__source",
+            },
+          ],
+          "instruction": "module",
+          "lineNumber": 0,
+        },
+        "projectBlockId": 5,
+        "type": "module",
+      },
+      {
+        "id": "__8f4e$group$$0__consumer",
+        "lines": [
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "__8f4e$group$$0__consumer",
+              },
+            ],
+            "instruction": "module",
+            "lineNumber": 0,
+          },
+          {
+            "arguments": [
+              {
+                "isEndAddress": false,
+                "referenceKind": "intermodular-reference",
+                "scope": "intermodule",
+                "targetMemoryId": "value",
+                "targetModuleId": "__8f4e$group$$0__source",
+                "type": "identifier",
+                "value": "&__8f4e$group$0__source:value",
+              },
+            ],
+            "instruction": "push",
+            "lineNumber": 1,
+          },
+          {
+            "arguments": [],
+            "instruction": "drop",
+            "lineNumber": 2,
+          },
+          {
+            "arguments": [],
+            "instruction": "moduleEnd",
+            "lineNumber": 3,
+          },
+        ],
+        "moduleLine": {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e$group$$0__consumer",
+            },
+          ],
+          "instruction": "module",
+          "lineNumber": 0,
+        },
+        "projectBlockId": 9,
+        "type": "module",
+      },
+    ],
+    "prototypes": [],
+  },
+  "cache": {
+    "keys": [
+      "root/groups/0:entry:main:module:0",
+      "root/groups/0:entry:main:module:1",
+    ],
+    "stats": {
+      "hits": 2,
+      "misses": 2,
+    },
+  },
+  "entryNames": [
+    "main",
+  ],
+  "moduleEntryNames": [
+    "main",
+    "main",
+  ],
+}

--- a/packages/compiler/packages/program-composer/tests/__snapshots__/private-exports.8f4e.program.snap
+++ b/packages/compiler/packages/program-composer/tests/__snapshots__/private-exports.8f4e.program.snap
@@ -1,0 +1,105 @@
+{
+  "ast": {
+    "constants": [],
+    "functions": [
+      {
+        "exportLine": undefined,
+        "functionEndLine": {
+          "arguments": [],
+          "instruction": "functionEnd",
+          "lineNumber": 6,
+        },
+        "functionLine": {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e$group$$0__hidden",
+            },
+          ],
+          "instruction": "function",
+          "lineNumber": 0,
+        },
+        "lines": [
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "__8f4e$group$$0__hidden",
+              },
+            ],
+            "instruction": "function",
+            "lineNumber": 0,
+          },
+          {
+            "arguments": [
+              {
+                "isInteger": true,
+                "type": "literal",
+                "value": 1,
+              },
+            ],
+            "instruction": "push",
+            "lineNumber": 2,
+          },
+          {
+            "arguments": [],
+            "ifBlock": {
+              "hasElse": false,
+              "matchingIfEndIndex": 4,
+              "resultTypes": [],
+            },
+            "instruction": "if",
+            "lineNumber": 3,
+          },
+          {
+            "arguments": [
+              {
+                "isInteger": true,
+                "type": "literal",
+                "value": 2,
+              },
+            ],
+            "instruction": "push",
+            "lineNumber": 4,
+          },
+          {
+            "arguments": [],
+            "ifEndBlock": {
+              "matchingIfIndex": 2,
+              "resultTypes": [],
+            },
+            "instruction": "ifEnd",
+            "lineNumber": 5,
+          },
+          {
+            "arguments": [],
+            "instruction": "functionEnd",
+            "lineNumber": 6,
+          },
+        ],
+        "name": "__8f4e$group$$0__hidden",
+        "projectBlockId": 5,
+        "type": "function",
+      },
+    ],
+    "modules": [],
+    "prototypes": [],
+  },
+  "cache": {
+    "keys": [
+      "root/groups/0:function:0",
+    ],
+    "stats": {
+      "hits": 1,
+      "misses": 1,
+    },
+  },
+  "entryNames": [
+    "main",
+  ],
+  "moduleEntryNames": [],
+}

--- a/packages/compiler/packages/program-composer/tests/__snapshots__/recursive-ordering.8f4e.program.snap
+++ b/packages/compiler/packages/program-composer/tests/__snapshots__/recursive-ordering.8f4e.program.snap
@@ -1,0 +1,136 @@
+{
+  "ast": {
+    "constants": [],
+    "functions": [],
+    "modules": [
+      {
+        "id": "__8f4e$group$$0$0__descendant",
+        "lines": [
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "__8f4e$group$$0$0__descendant",
+              },
+            ],
+            "instruction": "module",
+            "lineNumber": 0,
+          },
+          {
+            "arguments": [],
+            "instruction": "moduleEnd",
+            "lineNumber": 1,
+          },
+        ],
+        "moduleLine": {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e$group$$0$0__descendant",
+            },
+          ],
+          "instruction": "module",
+          "lineNumber": 0,
+        },
+        "projectBlockId": 12,
+        "type": "module",
+      },
+      {
+        "id": "__8f4e$group$$0__child",
+        "lines": [
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "__8f4e$group$$0__child",
+              },
+            ],
+            "instruction": "module",
+            "lineNumber": 0,
+          },
+          {
+            "arguments": [],
+            "instruction": "moduleEnd",
+            "lineNumber": 1,
+          },
+        ],
+        "moduleLine": {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e$group$$0__child",
+            },
+          ],
+          "instruction": "module",
+          "lineNumber": 0,
+        },
+        "projectBlockId": 8,
+        "type": "module",
+      },
+      {
+        "id": "root",
+        "lines": [
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "root",
+              },
+            ],
+            "instruction": "module",
+            "lineNumber": 0,
+          },
+          {
+            "arguments": [],
+            "instruction": "moduleEnd",
+            "lineNumber": 1,
+          },
+        ],
+        "moduleLine": {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "root",
+            },
+          ],
+          "instruction": "module",
+          "lineNumber": 0,
+        },
+        "projectBlockId": 4,
+        "type": "module",
+      },
+    ],
+    "prototypes": [],
+  },
+  "cache": {
+    "keys": [
+      "root/groups/0/groups/0:entry:main:module:0",
+      "root/groups/0:entry:main:module:0",
+      "root:entry:main:module:0",
+    ],
+    "stats": {
+      "hits": 3,
+      "misses": 3,
+    },
+  },
+  "entryNames": [
+    "main",
+  ],
+  "moduleEntryNames": [
+    "main",
+    "main",
+    "main",
+  ],
+}

--- a/packages/compiler/packages/program-composer/tests/__snapshots__/sibling-symbols.8f4e.program.snap
+++ b/packages/compiler/packages/program-composer/tests/__snapshots__/sibling-symbols.8f4e.program.snap
@@ -1,0 +1,269 @@
+{
+  "ast": {
+    "constants": [],
+    "functions": [
+      {
+        "exportLine": undefined,
+        "functionEndLine": {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+          ],
+          "instruction": "functionEnd",
+          "lineNumber": 2,
+        },
+        "functionLine": {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e$group$$0__helper",
+            },
+          ],
+          "instruction": "function",
+          "lineNumber": 0,
+        },
+        "lines": [
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "__8f4e$group$$0__helper",
+              },
+            ],
+            "instruction": "function",
+            "lineNumber": 0,
+          },
+          {
+            "arguments": [
+              {
+                "isInteger": true,
+                "type": "literal",
+                "value": 1,
+              },
+            ],
+            "instruction": "push",
+            "lineNumber": 1,
+          },
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "int",
+              },
+            ],
+            "instruction": "functionEnd",
+            "lineNumber": 2,
+          },
+        ],
+        "name": "__8f4e$group$$0__helper",
+        "projectBlockId": 5,
+        "type": "function",
+      },
+      {
+        "exportLine": undefined,
+        "functionEndLine": {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "int",
+            },
+          ],
+          "instruction": "functionEnd",
+          "lineNumber": 2,
+        },
+        "functionLine": {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e$group$$1__helper",
+            },
+          ],
+          "instruction": "function",
+          "lineNumber": 0,
+        },
+        "lines": [
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "__8f4e$group$$1__helper",
+              },
+            ],
+            "instruction": "function",
+            "lineNumber": 0,
+          },
+          {
+            "arguments": [
+              {
+                "isInteger": true,
+                "type": "literal",
+                "value": 2,
+              },
+            ],
+            "instruction": "push",
+            "lineNumber": 1,
+          },
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "int",
+              },
+            ],
+            "instruction": "functionEnd",
+            "lineNumber": 2,
+          },
+        ],
+        "name": "__8f4e$group$$1__helper",
+        "projectBlockId": 16,
+        "type": "function",
+      },
+    ],
+    "modules": [
+      {
+        "id": "__8f4e$group$$0__shared",
+        "lines": [
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "__8f4e$group$$0__shared",
+              },
+            ],
+            "instruction": "module",
+            "lineNumber": 0,
+          },
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "__8f4e$group$$0__helper",
+              },
+            ],
+            "instruction": "call",
+            "lineNumber": 1,
+          },
+          {
+            "arguments": [],
+            "instruction": "drop",
+            "lineNumber": 2,
+          },
+          {
+            "arguments": [],
+            "instruction": "moduleEnd",
+            "lineNumber": 3,
+          },
+        ],
+        "moduleLine": {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e$group$$0__shared",
+            },
+          ],
+          "instruction": "module",
+          "lineNumber": 0,
+        },
+        "projectBlockId": 9,
+        "type": "module",
+      },
+      {
+        "id": "__8f4e$group$$1__shared",
+        "lines": [
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "__8f4e$group$$1__shared",
+              },
+            ],
+            "instruction": "module",
+            "lineNumber": 0,
+          },
+          {
+            "arguments": [
+              {
+                "referenceKind": "plain",
+                "scope": "local",
+                "type": "identifier",
+                "value": "__8f4e$group$$1__helper",
+              },
+            ],
+            "instruction": "call",
+            "lineNumber": 1,
+          },
+          {
+            "arguments": [],
+            "instruction": "drop",
+            "lineNumber": 2,
+          },
+          {
+            "arguments": [],
+            "instruction": "moduleEnd",
+            "lineNumber": 3,
+          },
+        ],
+        "moduleLine": {
+          "arguments": [
+            {
+              "referenceKind": "plain",
+              "scope": "local",
+              "type": "identifier",
+              "value": "__8f4e$group$$1__shared",
+            },
+          ],
+          "instruction": "module",
+          "lineNumber": 0,
+        },
+        "projectBlockId": 20,
+        "type": "module",
+      },
+    ],
+    "prototypes": [],
+  },
+  "cache": {
+    "keys": [
+      "root/groups/0:entry:main:module:0",
+      "root/groups/0:function:0",
+      "root/groups/1:entry:main:module:0",
+      "root/groups/1:function:0",
+    ],
+    "stats": {
+      "hits": 4,
+      "misses": 4,
+    },
+  },
+  "entryNames": [
+    "main",
+  ],
+  "moduleEntryNames": [
+    "main",
+    "main",
+  ],
+}

--- a/packages/compiler/packages/program-composer/tests/composeProgram.integration.test.ts
+++ b/packages/compiler/packages/program-composer/tests/composeProgram.integration.test.ts
@@ -1,0 +1,49 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseProjectSource } from '@8f4e/project-preparser';
+import { describe, expect, it } from 'vitest';
+import { composeProgram, createCompilerCache } from '../src';
+
+const currentDirectory = path.dirname(fileURLToPath(import.meta.url));
+const fixtureDirectory = path.join(currentDirectory, 'fixtures');
+const snapshotDirectory = path.join(currentDirectory, '__snapshots__');
+
+function readFixtureNames(): string[] {
+	return readdirSync(fixtureDirectory, { withFileTypes: true })
+		.filter(entry => entry.isFile() && entry.name.endsWith('.8f4e'))
+		.map(entry => entry.name)
+		.sort();
+}
+
+function createCompositionSnapshot(fixtureName: string) {
+	const source = readFileSync(path.join(fixtureDirectory, fixtureName), 'utf8');
+	const project = parseProjectSource(source);
+	const cache = createCompilerCache();
+	composeProgram(project, cache);
+	const program = composeProgram(project, cache);
+
+	return {
+		entryNames: program.entryNames,
+		moduleEntryNames: program.moduleEntryNames,
+		ast: program.ast,
+		cache: {
+			keys: [...cache.ast.entries.keys()].sort(),
+			stats: cache.ast.stats,
+		},
+	};
+}
+
+describe('composeProgram fixtures', () => {
+	const fixtureNames = readFixtureNames();
+
+	it('has project fixtures', () => {
+		expect(fixtureNames.length).toBeGreaterThan(0);
+	});
+
+	it.each(fixtureNames)('matches the composed program snapshot for %s', async fixtureName => {
+		await expect(createCompositionSnapshot(fixtureName)).toMatchFileSnapshot(
+			path.join(snapshotDirectory, `${fixtureName}.program.snap`)
+		);
+	});
+});

--- a/packages/compiler/packages/program-composer/tests/fixtures/cache-namespaces.8f4e
+++ b/packages/compiler/packages/program-composer/tests/fixtures/cache-namespaces.8f4e
@@ -1,0 +1,11 @@
+8f4e/v1
+
+entry main
+module same
+moduleEnd
+
+group child
+module same
+moduleEnd
+groupEnd
+entryEnd

--- a/packages/compiler/packages/program-composer/tests/fixtures/intermodule-references.8f4e
+++ b/packages/compiler/packages/program-composer/tests/fixtures/intermodule-references.8f4e
@@ -1,0 +1,14 @@
+8f4e/v1
+
+entry main
+group audio
+module source
+int value
+moduleEnd
+
+module consumer
+push &source:value
+drop
+moduleEnd
+groupEnd
+entryEnd

--- a/packages/compiler/packages/program-composer/tests/fixtures/private-exports.8f4e
+++ b/packages/compiler/packages/program-composer/tests/fixtures/private-exports.8f4e
@@ -1,0 +1,13 @@
+8f4e/v1
+
+entry main
+group helpers
+function hidden
+#export publicName
+push 1
+if
+push 2
+ifEnd
+functionEnd
+groupEnd
+entryEnd

--- a/packages/compiler/packages/program-composer/tests/fixtures/recursive-ordering.8f4e
+++ b/packages/compiler/packages/program-composer/tests/fixtures/recursive-ordering.8f4e
@@ -1,0 +1,16 @@
+8f4e/v1
+
+entry main
+module root
+moduleEnd
+
+group child
+module child
+moduleEnd
+
+group descendant
+module descendant
+moduleEnd
+groupEnd
+groupEnd
+entryEnd

--- a/packages/compiler/packages/program-composer/tests/fixtures/sibling-symbols.8f4e
+++ b/packages/compiler/packages/program-composer/tests/fixtures/sibling-symbols.8f4e
@@ -1,0 +1,25 @@
+8f4e/v1
+
+entry main
+group left
+function helper
+push 1
+functionEnd int
+
+module shared
+call helper
+drop
+moduleEnd
+groupEnd
+
+group right
+function helper
+push 2
+functionEnd int
+
+module shared
+call helper
+drop
+moduleEnd
+groupEnd
+entryEnd

--- a/packages/compiler/packages/program-composer/tsconfig.json
+++ b/packages/compiler/packages/program-composer/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"extends": "@8f4e/config/tsconfig.node.json",
+	"compilerOptions": {
+		"outDir": "dist",
+		"rootDir": "src"
+	},
+	"include": ["src/**/*.ts"],
+	"exclude": ["node_modules", "src/**/*.test.ts"]
+}

--- a/packages/compiler/packages/program-composer/vite.config.ts
+++ b/packages/compiler/packages/program-composer/vite.config.ts
@@ -1,0 +1,18 @@
+import { createLibConfig } from '@8f4e/config/vite';
+import { defineConfig } from 'vite';
+
+const baseConfig = createLibConfig({
+	entry: './src/index.ts',
+	outDir: 'dist',
+	formats: ['es'],
+	fileName: () => 'index.js',
+	external: ['@8f4e/language-spec', '@8f4e/tokenizer'],
+});
+
+export default defineConfig({
+	...baseConfig,
+	build: {
+		...baseConfig.build,
+		emptyOutDir: false,
+	},
+});

--- a/packages/compiler/packages/program-composer/vitest.config.ts
+++ b/packages/compiler/packages/program-composer/vitest.config.ts
@@ -1,0 +1,8 @@
+import { createNodePreset } from '@8f4e/config/vitest';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig(
+	createNodePreset({
+		typecheckEnabled: true,
+	})
+);

--- a/packages/compiler/packages/project-preparser/src/__snapshots__/flat-project.8f4e.project.snap
+++ b/packages/compiler/packages/project-preparser/src/__snapshots__/flat-project.8f4e.project.snap
@@ -3,7 +3,7 @@
     {
       "code": [
         "constants env",
-        "const int tableSize 16",
+        "const TABLE_SIZE 16",
         "constantsEnd",
       ],
       "id": 9,

--- a/packages/compiler/packages/project-preparser/src/__snapshots__/nested-groups.8f4e.project.snap
+++ b/packages/compiler/packages/project-preparser/src/__snapshots__/nested-groups.8f4e.project.snap
@@ -7,7 +7,7 @@
         {
           "code": [
             "constants audioConstants",
-            "const int sampleRate 48000",
+            "const SAMPLE_RATE 48000",
             "constantsEnd",
           ],
           "id": 18,

--- a/packages/compiler/packages/project-preparser/src/fixtures/flat-project.8f4e
+++ b/packages/compiler/packages/project-preparser/src/fixtures/flat-project.8f4e
@@ -7,7 +7,7 @@ moduleEnd
 entryEnd
 
 constants env
-const int tableSize 16
+const TABLE_SIZE 16
 constantsEnd
 
 function increment

--- a/packages/compiler/packages/project-preparser/src/fixtures/nested-groups.8f4e
+++ b/packages/compiler/packages/project-preparser/src/fixtures/nested-groups.8f4e
@@ -16,7 +16,7 @@ push x
 functionEnd float
 
 constants audioConstants
-const int sampleRate 48000
+const SAMPLE_RATE 48000
 constantsEnd
 
 group oscillator

--- a/packages/compiler/packages/project-preparser/tests/__snapshots__/projectPreparser.integration.test.ts.snap
+++ b/packages/compiler/packages/project-preparser/tests/__snapshots__/projectPreparser.integration.test.ts.snap
@@ -45,7 +45,7 @@ exports[`project-preparser integration > parses project source into typed collec
       {
         "code": [
           "constants shared",
-          "const int tableSize 16",
+          "const TABLE_SIZE 16",
           "constantsEnd",
         ],
         "id": 8,

--- a/packages/compiler/packages/project-preparser/tests/projectPreparser.integration.test.ts
+++ b/packages/compiler/packages/project-preparser/tests/projectPreparser.integration.test.ts
@@ -13,7 +13,7 @@ describe('project-preparser integration', () => {
 			'includesEnd',
 			'',
 			'constants shared',
-			'const int tableSize 16',
+			'const TABLE_SIZE 16',
 			'constantsEnd',
 			'',
 			'function helper',

--- a/packages/compiler/packages/sub-program/AGENTS.md
+++ b/packages/compiler/packages/sub-program/AGENTS.md
@@ -6,11 +6,13 @@ This file extends the root and `packages/compiler/AGENTS.md` guidance for
 ## Package Scope
 
 - Package name: `@8f4e/sub-program`.
-- Owns private orchestration of all passes that compile one closed `ProjectObjectModel` into `CompiledSubProgram`.
+- Owns private orchestration of the global semantic, allocation, analysis, and code-generation passes that compile one
+  composed validated-AST program into `CompiledSubProgram`.
 - This package is an internal compiler stage. Consumers use `parseProjectSource` and `compileProject` from
   `@8f4e/compiler`; do not expose a parallel source input contract from this package.
-- A sub-program owns one namespace and memory layout and resolves all internal references within that boundary.
-- Keep whole-program composition, cross-sub-program linking, relocation, and final WebAssembly assembly outside this package.
+- The input already contains all recursively composed source units. This package plans them together as one namespace and
+  memory layout.
+- Keep recursive traversal, source parsing, and symbol qualification in `@8f4e/program-composer`.
 - Pass packages used exclusively by this pipeline live under `packages/`.
 
 ## Commands

--- a/packages/compiler/packages/sub-program/README.md
+++ b/packages/compiler/packages/sub-program/README.md
@@ -3,10 +3,10 @@
 Internal compiler orchestration package. It is available only through the `@8f4e/sub-program/internal` subpath used by
 `@8f4e/compiler`; project-facing consumers use `parseProjectSource` and `compileProject` from the compiler facade.
 
-The package consumes the canonical `ProjectObjectModel` after include resolution and runs the private compilation passes
-that produce emission-ready module, function, and memory artifacts. No separate source-level sub-program contract is
-exposed.
+The package consumes the validated-AST program produced by `@8f4e/program-composer` and runs the global compilation
+passes that produce emission-ready module, function, and memory artifacts. No separate source-level project contract is
+exposed; `ProjectObjectModel` remains owned by `@8f4e/language-spec`.
 
-Its private emission handoff contains indexes and memory addresses assigned within one unit. Composing multiple compiled
-units into one WebAssembly module will require relocation metadata; until that exists, composition should happen before
-final binary emission.
+All recursively owned projects have already been flattened with isolated internal symbols at this boundary. Memory
+addresses and function/type indexes are therefore assigned once for the complete program, avoiding a linker or
+relocation layer before final WebAssembly emission.

--- a/packages/compiler/packages/sub-program/package.json
+++ b/packages/compiler/packages/sub-program/package.json
@@ -27,9 +27,9 @@
     "@8f4e/memory-default-resolver": "*",
     "@8f4e/memory-planner": "*",
     "@8f4e/memory-reference-resolver": "*",
+    "@8f4e/program-composer": "*",
     "@8f4e/semantic-reference-resolver": "*",
     "@8f4e/stack-analyzer": "*",
-    "@8f4e/tokenizer": "*",
     "@8f4e/wasm-codegen": "*"
   },
   "devDependencies": {

--- a/packages/compiler/packages/sub-program/src/compileSubProgram.ts
+++ b/packages/compiler/packages/sub-program/src/compileSubProgram.ts
@@ -11,13 +11,7 @@ import type {
 	MemoryDefaults,
 	MemoryLayoutPlan,
 	MemoryPointerMetadataMap,
-	ProjectBlock,
-	ProjectObjectModel,
-	SourceMetadata,
 	ValidatedAST,
-	ValidatedConstantsAST,
-	ValidatedFunctionAST,
-	ValidatedModuleAST,
 	ValidatedPrototypeAST,
 } from '@8f4e/language-spec';
 import {
@@ -30,21 +24,15 @@ import {
 import { MemoryDefaultResolverError, resolveMemoryDefaults } from '@8f4e/memory-default-resolver';
 import { MemoryPlannerError, planSubProgramMemoryLayout } from '@8f4e/memory-planner';
 import { resolveMemoryReferences } from '@8f4e/memory-reference-resolver';
+import type { ComposedProgram } from '@8f4e/program-composer/internal';
 import { resolveSemanticReferences } from '@8f4e/semantic-reference-resolver';
 import { analyzeStack } from '@8f4e/stack-analyzer';
-import { compileToAST, createASTCache, SyntaxRulesError } from '@8f4e/tokenizer';
 import { compileFunction, compileModules } from '@8f4e/wasm-codegen';
 import {
 	assertUniqueModuleIds,
 	collectFunctionMetadataFromAsts,
 	collectNamespacesFromASTs,
 } from './semantic/buildNamespace';
-
-type CompilerDerivedSource = {
-	code: string[];
-	projectBlockId?: number;
-	source?: SourceMetadata;
-};
 
 interface CompiledSubProgram {
 	entryNames: string[];
@@ -63,39 +51,7 @@ export interface CompileSubProgramOptions extends CompileOptions {
 	startingFunctionIndex?: number;
 }
 
-/** Module source paired with cache and execution-entry metadata. */
-type ModuleCompilerSource = {
-	/** Source lines to parse. */
-	code: string[];
-	/** Stable cache namespace for the source lines. */
-	cacheKey: string;
-	/** Public entry that should dispatch to the compiled module. */
-	entryName: string;
-	/** Project code block creation index that produced this source, when compiling a project. */
-	projectBlockId?: number;
-	/** Source origin metadata for blocks expanded before compilation. */
-	source?: SourceMetadata;
-};
-
-type CompilerSource = {
-	code: string[];
-	cacheKey: string;
-	projectBlockId?: number;
-	source?: SourceMetadata;
-};
-
 const DEFAULT_STARTING_MEMORY_WORD_ADDRESS = 1;
-
-/**
- * Creates the default compiler cache used for validated AST reuse.
- *
- * @returns A compiler cache ready to store validated ASTs.
- */
-export function createCompilerCache(): CompilerCache {
-	return {
-		ast: createASTCache<ValidatedAST>(),
-	};
-}
 
 /** Built-in WebAssembly export names that user functions are not allowed to reuse. */
 const RESERVED_EXPORT_NAMES = ['initDefaults'];
@@ -203,142 +159,16 @@ function wrapMemoryPlannerError(error: unknown, subProgramAst: ResolveConstantsS
 	return getError(error.compilerErrorCode, error.line, ast ? getAstDiagnosticContext(ast) : undefined, error.details);
 }
 
-function attachSourceMetadataToSyntaxError(source: CompilerSource, error: unknown): unknown {
-	if (!(error instanceof SyntaxRulesError) || (source.projectBlockId === undefined && source.source === undefined)) {
-		return error;
-	}
-
-	error.context = {
-		...error.context,
-		...(source.projectBlockId !== undefined ? { projectBlockId: source.projectBlockId } : {}),
-		...(source.source !== undefined ? { source: source.source } : {}),
-	};
-	return error;
-}
-
-function attachSourceMetadataToAst<TAst extends ValidatedAST>(ast: TAst, source: CompilerSource): TAst {
-	if (source.projectBlockId === undefined && source.source === undefined) {
-		return ast;
-	}
-
-	return {
-		...ast,
-		...(source.projectBlockId !== undefined ? { projectBlockId: source.projectBlockId } : {}),
-		...(source.source !== undefined ? { source: source.source } : {}),
-	} as TAst;
-}
-
-function compileSourceToAST<TAst extends ValidatedAST>(source: CompilerSource, cache: CompilerCache): TAst {
-	try {
-		const ast = compileToAST(source.code, cache.ast, source.cacheKey) as TAst;
-		return attachSourceMetadataToAst(ast, source);
-	} catch (error) {
-		throw attachSourceMetadataToSyntaxError(source, error);
-	}
-}
-
-function createCompilerSource(module: CompilerDerivedSource | ProjectBlock, cacheKey: string): CompilerSource {
-	return {
-		code: module.code,
-		cacheKey,
-		...('id' in module ? { projectBlockId: module.id } : { projectBlockId: module.projectBlockId }),
-		...('source' in module ? { source: module.source } : {}),
-	};
-}
-
-function getAllProjectBlocks(project: ProjectObjectModel): ProjectBlock[] {
-	return [
-		...project.modules,
-		...project.functions,
-		...project.constants,
-		...project.prototypes,
-		...project.includes,
-		...project.notes,
-		...project.unknown,
-	];
-}
-
-function assertUniqueProjectBlockIds(project: ProjectObjectModel): void {
-	const ids = new Set<number>();
-	for (const block of getAllProjectBlocks(project)) {
-		if (!Number.isInteger(block.id)) throw new Error('Project block is missing numeric id');
-		if (ids.has(block.id)) throw new Error(`Project contains duplicate block id ${block.id}`);
-		ids.add(block.id);
-	}
-}
-
 /**
- * Compiles one source sub-program into emission-ready module, function, memory, and data-segment artifacts.
+ * Compiles one composed program into emission-ready module, function, memory, and data-segment artifacts.
  *
- * @param input - Closed source sub-program to compile.
+ * @param program - Parsed and recursively composed program to compile.
  * @param options - Compiler options for this compilation pass.
- * @param cache - Compiler cache used for reusable validated ASTs.
  * @returns The compiled sub-program artifacts.
  */
-export function compileSubProgram(
-	project: ProjectObjectModel,
-	options: CompileSubProgramOptions,
-	cache = createCompilerCache(),
-	includedFunctions: readonly CompilerDerivedSource[] = []
-): CompiledSubProgram {
-	assertUniqueProjectBlockIds(project);
-	const modules = project.modules.filter(block => !block.disabled);
-	const constants = project.constants.filter(block => !block.disabled);
-	const functions = project.functions.filter(block => !block.disabled);
-	const prototypes = project.prototypes.filter(block => !block.disabled);
-	const inputEntryNames = [...new Set(['main', ...modules.map(module => module.entry)])];
-
-	const prototypeSources = prototypes.map((prototype, index) => {
-		return createCompilerSource(prototype, `prototype:${index}`);
-	});
-
-	const astPrototypes = prototypeSources.map(source => compileSourceToAST<ValidatedPrototypeAST>(source, cache));
-
-	const moduleIndexByEntry = new Map<string, number>();
-	const moduleSources = modules.map(module => {
-		const index = moduleIndexByEntry.get(module.entry) ?? 0;
-		moduleIndexByEntry.set(module.entry, index + 1);
-		return {
-			code: module.code,
-			cacheKey: `entry:${module.entry}:module:${index}`,
-			entryName: module.entry,
-			projectBlockId: module.id,
-		};
-	}) satisfies ModuleCompilerSource[];
-
-	const constantsSources = constants.map((constantsBlock, index) => {
-		return createCompilerSource(constantsBlock, `constants:${index}`);
-	});
-
-	const functionSources = [
-		...functions.map((func, index) => createCompilerSource(func, `function:${index}`)),
-		...includedFunctions.map((func, index) => createCompilerSource(func, `include:function:${index}`)),
-	];
-
-	const astModuleEntries = moduleSources.map(source => {
-		const ast = compileSourceToAST<ValidatedModuleAST>(source, cache);
-		return {
-			entryName: source.entryName,
-			ast,
-		};
-	});
-	const astConstants = constantsSources.map(source => compileSourceToAST<ValidatedConstantsAST>(source, cache));
-	const astFunctions = functionSources.map(source => compileSourceToAST<ValidatedFunctionAST>(source, cache));
-	const entryNames = inputEntryNames;
-	const astModules = astModuleEntries.map(({ ast }) => ast);
-	const moduleEntryNames = astModuleEntries.map(({ entryName }) => entryName);
-	assertUniqueModuleIds(astModules);
-	const subProgramAst: ResolveConstantsSubProgramAST<
-		ValidatedPrototypeAST,
-		ValidatedModuleAST,
-		ValidatedConstantsAST,
-		ValidatedFunctionAST
-	> = {
-		prototypes: astPrototypes,
-		modules: astModules,
-		constants: astConstants,
-		functions: astFunctions,
-	};
+export function compileSubProgram(program: ComposedProgram, options: CompileSubProgramOptions): CompiledSubProgram {
+	const { ast: subProgramAst, entryNames, moduleEntryNames, cache } = program;
+	assertUniqueModuleIds(subProgramAst.modules);
 	let constantResolution: ReturnType<typeof resolveConstants>;
 	try {
 		constantResolution = resolveConstants({ ast: subProgramAst });

--- a/packages/compiler/packages/sub-program/src/index.test.ts
+++ b/packages/compiler/packages/sub-program/src/index.test.ts
@@ -1,4 +1,5 @@
 import { createFunctionId, type ProjectObjectModel } from '@8f4e/language-spec';
+import { composeProgram } from '@8f4e/program-composer/internal';
 import { describe, expect, it } from 'vitest';
 import { compileSubProgram } from '.';
 
@@ -15,7 +16,7 @@ const emptyProject: ProjectObjectModel = {
 
 describe('compileSubProgram', () => {
 	it('compiles one closed source unit into emission-ready artifacts', () => {
-		const compiled = compileSubProgram(emptyProject, { disableSharedMemory: true });
+		const compiled = compileSubProgram(composeProgram(emptyProject), { disableSharedMemory: true });
 
 		expect(compiled.entryNames).toEqual(['main']);
 		expect(compiled.compiledModules).toEqual([]);
@@ -33,7 +34,7 @@ describe('compileSubProgram', () => {
 			modules: [{ id: 3, entry: 'main', code: ['module caller', 'call two', 'drop', 'moduleEnd'] }],
 		};
 
-		const compiled = compileSubProgram(project, {
+		const compiled = compileSubProgram(composeProgram(project), {
 			disableSharedMemory: true,
 			startingFunctionIndex: 20,
 		});

--- a/packages/compiler/packages/sub-program/src/index.ts
+++ b/packages/compiler/packages/sub-program/src/index.ts
@@ -1,1 +1,1 @@
-export { type CompileSubProgramOptions, compileSubProgram, createCompilerCache } from './compileSubProgram';
+export { type CompileSubProgramOptions, compileSubProgram } from './compileSubProgram';

--- a/packages/compiler/src/compileProjectObjectModel.ts
+++ b/packages/compiler/src/compileProjectObjectModel.ts
@@ -1,25 +1,19 @@
-import type {
-	CompileOptions,
-	CompileResult,
-	CompilerCache,
-	ProjectObjectModel,
-	SourceMetadata,
-} from '@8f4e/language-spec';
-import { compileSubProgram, createCompilerCache } from '@8f4e/sub-program/internal';
+import type { CompileOptions, CompileResult, CompilerCache, ProjectObjectModel } from '@8f4e/language-spec';
+import {
+	composeProgram,
+	createCompilerCache,
+	type IncludedFunctionsByProjectUnit,
+} from '@8f4e/program-composer/internal';
+import { compileSubProgram } from '@8f4e/sub-program/internal';
 import { emitWasmProgram } from '@8f4e/wasm-codegen';
-
-type CompilerDerivedSource = {
-	code: string[];
-	projectBlockId?: number;
-	source?: SourceMetadata;
-};
 
 /** Synchronous compiler stage used after asynchronous project dependencies have been resolved. */
 export function compileProjectObjectModel(
 	project: ProjectObjectModel,
 	options: CompileOptions,
 	cache: CompilerCache = createCompilerCache(),
-	includedFunctions: readonly CompilerDerivedSource[] = []
+	includedFunctionsByUnit: IncludedFunctionsByProjectUnit = new Map()
 ): CompileResult {
-	return emitWasmProgram(compileSubProgram(project, options, cache, includedFunctions), options);
+	const program = composeProgram(project, cache, includedFunctionsByUnit);
+	return emitWasmProgram(compileSubProgram(program, options), options);
 }

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,11 +1,58 @@
 import type { CompileProjectOptions, CompileResult, ProjectObjectModel } from '@8f4e/language-spec';
+import {
+	createCompilerCache,
+	getChildProjectUnitKey,
+	type IncludedFunctionsByProjectUnit,
+	type ProjectUnitKey,
+	ROOT_PROJECT_UNIT_KEY,
+} from '@8f4e/program-composer/internal';
 import { parseProjectSource, resolveProjectIncludesAsync } from '@8f4e/project-preparser';
-import { createCompilerCache } from '@8f4e/sub-program/internal';
 import { deriveEffectiveMemorySize } from '@8f4e/wasm-codegen';
 import { compileProjectObjectModel } from './compileProjectObjectModel';
 
 export { serializeDiagnostic } from './diagnostic';
 export { deriveEffectiveMemorySize, parseProjectSource };
+
+/**
+ * Resolves include blocks independently for every project unit in the recursive tree.
+ * Reusing loaded source text does not deduplicate the resulting functions: each unit receives and compiles its own
+ * qualified copies.
+ */
+async function resolveRecursiveProjectIncludes(
+	project: ProjectObjectModel,
+	resolveInclude: NonNullable<CompileProjectOptions['resolveInclude']>,
+	unitKey: ProjectUnitKey = ROOT_PROJECT_UNIT_KEY,
+	result: Map<ProjectUnitKey, Awaited<ReturnType<typeof resolveProjectIncludesAsync>>> = new Map()
+): Promise<IncludedFunctionsByProjectUnit> {
+	const includedFunctions = await resolveProjectIncludesAsync(project.includes, resolveInclude);
+	if (includedFunctions.length > 0) {
+		result.set(unitKey, includedFunctions);
+	}
+	await Promise.all(
+		project.groups.map((group, index) =>
+			resolveRecursiveProjectIncludes(group, resolveInclude, getChildProjectUnitKey(unitKey, group, index), result)
+		)
+	);
+	return result;
+}
+
+/**
+ * Memoizes include source loading across recursive project units.
+ * Only the resolver's source-text promise is shared; per-unit include expansion and compilation remain independent.
+ */
+function createMemoizedIncludeResolver(
+	resolveInclude: CompileProjectOptions['resolveInclude']
+): NonNullable<CompileProjectOptions['resolveInclude']> {
+	const includeSourcePromises = new Map<string, Promise<string | undefined>>();
+	return includeId => {
+		let source = includeSourcePromises.get(includeId);
+		if (!source) {
+			source = Promise.resolve(resolveInclude?.(includeId));
+			includeSourcePromises.set(includeId, source);
+		}
+		return source;
+	};
+}
 
 /** Compiles a canonical project object directly into one complete WebAssembly program. */
 export async function compileProject(
@@ -13,6 +60,7 @@ export async function compileProject(
 	options: CompileProjectOptions = {}
 ): Promise<CompileResult> {
 	const { resolveInclude, cache = createCompilerCache(), ...compilerOptions } = options;
-	const includedFunctions = await resolveProjectIncludesAsync(project.includes, resolveInclude ?? (() => undefined));
-	return compileProjectObjectModel(project, compilerOptions, cache, includedFunctions);
+	const memoizedResolveInclude = createMemoizedIncludeResolver(resolveInclude);
+	const includedFunctionsByUnit = await resolveRecursiveProjectIncludes(project, memoizedResolveInclude);
+	return compileProjectObjectModel(project, compilerOptions, cache, includedFunctionsByUnit);
 }

--- a/packages/compiler/src/project-api.test.ts
+++ b/packages/compiler/src/project-api.test.ts
@@ -1,5 +1,5 @@
 import type { ProjectObjectModel } from '@8f4e/language-spec';
-import { WASM_MEMORY_PAGE_SIZE } from '@8f4e/language-spec';
+import { ErrorCode, WASM_MEMORY_PAGE_SIZE } from '@8f4e/language-spec';
 import { describe, expect, it } from 'vitest';
 import { compileProject, parseProjectSource } from '.';
 
@@ -95,7 +95,7 @@ describe('project compiler API', () => {
 		expect(new Int32Array(memory.buffer)[9]).toBe(7);
 	});
 
-	it('keeps recursively owned group blocks outside root compilation', async () => {
+	it('composes recursively owned group blocks before root blocks', async () => {
 		const grouped = parseProjectSource(
 			[
 				'8f4e/v1',
@@ -125,8 +125,107 @@ describe('project compiler API', () => {
 			},
 		]);
 		const result = await compileProject(grouped, { disableSharedMemory: true });
-		expect(result.compiledModules.root).toBeDefined();
-		expect(result.compiledModules.grouped).toBeUndefined();
+		const compiledModules = Object.values(result.compiledModules).sort((left, right) => left.index - right.index);
+		expect(compiledModules).toMatchObject([
+			{ ast: { projectBlockId: 6 }, executionEntryName: 'main' },
+			{ id: 'root', executionEntryName: 'main' },
+		]);
+		expect(compiledModules[0]?.id).toContain('grouped');
+		expect(result.memoryPlan.modules[compiledModules[0]!.id]).toBeDefined();
+	});
+
+	it('isolates same-named functions in sibling groups and executes both groups', async () => {
+		const createGroup = (firstId: number, value: number): ProjectObjectModel => ({
+			...directProject,
+			modules: [
+				{
+					id: firstId + 1,
+					entry: 'main',
+					code: ['module shared', 'int output', 'push &output', 'call value', 'store', 'moduleEnd'],
+				},
+			],
+			functions: [{ id: firstId, code: ['function value', `push ${value}`, 'functionEnd int'] }],
+			groups: [],
+		});
+		const result = await compileProject(
+			{
+				...directProject,
+				modules: [],
+				functions: [],
+				groups: [createGroup(10, 7), createGroup(20, 11)],
+			},
+			{ disableSharedMemory: true }
+		);
+		const modules = Object.values(result.compiledModules).sort((left, right) => left.index - right.index);
+		const memory = new WebAssembly.Memory({ initial: 1, maximum: 1 });
+		const { instance } = await WebAssembly.instantiate(result.codeBuffer, { host: { memory } });
+		(instance.exports.initDefaults as CallableFunction)();
+		(instance.exports.main as CallableFunction)();
+
+		expect(modules).toHaveLength(2);
+		expect(modules[0]?.id).not.toBe(modules[1]?.id);
+		expect(new Int32Array(memory.buffer)[result.memoryPlan.modules[modules[0]!.id]!.byteAddress / 4]).toBe(7);
+		expect(new Int32Array(memory.buffer)[result.memoryPlan.modules[modules[1]!.id]!.byteAddress / 4]).toBe(11);
+	});
+
+	it('resolves and scopes includes owned by nested groups', async () => {
+		const result = await compileProject(
+			{
+				...directProject,
+				modules: [],
+				functions: [],
+				groups: [
+					{
+						...directProject,
+						modules: [
+							{
+								id: 11,
+								entry: 'main',
+								code: ['module included', 'int output', 'push &output', 'call includedValue', 'store', 'moduleEnd'],
+							},
+						],
+						functions: [],
+						includes: [{ id: 12, code: ['includes', 'include nested-helper', 'includesEnd'] }],
+						groups: [],
+					},
+				],
+			},
+			{
+				disableSharedMemory: true,
+				resolveInclude: includeId =>
+					includeId === 'nested-helper'
+						? ['function helper', '#export includedValue', 'push 13', 'functionEnd int'].join('\n')
+						: undefined,
+			}
+		);
+		const module = Object.values(result.compiledModules)[0]!;
+		const memory = new WebAssembly.Memory({ initial: 1, maximum: 1 });
+		const { instance } = await WebAssembly.instantiate(result.codeBuffer, { host: { memory } });
+		(instance.exports.initDefaults as CallableFunction)();
+		(instance.exports.main as CallableFunction)();
+
+		expect(new Int32Array(memory.buffer)[result.memoryPlan.modules[module.id]!.byteAddress / 4]).toBe(13);
+	});
+
+	it('does not expose nested functions to the root project namespace', async () => {
+		const compilation = compileProject(
+			{
+				...directProject,
+				modules: [{ id: 1, entry: 'main', code: ['module root', 'call hidden', 'moduleEnd'] }],
+				functions: [],
+				groups: [
+					{
+						...directProject,
+						modules: [],
+						functions: [{ id: 2, code: ['function hidden', 'functionEnd'] }],
+						groups: [],
+					},
+				],
+			},
+			{ disableSharedMemory: true }
+		);
+
+		await expect(compilation).rejects.toMatchObject({ code: ErrorCode.UNDEFINED_FUNCTION });
 	});
 
 	it('preserves module array order while grouping execution by entry', async () => {

--- a/packages/compiler/tests/compilerOptionsAndCache.test.ts
+++ b/packages/compiler/tests/compilerOptionsAndCache.test.ts
@@ -67,15 +67,15 @@ push 1
 functionEnd int
 `;
 		const first = await compileFixtureProgramSource(source);
-		const cachedModuleAst = first.compileResult.cache.ast.entries.get('entry:main:module:0')?.ast;
-		const cachedFunctionAst = first.compileResult.cache.ast.entries.get('function:0')?.ast;
+		const cachedModuleAst = first.compileResult.cache.ast.entries.get('root:entry:main:module:0')?.ast;
+		const cachedFunctionAst = first.compileResult.cache.ast.entries.get('root:function:0')?.ast;
 		const second = await compileFixtureProgramSource(source, {
 			cache: first.compileResult.cache,
 		});
 
 		expect(second.compileResult.cache).toBe(first.compileResult.cache);
-		expect(second.compileResult.cache.ast.entries.get('entry:main:module:0')?.ast).toBe(cachedModuleAst);
-		expect(second.compileResult.cache.ast.entries.get('function:0')?.ast).toBe(cachedFunctionAst);
+		expect(second.compileResult.cache.ast.entries.get('root:entry:main:module:0')?.ast).toBe(cachedModuleAst);
+		expect(second.compileResult.cache.ast.entries.get('root:function:0')?.ast).toBe(cachedFunctionAst);
 		expect(second.compileResult.cache.ast.stats.hits).toBeGreaterThanOrEqual(2);
 	});
 
@@ -95,12 +95,12 @@ const SIZE ${size}
 constantsEnd
 `;
 		const first = await compileFixtureProgramSource(createSource(2));
-		const cachedModuleAst = first.compileResult.cache.ast.entries.get('entry:main:module:0')?.ast;
+		const cachedModuleAst = first.compileResult.cache.ast.entries.get('root:entry:main:module:0')?.ast;
 		const second = await compileFixtureProgramSource(createSource(4), {
 			cache: first.compileResult.cache,
 		});
 
-		expect(second.compileResult.cache.ast.entries.get('entry:main:module:0')?.ast).toBe(cachedModuleAst);
+		expect(second.compileResult.cache.ast.entries.get('root:entry:main:module:0')?.ast).toBe(cachedModuleAst);
 		expect(second.compileResult.memoryPlan.modules.cachedConstants!.memory.buffer!.numberOfElements).toBe(4);
 		const cachedMemoryDeclaration = cachedModuleAst?.lines.find(isMemoryDeclarationLine);
 		expect(cachedMemoryDeclaration?.arguments[1]).toEqual(expect.objectContaining({ value: 'SIZE' }));

--- a/packages/compiler/vite.config.ts
+++ b/packages/compiler/vite.config.ts
@@ -8,7 +8,13 @@ export default defineConfig({
 		emptyOutDir: false,
 		rollupOptions: {
 			...createEsLibConfig('./src/index.ts', 'dist').build?.rollupOptions,
-			external: ['@8f4e/language-spec', '@8f4e/project-preparser', '@8f4e/sub-program/internal', '@8f4e/wasm-codegen'],
+			external: [
+				'@8f4e/language-spec',
+				'@8f4e/program-composer/internal',
+				'@8f4e/project-preparser',
+				'@8f4e/sub-program/internal',
+				'@8f4e/wasm-codegen',
+			],
 		},
 	},
 });

--- a/packages/editor/packages/editor-state/src/features/global-editor-directives/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/global-editor-directives/effect.test.ts
@@ -1,0 +1,59 @@
+import type { State } from '@8f4e/editor-state-types';
+import createStateManager from '@8f4e/state-manager';
+import { describe, expect, it, vi } from 'vitest';
+import { createMockCodeBlock, createMockState } from '~/pureHelpers/testingUtils/testUtils';
+import { createMockEventDispatcherWithVitest } from '~/pureHelpers/testingUtils/vitestTestUtils';
+import runtimeEffect from '../runtime/effect';
+import globalEditorDirectivesEffect from './effect';
+
+describe('globalEditorDirectivesEffect', () => {
+	it('keeps the runtime alive when the rendered project-group slice changes', async () => {
+		const destroyRuntime = vi.fn();
+		const runtimeFactory = vi.fn(() => destroyRuntime);
+		const nestedCodeBlocks = [createMockCodeBlock({ code: ['module nested', 'moduleEnd'] })];
+		const rootCodeBlocks = [
+			createMockCodeBlock({
+				code: ['module projectConfig', '; @config runtime WebWorkerRuntime', 'moduleEnd'],
+			}),
+			createMockCodeBlock({
+				code: ['group nested', 'groupEnd'],
+				nestedProjectCodeBlocks: nestedCodeBlocks,
+			}),
+		];
+		const state = createMockState({
+			runtimeRegistry: {
+				WebWorkerRuntime: {
+					id: 'WebWorkerRuntime',
+					factory: runtimeFactory,
+				},
+			},
+			codeBlockRendering: {
+				rootCodeBlocks,
+				codeBlocks: rootCodeBlocks,
+			},
+		});
+		const store = createStateManager(state as State);
+		const events = createMockEventDispatcherWithVitest();
+
+		await runtimeEffect(store, events);
+		globalEditorDirectivesEffect(store);
+		store.set('codeBlockRendering.codeBlocks', rootCodeBlocks);
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		expect(state.editorConfig.runtime).toBe('WebWorkerRuntime');
+		expect(runtimeFactory).toHaveBeenCalledTimes(1);
+
+		store.set('codeBlockRendering.codeBlocks', nestedCodeBlocks);
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		expect(state.editorConfig.runtime).toBe('WebWorkerRuntime');
+		expect(runtimeFactory).toHaveBeenCalledTimes(1);
+		expect(destroyRuntime).not.toHaveBeenCalled();
+
+		store.set('codeBlockRendering.codeBlocks', rootCodeBlocks);
+		await new Promise(resolve => setTimeout(resolve, 0));
+
+		expect(runtimeFactory).toHaveBeenCalledTimes(1);
+		expect(destroyRuntime).not.toHaveBeenCalled();
+	});
+});

--- a/packages/editor/packages/editor-state/src/features/global-editor-directives/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/global-editor-directives/effect.ts
@@ -1,4 +1,4 @@
-import type { CodeError, State } from '@8f4e/editor-state-types';
+import type { CodeBlockGraphicData, CodeError, State } from '@8f4e/editor-state-types';
 import type { StateManager } from '@8f4e/state-manager';
 import deepEqual from '../../shared/utils/deepEqual';
 import { resolveEditorConfigEntries, validateEditorConfigEntries } from '../editor-config/validators';
@@ -13,18 +13,27 @@ function withOwnerId(errors: CodeError[]): CodeError[] {
 	}));
 }
 
+function collectProjectCodeBlocks(codeBlocks: CodeBlockGraphicData[]): CodeBlockGraphicData[] {
+	return codeBlocks.flatMap(codeBlock => [
+		codeBlock,
+		...(codeBlock.nestedProjectCodeBlocks ? collectProjectCodeBlocks(codeBlock.nestedProjectCodeBlocks) : []),
+	]);
+}
+
 /**
  * Global-editor-directives effect.
  *
- * Scans all code blocks in `codeBlockRendering.codeBlocks` for global `; @<name>`
- * editor directives and updates `state.globalEditorDirectives` with the resolved values.
+ * Scans the complete recursive project tree for global `; @<name>` editor directives and
+ * updates `state.globalEditorDirectives` with the resolved values. The rendered project slice
+ * is intentionally ignored so navigating into a project group cannot change global state.
  *
  * Conflicting directive values are written to `state.codeErrors.editorDirectiveErrors`.
  */
 export default function globalEditorDirectivesEffect(store: StateManager<State>): void {
 	function resolve(): void {
 		const state = store.getState();
-		const { resolved, errors } = resolveGlobalEditorDirectives(state.codeBlockRendering.codeBlocks);
+		const projectCodeBlocks = collectProjectCodeBlocks(state.codeBlockRendering.rootCodeBlocks);
+		const { resolved, errors } = resolveGlobalEditorDirectives(projectCodeBlocks);
 		const { configEntries, ...globalEditorDirectives } = resolved;
 		const nextEditorConfig = resolveEditorConfigEntries(configEntries ?? [], state.editorConfigValidators);
 		const nextErrors = [...errors, ...validateEditorConfigEntries(configEntries ?? [], state.editorConfigValidators)];


### PR DESCRIPTION
## Summary

- add a program-composer compiler package that recursively composes project groups into one program
- namespace nested symbols and compiler cache entries to prevent group conflicts
- keep sub-program compilation private behind the project compiler API
- keep root runtime directives active while navigating nested editor slices
- cover composition with fixture-based snapshot tests and editor navigation with a regression test

## Rationale

Project groups should compile as one flattened program while preserving their recursive project representation. This creates a stable checkpoint before further runtime-startup investigation.

## Tests

- npx nx run @8f4e/program-composer:test
- npx nx run @8f4e/compiler:test
- npx nx run @8f4e/editor-state:test
- npx nx run app:build
- affected typechecks and Biome checks via pre-commit hooks

## Known follow-up

The delayed Web Worker runtime initialization observed during local development remains unresolved and is intentionally not addressed in this PR.