### PR TITLE
fix: preserve project group root code

### DIFF
--- a/docs/todos/477-establish-project-object-model.md
+++ b/docs/todos/477-establish-project-object-model.md
@@ -51,6 +51,7 @@ interface ProjectObjectModel {
 interface ProjectGroupObjectModel extends ProjectObjectModel {
 	name: ProjectGroupName;
 	entry: ProjectEntryName;
+	code: string[];
 	exposures: ProjectMemoryExposure[];
 }
 
@@ -81,8 +82,9 @@ blocks remain available to editors without entering compilation.
 Groups use the same object model recursively rather than referencing root-owned blocks by id. A nested model owns its
 modules, functions, constants, prototypes, includes, notes, unknown blocks, and further groups. Identity fields are not
 part of the root project model: child groups require a sibling-unique `name` and an `entry` through
-`ProjectGroupObjectModel`. A group's canonical path is formed from its ancestors' encoded names. The root path is empty,
-so module identities are readable and deterministic: `counter`, `audio/counter`, and
+`ProjectGroupObjectModel`. Its `code` retains every source line owned by the group wrapper, while nested project blocks
+remain in their typed collections. A group's canonical path is formed from its ancestors' encoded names. The root path
+is empty, so module identities are readable and deterministic: `counter`, `audio/counter`, and
 `audio/voices/counter`. The same identity keys `compiledModules`, `memoryPlan.modules`,
 `memoryDefaultsByModuleId`, and `pointerMetadataByModuleId` without a transformed result map. The compiler recursively
 parses and isolates these models before flattening them into one globally planned program; it does not merge

--- a/packages/cli/tests/compileProjectModules.test.ts
+++ b/packages/cli/tests/compileProjectModules.test.ts
@@ -124,6 +124,7 @@ describe('compileProjectModules', () => {
 						]),
 						id: 1,
 						name: 'nested',
+						code: ['group nested', 'groupEnd'],
 						exposures: [],
 					},
 				],

--- a/packages/compiler/packages/language-spec/src/project.test.ts
+++ b/packages/compiler/packages/language-spec/src/project.test.ts
@@ -21,6 +21,7 @@ describe('ProjectObjectModel', () => {
 		expectTypeOf<ProjectObjectModel['functions']>().toEqualTypeOf<ProjectBlock[]>();
 		expectTypeOf<ProjectObjectModel['groups']>().toEqualTypeOf<ProjectGroupObjectModel[]>();
 		expectTypeOf<ProjectGroupObjectModel['entry']>().toEqualTypeOf<ProjectEntryName>();
+		expectTypeOf<ProjectGroupObjectModel['code']>().toEqualTypeOf<string[]>();
 		expectTypeOf<ProjectGroupObjectModel['exposures']>().toEqualTypeOf<ProjectMemoryExposure[]>();
 	});
 

--- a/packages/compiler/packages/language-spec/src/project.ts
+++ b/packages/compiler/packages/language-spec/src/project.ts
@@ -90,6 +90,8 @@ export interface ProjectMemoryExposure {
 export interface ProjectGroupObjectModel extends ProjectObjectModel {
 	name: ProjectGroupName;
 	entry: ProjectEntryName;
+	/** Source lines owned by the group wrapper, excluding recursively owned child blocks. */
+	code: string[];
 	/** Ordered public memory aliases exposed to the enclosing project. */
 	exposures: ProjectMemoryExposure[];
 }

--- a/packages/compiler/packages/project-preparser/src/__snapshots__/memory-exposures.8f4e.project.snap
+++ b/packages/compiler/packages/project-preparser/src/__snapshots__/memory-exposures.8f4e.project.snap
@@ -3,6 +3,14 @@
   "functions": [],
   "groups": [
     {
+      "code": [
+        "group audio",
+        "expose int exposedValue &source:value",
+        "expose int* exposedInput &consumer:input",
+        "",
+        "",
+        "groupEnd",
+      ],
       "constants": [],
       "entry": "main",
       "exposures": [

--- a/packages/compiler/packages/project-preparser/src/__snapshots__/multiple-entry-groups.8f4e.project.snap
+++ b/packages/compiler/packages/project-preparser/src/__snapshots__/multiple-entry-groups.8f4e.project.snap
@@ -3,6 +3,10 @@
   "functions": [],
   "groups": [
     {
+      "code": [
+        "group audio",
+        "groupEnd",
+      ],
       "constants": [],
       "entry": "main",
       "exposures": [],
@@ -26,12 +30,21 @@
       "unknown": [],
     },
     {
+      "code": [
+        "group visuals",
+        "",
+        "groupEnd",
+      ],
       "constants": [],
       "entry": "main",
       "exposures": [],
       "functions": [],
       "groups": [
         {
+          "code": [
+            "group shaderHelpers",
+            "groupEnd",
+          ],
           "constants": [],
           "entry": "main",
           "exposures": [],
@@ -73,6 +86,10 @@
       "unknown": [],
     },
     {
+      "code": [
+        "group assertions",
+        "groupEnd",
+      ],
       "constants": [],
       "entry": "test",
       "exposures": [],

--- a/packages/compiler/packages/project-preparser/src/__snapshots__/nested-groups.8f4e.project.snap
+++ b/packages/compiler/packages/project-preparser/src/__snapshots__/nested-groups.8f4e.project.snap
@@ -3,6 +3,13 @@
   "functions": [],
   "groups": [
     {
+      "code": [
+        "group audio",
+        "",
+        "",
+        "",
+        "groupEnd",
+      ],
       "constants": [
         {
           "code": [
@@ -28,6 +35,11 @@
       ],
       "groups": [
         {
+          "code": [
+            "group oscillator",
+            "",
+            "groupEnd",
+          ],
           "constants": [],
           "entry": "main",
           "exposures": [],

--- a/packages/compiler/packages/project-preparser/src/index.test.ts
+++ b/packages/compiler/packages/project-preparser/src/index.test.ts
@@ -143,6 +143,7 @@ describe('parseProjectSource', () => {
 			{
 				name: 'audio',
 				entry: 'main',
+				code: ['group audio', 'groupEnd'],
 				exposures: [],
 				modules: [{ id: 5, code: validModuleBlock, entry: 'main' }],
 				functions: [{ id: 10, code: validFunctionBlock }],
@@ -155,6 +156,7 @@ describe('parseProjectSource', () => {
 					{
 						name: 'oscillator',
 						entry: 'main',
+						code: ['group oscillator', 'groupEnd'],
 						exposures: [],
 						modules: [],
 						functions: [],
@@ -166,6 +168,33 @@ describe('parseProjectSource', () => {
 						groups: [],
 					},
 				],
+			},
+		]);
+	});
+
+	it('preserves every group-root source line while extracting nested blocks', () => {
+		const groupCode = [
+			'group audio',
+			'; this comment belongs to the group block',
+			'futureInstruction anything',
+			'expose int level &voice:level',
+			'',
+			'groupEnd',
+		];
+		const project = parseProjectSource(
+			['8f4e/v1', 'entry main', ...groupCode.slice(0, -1), ...validModuleBlock, groupCode.at(-1)!, 'entryEnd'].join(
+				'\n'
+			)
+		);
+
+		expect(project.groups[0].code).toEqual(groupCode);
+		expect(project.groups[0].modules).toEqual([{ id: 8, code: validModuleBlock, entry: 'main' }]);
+		expect(project.groups[0].exposures).toEqual([
+			{
+				type: 'int',
+				name: 'level',
+				targetModuleName: 'voice',
+				targetMemoryName: 'level',
 			},
 		]);
 	});

--- a/packages/compiler/packages/project-preparser/src/parseProjectSource.ts
+++ b/packages/compiler/packages/project-preparser/src/parseProjectSource.ts
@@ -23,6 +23,7 @@ type ProjectContainerContentOptions = {
 	container: ProjectContainerDelimiter;
 	validateDocumentOpener: (opener: string, line: string, lineNumber: number) => void;
 	exposures?: ProjectMemoryExposure[];
+	rootCode?: string[];
 };
 type ParsedProjectBlock = { block: ProjectBlock; type: DocumentBlockType; nextIndex: number };
 
@@ -39,11 +40,12 @@ function createEmptyProject(): ProjectObjectModel {
 	};
 }
 
-function createEmptyProjectGroup(name: string, entry: string): ProjectGroupObjectModel {
+function createEmptyProjectGroup(name: string, entry: string, openerLine: string): ProjectGroupObjectModel {
 	return {
 		...createEmptyProject(),
 		name,
 		entry,
+		code: [openerLine],
 		exposures: [],
 	};
 }
@@ -126,17 +128,22 @@ export function parseProjectSource(text: string): ProjectObjectModel {
 
 	function readProjectContainerContents(startIndex: number, options: ProjectContainerContentOptions): number {
 		for (let i = startIndex; i < lines.length; ) {
-			const trimmed = lines[i].trim();
-			if (isProjectGapLine(trimmed)) {
-				i += 1;
-				continue;
-			}
+			const line = lines[i];
+			const trimmed = line.trim();
 			const closer = getProjectCloserKeyword(trimmed);
-			if (closer === options.container.closer) return i + 1;
+			if (closer === options.container.closer) {
+				options.rootCode?.push(line);
+				return i + 1;
+			}
 			if (closer) {
 				throw new Error(
 					`Parse error at line ${i + 1}: closer "${closer}" does not match opener "${options.container.opener}"`
 				);
+			}
+			if (isProjectGapLine(trimmed)) {
+				options.rootCode?.push(line);
+				i += 1;
+				continue;
 			}
 			if (options.exposures && startsWithInstruction(trimmed, 'expose')) {
 				const exposure = parseProjectMemoryExposureLine(trimmed, i + 1);
@@ -144,11 +151,17 @@ export function parseProjectSource(text: string): ProjectObjectModel {
 					throw new Error(`Parse error at line ${i + 1}: duplicate exposure "${exposure.name}"`);
 				}
 				options.exposures.push(exposure);
+				options.rootCode?.push(line);
 				i += 1;
 				continue;
 			}
 
 			const opener = getProjectOpenerKeyword(trimmed);
+			if (!opener && options.rootCode) {
+				options.rootCode.push(line);
+				i += 1;
+				continue;
+			}
 			if (!opener) throw new Error(`Parse error at line ${i + 1}: expected opener keyword, got "${trimmed}"`);
 			if (opener === GROUP_BLOCK_DELIMITER.opener) {
 				const nested = readProjectGroup(i, options.entry);
@@ -173,13 +186,14 @@ export function parseProjectSource(text: string): ProjectObjectModel {
 		if (getProjectOpenerKeyword(openerLine.trim()) !== GROUP_BLOCK_DELIMITER.opener) {
 			throw new Error(`Parse error at line ${startIndex + 1}: expected group opener`);
 		}
-		const group = createEmptyProjectGroup(getProjectBlockName(openerLine, startIndex + 1, 'group'), entry);
+		const group = createEmptyProjectGroup(getProjectBlockName(openerLine, startIndex + 1, 'group'), entry, openerLine);
 		return {
 			nextIndex: readProjectContainerContents(startIndex + 1, {
 				project: group,
 				entry,
 				container: GROUP_BLOCK_DELIMITER,
 				exposures: group.exposures,
+				rootCode: group.code,
 				validateDocumentOpener: (opener, _line, lineNumber) => {
 					if (opener === ENTRY_BLOCK_DELIMITER.opener) {
 						throw new Error(`Parse error at line ${lineNumber}: entry blocks cannot be nested inside groups`);

--- a/packages/compiler/packages/project-preparser/tests/__snapshots__/projectPreparser.integration.test.ts.snap
+++ b/packages/compiler/packages/project-preparser/tests/__snapshots__/projectPreparser.integration.test.ts.snap
@@ -62,6 +62,10 @@ exports[`project-preparser integration > parses project source into typed collec
     ],
     "groups": [
       {
+        "code": [
+          "group audio",
+          "groupEnd",
+        ],
         "constants": [],
         "entry": "main",
         "exposures": [],

--- a/packages/compiler/src/project-api.test.ts
+++ b/packages/compiler/src/project-api.test.ts
@@ -114,6 +114,7 @@ describe('project compiler API', () => {
 			{
 				name: 'audio',
 				entry: 'main',
+				code: ['group audio', 'groupEnd'],
 				exposures: [],
 				modules: [{ id: 6, entry: 'main', code: ['module grouped', 'int value 1', 'moduleEnd'] }],
 				functions: [],
@@ -143,6 +144,7 @@ describe('project compiler API', () => {
 			...directProject,
 			name,
 			entry: 'main',
+			code: [`group ${name}`, 'groupEnd'],
 			exposures: [],
 			modules: [
 				{
@@ -186,6 +188,7 @@ describe('project compiler API', () => {
 						...directProject,
 						name: 'included',
 						entry: 'main',
+						code: ['group included', 'groupEnd'],
 						exposures: [],
 						modules: [
 							{
@@ -228,6 +231,7 @@ describe('project compiler API', () => {
 						...directProject,
 						name: 'hidden',
 						entry: 'main',
+						code: ['group hidden', 'groupEnd'],
 						exposures: [],
 						modules: [],
 						functions: [{ id: 2, code: ['function hidden', 'functionEnd'] }],

--- a/packages/editor/packages/editor-state/src/features/code-blocks/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/effect.test.ts
@@ -187,6 +187,7 @@ describe('code block rendering home directive', () => {
 						...EMPTY_DEFAULT_PROJECT,
 						name: 'Audio',
 						entry: 'main',
+						code: ['group Audio', '; keep this comment', 'expose int level &voice:level', 'groupEnd'],
 						exposures: [
 							{
 								type: 'int',
@@ -212,7 +213,13 @@ describe('code block rendering home directive', () => {
 		expect(state.codeBlockRendering.codeBlocks.map(block => block.name)).toEqual(['root', 'Audio']);
 		const groupBlock = state.codeBlockRendering.codeBlocks[1];
 		expect(groupBlock.projectPath).toBe('');
-		expect(groupBlock.code).toContain('expose int level &voice:level');
+		expect(groupBlock.code).toEqual([
+			'group Audio',
+			'; keep this comment',
+			'expose int level &voice:level',
+			'; @pos 0 -6',
+			'groupEnd',
+		]);
 		expect(groupBlock.nestedProjectCodeBlocks).toHaveLength(1);
 		expect(groupBlock.nestedProjectCodeBlocks?.[0]).toMatchObject({
 			name: 'voice',
@@ -232,6 +239,7 @@ describe('code block rendering home directive', () => {
 						...EMPTY_DEFAULT_PROJECT,
 						name: 'Audio',
 						entry: 'main',
+						code: ['group Audio', 'groupEnd'],
 						exposures: [],
 						modules: [{ id: 1, entry: 'main', code: ['module voice', 'moduleEnd'] }],
 					},

--- a/packages/editor/packages/editor-state/src/features/code-blocks/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/effect.ts
@@ -6,7 +6,6 @@ import {
 	type ProjectObjectModel,
 	ROOT_PROJECT_GROUP_PATH,
 } from '@8f4e/language-spec';
-import { serializeProjectMemoryExposure } from '@8f4e/project-preparser';
 import type { StateManager } from '@8f4e/state-manager';
 import gapCalculator from '../code-editing/gapCalculator';
 import { moveCaret } from '../code-editing/moveCaret';
@@ -303,17 +302,18 @@ export default function codeBlockRendering(store: StateManager<State>, events: E
 				const groupName = group.name;
 				const gridX = groupIndex * 24;
 				const gridY = -6;
+				const groupCode = [...group.code];
+				if (!parsePos(parseBlockDirectives(groupCode))) {
+					let closerIndex = groupCode.length - 1;
+					while (closerIndex >= 0 && groupCode[closerIndex].trim() === '') closerIndex -= 1;
+					groupCode.splice(closerIndex, 0, `; @pos ${gridX} ${gridY}`);
+				}
 				const creationIndex = nextCodeBlockCreationIndex;
 				nextCodeBlockCreationIndex += 1;
 				return createGraphicCodeBlock(
 					{
 						id: creationIndex,
-						code: [
-							`group ${groupName}`,
-							...group.exposures.map(serializeProjectMemoryExposure),
-							`; @pos ${gridX} ${gridY}`,
-							'groupEnd',
-						],
+						code: groupCode,
 						blockType: 'unknown',
 						entry: group.entry,
 					},

--- a/packages/editor/packages/editor-state/src/features/project-export/README.md
+++ b/packages/editor/packages/editor-state/src/features/project-export/README.md
@@ -46,9 +46,6 @@ The canonical structure is defined by `@8f4e/language-spec`:
 
 ```typescript
 interface ProjectObjectModel {
-	id?: string;
-	name?: string;
-	entry?: ProjectEntryName;
 	modules: ProjectModuleBlock[];
 	functions: ProjectBlock[];
 	constants: ProjectBlock[];
@@ -56,15 +53,23 @@ interface ProjectObjectModel {
 	includes: ProjectBlock[];
 	notes: ProjectBlock[];
 	unknown: ProjectBlock[];
-	groups: ProjectObjectModel[];
+	groups: ProjectGroupObjectModel[];
+}
+
+interface ProjectGroupObjectModel extends ProjectObjectModel {
+	name: ProjectGroupName;
+	entry: ProjectEntryName;
+	code: string[];
+	exposures: ProjectMemoryExposure[];
 }
 ```
 
 Collection membership defines block type. The adapter uses the editor's already-known block type and does not make the
 compiler rediscover it from source text. Project groups are rendered as ordinary `CodeBlockGraphicData` values whose
 optional `nestedProjectCodeBlocks` field owns the child project slice. Export recursively traverses that tree from
-`rootCodeBlocks`, regardless of which slice `codeBlocks` currently points to. Compilation currently consumes only the
-root project; recursive sub-program composition is intentionally deferred.
+`rootCodeBlocks`, regardless of which slice `codeBlocks` currently points to. A group's `code` retains all source lines
+owned by its visible wrapper, including comments and editor directives, while its nested blocks stay in the recursive
+collections. Compilation recursively composes those collections into one program.
 
 ## References
 

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeCodeBlocks.test.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeCodeBlocks.test.ts
@@ -114,7 +114,7 @@ describe('convertGraphicDataToProjectStructure', () => {
 			createMockCodeBlock({
 				name: 'Audio',
 				entry: 'main',
-				code: ['group Audio', 'expose int level &voice:level', 'groupEnd'],
+				code: ['group Audio', '; keep this comment', 'expose int level &voice:level', 'groupEnd'],
 				nestedProjectCodeBlocks: [
 					createMockCodeBlock({
 						name: 'Oscillator',
@@ -136,6 +136,7 @@ describe('convertGraphicDataToProjectStructure', () => {
 		expect(result.groups[0]).toMatchObject({
 			name: 'Audio',
 			entry: 'main',
+			code: ['group Audio', '; keep this comment', 'expose int level &voice:level', 'groupEnd'],
 			exposures: [
 				{
 					type: 'int',
@@ -168,6 +169,7 @@ describe('convertGraphicDataToProjectStructure', () => {
 			{
 				name: 'Empty',
 				entry: 'main',
+				code: ['group Empty', 'groupEnd'],
 				exposures: [],
 				modules: [],
 				functions: [],

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeCodeBlocks.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeCodeBlocks.ts
@@ -27,6 +27,7 @@ export default function convertGraphicDataToProjectStructure(codeBlocks: CodeBlo
 				...convertGraphicDataToProjectStructure(codeBlock.nestedProjectCodeBlocks),
 				name: codeBlock.name,
 				entry: codeBlock.entry!,
+				code: codeBlock.code,
 				exposures: codeBlock.code.flatMap(line => {
 					const exposure = tryParseProjectMemoryExposureLine(line);
 					return exposure ? [exposure] : [];

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeTo8f4e.test.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeTo8f4e.test.ts
@@ -109,6 +109,13 @@ describe('serializeProjectTo8f4e', () => {
 					id: 'audio-id',
 					name: 'audio',
 					entry: 'main',
+					code: [
+						'group audio',
+						'; retain this group comment',
+						'futureInstruction anything',
+						'expose int count &counter:count',
+						'groupEnd',
+					],
 					exposures: [
 						{
 							type: 'int',
@@ -123,6 +130,7 @@ describe('serializeProjectTo8f4e', () => {
 						createProject({
 							name: 'notes',
 							entry: 'main',
+							code: ['group notes', 'groupEnd'],
 							exposures: [],
 							notes: [{ id: 3, code: validNoteBlock }],
 						}),
@@ -136,6 +144,13 @@ describe('serializeProjectTo8f4e', () => {
 		expect(parsed.groups[0]).toMatchObject({
 			name: 'audio',
 			entry: 'main',
+			code: [
+				'group audio',
+				'; retain this group comment',
+				'futureInstruction anything',
+				'expose int count &counter:count',
+				'groupEnd',
+			],
 			exposures: [
 				{
 					type: 'int',

--- a/packages/editor/packages/editor-state/src/features/project-export/serializeTo8f4e.ts
+++ b/packages/editor/packages/editor-state/src/features/project-export/serializeTo8f4e.ts
@@ -1,5 +1,4 @@
 import type { ProjectGroupObjectModel, ProjectModuleBlock, ProjectObjectModel } from '@8f4e/language-spec';
-import { serializeProjectMemoryExposure } from '@8f4e/project-preparser';
 import { FORMAT_HEADER, getCloserKeyword, getExpectedCloserPrefix, getOpenerKeyword } from '../project-format';
 
 function validateCodeBlock(code: string[], blockIndex: number): void {
@@ -68,17 +67,23 @@ function getDocumentBlocks(project: ProjectObjectModel) {
 }
 
 function getAllBlocks(project: ProjectObjectModel): Array<{ code: string[] }> {
-	return [...getDocumentBlocks(project), ...project.modules, ...project.groups.flatMap(getAllBlocks)];
+	return [
+		...getDocumentBlocks(project),
+		...project.modules,
+		...project.groups.flatMap(group => [group, ...getAllBlocks(group)]),
+	];
 }
 
 function serializeGroup(group: ProjectGroupObjectModel): string[] {
+	let closerIndex = group.code.length - 1;
+	while (closerIndex >= 0 && group.code[closerIndex].trim() === '') closerIndex -= 1;
+
 	return [
-		`group ${group.name}`,
-		...group.exposures.map(serializeProjectMemoryExposure),
+		...group.code.slice(0, closerIndex),
 		...getDocumentBlocks(group).flatMap(block => block.code),
 		...group.modules.flatMap(module => module.code),
 		...group.groups.flatMap(serializeGroup),
-		'groupEnd',
+		...group.code.slice(closerIndex),
 	];
 }
 


### PR DESCRIPTION
## Summary

- add required `code` source lines to `ProjectGroupObjectModel`
- preserve comments, directives, blank lines, exposures, and arbitrary group-root instructions through parsing and editor import/export
- serialize nested blocks inside the preserved group wrapper
- update object-model documentation and parser snapshots

## Rationale

The previous object model reduced project groups to exposures and recursively owned blocks. The editor therefore reconstructed group wrappers and silently discarded comments and other root-level source. The group wrapper source is now part of the compiler-owned canonical contract, with no compatibility shim because the project is unreleased.

## Tests

- `npx nx run-many -t test -p @8f4e/language-spec,@8f4e/project-preparser,@8f4e/compiler,@8f4e/cli,@8f4e/editor-state -- --runInBand`
- `npx nx run-many --target=typecheck --all`
- relevant Nx lint targets and Biome checks