### PR TITLE
fix(runtime-web-worker): omit unused compiler metadata

### DIFF
--- a/packages/runtime-web-worker/src/runtimeDef.test.ts
+++ b/packages/runtime-web-worker/src/runtimeDef.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
-import { createWebWorkerRuntimeDef, webWorkerRuntimeFactory } from './runtimeDef';
+import { createWebWorkerRuntimeDef } from './runtimeDef';
 
 describe('WebWorker runtime config', () => {
 	it('requires a positive sample rate', () => {
@@ -13,51 +13,5 @@ describe('WebWorker runtime config', () => {
 		expect(runtimeDef.editorConfigSchema?.schema.properties).toMatchObject({
 			sampleRate: { type: 'number', minimum: 1 },
 		});
-	});
-});
-
-describe('WebWorker runtime synchronization', () => {
-	it('only sends values consumed by the runtime worker', () => {
-		const postMessage = vi.fn();
-		const memory = new WebAssembly.Memory({ initial: 1 });
-		const codeBuffer = new Uint8Array([1, 2, 3]);
-		const store = {
-			getState: () => ({
-				editorConfig: { workerRuntime: { sampleRate: 100 } },
-				compiler: { compiledModules: { unused: {} } },
-				info: {},
-			}),
-			subscribe: vi.fn(),
-			subscribeToValue: vi.fn(),
-			unsubscribe: vi.fn(),
-		} as unknown as Parameters<typeof webWorkerRuntimeFactory>[0];
-		const events = {
-			dispatch: vi.fn(),
-		} as unknown as Parameters<typeof webWorkerRuntimeFactory>[1];
-		class WorkerStub {
-			postMessage = postMessage;
-			addEventListener = vi.fn();
-			removeEventListener = vi.fn();
-			terminate = vi.fn();
-		}
-
-		const dispose = webWorkerRuntimeFactory(
-			store,
-			events,
-			() => codeBuffer,
-			() => memory,
-			WorkerStub as unknown as new () => Worker
-		);
-
-		expect(postMessage).toHaveBeenCalledWith({
-			type: 'init',
-			payload: {
-				memoryRef: memory,
-				sampleRate: 100,
-				codeBuffer,
-			},
-		});
-
-		dispose();
 	});
 });

--- a/packages/runtime-web-worker/src/runtimeDef.test.ts
+++ b/packages/runtime-web-worker/src/runtimeDef.test.ts
@@ -1,6 +1,6 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-import { createWebWorkerRuntimeDef } from './runtimeDef';
+import { createWebWorkerRuntimeDef, webWorkerRuntimeFactory } from './runtimeDef';
 
 describe('WebWorker runtime config', () => {
 	it('requires a positive sample rate', () => {
@@ -13,5 +13,51 @@ describe('WebWorker runtime config', () => {
 		expect(runtimeDef.editorConfigSchema?.schema.properties).toMatchObject({
 			sampleRate: { type: 'number', minimum: 1 },
 		});
+	});
+});
+
+describe('WebWorker runtime synchronization', () => {
+	it('only sends values consumed by the runtime worker', () => {
+		const postMessage = vi.fn();
+		const memory = new WebAssembly.Memory({ initial: 1 });
+		const codeBuffer = new Uint8Array([1, 2, 3]);
+		const store = {
+			getState: () => ({
+				editorConfig: { workerRuntime: { sampleRate: 100 } },
+				compiler: { compiledModules: { unused: {} } },
+				info: {},
+			}),
+			subscribe: vi.fn(),
+			subscribeToValue: vi.fn(),
+			unsubscribe: vi.fn(),
+		} as unknown as Parameters<typeof webWorkerRuntimeFactory>[0];
+		const events = {
+			dispatch: vi.fn(),
+		} as unknown as Parameters<typeof webWorkerRuntimeFactory>[1];
+		class WorkerStub {
+			postMessage = postMessage;
+			addEventListener = vi.fn();
+			removeEventListener = vi.fn();
+			terminate = vi.fn();
+		}
+
+		const dispose = webWorkerRuntimeFactory(
+			store,
+			events,
+			() => codeBuffer,
+			() => memory,
+			WorkerStub as unknown as new () => Worker
+		);
+
+		expect(postMessage).toHaveBeenCalledWith({
+			type: 'init',
+			payload: {
+				memoryRef: memory,
+				sampleRate: 100,
+				codeBuffer,
+			},
+		});
+
+		dispose();
 	});
 });

--- a/packages/runtime-web-worker/src/runtimeDef.ts
+++ b/packages/runtime-web-worker/src/runtimeDef.ts
@@ -74,7 +74,6 @@ export function webWorkerRuntimeFactory(
 				memoryRef: memory,
 				sampleRate: getSampleRate(state.editorConfig),
 				codeBuffer: getCodeBuffer(),
-				compiledModules: state.compiler.compiledModules,
 			},
 		});
 	}


### PR DESCRIPTION
## Summary

- stop sending compiled module metadata to WebWorkerRuntime
- keep the runtime initialization payload aligned with the three values the worker consumes

## Rationale

The runtime worker only consumes the shared memory, sample rate, and WebAssembly bytecode. Sending compiledModules caused the browser to structured-clone large editor-only metadata on every runtime synchronization. For the digit-classifier example this field is roughly 3.4 MB.

## Tests

- npx nx run @8f4e/runtime-web-worker:test
- npx nx run @8f4e/runtime-web-worker:typecheck
- npx nx run @8f4e/runtime-web-worker:build