### PR TITLE
fix(editor-default): isolate editor instance services

### DIFF
--- a/packages/editor/packages/editor-default/README.md
+++ b/packages/editor/packages/editor-default/README.md
@@ -15,6 +15,8 @@ await mountDefaultEditor(canvas);
 The host controls the canvas's layout dimensions with CSS. The editor observes that rendered size and adapts its
 drawing buffer and UI automatically.
 
+Each mounted editor owns its compiler worker, compiled memory and code-buffer state, and lazy runtime registry.
+
 Build, test, and type-check it from the workspace root:
 
 ```bash

--- a/packages/editor/packages/editor-default/src/compiler-callback.test.ts
+++ b/packages/editor/packages/editor-default/src/compiler-callback.test.ts
@@ -1,0 +1,149 @@
+import type { Editor } from '@8f4e/editor-core';
+import type { CompileProjectOptions, ProjectObjectModel } from '@8f4e/language-spec';
+import { describe, expect, it, vi } from 'vitest';
+import { createCompilerService } from './compiler-callback';
+
+type MessageListener = (event: MessageEvent) => void;
+
+class FakeWorker {
+	readonly postedMessages: unknown[] = [];
+	readonly terminate = vi.fn();
+	private readonly messageListeners = new Set<MessageListener>();
+
+	addEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+		if (type === 'message' && typeof listener === 'function') {
+			this.messageListeners.add(listener as MessageListener);
+		}
+	}
+
+	removeEventListener(type: string, listener: EventListenerOrEventListenerObject): void {
+		if (type === 'message' && typeof listener === 'function') {
+			this.messageListeners.delete(listener as MessageListener);
+		}
+	}
+
+	postMessage(message: unknown): void {
+		this.postedMessages.push(message);
+	}
+
+	emitMessage(data: unknown): void {
+		for (const listener of this.messageListeners) {
+			listener({ data } as MessageEvent);
+		}
+	}
+}
+
+function createEditor() {
+	return {
+		updateMemoryViews: vi.fn(),
+	} as unknown as Editor;
+}
+
+function createSuccessMessage(codeBuffer: Uint8Array, wasmMemory: WebAssembly.Memory) {
+	return {
+		type: 'success',
+		compilationId: 0,
+		payload: {
+			wasmMemory,
+			codeBuffer,
+			compiledModules: [],
+			memoryPlan: {},
+			memoryDefaultsByModuleId: {},
+			pointerMetadataByModuleId: {},
+			projectMemoryExposuresByGroupPath: {},
+			requiredMemoryBytes: 0,
+			allocatedMemoryBytes: 0,
+			astCacheStats: {},
+			hasWasmInstanceBeenReset: false,
+			memoryAction: 'none',
+			compiledFunctions: [],
+			initOnlyReran: false,
+		},
+	};
+}
+
+describe('compiler service', () => {
+	it('isolates workers, include resolution, memory, and code buffers between instances', async () => {
+		const workers: FakeWorker[] = [];
+		const createWorker = () => {
+			const worker = new FakeWorker();
+			workers.push(worker);
+			return worker as unknown as Worker;
+		};
+		const firstService = createCompilerService(createWorker);
+		const secondService = createCompilerService(createWorker);
+		const firstEditor = createEditor();
+		const secondEditor = createEditor();
+		const firstMemory = new WebAssembly.Memory({ initial: 1 });
+		const secondMemory = new WebAssembly.Memory({ initial: 1 });
+		const firstCodeBuffer = new Uint8Array([1, 2, 3]);
+		const secondCodeBuffer = new Uint8Array([4, 5]);
+		const project = {} as ProjectObjectModel;
+
+		const firstCompilation = firstService.compileCode(
+			project,
+			{ resolveInclude: includeId => `first:${includeId}` } as CompileProjectOptions,
+			firstEditor
+		);
+		const secondCompilation = secondService.compileCode(
+			project,
+			{ resolveInclude: includeId => `second:${includeId}` } as CompileProjectOptions,
+			secondEditor
+		);
+
+		expect(workers).toHaveLength(2);
+
+		workers[0].emitMessage({ type: 'resolveInclude', payload: { requestId: 10, includeId: 'module' } });
+		workers[1].emitMessage({ type: 'resolveInclude', payload: { requestId: 20, includeId: 'module' } });
+		await vi.waitFor(() => {
+			expect(workers[0].postedMessages).toContainEqual({
+				type: 'resolveIncludeResult',
+				payload: { requestId: 10, source: 'first:module' },
+			});
+			expect(workers[1].postedMessages).toContainEqual({
+				type: 'resolveIncludeResult',
+				payload: { requestId: 20, source: 'second:module' },
+			});
+		});
+
+		workers[0].emitMessage(createSuccessMessage(firstCodeBuffer, firstMemory));
+		workers[1].emitMessage(createSuccessMessage(secondCodeBuffer, secondMemory));
+		await Promise.all([firstCompilation, secondCompilation]);
+
+		expect(firstService.getMemory()).toBe(firstMemory);
+		expect(secondService.getMemory()).toBe(secondMemory);
+		expect(firstService.getCodeBuffer()).toBe(firstCodeBuffer);
+		expect(secondService.getCodeBuffer()).toBe(secondCodeBuffer);
+		expect(firstEditor.updateMemoryViews).toHaveBeenCalledWith(firstMemory);
+		expect(secondEditor.updateMemoryViews).toHaveBeenCalledWith(secondMemory);
+
+		firstService.dispose();
+		expect(workers[0].terminate).toHaveBeenCalledOnce();
+		expect(workers[1].terminate).not.toHaveBeenCalled();
+
+		secondService.dispose();
+		expect(workers[1].terminate).toHaveBeenCalledOnce();
+	});
+
+	it('does not recreate its worker after disposal', async () => {
+		const worker = new FakeWorker();
+		const service = createCompilerService(() => worker as unknown as Worker);
+		service.dispose();
+
+		await expect(
+			service.compileCode({} as ProjectObjectModel, {} as CompileProjectOptions, createEditor())
+		).rejects.toThrow('Compiler service has been disposed');
+		expect(worker.terminate).not.toHaveBeenCalled();
+	});
+
+	it('rejects pending compilations when disposed', async () => {
+		const worker = new FakeWorker();
+		const service = createCompilerService(() => worker as unknown as Worker);
+		const compilation = service.compileCode({} as ProjectObjectModel, {} as CompileProjectOptions, createEditor());
+
+		service.dispose();
+
+		await expect(compilation).rejects.toThrow('Compiler service has been disposed');
+		expect(worker.terminate).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/editor/packages/editor-default/src/compiler-callback.ts
+++ b/packages/editor/packages/editor-default/src/compiler-callback.ts
@@ -9,109 +9,143 @@ import type {
 	ProjectObjectModel,
 } from '@8f4e/language-spec';
 
-let compilerWorker: Worker | null = null;
-
-let memoryRef: WebAssembly.Memory | null = null;
-let codeBuffer: Uint8Array = new Uint8Array();
-let nextCompilationId = 0;
-let includeResolver: ProjectIncludeResolver | undefined;
-
-async function handleIncludeRequest({ data }: MessageEvent): Promise<void> {
-	if (data.type !== 'resolveInclude') return;
-	const request = data as ResolveIncludeRequestMessage;
-	let response: ResolveIncludeResultMessage;
-	try {
-		response = {
-			type: 'resolveIncludeResult',
-			payload: {
-				requestId: request.payload.requestId,
-				source: await includeResolver?.(request.payload.includeId),
-			},
-		};
-	} catch (error) {
-		response = {
-			type: 'resolveIncludeResult',
-			payload: {
-				requestId: request.payload.requestId,
-				error: serializeDiagnostic(error),
-			},
-		};
-	}
-	compilerWorker?.postMessage(response);
+export interface CompilerService {
+	compileCode: (
+		project: ProjectObjectModel,
+		compilerOptions: CompileProjectOptions,
+		editor: Editor
+	) => Promise<CompilationResult>;
+	getMemory: () => WebAssembly.Memory | null;
+	getCodeBuffer: () => Uint8Array;
+	dispose: () => void;
 }
 
-function getCompilerWorker(): Worker {
-	if (!compilerWorker) {
-		compilerWorker = new CompilerWorker();
-		compilerWorker.addEventListener('message', handleIncludeRequest);
+export function createCompilerService(createWorker: () => Worker = () => new CompilerWorker()): CompilerService {
+	let compilerWorker: Worker | null = null;
+	let memoryRef: WebAssembly.Memory | null = null;
+	let codeBuffer: Uint8Array = new Uint8Array();
+	let nextCompilationId = 0;
+	let includeResolver: ProjectIncludeResolver | undefined;
+	let disposed = false;
+	const pendingCompilations = new Map<
+		number,
+		{
+			handleMessage: (event: MessageEvent) => void;
+			reject: (error: Error) => void;
+		}
+	>();
+
+	async function handleIncludeRequest({ data }: MessageEvent): Promise<void> {
+		if (data.type !== 'resolveInclude') return;
+		const request = data as ResolveIncludeRequestMessage;
+		let response: ResolveIncludeResultMessage;
+		try {
+			response = {
+				type: 'resolveIncludeResult',
+				payload: {
+					requestId: request.payload.requestId,
+					source: await includeResolver?.(request.payload.includeId),
+				},
+			};
+		} catch (error) {
+			response = {
+				type: 'resolveIncludeResult',
+				payload: {
+					requestId: request.payload.requestId,
+					error: serializeDiagnostic(error),
+				},
+			};
+		}
+		compilerWorker?.postMessage(response);
 	}
 
-	return compilerWorker;
-}
+	function getCompilerWorker(): Worker {
+		if (disposed) {
+			throw new Error('Compiler service has been disposed');
+		}
 
-export async function compileCode(
-	project: ProjectObjectModel,
-	compilerOptions: CompileProjectOptions,
-	editor: Editor
-): Promise<CompilationResult> {
-	const { resolveInclude, ...serializableCompilerOptions } = compilerOptions;
-	includeResolver = resolveInclude;
-	const compilationId = nextCompilationId++;
-	const worker = getCompilerWorker();
+		if (!compilerWorker) {
+			compilerWorker = createWorker();
+			compilerWorker.addEventListener('message', handleIncludeRequest);
+		}
 
-	return new Promise((resolve, reject) => {
-		const handleMessage = async ({ data }: MessageEvent) => {
-			if (data.compilationId !== compilationId) return;
-			switch (data.type) {
-				case 'success':
-					worker.removeEventListener('message', handleMessage);
-					memoryRef = data.payload.wasmMemory;
-					codeBuffer = data.payload.codeBuffer;
+		return compilerWorker;
+	}
 
-					editor.updateMemoryViews(data.payload.wasmMemory);
+	return {
+		async compileCode(project, compilerOptions, editor) {
+			const { resolveInclude, ...serializableCompilerOptions } = compilerOptions;
+			const worker = getCompilerWorker();
+			includeResolver = resolveInclude;
+			const compilationId = nextCompilationId++;
 
-					resolve({
-						compiledModules: data.payload.compiledModules,
-						memoryPlan: data.payload.memoryPlan,
-						memoryDefaultsByModuleId: data.payload.memoryDefaultsByModuleId,
-						pointerMetadataByModuleId: data.payload.pointerMetadataByModuleId,
-						projectMemoryExposuresByGroupPath: data.payload.projectMemoryExposuresByGroupPath,
-						codeBuffer: data.payload.codeBuffer,
-						requiredMemoryBytes: data.payload.requiredMemoryBytes,
-						allocatedMemoryBytes: data.payload.allocatedMemoryBytes,
-						astCacheStats: data.payload.astCacheStats,
-						hasWasmInstanceBeenReset: data.payload.hasWasmInstanceBeenReset,
-						memoryAction: data.payload.memoryAction,
-						compiledFunctions: data.payload.compiledFunctions,
-						byteCodeSize: data.payload.codeBuffer.length,
-						initOnlyReran: data.payload.initOnlyReran,
-					});
-					break;
-				case 'compilationError':
-					worker.removeEventListener('message', handleMessage);
-					reject(data.payload as CompilerDiagnostic);
-					break;
+			return new Promise((resolve, reject) => {
+				const handleMessage = ({ data }: MessageEvent) => {
+					if (data.compilationId !== compilationId) return;
+					switch (data.type) {
+						case 'success':
+							worker.removeEventListener('message', handleMessage);
+							pendingCompilations.delete(compilationId);
+							memoryRef = data.payload.wasmMemory;
+							codeBuffer = data.payload.codeBuffer;
+
+							editor.updateMemoryViews(data.payload.wasmMemory);
+
+							resolve({
+								compiledModules: data.payload.compiledModules,
+								memoryPlan: data.payload.memoryPlan,
+								memoryDefaultsByModuleId: data.payload.memoryDefaultsByModuleId,
+								pointerMetadataByModuleId: data.payload.pointerMetadataByModuleId,
+								projectMemoryExposuresByGroupPath: data.payload.projectMemoryExposuresByGroupPath,
+								codeBuffer: data.payload.codeBuffer,
+								requiredMemoryBytes: data.payload.requiredMemoryBytes,
+								allocatedMemoryBytes: data.payload.allocatedMemoryBytes,
+								astCacheStats: data.payload.astCacheStats,
+								hasWasmInstanceBeenReset: data.payload.hasWasmInstanceBeenReset,
+								memoryAction: data.payload.memoryAction,
+								compiledFunctions: data.payload.compiledFunctions,
+								byteCodeSize: data.payload.codeBuffer.length,
+								initOnlyReran: data.payload.initOnlyReran,
+							});
+							break;
+						case 'compilationError':
+							worker.removeEventListener('message', handleMessage);
+							pendingCompilations.delete(compilationId);
+							reject(data.payload as CompilerDiagnostic);
+							break;
+					}
+				};
+
+				pendingCompilations.set(compilationId, { handleMessage, reject });
+				worker.addEventListener('message', handleMessage);
+
+				worker.postMessage({
+					type: 'compile',
+					compilationId,
+					payload: {
+						project,
+						compilerOptions: serializableCompilerOptions,
+					},
+				});
+			});
+		},
+		getMemory: () => memoryRef,
+		getCodeBuffer: () => codeBuffer,
+		dispose: () => {
+			if (disposed) {
+				return;
 			}
-		};
 
-		worker.addEventListener('message', handleMessage);
-
-		worker.postMessage({
-			type: 'compile',
-			compilationId,
-			payload: {
-				project,
-				compilerOptions: serializableCompilerOptions,
-			},
-		});
-	});
-}
-
-// Export memory getter for runtimes to access
-export function getMemory(): WebAssembly.Memory | null {
-	return memoryRef;
-}
-
-export function getCodeBuffer(): Uint8Array {
-	return codeBuffer;
+			disposed = true;
+			const disposalError = new Error('Compiler service has been disposed');
+			for (const { handleMessage, reject } of pendingCompilations.values()) {
+				compilerWorker?.removeEventListener('message', handleMessage);
+				reject(disposalError);
+			}
+			pendingCompilations.clear();
+			compilerWorker?.removeEventListener('message', handleIncludeRequest);
+			compilerWorker?.terminate();
+			compilerWorker = null;
+		},
+	};
 }

--- a/packages/editor/packages/editor-default/src/index.ts
+++ b/packages/editor/packages/editor-default/src/index.ts
@@ -1,8 +1,8 @@
 import initEditor, { type Editor } from '@8f4e/editor-core';
-import { compileCode } from './compiler-callback';
+import { createCompilerService } from './compiler-callback';
 import { getListOfModules, getModule, getModuleDependencies } from './examples/moduleRegistry';
 import { getListOfProjects, getProject } from './examples/projectRegistry';
-import { runtimeRegistry } from './runtime-registry';
+import { createRuntimeRegistry } from './runtime-registry';
 import { resolveStdlibInclude } from './stdlib-resolver';
 import {
 	exportBinaryCode,
@@ -16,29 +16,45 @@ import {
 } from './storage-callbacks';
 
 export async function mountDefaultEditor(canvas: HTMLCanvasElement): Promise<Editor> {
-	const editor = await initEditor(canvas, {
-		runtimeRegistry,
-		callbacks: {
-			getListOfModules,
-			getModule,
-			getModuleDependencies,
-			getListOfProjects,
-			getProject,
-			resolveInclude: resolveStdlibInclude,
-			compileCode: (input, compilerOptions) => compileCode(input, compilerOptions, editor),
-			loadSession,
-			saveSession,
-			loadBrowserLocalNotes,
-			saveBrowserLocalNotes,
-			importProject,
-			exportProject,
-			exportBinaryCode,
-			exportCanvasScreenshot,
-		},
-	});
+	const compilerService = createCompilerService();
+	let editor: Editor;
+	try {
+		editor = await initEditor(canvas, {
+			runtimeRegistry: createRuntimeRegistry(compilerService),
+			callbacks: {
+				getListOfModules,
+				getModule,
+				getModuleDependencies,
+				getListOfProjects,
+				getProject,
+				resolveInclude: resolveStdlibInclude,
+				compileCode: (input, compilerOptions) => compilerService.compileCode(input, compilerOptions, editor),
+				loadSession,
+				saveSession,
+				loadBrowserLocalNotes,
+				saveBrowserLocalNotes,
+				importProject,
+				exportProject,
+				exportBinaryCode: fileName => exportBinaryCode(fileName, compilerService.getCodeBuffer()),
+				exportCanvasScreenshot,
+			},
+		});
+	} catch (error) {
+		compilerService.dispose();
+		throw error;
+	}
 
 	// @ts-expect-error - Expose state for debugging purposes
 	window.state = editor.state;
 
-	return editor;
+	return {
+		...editor,
+		dispose: () => {
+			try {
+				editor.dispose();
+			} finally {
+				compilerService.dispose();
+			}
+		},
+	};
 }

--- a/packages/editor/packages/editor-default/src/runtime-registry.test.ts
+++ b/packages/editor/packages/editor-default/src/runtime-registry.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createRuntimeRegistry } from './runtime-registry';
+
+function createCompilerArtifactsStub() {
+	return {
+		getMemory: vi.fn(() => null),
+		getCodeBuffer: vi.fn(() => new Uint8Array()),
+	};
+}
+
+describe('runtime registry', () => {
+	it('creates independent lazy runtime entries for each editor instance', () => {
+		const firstRegistry = createRuntimeRegistry(createCompilerArtifactsStub());
+		const secondRegistry = createRuntimeRegistry(createCompilerArtifactsStub());
+
+		expect(firstRegistry).not.toBe(secondRegistry);
+		expect(firstRegistry.WebWorkerRuntime).not.toBe(secondRegistry.WebWorkerRuntime);
+		expect(firstRegistry.MainThreadRuntime).not.toBe(secondRegistry.MainThreadRuntime);
+		expect(firstRegistry.AudioWorkletRuntime).not.toBe(secondRegistry.AudioWorkletRuntime);
+	});
+});

--- a/packages/editor/packages/editor-default/src/runtime-registry.ts
+++ b/packages/editor/packages/editor-default/src/runtime-registry.ts
@@ -4,11 +4,13 @@ import type {
 	RuntimeRegistry,
 	RuntimeRegistryEntry,
 } from '@8f4e/editor-core';
-import { getCodeBuffer, getMemory } from './compiler-callback';
+import type { CompilerService } from './compiler-callback';
+
+type CompilerArtifacts = Pick<CompilerService, 'getCodeBuffer' | 'getMemory'>;
 
 /**
  * Creates a lazy runtime registry entry that defers loading the runtime implementation and schema
- * until the runtime is first selected. Uses a cached Promise singleton for idempotent, race-safe
+ * until the runtime is first selected. Uses a cached Promise per registry entry for idempotent, race-safe
  * loading. Once loaded, the full schema replaces the stub and config is revalidated.
  */
 function createLazyRuntimeEntry(
@@ -60,42 +62,44 @@ function createLazyRuntimeEntry(
 }
 
 /**
- * Runtime registry for the application.
+ * Creates a runtime registry for one editor instance.
  * Maps runtime IDs to their editor-config schema contributions and factory functions.
  * Runtimes are lazy-loaded on first selection. Each runtime starts with a minimal stub schema
  * and replaces it with the full schema after loading.
  */
-export const runtimeRegistry: RuntimeRegistry = {
-	WebWorkerRuntime: createLazyRuntimeEntry(
-		'WebWorkerRuntime',
-		{ root: 'workerRuntime', defaults: { sampleRate: 50 }, schema: { type: 'object' } },
-		async () => {
-			const [{ createWebWorkerRuntimeDef }, { default: WebWorkerRuntime }] = await Promise.all([
-				import('@8f4e/runtime-web-worker/runtime-def'),
-				import('@8f4e/runtime-web-worker?worker'),
-			]);
-			return createWebWorkerRuntimeDef(getCodeBuffer, getMemory, WebWorkerRuntime);
-		}
-	),
+export function createRuntimeRegistry({ getCodeBuffer, getMemory }: CompilerArtifacts): RuntimeRegistry {
+	return {
+		WebWorkerRuntime: createLazyRuntimeEntry(
+			'WebWorkerRuntime',
+			{ root: 'workerRuntime', defaults: { sampleRate: 50 }, schema: { type: 'object' } },
+			async () => {
+				const [{ createWebWorkerRuntimeDef }, { default: WebWorkerRuntime }] = await Promise.all([
+					import('@8f4e/runtime-web-worker/runtime-def'),
+					import('@8f4e/runtime-web-worker?worker'),
+				]);
+				return createWebWorkerRuntimeDef(getCodeBuffer, getMemory, WebWorkerRuntime);
+			}
+		),
 
-	MainThreadRuntime: createLazyRuntimeEntry(
-		'MainThreadRuntime',
-		{ root: 'mainThreadRuntime', defaults: { sampleRate: 50 }, schema: { type: 'object' } },
-		async () => {
-			const { createMainThreadRuntimeDef } = await import('@8f4e/runtime-main-thread/runtime-def');
-			return createMainThreadRuntimeDef(getCodeBuffer, getMemory);
-		}
-	),
+		MainThreadRuntime: createLazyRuntimeEntry(
+			'MainThreadRuntime',
+			{ root: 'mainThreadRuntime', defaults: { sampleRate: 50 }, schema: { type: 'object' } },
+			async () => {
+				const { createMainThreadRuntimeDef } = await import('@8f4e/runtime-main-thread/runtime-def');
+				return createMainThreadRuntimeDef(getCodeBuffer, getMemory);
+			}
+		),
 
-	AudioWorkletRuntime: createLazyRuntimeEntry(
-		'AudioWorkletRuntime',
-		{ root: 'audioRuntime', defaults: { sampleRate: 48000 }, schema: { type: 'object' } },
-		async () => {
-			const [{ createAudioWorkletRuntimeDef }, { default: audioWorkletUrl }] = await Promise.all([
-				import('@8f4e/runtime-audio-worklet/runtime-def'),
-				import('@8f4e/runtime-audio-worklet/worklet?url'),
-			]);
-			return createAudioWorkletRuntimeDef(getCodeBuffer, getMemory, audioWorkletUrl);
-		}
-	),
-};
+		AudioWorkletRuntime: createLazyRuntimeEntry(
+			'AudioWorkletRuntime',
+			{ root: 'audioRuntime', defaults: { sampleRate: 48000 }, schema: { type: 'object' } },
+			async () => {
+				const [{ createAudioWorkletRuntimeDef }, { default: audioWorkletUrl }] = await Promise.all([
+					import('@8f4e/runtime-audio-worklet/runtime-def'),
+					import('@8f4e/runtime-audio-worklet/worklet?url'),
+				]);
+				return createAudioWorkletRuntimeDef(getCodeBuffer, getMemory, audioWorkletUrl);
+			}
+		),
+	};
+}

--- a/packages/editor/packages/editor-default/src/storage-callbacks.ts
+++ b/packages/editor/packages/editor-default/src/storage-callbacks.ts
@@ -1,7 +1,6 @@
 import { parseProjectSource } from '@8f4e/compiler';
 import type { BrowserLocalNoteStorageBlock } from '@8f4e/editor-core';
 import type { ProjectObjectModel } from '@8f4e/language-spec';
-import { getCodeBuffer } from './compiler-callback';
 import { getDefaultProjectUrl, getProject } from './examples/projectRegistry';
 
 // Storage key constants
@@ -109,8 +108,8 @@ export async function exportProject(data: string, fileName: string): Promise<voi
 	});
 }
 
-export async function exportBinaryCode(fileName: string): Promise<void> {
-	const blob = new Blob([new Uint8Array(getCodeBuffer())], { type: 'application/wasm' });
+export async function exportBinaryCode(fileName: string, codeBuffer: Uint8Array): Promise<void> {
+	const blob = new Blob([new Uint8Array(codeBuffer)], { type: 'application/wasm' });
 
 	await saveBlobWithPickerFallback(blob, fileName, {
 		description: 'WebAssembly Binary',


### PR DESCRIPTION
## Summary

- create compiler worker, compiled memory, and code-buffer state per mounted editor
- create lazy runtime registry entries per mounted editor
- route binary export through the owning compiler service
- dispose the compiler worker with the editor and reject pending compilations
- document and test instance isolation

## Rationale

The default composition previously kept compiler and runtime state in module-level singletons. Multiple editors on one page could therefore share a worker, compiled artifacts, include resolution, and lazy runtime entries. This makes those resources part of each mounted editor lifecycle instead.

Input focus/routing and persistence namespacing remain separate follow-up work for full multi-editor support.

## Tests

- npx nx run @8f4e/editor-default:typecheck
- npx nx run @8f4e/editor-default:test
- npx nx run @8f4e/editor-default:lint
- npx nx run @8f4e/editor-website:build