### PR TITLE
Fix editor canvas sizing responsibilities

### DIFF
--- a/packages/editor/packages/editor-core/README.md
+++ b/packages/editor/packages/editor-core/README.md
@@ -13,6 +13,7 @@ renderers can replace it.
 - Wire browser input events into internal events: window `keydown`/`keyup`; canvas `mousedown`/`mouseup`/`mousemove`/`contextmenu`; window `wheel` when viewport dragging is enabled.
 - Translate DOM input data into internal event payloads (coordinates, movement deltas, button state, canvas size).
 - Initialize the UI renderer with state and memory views, and forward resize and post-process events.
+- Observe the canvas's CSS dimensions and adapt the drawing buffer and editor viewport when its host resizes it.
 - Expose state access, memory view updates, and state machine callbacks as extension points.
 
 ## Docs

--- a/packages/editor/packages/editor-core/src/index.test.ts
+++ b/packages/editor/packages/editor-core/src/index.test.ts
@@ -106,7 +106,7 @@ describe('editor init', () => {
 
 	it('sizes the viewport before loading the session', async () => {
 		const { default: init } = await import('./index');
-		const canvas = { width: 640, height: 480 } as HTMLCanvasElement;
+		const canvas = { width: 300, height: 150, clientWidth: 640, clientHeight: 480 } as HTMLCanvasElement;
 
 		await init(canvas, {
 			runtimeRegistry: {
@@ -126,6 +126,60 @@ describe('editor init', () => {
 			['loadSession'],
 		]);
 		expect(view.resize).toHaveBeenCalledWith(640, 480);
+	});
+
+	it('adapts to the canvas display size and stops observing when disposed', async () => {
+		const { default: init } = await import('./index');
+		let resizeCallback: ResizeObserverCallback = () => {};
+		const observe = vi.fn();
+		const disconnect = vi.fn();
+		class ResizeObserverMock {
+			constructor(callback: ResizeObserverCallback) {
+				resizeCallback = callback;
+			}
+
+			observe = observe;
+			disconnect = disconnect;
+		}
+		const canvas = {
+			width: 640,
+			height: 480,
+			clientWidth: 640,
+			clientHeight: 480,
+			ownerDocument: {
+				defaultView: {
+					ResizeObserver: ResizeObserverMock,
+					navigator: {},
+				},
+			},
+		} as unknown as HTMLCanvasElement;
+
+		const editor = await init(canvas, {
+			runtimeRegistry: {
+				WebWorkerRuntime: {
+					id: 'WebWorkerRuntime',
+					factory: () => () => {},
+				},
+			},
+			callbacks: {
+				loadSession: async () => null,
+			},
+		});
+
+		expect(observe).toHaveBeenCalledWith(canvas);
+
+		Object.assign(canvas, { clientWidth: 800, clientHeight: 600 });
+		resizeCallback([], {} as ResizeObserver);
+
+		expect(events.dispatch).toHaveBeenCalledWith('resize', { canvasWidth: 800, canvasHeight: 600 });
+		expect(view.resize).toHaveBeenLastCalledWith(800, 600);
+
+		view.resize.mockClear();
+		resizeCallback([], {} as ResizeObserver);
+		expect(view.resize).not.toHaveBeenCalled();
+
+		editor.dispose();
+		expect(disconnect).toHaveBeenCalledWith();
 	});
 
 	it('renders one fresh frame before exporting a canvas screenshot', async () => {

--- a/packages/editor/packages/editor-core/src/index.ts
+++ b/packages/editor/packages/editor-core/src/index.ts
@@ -92,6 +92,22 @@ interface Options {
 	frameTexture?: WebUiOptions['frameTexture'];
 }
 
+interface CanvasSize {
+	width: number;
+	height: number;
+}
+
+function getCanvasDisplaySize(canvas: HTMLCanvasElement): CanvasSize | null {
+	const width = Math.floor(canvas.clientWidth);
+	const height = Math.floor(canvas.clientHeight);
+
+	if (!Number.isFinite(width) || !Number.isFinite(height) || width <= 0 || height <= 0) {
+		return null;
+	}
+
+	return { width, height };
+}
+
 async function getCanvasPngBlob(canvas: HTMLCanvasElement): Promise<Blob> {
 	return new Promise<Blob>((resolve, reject) => {
 		canvas.toBlob(result => {
@@ -217,19 +233,34 @@ export default async function init(canvas: HTMLCanvasElement, options: Options):
 		view.loadBackgroundEffect(effect);
 	});
 
+	let currentCanvasSize: CanvasSize | null = null;
+	const resize = (width: number, height: number) => {
+		events.dispatch('resize', { canvasWidth: width, canvasHeight: height });
+		view.resize(width, height);
+		currentCanvasSize = { width, height };
+	};
+	const initialCanvasSize = getCanvasDisplaySize(canvas) ?? {
+		width: canvas.width,
+		height: canvas.height,
+	};
+	const resizeObserver = browserWindow?.ResizeObserver
+		? new browserWindow.ResizeObserver(() => {
+				const size = getCanvasDisplaySize(canvas);
+				if (!size || (size.width === currentCanvasSize?.width && size.height === currentCanvasSize.height)) {
+					return;
+				}
+
+				resize(size.width, size.height);
+			})
+		: null;
+
 	events.dispatch('init');
-	events.dispatch('resize', {
-		canvasWidth: canvas.width,
-		canvasHeight: canvas.height,
-	});
-	view.resize(canvas.width, canvas.height);
+	resize(initialCanvasSize.width, initialCanvasSize.height);
+	resizeObserver?.observe(canvas);
 	events.dispatch('loadSession');
 
 	return {
-		resize: (width: number, height: number) => {
-			events.dispatch('resize', { canvasWidth: width, canvasHeight: height });
-			view.resize(width, height);
-		},
+		resize,
 		updateMemoryViews: (memoryRef: MemoryRef) => {
 			currentMemoryRef = memoryRef instanceof WebAssembly.Memory ? memoryRef : null;
 			pluginServices.invalidateWasmExports();
@@ -237,6 +268,7 @@ export default async function init(canvas: HTMLCanvasElement, options: Options):
 		},
 		getMemoryViews: () => memoryViews,
 		dispose: () => {
+			resizeObserver?.disconnect();
 			view.destroy();
 			renderProjection.dispose();
 			cleanupPointer();

--- a/packages/editor/packages/editor-default/README.md
+++ b/packages/editor/packages/editor-default/README.md
@@ -12,6 +12,9 @@ import { mountDefaultEditor } from '@8f4e/editor-default';
 await mountDefaultEditor(canvas);
 ```
 
+The host controls the canvas's layout dimensions with CSS. The editor observes that rendered size and adapts its
+drawing buffer and UI automatically.
+
 Build, test, and type-check it from the workspace root:
 
 ```bash

--- a/packages/editor/packages/editor-default/src/index.ts
+++ b/packages/editor/packages/editor-default/src/index.ts
@@ -15,39 +15,7 @@ import {
 	saveSession,
 } from './storage-callbacks';
 
-export interface CanvasSize {
-	width: number;
-	height: number;
-}
-
-export interface MountDefaultEditorOptions {
-	fixedCanvasSize?: CanvasSize;
-}
-
-function applyCanvasSize(canvas: HTMLCanvasElement, size: CanvasSize): void {
-	canvas.width = size.width;
-	canvas.height = size.height;
-	canvas.style.width = '';
-	canvas.style.height = '';
-}
-
-function getCanvasSize({ fixedCanvasSize }: MountDefaultEditorOptions = {}): CanvasSize {
-	if (fixedCanvasSize) {
-		return fixedCanvasSize;
-	}
-
-	return {
-		width: window.innerWidth,
-		height: window.innerHeight,
-	};
-}
-
-export async function mountDefaultEditor(
-	canvas: HTMLCanvasElement,
-	options: MountDefaultEditorOptions = {}
-): Promise<Editor> {
-	const initialCanvasSize = getCanvasSize(options);
-	applyCanvasSize(canvas, initialCanvasSize);
+export async function mountDefaultEditor(canvas: HTMLCanvasElement): Promise<Editor> {
 	const editor = await initEditor(canvas, {
 		runtimeRegistry,
 		callbacks: {
@@ -71,19 +39,6 @@ export async function mountDefaultEditor(
 
 	// @ts-expect-error - Expose state for debugging purposes
 	window.state = editor.state;
-
-	const resizeEditor = () => {
-		if (options.fixedCanvasSize) {
-			return;
-		}
-		const nextCanvasSize = getCanvasSize(options);
-		applyCanvasSize(canvas, nextCanvasSize);
-		editor.resize(nextCanvasSize.width, nextCanvasSize.height);
-	};
-
-	resizeEditor();
-
-	window.addEventListener('resize', resizeEditor);
 
 	return editor;
 }

--- a/packages/editor/packages/editor-website/src/index.html
+++ b/packages/editor/packages/editor-website/src/index.html
@@ -14,11 +14,15 @@
 
 		html,
 		body {
+			width: 100%;
 			height: 100%;
 			overflow: hidden;
 		}
 
 		canvas {
+			display: block;
+			width: 100%;
+			height: 100%;
 			image-rendering: pixelated;
 		}
 	</style>
@@ -26,7 +30,7 @@
 </head>
 
 <body>
-	<canvas id="glcanvas" width="500" height="500"></canvas>
+	<canvas id="glcanvas"></canvas>
 	<script src="./main.ts" type="module"></script>
 </body>
 


### PR DESCRIPTION
## Summary

- make the editor website own the full-viewport canvas layout
- make editor-core observe the canvas display size and adapt its renderer and viewport
- remove viewport sizing and window resize handling from editor-default
- disconnect the resize observer during editor disposal

## Rationale

This separates host layout from reusable editor behavior. The website decides how much space the canvas occupies, while the editor responds to the space provided by any host or container.

## Test notes

- `npx nx run @8f4e/editor-core:test`
- `npx nx run @8f4e/editor-default:test`
- `npx nx run-many --target=lint --projects=@8f4e/editor-core,@8f4e/editor-default,@8f4e/editor-website`
- `npx nx run @8f4e/editor-website:build`