### PR TITLE
Scope editor dev builds to project dependencies

### DIFF
--- a/packages/editor/packages/editor-website/AGENTS.md
+++ b/packages/editor/packages/editor-website/AGENTS.md
@@ -3,4 +3,6 @@
 - Keep this package thin: HTML, hosting assets, deployment configuration, and mounting the default composition.
 - Product behavior and integration wiring belong in `@8f4e/editor-default`.
 - Reusable editor behavior belongs in `@8f4e/editor-core`.
+- Keep the `dev` workflow scoped to the website dependency graph; use the `build-deps` and `watch-deps` targets rather
+  than building or watching every workspace project.
 - Run `npx nx run @8f4e/editor-website:build` after changing this package.

--- a/packages/editor/packages/editor-website/project.json
+++ b/packages/editor/packages/editor-website/project.json
@@ -4,14 +4,25 @@
   "projectType": "application",
   "targets": {
     "dev": {
+      "continuous": true,
       "executor": "nx:run-commands",
+      "dependsOn": ["watch-deps"],
       "options": {
-        "commands": [
-          "nx run-many --target=build --all && nx watch --all -- nx run-many --target=build --all",
-          "vite"
-        ],
-        "parallel": true,
+        "command": "vite",
         "cwd": "{projectRoot}"
+      }
+    },
+    "build-deps": {
+      "executor": "nx:noop",
+      "dependsOn": ["^build"]
+    },
+    "watch-deps": {
+      "continuous": true,
+      "executor": "nx:run-commands",
+      "dependsOn": ["build-deps"],
+      "options": {
+        "command": "nx watch --projects=@8f4e/editor-website --includeDependencies -- nx run @8f4e/editor-website:build-deps",
+        "cwd": "{workspaceRoot}"
       }
     },
     "lint": {


### PR DESCRIPTION
## Summary

- replace the editor website dev workflow build-all command with dependency-scoped Nx targets
- build transitive dependencies before starting the development server
- watch only the website and its dependency graph
- rebuild the dependency pipeline when a relevant project changes
- document that the workflow must remain dependency-scoped

## Rationale

The previous workflow built and watched every Nx project, pulling unrelated applications such as the metrics dashboard into editor development. The new pipeline uses the project graph and Nx caching while still rebundling dependent editor packages when a lower-level library changes.

## Test notes

- generated the build-deps task graph and confirmed it excludes the metrics dashboard and website production build
- `npx nx run @8f4e/editor-website:build-deps`
- started `npx nx run @8f4e/editor-website:dev` and confirmed Vite and the dependency watcher both started
- changed an editor-core file and confirmed the watcher rebuilt editor-core and editor-default
- confirmed Ctrl-C stopped both continuous processes
- `npx nx run @8f4e/editor-website:build`