### PR TITLE
feat(editor-state): copy project groups recursively

### DIFF
--- a/packages/compiler/packages/language-spec/src/instructions.test.ts
+++ b/packages/compiler/packages/language-spec/src/instructions.test.ts
@@ -10,6 +10,8 @@ import {
 	isFunctionBodyInstructionName,
 	isFunctionPreBodyInstructionName,
 	isImportedFunctionDeclarationInstructionName,
+	isKnownInstructionName,
+	isSubProgramInstructionName,
 	stackBlockInstructionPairs,
 } from './instructions';
 
@@ -60,5 +62,16 @@ describe('function instruction classification', () => {
 				])
 			),
 		}).toMatchSnapshot();
+	});
+});
+
+describe('instruction name classification', () => {
+	it('includes project instructions in the complete set but excludes them from subprograms', () => {
+		expect(isKnownInstructionName('group')).toBe(true);
+		expect(isKnownInstructionName('groupEnd')).toBe(true);
+		expect(isKnownInstructionName('expose')).toBe(true);
+		expect(isSubProgramInstructionName('group')).toBe(false);
+		expect(isSubProgramInstructionName('expose')).toBe(false);
+		expect(isSubProgramInstructionName('push')).toBe(true);
 	});
 });

--- a/packages/compiler/packages/language-spec/src/instructions.ts
+++ b/packages/compiler/packages/language-spec/src/instructions.ts
@@ -13,6 +13,8 @@ import type {
 } from './instructionSpecTypes';
 import type { MemoryDeclarationInstruction } from './memory';
 import { memoryDeclarationInstructions } from './memory';
+import type { ProjectInstructionName } from './project';
+import { projectInstructionNames } from './project';
 
 type InstructionSpecEntry = readonly [InstructionSpecName, InstructionSpec];
 
@@ -234,24 +236,38 @@ export function isImportedFunctionDeclarationInstructionName(
 	return importedFunctionDeclarationInstructionNameSet.has(instruction);
 }
 
-export type Instruction =
+export type SubProgramInstruction =
 	| CodegenInstructionName
 	| MemoryDeclarationInstruction
 	| SemanticInstructionName
 	| DocumentOnlyInstructionName;
 
-export const knownInstructionNameSet: ReadonlySet<string> = new Set([
+/** Instructions accepted by the tokenizer after project-level source has been extracted. */
+export const subProgramInstructionNameSet: ReadonlySet<string> = new Set([
 	...codegenInstructionNames,
 	...memoryDeclarationInstructions,
 	...semanticInstructionNames,
 	...documentOnlyInstructionNames,
 ]);
 
+export type Instruction = SubProgramInstruction | ProjectInstructionName;
+
+/** Every instruction name accepted anywhere in an 8f4e project source. */
+export const knownInstructionNameSet: ReadonlySet<string> = new Set([
+	...subProgramInstructionNameSet,
+	...projectInstructionNames,
+]);
+
+/** Checks whether an instruction is accepted by the subprogram tokenizer. */
+export function isSubProgramInstructionName(instruction: string): instruction is SubProgramInstruction {
+	return subProgramInstructionNameSet.has(instruction);
+}
+
 /**
- * Checks whether a string is one of the compiler's registered instruction names.
+ * Checks whether a string is an instruction accepted anywhere in project source.
  *
  * @param instruction - Instruction keyword to inspect.
- * @returns True when the keyword belongs to a known compiler instruction.
+ * @returns True when the keyword belongs to a known project or subprogram instruction.
  */
 export function isKnownInstructionName(instruction: string): instruction is Instruction {
 	return knownInstructionNameSet.has(instruction);

--- a/packages/compiler/packages/language-spec/src/project.test.ts
+++ b/packages/compiler/packages/language-spec/src/project.test.ts
@@ -10,6 +10,8 @@ import {
 	type ProjectMemoryExposure,
 	type ProjectModuleBlock,
 	type ProjectObjectModel,
+	projectInstructionNames,
+	projectInstructions,
 	ROOT_PROJECT_GROUP_PATH,
 } from './project';
 
@@ -35,5 +37,14 @@ describe('ProjectObjectModel', () => {
 		expect(createProjectModuleId(voicesPath, 'counter-left')).toBe('audio/voices%2Flead/counter-left');
 		expect(getProjectGroupPathFromModuleId('counter')).toBe(ROOT_PROJECT_GROUP_PATH);
 		expect(getProjectGroupPathFromModuleId('audio/voices/counter')).toBe('audio/voices');
+	});
+
+	it('defines project-level source instructions', () => {
+		expect(projectInstructions).toEqual({
+			entry: { opener: 'entry', closer: 'entryEnd' },
+			group: { opener: 'group', closer: 'groupEnd' },
+			expose: 'expose',
+		});
+		expect(projectInstructionNames).toEqual(['entry', 'entryEnd', 'group', 'groupEnd', 'expose']);
 	});
 });

--- a/packages/compiler/packages/language-spec/src/project.ts
+++ b/packages/compiler/packages/language-spec/src/project.ts
@@ -17,9 +17,6 @@ export const projectInstructionNames = [
 
 export type ProjectInstructionName = (typeof projectInstructionNames)[number];
 
-/** Project-level instruction lookup shared by compiler tooling and editor syntax highlighting. */
-export const projectInstructionNameSet: ReadonlySet<string> = new Set(projectInstructionNames);
-
 /** Stable identity shared by project actors and compiler diagnostics. */
 export type ProjectBlockId = number;
 

--- a/packages/compiler/packages/language-spec/src/project.ts
+++ b/packages/compiler/packages/language-spec/src/project.ts
@@ -1,5 +1,25 @@
 import type { MemoryDeclarationInstruction, PlannedMemoryDeclaration } from './memory';
 
+/** Project-level source instructions consumed before individual code blocks are tokenized. */
+export const projectInstructions = {
+	entry: { opener: 'entry', closer: 'entryEnd' },
+	group: { opener: 'group', closer: 'groupEnd' },
+	expose: 'expose',
+} as const;
+
+export const projectInstructionNames = [
+	projectInstructions.entry.opener,
+	projectInstructions.entry.closer,
+	projectInstructions.group.opener,
+	projectInstructions.group.closer,
+	projectInstructions.expose,
+] as const;
+
+export type ProjectInstructionName = (typeof projectInstructionNames)[number];
+
+/** Project-level instruction lookup shared by compiler tooling and editor syntax highlighting. */
+export const projectInstructionNameSet: ReadonlySet<string> = new Set(projectInstructionNames);
+
 /** Stable identity shared by project actors and compiler diagnostics. */
 export type ProjectBlockId = number;
 

--- a/packages/compiler/packages/project-preparser/src/delimiters.ts
+++ b/packages/compiler/packages/project-preparser/src/delimiters.ts
@@ -1,8 +1,12 @@
-import { documentBlockInstructionByType, documentBlockInstructionPairs } from '@8f4e/language-spec';
+import {
+	documentBlockInstructionByType,
+	documentBlockInstructionPairs,
+	projectInstructions,
+} from '@8f4e/language-spec';
 
 export const FORMAT_HEADER = '8f4e/v1';
-export const ENTRY_BLOCK_DELIMITER = { type: 'entry', opener: 'entry', closer: 'entryEnd' } as const;
-export const GROUP_BLOCK_DELIMITER = { type: 'group', opener: 'group', closer: 'groupEnd' } as const;
+export const ENTRY_BLOCK_DELIMITER = { type: 'entry', ...projectInstructions.entry } as const;
+export const GROUP_BLOCK_DELIMITER = { type: 'group', ...projectInstructions.group } as const;
 export const INCLUDES_BLOCK_DELIMITER = {
 	type: documentBlockInstructionByType.includes.type,
 	opener: documentBlockInstructionByType.includes.start,

--- a/packages/compiler/packages/project-preparser/src/projectMemoryExposure.ts
+++ b/packages/compiler/packages/project-preparser/src/projectMemoryExposure.ts
@@ -3,10 +3,11 @@ import {
 	isValidModuleName,
 	type MemoryDeclarationInstruction,
 	type ProjectMemoryExposure,
+	projectInstructions,
 } from '@8f4e/language-spec';
 import { startsWithInstruction } from './projectKeywords';
 
-const EXPOSURE_INSTRUCTION = 'expose';
+const EXPOSURE_INSTRUCTION = projectInstructions.expose;
 
 function isValidNamedMemoryReference(value: string): boolean {
 	return value.length > 0 && !/[&:.\s]/.test(value) && !/^\d+$/.test(value);

--- a/packages/compiler/packages/sub-program/packages/tokenizer/src/syntax/validateInstructionArguments.test.ts
+++ b/packages/compiler/packages/sub-program/packages/tokenizer/src/syntax/validateInstructionArguments.test.ts
@@ -19,6 +19,14 @@ describe('validateInstructionArguments', () => {
 		);
 	});
 
+	it('rejects project-level instructions', () => {
+		for (const instruction of ['group', 'groupEnd', 'expose']) {
+			expect(() => validateInstructionArguments(instruction, [])).toThrow(
+				expect.objectContaining({ code: SyntaxErrorCode.UNRECOGNISED_INSTRUCTION })
+			);
+		}
+	});
+
 	it('accepts one-argument map rows', () => {
 		expect(() =>
 			validateInstructionArguments('map', [{ type: ArgumentType.LITERAL, value: 1, isInteger: true }])

--- a/packages/compiler/packages/sub-program/packages/tokenizer/src/syntax/validateInstructionArguments.ts
+++ b/packages/compiler/packages/sub-program/packages/tokenizer/src/syntax/validateInstructionArguments.ts
@@ -5,8 +5,8 @@ import {
 	getInstructionSpec,
 	isArrayMemoryDeclarationInstructionName,
 	isBlockResultTypeIdentifier,
-	isKnownInstructionName,
 	isMemoryDeclarationInstructionName,
+	isSubProgramInstructionName,
 	isValidModuleName,
 	MODULE_NAME_PATTERN,
 	SCALAR_TYPE_IDENTIFIERS,
@@ -149,7 +149,7 @@ function validateArgumentShape(argument: Argument, rule: SourceArgumentShapeRule
  * @returns Nothing.
  */
 export default function validateInstructionArguments(instruction: string, args: Argument[]): void {
-	if (!isKnownInstructionName(instruction)) {
+	if (!isSubProgramInstructionName(instruction)) {
 		throw new SyntaxRulesError(SyntaxErrorCode.UNRECOGNISED_INSTRUCTION);
 	}
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/clipboard/clipboardUtils.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/clipboard/clipboardUtils.test.ts
@@ -2,9 +2,9 @@ import { describe, expect, it } from 'vitest';
 import { createMockCodeBlock } from '~/pureHelpers/testingUtils/testUtils';
 
 import { extractGroupName } from '../group/extractGroupName';
-import { parseClipboardData, serializeGroupToClipboard } from './clipboardUtils';
+import { parseClipboardData, serializeCodeBlocksToClipboard } from './clipboardUtils';
 
-describe('serializeGroupToClipboard', () => {
+describe('serializeCodeBlocksToClipboard', () => {
 	it('should serialize group blocks with relative coordinates', () => {
 		const anchor = createMockCodeBlock({
 			code: ['module foo', 'moduleEnd'],
@@ -18,7 +18,7 @@ describe('serializeGroupToClipboard', () => {
 			gridY: 24,
 		});
 
-		const result = serializeGroupToClipboard([anchor, block2], anchor);
+		const result = serializeCodeBlocksToClipboard([anchor, block2], anchor);
 		const parsed = JSON.parse(result);
 
 		expect(parsed).toHaveLength(2);
@@ -40,7 +40,7 @@ describe('serializeGroupToClipboard', () => {
 			disabled: true,
 		});
 
-		const result = serializeGroupToClipboard([anchor], anchor);
+		const result = serializeCodeBlocksToClipboard([anchor], anchor);
 		const parsed = JSON.parse(result);
 
 		expect(parsed[0].code).toContain('; @disabled');
@@ -55,7 +55,7 @@ describe('serializeGroupToClipboard', () => {
 			disabled: false,
 		});
 
-		const result = serializeGroupToClipboard([anchor], anchor);
+		const result = serializeCodeBlocksToClipboard([anchor], anchor);
 		const parsed = JSON.parse(result);
 
 		expect(parsed[0].code).not.toContain('; @disabled');
@@ -75,7 +75,7 @@ describe('serializeGroupToClipboard', () => {
 			gridY: 8,
 		});
 
-		const result = serializeGroupToClipboard([anchor, block2], anchor);
+		const result = serializeCodeBlocksToClipboard([anchor, block2], anchor);
 		const parsed = JSON.parse(result);
 
 		expect(parsed[1].gridCoordinates).toEqual({ x: -5, y: -2 });
@@ -88,15 +88,79 @@ describe('serializeGroupToClipboard', () => {
 			gridY: 0,
 		});
 
-		const result = serializeGroupToClipboard([anchor], anchor);
+		const result = serializeCodeBlocksToClipboard([anchor], anchor);
 		const parsed = JSON.parse(result);
 
 		expect(parsed[0].code).toEqual(['module test', '', '; comment', '', 'moduleEnd']);
+	});
+
+	it('serializes project-group contents recursively', () => {
+		const nestedModule = createMockCodeBlock({
+			code: ['module voice', 'moduleEnd'],
+			gridX: 4,
+			gridY: 6,
+			entry: 'main',
+		});
+		const nestedGroup = createMockCodeBlock({
+			code: ['group modulation', 'groupEnd'],
+			gridX: -3,
+			gridY: 8,
+			entry: 'main',
+			nestedProjectCodeBlocks: [nestedModule],
+		});
+		const group = createMockCodeBlock({
+			code: ['group audio', '; keep me', 'groupEnd'],
+			gridX: 10,
+			gridY: 20,
+			entry: 'main',
+			nestedProjectCodeBlocks: [nestedGroup],
+		});
+
+		const parsed = JSON.parse(serializeCodeBlocksToClipboard([group], group));
+
+		expect(parsed).toEqual([
+			{
+				code: ['group audio', '; keep me', 'groupEnd'],
+				gridCoordinates: { x: 0, y: 0 },
+				entry: 'main',
+				nestedProjectCodeBlocks: [
+					{
+						code: ['group modulation', 'groupEnd'],
+						gridCoordinates: { x: -3, y: 8 },
+						entry: 'main',
+						nestedProjectCodeBlocks: [
+							{
+								code: ['module voice', 'moduleEnd'],
+								gridCoordinates: { x: 4, y: 6 },
+								entry: 'main',
+							},
+						],
+					},
+				],
+			},
+		]);
 	});
 });
 
 describe('parseClipboardData', () => {
 	describe('multi-block detection', () => {
+		it('parses a single project group with recursively owned blocks', () => {
+			const clipboardText = JSON.stringify([
+				{
+					code: ['group audio', 'groupEnd'],
+					gridCoordinates: { x: 0, y: 0 },
+					nestedProjectCodeBlocks: [{ code: ['module voice', 'moduleEnd'], gridCoordinates: { x: 4, y: 6 } }],
+				},
+			]);
+
+			const result = parseClipboardData(clipboardText);
+
+			expect(result.type).toBe('multi');
+			if (result.type === 'multi') {
+				expect(result.blocks[0].nestedProjectCodeBlocks?.[0].code).toEqual(['module voice', 'moduleEnd']);
+			}
+		});
+
 		it('should parse valid multi-block JSON array', () => {
 			const clipboardText = JSON.stringify([
 				{ code: ['module foo', 'moduleEnd'], gridCoordinates: { x: 0, y: 0 } },

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/clipboard/clipboardUtils.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/clipboard/clipboardUtils.ts
@@ -8,27 +8,43 @@ import type { CodeBlockGraphicData } from '@8f4e/editor-state-types';
 export interface ClipboardCodeBlock {
 	code: string[];
 	gridCoordinates: { x: number; y: number };
+	entry?: string;
+	nestedProjectCodeBlocks?: ClipboardCodeBlock[];
+}
+
+function createClipboardCodeBlock(block: CodeBlockGraphicData, origin: { x: number; y: number }): ClipboardCodeBlock {
+	return {
+		code: block.code,
+		gridCoordinates: {
+			x: block.gridX - origin.x,
+			y: block.gridY - origin.y,
+		},
+		...(block.entry === undefined ? {} : { entry: block.entry }),
+		...(block.nestedProjectCodeBlocks === undefined
+			? {}
+			: {
+					nestedProjectCodeBlocks: block.nestedProjectCodeBlocks.map(child =>
+						createClipboardCodeBlock(child, { x: 0, y: 0 })
+					),
+				}),
+	};
 }
 
 /**
- * Serializes a group of code blocks into a clipboard payload.
+ * Serializes code blocks and recursively owned project-group slices into a clipboard payload.
  * The payload is a JSON array where gridCoordinates are relative to the anchor block.
  *
- * @param groupBlocks - Array of code blocks to copy (must all be from the same group)
+ * @param codeBlocks - Array of code blocks to copy from the same rendered project slice
  * @param anchorBlock - The block to use as the reference point (0,0)
  * @returns JSON string representation of the code blocks
  */
-export function serializeGroupToClipboard(
-	groupBlocks: CodeBlockGraphicData[],
+export function serializeCodeBlocksToClipboard(
+	codeBlocks: CodeBlockGraphicData[],
 	anchorBlock: CodeBlockGraphicData
 ): string {
-	const clipboardBlocks: ClipboardCodeBlock[] = groupBlocks.map(block => ({
-		code: block.code,
-		gridCoordinates: {
-			x: block.gridX - anchorBlock.gridX,
-			y: block.gridY - anchorBlock.gridY,
-		},
-	}));
+	const clipboardBlocks = codeBlocks.map(block =>
+		createClipboardCodeBlock(block, { x: anchorBlock.gridX, y: anchorBlock.gridY })
+	);
 
 	return JSON.stringify(clipboardBlocks);
 }
@@ -60,6 +76,15 @@ function isValidClipboardCodeBlock(obj: unknown): obj is ClipboardCodeBlock {
 	if (typeof coords.x !== 'number' || typeof coords.y !== 'number') {
 		return false;
 	}
+	if (block.entry !== undefined && typeof block.entry !== 'string') {
+		return false;
+	}
+	if (
+		block.nestedProjectCodeBlocks !== undefined &&
+		(!Array.isArray(block.nestedProjectCodeBlocks) || !block.nestedProjectCodeBlocks.every(isValidClipboardCodeBlock))
+	) {
+		return false;
+	}
 
 	return true;
 }
@@ -82,13 +107,15 @@ export function parseClipboardData(
 		return { type: 'single', text: clipboardText };
 	}
 
-	// Check if it's an array with at least 2 elements
-	if (!Array.isArray(parsed) || parsed.length < 2) {
+	if (!Array.isArray(parsed) || parsed.length === 0) {
 		return { type: 'single', text: clipboardText };
 	}
 
 	// Check if every element matches the expected code block shape
 	if (!parsed.every(isValidClipboardCodeBlock)) {
+		return { type: 'single', text: clipboardText };
+	}
+	if (parsed.length === 1 && parsed[0].nestedProjectCodeBlocks === undefined) {
 		return { type: 'single', text: clipboardText };
 	}
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/copyPaste.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/copyPaste.test.ts
@@ -3,6 +3,7 @@ import createStateManager from '@8f4e/state-manager';
 import { beforeEach, describe, expect, it, type MockInstance, vi } from 'vitest';
 import { createMockCodeBlock, createMockState } from '~/pureHelpers/testingUtils/testUtils';
 import { createMockEventDispatcherWithVitest } from '~/pureHelpers/testingUtils/vitestTestUtils';
+import convertGraphicDataToProjectStructure from '../../../project-export/serializeCodeBlocks';
 import groupCopier from '../group/copier/effect';
 import codeBlockCreator from './effect';
 
@@ -161,6 +162,140 @@ describe('codeBlockCreator - group copy/paste', () => {
 			expect(parsed[0].code[0]).toBe('module bar');
 			expect(parsed[1].code[0]).toBe('module foo');
 			expect(parsed[2].code[0]).toBe('module baz');
+		});
+	});
+
+	describe('Copy project group', () => {
+		it('copies and pastes the complete recursive project-group tree', async () => {
+			let clipboardText = '';
+			mockState.callbacks.writeClipboardText = vi.fn(async text => {
+				clipboardText = text;
+			});
+			mockState.callbacks.readClipboardText = vi.fn(async () => clipboardText);
+			mockState.codeBlockRendering.nextCodeBlockCreationIndex = 20;
+
+			const nestedModule = createMockCodeBlock({
+				name: 'voice',
+				code: ['module voice', 'moduleEnd'],
+				blockType: 'module',
+				entry: 'main',
+				projectPath: 'audio/modulation',
+				gridX: 4,
+				gridY: 6,
+				creationIndex: 4,
+			});
+			const nestedGroup = createMockCodeBlock({
+				name: 'modulation',
+				code: ['group modulation', '; nested comment', 'groupEnd'],
+				entry: 'main',
+				projectPath: 'audio',
+				gridX: -3,
+				gridY: 8,
+				creationIndex: 3,
+				nestedProjectCodeBlocks: [nestedModule],
+			});
+			const module = createMockCodeBlock({
+				name: 'output',
+				code: ['module output', 'moduleEnd'],
+				blockType: 'module',
+				entry: 'main',
+				projectPath: 'audio',
+				gridX: 2,
+				gridY: 3,
+				creationIndex: 2,
+			});
+			const functionBlock = createMockCodeBlock({
+				name: 'process',
+				code: ['function process', 'functionEnd'],
+				blockType: 'function',
+				projectPath: 'audio',
+				gridX: 12,
+				gridY: 5,
+				creationIndex: 1,
+			});
+			const group = createMockCodeBlock({
+				name: 'audio',
+				code: ['group audio', '; root comment', 'groupEnd'],
+				entry: 'main',
+				gridX: 10,
+				gridY: 20,
+				creationIndex: 0,
+				nestedProjectCodeBlocks: [module, functionBlock, nestedGroup],
+			});
+			const rootCodeBlocks = [group];
+			mockState.codeBlockRendering.rootCodeBlocks = rootCodeBlocks;
+			mockState.codeBlockRendering.codeBlocks = rootCodeBlocks;
+
+			codeBlockCreator(store, mockEvents);
+			const onCalls = (mockEvents.on as unknown as MockInstance).mock.calls;
+			const copyCodeBlock = onCalls.find(call => call[0] === 'copyCodeBlock')![1];
+			const addCodeBlock = onCalls.find(call => call[0] === 'addCodeBlock')![1];
+
+			copyCodeBlock({ codeBlock: group });
+			await new Promise(resolve => setTimeout(resolve, 0));
+			expect(JSON.parse(clipboardText)[0].nestedProjectCodeBlocks).toHaveLength(3);
+
+			await addCodeBlock({ x: 100, y: 100, isNew: false, code: [''] });
+
+			expect(rootCodeBlocks).toHaveLength(2);
+			const pastedGroup = rootCodeBlocks[1];
+			expect(pastedGroup).toMatchObject({
+				name: 'audio1',
+				entry: 'main',
+				projectPath: '',
+			});
+			expect(pastedGroup.code).toContain('; root comment');
+			expect(pastedGroup.nestedProjectCodeBlocks).toHaveLength(3);
+			expect(pastedGroup.nestedProjectCodeBlocks?.[0]).toMatchObject({
+				name: 'output',
+				blockType: 'module',
+				entry: 'main',
+				projectPath: 'audio1',
+				gridX: 2,
+				gridY: 3,
+			});
+			expect(pastedGroup.nestedProjectCodeBlocks?.[1]).toMatchObject({
+				name: 'process',
+				blockType: 'function',
+				projectPath: 'audio1',
+			});
+			const pastedNestedGroup = pastedGroup.nestedProjectCodeBlocks?.[2];
+			expect(pastedNestedGroup).toMatchObject({
+				name: 'modulation',
+				projectPath: 'audio1',
+			});
+			expect(pastedNestedGroup?.code).toContain('; nested comment');
+			expect(pastedNestedGroup?.nestedProjectCodeBlocks?.[0]).toMatchObject({
+				name: 'voice',
+				blockType: 'module',
+				entry: 'main',
+				projectPath: 'audio1/modulation',
+				gridX: 4,
+				gridY: 6,
+			});
+			const pastedCreationIndexes = [
+				pastedGroup.creationIndex,
+				...pastedGroup.nestedProjectCodeBlocks!.flatMap(block => [
+					block.creationIndex,
+					...(block.nestedProjectCodeBlocks?.map(child => child.creationIndex) ?? []),
+				]),
+			];
+			expect(new Set(pastedCreationIndexes).size).toBe(pastedCreationIndexes.length);
+			expect(Math.min(...pastedCreationIndexes)).toBe(20);
+
+			const pastedProjectGroup = convertGraphicDataToProjectStructure(rootCodeBlocks).groups[1];
+			expect(pastedProjectGroup).toMatchObject({
+				name: 'audio1',
+				entry: 'main',
+				modules: [{ entry: 'main', code: expect.arrayContaining(['module output']) }],
+				functions: [{ code: expect.arrayContaining(['function process']) }],
+				groups: [
+					{
+						name: 'modulation',
+						modules: [{ entry: 'main', code: expect.arrayContaining(['module voice']) }],
+					},
+				],
+			});
 		});
 	});
 

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.test.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.test.ts
@@ -16,7 +16,7 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 		mockEvents = createMockEventDispatcherWithVitest();
 	});
 
-	describe('Paste Module (readClipboardText callback)', () => {
+	describe('Paste Code Block (readClipboardText callback)', () => {
 		it('should read from clipboard callback when pasting a module', async () => {
 			const mockReadClipboard = vi.fn().mockResolvedValue('module test\n\nmoduleEnd');
 			mockState.callbacks.readClipboardText = mockReadClipboard;
@@ -30,7 +30,7 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 
 			const addCodeBlockCallback = addCodeBlockCall![1];
 
-			// Trigger paste module (code.length < 2 triggers clipboard read)
+			// Trigger paste code block (code.length < 2 triggers clipboard read)
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: false, code: [''] });
 
 			// Verify clipboard was read
@@ -53,7 +53,7 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 			const addCodeBlockCall = onCalls.find(call => call[0] === 'addCodeBlock');
 			const addCodeBlockCallback = addCodeBlockCall![1];
 
-			// Trigger paste module (code.length < 2 triggers clipboard read)
+			// Trigger paste code block (code.length < 2 triggers clipboard read)
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: false, code: [''] });
 
 			// Verify no code block was added
@@ -70,7 +70,7 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 			const addCodeBlockCall = onCalls.find(call => call[0] === 'addCodeBlock');
 			const addCodeBlockCallback = addCodeBlockCall![1];
 
-			// Trigger paste module (code.length < 2 triggers clipboard read)
+			// Trigger paste code block (code.length < 2 triggers clipboard read)
 			await addCodeBlockCallback({ x: 100, y: 100, isNew: false, code: [''] });
 
 			// Verify clipboard was attempted

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.ts
@@ -7,7 +7,7 @@ import replaceCodeBlocksInPlace from '../../replaceCodeBlocksInPlace';
 import getBlockType from '../../utils/codeParsers/getBlockType';
 import { createCodeBlockGraphicData } from '../../utils/createCodeBlockGraphicData';
 import getCodeBlockNameFromSource from '../../utils/getCodeBlockNameFromSource';
-import { parseClipboardData } from '../clipboard/clipboardUtils';
+import { parseClipboardData, serializeCodeBlocksToClipboard } from '../clipboard/clipboardUtils';
 import upsertDisabled from '../directives/disabled/upsert';
 import upsertPos from '../directives/pos/upsert';
 import findEntryNameAtPosition from '../entryOutlines/findEntryNameAtPosition';
@@ -273,7 +273,11 @@ export default function codeBlockCreator(store: StateManager<State>, events: Eve
 	function onCopyCodeBlock({ codeBlock }: { codeBlock: CodeBlockGraphicData }): void {
 		// Use callback if available, otherwise fail silently
 		if (state.callbacks.writeClipboardText) {
-			state.callbacks.writeClipboardText(codeBlock.code.join('\n')).catch(() => {
+			const clipboardText =
+				codeBlock.nestedProjectCodeBlocks === undefined
+					? codeBlock.code.join('\n')
+					: serializeCodeBlocksToClipboard([codeBlock], codeBlock);
+			state.callbacks.writeClipboardText(clipboardText).catch(() => {
 				// Fail silently if clipboard write fails
 				return undefined;
 			});

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/pasteMultipleBlocks.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/pasteMultipleBlocks.ts
@@ -1,4 +1,5 @@
 import type { CodeBlockGraphicData, State } from '@8f4e/editor-state-types';
+import { createChildProjectGroupPath, type ProjectGroupPath, ROOT_PROJECT_GROUP_PATH } from '@8f4e/language-spec';
 import type { StateManager } from '@8f4e/state-manager';
 import replaceCodeBlocksInPlace from '../../replaceCodeBlocksInPlace';
 import getBlockType from '../../utils/codeParsers/getBlockType';
@@ -9,7 +10,7 @@ import type { ClipboardCodeBlock } from '../clipboard/clipboardUtils';
 import upsertPos from '../directives/pos/upsert';
 import { hasDirective } from '../directives/utils';
 import { extractGroupName } from '../group/extractGroupName';
-import { createGroupNameMapping } from '../group/getUniqueGroupName';
+import { createGroupNameMapping, getUniqueGroupName } from '../group/getUniqueGroupName';
 import { replaceGroupName } from '../group/replaceGroupName';
 import { findProjectSlicePath } from '../projectGroupNavigation/effect';
 
@@ -59,6 +60,45 @@ function changeCodeBlockNameInCode(code: string[], instruction: string, name: st
 	});
 }
 
+function createPastedCodeBlock(
+	state: State,
+	clipboardBlock: ClipboardCodeBlock,
+	code: string[],
+	gridX: number,
+	gridY: number,
+	projectPath: ProjectGroupPath
+): CodeBlockGraphicData {
+	const creationIndex = state.codeBlockRendering.nextCodeBlockCreationIndex;
+	state.codeBlockRendering.nextCodeBlockCreationIndex += 1;
+	const name = getCodeBlockNameFromSource(code);
+	const codeBlock = createCodeBlockGraphicData({
+		code,
+		name,
+		projectPath,
+		gridX,
+		gridY,
+		x: gridX * state.viewport.vGrid,
+		y: gridY * state.viewport.hGrid,
+		creationIndex,
+		blockType: getBlockType(code),
+		entry: clipboardBlock.entry,
+		disabled: hasDirective(code, 'disabled'),
+		alwaysOnTop: hasDirective(code, 'alwaysOnTop'),
+	});
+
+	if (clipboardBlock.nestedProjectCodeBlocks !== undefined) {
+		const childProjectPath = createChildProjectGroupPath(projectPath, name);
+		codeBlock.nestedProjectCodeBlocks = clipboardBlock.nestedProjectCodeBlocks.map(child => {
+			const childGridX = child.gridCoordinates.x;
+			const childGridY = child.gridCoordinates.y;
+			const childCode = upsertPos([...child.code], childGridX, childGridY);
+			return createPastedCodeBlock(state, child, childCode, childGridX, childGridY, childProjectPath);
+		});
+	}
+
+	return codeBlock;
+}
+
 /**
  * Handles pasting multiple blocks from clipboard with collision resolution and reference updating.
  * This function:
@@ -84,10 +124,9 @@ export function pasteMultipleBlocks(
 	if (!state.featureFlags.editing) {
 		return;
 	}
-	const projectPath = findProjectSlicePath(
-		state.codeBlockRendering.rootCodeBlocks,
-		state.codeBlockRendering.codeBlocks
-	)!;
+	const projectPath =
+		findProjectSlicePath(state.codeBlockRendering.rootCodeBlocks, state.codeBlockRendering.codeBlocks) ??
+		ROOT_PROJECT_GROUP_PATH;
 
 	// Calculate paste anchor grid position
 	const anchorGridX = Math.round((state.viewport.x + x) / state.viewport.vGrid);
@@ -104,6 +143,19 @@ export function pasteMultipleBlocks(
 
 	// Create group name mapping to avoid collisions
 	const groupNameMapping = createGroupNameMapping(pastedGroupNames, state.codeBlockRendering.codeBlocks);
+	const existingProjectGroupNames = new Set(
+		state.codeBlockRendering.codeBlocks
+			.filter(block => block.nestedProjectCodeBlocks !== undefined)
+			.map(block => block.name)
+	);
+	const projectGroupNameMapping = new Map<string, string>();
+	for (const block of blocks) {
+		if (block.nestedProjectCodeBlocks === undefined) continue;
+		const originalName = getCodeBlockNameFromSource(block.code);
+		const newName = getUniqueGroupName(originalName, existingProjectGroupNames);
+		projectGroupNameMapping.set(originalName, newName);
+		existingProjectGroupNames.add(newName);
+	}
 
 	// First pass: determine name mappings for all pasted blocks.
 	const nameMapping = new Map<string, string[]>(); // Maps `<type>:<originalName>` to array of new names.
@@ -143,6 +195,13 @@ export function pasteMultipleBlocks(
 		nameMapping.get(key)!.push(newName);
 		processedNames.add(`${type}:${newName}`);
 	}
+	const simpleNameMapping = new Map<string, string>();
+	for (const [mappingKey, newNameArray] of nameMapping.entries()) {
+		const [, originalMappedName] = mappingKey.split(':');
+		if (newNameArray.length > 0) {
+			simpleNameMapping.set(originalMappedName, newNameArray[0]);
+		}
+	}
 
 	// Second pass: create blocks with updated names and inter-module references.
 	const newBlocks: CodeBlockGraphicData[] = [];
@@ -155,6 +214,12 @@ export function pasteMultipleBlocks(
 
 		// Process code: update names, inter-module references, and rename groups.
 		let code = [...clipboardBlock.code];
+		const isProjectGroup = clipboardBlock.nestedProjectCodeBlocks !== undefined;
+		const originalProjectGroupName = isProjectGroup ? getCodeBlockNameFromSource(code) : undefined;
+		if (originalProjectGroupName) {
+			const newProjectGroupName = projectGroupNameMapping.get(originalProjectGroupName)!;
+			code = changeCodeBlockNameInCode(code, 'group', newProjectGroupName);
+		}
 
 		// Update module/function names to ensure uniqueness.
 		const blockType = getBlockType(code);
@@ -176,16 +241,10 @@ export function pasteMultipleBlocks(
 			}
 		}
 
-		// Update inter-module references in the code
-		// Build a simple name mapping from first occurrence of each original name to its new name.
-		const simpleNameMapping = new Map<string, string>();
-		for (const [mappingKey, newNameArray] of nameMapping.entries()) {
-			const [, originalMappedName] = mappingKey.split(':');
-			if (newNameArray.length > 0) {
-				simpleNameMapping.set(originalMappedName, newNameArray[0]);
-			}
+		if (!isProjectGroup) {
+			code = updateInterModuleReferences(code, simpleNameMapping);
+			code = updateInterModuleReferences(code, projectGroupNameMapping);
 		}
-		code = updateInterModuleReferences(code, simpleNameMapping);
 
 		// Rename group if needed
 		const originalGroupName = extractGroupName(code);
@@ -198,24 +257,7 @@ export function pasteMultipleBlocks(
 		// Add canonical @pos directive to code
 		code = upsertPos(code, gridX, gridY);
 
-		// Parse disabled state from @disabled directive in code
-		const disabled = hasDirective(code, 'disabled');
-
-		const creationIndex = state.codeBlockRendering.nextCodeBlockCreationIndex;
-		state.codeBlockRendering.nextCodeBlockCreationIndex++;
-
-		const codeBlock = createCodeBlockGraphicData({
-			code,
-			name: getCodeBlockNameFromSource(code),
-			projectPath,
-			gridX,
-			gridY,
-			x: gridX * state.viewport.vGrid,
-			y: gridY * state.viewport.hGrid,
-			creationIndex,
-			disabled,
-			alwaysOnTop: hasDirective(code, 'alwaysOnTop'),
-		});
+		const codeBlock = createPastedCodeBlock(state, clipboardBlock, code, gridX, gridY, projectPath);
 
 		// Add block immediately so next iteration's ID uniqueness check sees it
 		state.codeBlockRendering.codeBlocks.push(codeBlock);

--- a/packages/editor/packages/editor-state/src/features/code-blocks/features/group/copier/effect.ts
+++ b/packages/editor/packages/editor-state/src/features/code-blocks/features/group/copier/effect.ts
@@ -1,7 +1,7 @@
 import type { CodeBlockGraphicData, EventDispatcher, State } from '@8f4e/editor-state-types';
 
 import type { StateManager } from '@8f4e/state-manager';
-import { serializeGroupToClipboard } from '../../clipboard/clipboardUtils';
+import { serializeCodeBlocksToClipboard } from '../../clipboard/clipboardUtils';
 
 export default function groupCopier(store: StateManager<State>, events: EventDispatcher): void {
 	const state = store.getState();
@@ -26,7 +26,7 @@ export default function groupCopier(store: StateManager<State>, events: EventDis
 		const sortedBlocks = [...groupBlocks].sort((a, b) => a.creationIndex - b.creationIndex);
 
 		// Serialize to clipboard using the selected block as anchor
-		const clipboardData = serializeGroupToClipboard(sortedBlocks, codeBlock);
+		const clipboardData = serializeCodeBlocksToClipboard(sortedBlocks, codeBlock);
 
 		state.callbacks.writeClipboardText(clipboardData).catch(() => {
 			// Fail silently if clipboard write fails

--- a/packages/editor/packages/editor-state/src/features/menu/menus/mainMenu.ts
+++ b/packages/editor/packages/editor-state/src/features/menu/menus/mainMenu.ts
@@ -31,7 +31,7 @@ export const mainMenu: MenuGenerator = state => [
 					close: true,
 				},
 				{
-					title: 'Paste Module',
+					title: 'Paste Code Block',
 					action: 'addCodeBlock',
 					payload: { isPaste: true },
 					close: true,

--- a/packages/editor/packages/editor-state/tests/menu/clipboard.test.ts
+++ b/packages/editor/packages/editor-state/tests/menu/clipboard.test.ts
@@ -5,7 +5,7 @@ import { createMockCodeBlock, createMockState } from '../../src/pureHelpers/test
 
 describe('menus - clipboard callback disabled state', () => {
 	describe('mainMenu', () => {
-		it('should disable "Paste Module" when readClipboardText is not provided', () => {
+		it('should disable "Paste Code Block" when readClipboardText is not provided', () => {
 			const mockState = createMockState({
 				editorMode: 'edit',
 				callbacks: { readClipboardText: undefined },
@@ -13,12 +13,12 @@ describe('menus - clipboard callback disabled state', () => {
 
 			const menu = mainMenu(mockState as State);
 
-			const pasteModuleItem = menu.find(item => item.title === 'Paste Module');
-			expect(pasteModuleItem).toBeDefined();
-			expect(pasteModuleItem?.disabled).toBe(true);
+			const pasteCodeBlockItem = menu.find(item => item.title === 'Paste Code Block');
+			expect(pasteCodeBlockItem).toBeDefined();
+			expect(pasteCodeBlockItem?.disabled).toBe(true);
 		});
 
-		it('should enable "Paste Module" when readClipboardText is provided', () => {
+		it('should enable "Paste Code Block" when readClipboardText is provided', () => {
 			const mockState = createMockState({
 				editorMode: 'edit',
 				callbacks: { readClipboardText: async () => 'test' },
@@ -26,20 +26,20 @@ describe('menus - clipboard callback disabled state', () => {
 
 			const menu = mainMenu(mockState as State);
 
-			const pasteModuleItem = menu.find(item => item.title === 'Paste Module');
-			expect(pasteModuleItem).toBeDefined();
-			expect(pasteModuleItem?.disabled).toBe(false);
+			const pasteCodeBlockItem = menu.find(item => item.title === 'Paste Code Block');
+			expect(pasteCodeBlockItem).toBeDefined();
+			expect(pasteCodeBlockItem?.disabled).toBe(false);
 		});
 
-		it('should not show "Paste Module" when editing is disabled', () => {
+		it('should not show "Paste Code Block" when editing is disabled', () => {
 			const mockState = createMockState({
 				featureFlags: { editing: false },
 			});
 
 			const menu = mainMenu(mockState as State);
 
-			const pasteModuleItem = menu.find(item => item.title === 'Paste Module');
-			expect(pasteModuleItem).toBeUndefined();
+			const pasteCodeBlockItem = menu.find(item => item.title === 'Paste Code Block');
+			expect(pasteCodeBlockItem).toBeUndefined();
 		});
 	});
 

--- a/packages/editor/packages/web-ui/packages/render-projection/src/syntax-highlighting/highlightSyntax8f4e.test.ts
+++ b/packages/editor/packages/web-ui/packages/render-projection/src/syntax-highlighting/highlightSyntax8f4e.test.ts
@@ -23,4 +23,10 @@ describe('highlightSyntax8f4e', () => {
 		expect(colors[0]).toBe('comment');
 		expect(colors.slice(1)).toEqual(new Array(colors.length - 1).fill(undefined));
 	});
+
+	it('highlights project group instructions', () => {
+		const colors = highlightSyntax8f4e(['group audio', 'expose int level &voice:level', 'groupEnd'], syntaxFonts);
+
+		expect(colors.map(line => line[0])).toEqual(['instruction', 'instruction', 'instruction']);
+	});
 });

--- a/packages/editor/packages/web-ui/packages/render-projection/src/syntax-highlighting/highlightSyntax8f4e.ts
+++ b/packages/editor/packages/web-ui/packages/render-projection/src/syntax-highlighting/highlightSyntax8f4e.ts
@@ -1,10 +1,12 @@
-import { knownInstructionNameSet } from '@8f4e/language-spec';
+import { knownInstructionNameSet, projectInstructionNameSet } from '@8f4e/language-spec';
 import highlightEditorDirective from './highlightEditorDirective';
 import type { SyntaxFonts, SyntaxHighlighting } from './types';
 
+const highlightedInstructionNameSet = new Set([...knownInstructionNameSet, ...projectInstructionNameSet]);
+
 const instructionRegExp = new RegExp(
 	'(?<=^|\\s)(?:' +
-		[...knownInstructionNameSet]
+		[...highlightedInstructionNameSet]
 			.sort((a, b) => b.length - a.length)
 			.join('|')
 			.replaceAll(/\*/g, '\\*')

--- a/packages/editor/packages/web-ui/packages/render-projection/src/syntax-highlighting/highlightSyntax8f4e.ts
+++ b/packages/editor/packages/web-ui/packages/render-projection/src/syntax-highlighting/highlightSyntax8f4e.ts
@@ -1,12 +1,10 @@
-import { knownInstructionNameSet, projectInstructionNameSet } from '@8f4e/language-spec';
+import { knownInstructionNameSet } from '@8f4e/language-spec';
 import highlightEditorDirective from './highlightEditorDirective';
 import type { SyntaxFonts, SyntaxHighlighting } from './types';
 
-const highlightedInstructionNameSet = new Set([...knownInstructionNameSet, ...projectInstructionNameSet]);
-
 const instructionRegExp = new RegExp(
 	'(?<=^|\\s)(?:' +
-		[...highlightedInstructionNameSet]
+		[...knownInstructionNameSet]
 			.sort((a, b) => b.length - a.length)
 			.join('|')
 			.replaceAll(/\*/g, '\\*')

--- a/packages/editor/packages/web-ui/screenshot-tests/utils/generateContextMenuMock.ts
+++ b/packages/editor/packages/web-ui/screenshot-tests/utils/generateContextMenuMock.ts
@@ -14,7 +14,7 @@ export default function generateContextMenuMock(): ContextMenu {
 				close: true,
 			},
 			{
-				title: '.................. Paste Module',
+				title: '.............. Paste Code Block',
 				action: 'addCodeBlock',
 				payload: {
 					isPaste: true,


### PR DESCRIPTION
## Summary

- serialize project-group clipboard payloads recursively
- copy modules, functions, constants, notes, and nested project groups with their wrapper source
- restore entries, positions, block types, project paths, and fresh creation IDs during paste
- rename pasted top-level project groups on name collisions and update enclosing references
- keep the existing plain-text clipboard format for ordinary single blocks

## Rationale

Copying a project group previously wrote only its visible wrapper code to the clipboard, so pasting silently lost the recursively owned project. The existing editor clipboard block format now owns an optional nested block collection and is used recursively instead of introducing another project serialization contract.

## Tests

- `npx nx run @8f4e/editor-state:test -- --runInBand` — 1,069 tests passed
- `npx nx run-many -t lint,typecheck -p @8f4e/editor-state`
- pre-commit affected typecheck and Biome checks