### PR TITLE
fix(editor-core): scope input to editor canvas

### DIFF
--- a/packages/editor/packages/editor-core/README.md
+++ b/packages/editor/packages/editor-core/README.md
@@ -10,7 +10,8 @@ renderers can replace it.
 ## Responsibilities
 
 - Initialize the editor-state store and event dispatcher for the web runtime.
-- Wire browser input events into internal events: window `keydown`/`keyup`; canvas `mousedown`/`mouseup`/`mousemove`/`contextmenu`; window `wheel` when viewport dragging is enabled.
+- Make the canvas focusable and wire its keyboard, mouse, and wheel input into internal events, so each editor only
+  handles input directed at its own canvas.
 - Translate DOM input data into internal event payloads (coordinates, movement deltas, button state, canvas size).
 - Initialize the UI renderer with state and memory views, and forward resize and post-process events.
 - Observe the canvas's CSS dimensions and adapt the drawing buffer and editor viewport when its host resizes it.

--- a/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/binaryAssets/plugin.test.ts
+++ b/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/binaryAssets/plugin.test.ts
@@ -122,6 +122,7 @@ describe('binary assets plugin', () => {
 			memoryViews,
 			window: {} as Window,
 			navigator: {} as Navigator,
+			inputTarget: {} as HTMLElement,
 			setErrors: vi.fn(),
 			services,
 		});
@@ -163,6 +164,7 @@ describe('binary assets plugin', () => {
 			memoryViews,
 			window: {} as Window,
 			navigator: {} as Navigator,
+			inputTarget: {} as HTMLElement,
 			setErrors: vi.fn(),
 			services,
 		});
@@ -191,6 +193,7 @@ describe('binary assets plugin', () => {
 			memoryViews,
 			window: {} as Window,
 			navigator: {} as Navigator,
+			inputTarget: {} as HTMLElement,
 			setErrors: vi.fn(),
 			services,
 		});
@@ -246,6 +249,7 @@ describe('binary assets plugin', () => {
 			memoryViews,
 			window: {} as Window,
 			navigator: {} as Navigator,
+			inputTarget: {} as HTMLElement,
 			setErrors: vi.fn(),
 			services,
 		});
@@ -303,6 +307,7 @@ describe('binary assets plugin', () => {
 			memoryViews,
 			window: {} as Window,
 			navigator: {} as Navigator,
+			inputTarget: {} as HTMLElement,
 			setErrors: vi.fn(),
 			services,
 		});

--- a/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/keyboardMemory/plugin.test.ts
+++ b/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/keyboardMemory/plugin.test.ts
@@ -1,6 +1,6 @@
 import type { State } from '@8f4e/editor-state-types';
 import type { StateManager } from '@8f4e/state-manager';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import keyboardMemoryPlugin from './plugin';
 
 type WindowListener = (event: KeyboardEvent) => void;
@@ -86,16 +86,10 @@ function createMemoryPlan(memories: Record<string, { wordAlignedAddress: number 
 }
 
 describe('keyboardMemoryPlugin', () => {
-	const originalWindow = globalThis.window;
 	let mockWindow: MockWindow;
 
 	beforeEach(() => {
 		mockWindow = createMockWindow();
-		Object.assign(globalThis, { window: mockWindow });
-	});
-
-	afterEach(() => {
-		Object.assign(globalThis, { window: originalWindow });
 	});
 
 	it('writes keyCode and keyPressed values and tracks latest still-pressed key', () => {
@@ -127,6 +121,7 @@ describe('keyboardMemoryPlugin', () => {
 			events: {} as never,
 			window: mockWindow as unknown as Window,
 			navigator: {} as Navigator,
+			inputTarget: mockWindow as unknown as HTMLElement,
 			memoryViews: {} as never,
 			services: {} as never,
 			setErrors: () => {},
@@ -174,6 +169,7 @@ describe('keyboardMemoryPlugin', () => {
 			events: {} as never,
 			window: mockWindow as unknown as Window,
 			navigator: {} as Navigator,
+			inputTarget: mockWindow as unknown as HTMLElement,
 			memoryViews: {} as never,
 			services: {} as never,
 			setErrors: () => {},

--- a/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/keyboardMemory/plugin.ts
+++ b/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/keyboardMemory/plugin.ts
@@ -25,10 +25,7 @@ function writeIntegerToMemory(state: State, wordAlignedAddress: number | undefin
 	state.callbacks.setWordInMemory?.(wordAlignedAddress, value, true);
 }
 
-export default function keyboardMemoryPlugin({
-	store,
-	window: targetWindow,
-}: EditorEnvironmentPluginContext): () => void {
+export default function keyboardMemoryPlugin({ store, inputTarget }: EditorEnvironmentPluginContext): () => void {
 	const pressOrder: number[] = [];
 
 	function upsertPressedKeyCode(keyCode: number): void {
@@ -93,13 +90,13 @@ export default function keyboardMemoryPlugin({
 		writeIntegerToMemory(state, keyPressedWordAlignedAddress, 0);
 	}
 
-	targetWindow.addEventListener('keydown', onKeydown);
-	targetWindow.addEventListener('keyup', onKeyup);
-	targetWindow.addEventListener('blur', onBlur);
+	inputTarget.addEventListener('keydown', onKeydown);
+	inputTarget.addEventListener('keyup', onKeyup);
+	inputTarget.addEventListener('blur', onBlur);
 
 	return () => {
-		targetWindow.removeEventListener('keydown', onKeydown);
-		targetWindow.removeEventListener('keyup', onKeyup);
-		targetWindow.removeEventListener('blur', onBlur);
+		inputTarget.removeEventListener('keydown', onKeydown);
+		inputTarget.removeEventListener('keyup', onKeyup);
+		inputTarget.removeEventListener('blur', onBlur);
 	};
 }

--- a/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/manager.test.ts
+++ b/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/manager.test.ts
@@ -48,6 +48,7 @@ describe('editor environment plugin manager', () => {
 	} as EventDispatcher;
 	const windowMock = {} as Window;
 	const navigatorMock = {} as Navigator;
+	const inputTargetMock = {} as HTMLElement;
 	const memoryViewsMock = {} as EditorEnvironmentPluginContext['memoryViews'];
 	const services = {
 		getWasmExports: vi.fn(),
@@ -69,6 +70,7 @@ describe('editor environment plugin manager', () => {
 		const cleanup = createEditorEnvironmentPluginManager(store, events, {
 			window: windowMock,
 			navigator: navigatorMock,
+			inputTarget: inputTargetMock,
 			memoryViews: memoryViewsMock,
 			services,
 			registry,
@@ -87,6 +89,7 @@ describe('editor environment plugin manager', () => {
 				events,
 				window: windowMock,
 				navigator: navigatorMock,
+				inputTarget: inputTargetMock,
 				memoryViews: memoryViewsMock,
 				services,
 			})
@@ -112,6 +115,7 @@ describe('editor environment plugin manager', () => {
 		const cleanup = createEditorEnvironmentPluginManager(store, events, {
 			window: windowMock,
 			navigator: navigatorMock,
+			inputTarget: inputTargetMock,
 			memoryViews: memoryViewsMock,
 			services,
 			registry,
@@ -141,6 +145,7 @@ describe('editor environment plugin manager', () => {
 		createEditorEnvironmentPluginManager(store, events, {
 			window: windowMock,
 			navigator: navigatorMock,
+			inputTarget: inputTargetMock,
 			memoryViews: memoryViewsMock,
 			services,
 			registry,
@@ -174,6 +179,7 @@ describe('editor environment plugin manager', () => {
 		createEditorEnvironmentPluginManager(store, events, {
 			window: windowMock,
 			navigator: navigatorMock,
+			inputTarget: inputTargetMock,
 			memoryViews: memoryViewsMock,
 			services,
 			registry,
@@ -208,6 +214,7 @@ describe('editor environment plugin manager', () => {
 		createEditorEnvironmentPluginManager(store, events, {
 			window: windowMock,
 			navigator: navigatorMock,
+			inputTarget: inputTargetMock,
 			memoryViews: memoryViewsMock,
 			services,
 			registry,

--- a/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/manager.ts
+++ b/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/manager.ts
@@ -14,6 +14,7 @@ interface ActivePlugin {
 interface EditorEnvironmentPluginManagerOptions {
 	window: Window;
 	navigator: Navigator;
+	inputTarget: HTMLElement;
 	memoryViews: MemoryViews;
 	services: EditorEnvironmentPluginServices;
 	registry?: EditorEnvironmentPluginRegistryEntry[];
@@ -143,6 +144,7 @@ export function createEditorEnvironmentPluginManager(
 					events,
 					window: options.window,
 					navigator: options.navigator,
+					inputTarget: options.inputTarget,
 					memoryViews: options.memoryViews,
 					services: options.services,
 					setErrors: errors => setPluginErrors(entry.id, errors),

--- a/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/midi/plugin.test.ts
+++ b/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/midi/plugin.test.ts
@@ -19,6 +19,7 @@ function createContext(): EditorEnvironmentPluginContext {
 		events: {} as never,
 		window: {} as Window,
 		navigator: {} as Navigator,
+		inputTarget: {} as HTMLElement,
 		memoryViews: {} as never,
 		services: {
 			getWasmExports: vi.fn(),

--- a/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/types.ts
+++ b/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/types.ts
@@ -8,6 +8,7 @@ export interface EditorEnvironmentPluginContext {
 	events: EventDispatcher;
 	window: Window;
 	navigator: Navigator;
+	inputTarget: HTMLElement;
 	memoryViews: MemoryViews;
 	services: EditorEnvironmentPluginServices;
 	setErrors: (errors: CodeError[]) => void;

--- a/packages/editor/packages/editor-core/src/events/keyboardEvents.test.ts
+++ b/packages/editor/packages/editor-core/src/events/keyboardEvents.test.ts
@@ -1,27 +1,27 @@
 import type { State } from '@8f4e/editor-state-types';
 import type { StateManager } from '@8f4e/state-manager';
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { EventDispatcher } from '.';
 import keyboardEvents from './keyboardEvents';
 
-type WindowListener = (event: KeyboardEvent) => void;
+type KeyboardListener = (event: KeyboardEvent) => void;
 
-interface MockWindow {
-	addEventListener: (type: string, listener: WindowListener) => void;
-	removeEventListener: (type: string, listener: WindowListener) => void;
+interface MockInputTarget {
+	addEventListener: (type: string, listener: KeyboardListener) => void;
+	removeEventListener: (type: string, listener: KeyboardListener) => void;
 	emit: (type: string, event: KeyboardEvent) => void;
 }
 
-function createMockWindow(): MockWindow {
-	const listeners = new Map<string, Set<WindowListener>>();
+function createMockInputTarget(): MockInputTarget {
+	const listeners = new Map<string, Set<KeyboardListener>>();
 
 	return {
-		addEventListener: (type: string, listener: WindowListener) => {
-			const group = listeners.get(type) ?? new Set<WindowListener>();
+		addEventListener: (type: string, listener: KeyboardListener) => {
+			const group = listeners.get(type) ?? new Set<KeyboardListener>();
 			group.add(listener);
 			listeners.set(type, group);
 		},
-		removeEventListener: (type: string, listener: WindowListener) => {
+		removeEventListener: (type: string, listener: KeyboardListener) => {
 			listeners.get(type)?.delete(listener);
 		},
 		emit: (type: string, event: KeyboardEvent) => {
@@ -48,8 +48,7 @@ function createKeyboardEventLike(key: string): KeyboardEvent {
 }
 
 describe('keyboardEvents mode switching', () => {
-	const originalWindow = globalThis.window;
-	let mockWindow: MockWindow;
+	let inputTarget: MockInputTarget;
 	let featureFlags: State['featureFlags'];
 	let editorMode: State['editorMode'];
 	let codeBlockRendering: Pick<State['codeBlockRendering'], 'showHiddenCodeBlocks'>;
@@ -58,8 +57,7 @@ describe('keyboardEvents mode switching', () => {
 	let store: StateManager<State>;
 
 	beforeEach(() => {
-		mockWindow = createMockWindow();
-		Object.assign(globalThis, { window: mockWindow });
+		inputTarget = createMockInputTarget();
 
 		featureFlags = {
 			contextMenu: true,
@@ -97,15 +95,11 @@ describe('keyboardEvents mode switching', () => {
 		} as unknown as StateManager<State>;
 	});
 
-	afterEach(() => {
-		Object.assign(globalThis, { window: originalWindow });
-	});
-
 	it('enters edit mode when e is pressed in view mode', () => {
-		const cleanup = keyboardEvents(events, store);
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
 		const event = createKeyboardEventLike('e');
 
-		mockWindow.emit('keydown', event);
+		inputTarget.emit('keydown', event);
 
 		expect(events.dispatch).toHaveBeenCalledWith('enterEditMode');
 		expect(event.preventDefault as ReturnType<typeof vi.fn>).toHaveBeenCalled();
@@ -113,10 +107,10 @@ describe('keyboardEvents mode switching', () => {
 	});
 
 	it('enters presentation mode when p is pressed in view mode', () => {
-		const cleanup = keyboardEvents(events, store);
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
 		const event = createKeyboardEventLike('p');
 
-		mockWindow.emit('keydown', event);
+		inputTarget.emit('keydown', event);
 
 		expect(events.dispatch).toHaveBeenCalledWith('enterPresentationMode');
 		cleanup();
@@ -124,10 +118,10 @@ describe('keyboardEvents mode switching', () => {
 
 	it('returns to view mode when Escape is pressed in edit mode', () => {
 		editorMode = 'edit';
-		const cleanup = keyboardEvents(events, store);
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
 		const event = createKeyboardEventLike('Escape');
 
-		mockWindow.emit('keydown', event);
+		inputTarget.emit('keydown', event);
 
 		expect(events.dispatch).toHaveBeenCalledWith('exitToViewMode');
 		expect(event.preventDefault as ReturnType<typeof vi.fn>).toHaveBeenCalled();
@@ -136,10 +130,10 @@ describe('keyboardEvents mode switching', () => {
 
 	it('returns to view mode when Escape is pressed in presentation mode', () => {
 		editorMode = 'presentation';
-		const cleanup = keyboardEvents(events, store);
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
 		const event = createKeyboardEventLike('Escape');
 
-		mockWindow.emit('keydown', event);
+		inputTarget.emit('keydown', event);
 
 		expect(events.dispatch).toHaveBeenCalledWith('exitToViewMode');
 		expect(event.preventDefault as ReturnType<typeof vi.fn>).toHaveBeenCalled();
@@ -148,10 +142,10 @@ describe('keyboardEvents mode switching', () => {
 
 	it('keeps i as text insertion while already in edit mode', () => {
 		editorMode = 'edit';
-		const cleanup = keyboardEvents(events, store);
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
 		const event = createKeyboardEventLike('i');
 
-		mockWindow.emit('keydown', event);
+		inputTarget.emit('keydown', event);
 
 		expect(events.dispatch).toHaveBeenCalledWith('insertText', { text: 'i' });
 		cleanup();
@@ -159,10 +153,10 @@ describe('keyboardEvents mode switching', () => {
 
 	it('ignores text insertion while in presentation mode', () => {
 		editorMode = 'presentation';
-		const cleanup = keyboardEvents(events, store);
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
 		const event = createKeyboardEventLike('i');
 
-		mockWindow.emit('keydown', event);
+		inputTarget.emit('keydown', event);
 
 		expect(events.dispatch).not.toHaveBeenCalled();
 		cleanup();
@@ -170,10 +164,10 @@ describe('keyboardEvents mode switching', () => {
 
 	it('jumps to the previous presentation stop when ArrowLeft is pressed in presentation mode', () => {
 		editorMode = 'presentation';
-		const cleanup = keyboardEvents(events, store);
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
 		const event = createKeyboardEventLike('ArrowLeft');
 
-		mockWindow.emit('keydown', event);
+		inputTarget.emit('keydown', event);
 
 		expect(events.dispatch).toHaveBeenCalledWith('previousPresentationStop');
 		expect(event.preventDefault as ReturnType<typeof vi.fn>).toHaveBeenCalled();
@@ -182,10 +176,10 @@ describe('keyboardEvents mode switching', () => {
 
 	it('jumps to the next presentation stop when ArrowRight is pressed in presentation mode', () => {
 		editorMode = 'presentation';
-		const cleanup = keyboardEvents(events, store);
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
 		const event = createKeyboardEventLike('ArrowRight');
 
-		mockWindow.emit('keydown', event);
+		inputTarget.emit('keydown', event);
 
 		expect(events.dispatch).toHaveBeenCalledWith('nextPresentationStop');
 		expect(event.preventDefault as ReturnType<typeof vi.fn>).toHaveBeenCalled();
@@ -194,10 +188,10 @@ describe('keyboardEvents mode switching', () => {
 
 	it('does not enter alternate modes when modeToggling is disabled', () => {
 		featureFlags.modeToggling = false;
-		const cleanup = keyboardEvents(events, store);
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
 		const enterEditEvent = createKeyboardEventLike('e');
 
-		mockWindow.emit('keydown', enterEditEvent);
+		inputTarget.emit('keydown', enterEditEvent);
 
 		expect(events.dispatch).not.toHaveBeenCalledWith('enterEditMode');
 		cleanup();
@@ -206,10 +200,10 @@ describe('keyboardEvents mode switching', () => {
 	it('still exits presentation mode with Escape when modeToggling is disabled', () => {
 		featureFlags.modeToggling = false;
 		editorMode = 'presentation';
-		const cleanup = keyboardEvents(events, store);
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
 		const event = createKeyboardEventLike('Escape');
 
-		mockWindow.emit('keydown', event);
+		inputTarget.emit('keydown', event);
 
 		expect(events.dispatch).toHaveBeenCalledWith('exitToViewMode');
 		expect(event.preventDefault as ReturnType<typeof vi.fn>).toHaveBeenCalled();
@@ -218,32 +212,76 @@ describe('keyboardEvents mode switching', () => {
 
 	it('dispatches literal tab insertion when Tab is pressed', () => {
 		editorMode = 'edit';
-		const cleanup = keyboardEvents(events, store);
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
 		const event = createKeyboardEventLike('Tab');
 
-		mockWindow.emit('keydown', event);
+		inputTarget.emit('keydown', event);
 
 		expect(events.dispatch).toHaveBeenCalledWith('insertText', { text: '\t' });
 		expect(event.preventDefault as ReturnType<typeof vi.fn>).toHaveBeenCalled();
 		cleanup();
 	});
 
+	it('leaves Tab unhandled in view mode so focus can move to another editor', () => {
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
+		const event = createKeyboardEventLike('Tab');
+
+		inputTarget.emit('keydown', event);
+
+		expect(events.dispatch).not.toHaveBeenCalledWith('insertText', expect.anything());
+		expect(event.preventDefault as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+		cleanup();
+	});
+
 	it('reveals hidden code blocks while F9 is held', () => {
-		const cleanup = keyboardEvents(events, store);
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
 		const keydownEvent = createKeyboardEventLike('F9');
 		const keyupEvent = createKeyboardEventLike('F9');
 
-		mockWindow.emit('keydown', keydownEvent);
+		inputTarget.emit('keydown', keydownEvent);
 
 		expect(set).toHaveBeenCalledWith('codeBlockRendering.showHiddenCodeBlocks', true);
 		expect(codeBlockRendering.showHiddenCodeBlocks).toBe(true);
 		expect(keydownEvent.preventDefault as ReturnType<typeof vi.fn>).toHaveBeenCalled();
 
-		mockWindow.emit('keyup', keyupEvent);
+		inputTarget.emit('keyup', keyupEvent);
 
 		expect(set).toHaveBeenCalledWith('codeBlockRendering.showHiddenCodeBlocks', false);
 		expect(codeBlockRendering.showHiddenCodeBlocks).toBe(false);
 		expect(keyupEvent.preventDefault as ReturnType<typeof vi.fn>).toHaveBeenCalled();
+		cleanup();
+	});
+
+	it('routes a key event only to the editor that owns its target', () => {
+		editorMode = 'edit';
+		const secondInputTarget = createMockInputTarget();
+		const secondEvents = {
+			on: vi.fn(),
+			off: vi.fn(),
+			dispatch: vi.fn(),
+		};
+		const cleanupFirst = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
+		const cleanupSecond = keyboardEvents(secondInputTarget as unknown as HTMLElement, secondEvents, store);
+
+		inputTarget.emit('keydown', createKeyboardEventLike('a'));
+
+		expect(events.dispatch).toHaveBeenCalledWith('insertText', { text: 'a' });
+		expect(secondEvents.dispatch).not.toHaveBeenCalled();
+
+		secondInputTarget.emit('keydown', createKeyboardEventLike('b'));
+
+		expect(secondEvents.dispatch).toHaveBeenCalledWith('insertText', { text: 'b' });
+		cleanupFirst();
+		cleanupSecond();
+	});
+
+	it('stops temporarily revealing hidden blocks when the canvas loses focus', () => {
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
+
+		inputTarget.emit('keydown', createKeyboardEventLike('F9'));
+		inputTarget.emit('blur', createKeyboardEventLike(''));
+
+		expect(codeBlockRendering.showHiddenCodeBlocks).toBe(false);
 		cleanup();
 	});
 });

--- a/packages/editor/packages/editor-core/src/events/keyboardEvents.ts
+++ b/packages/editor/packages/editor-core/src/events/keyboardEvents.ts
@@ -29,7 +29,7 @@ function getDirectionFromArrowKey(key: string): Direction | null {
 }
 
 /**
- * Sets up global keyboard event handling for the editor and dispatches high-level
+ * Sets up keyboard event handling for the editor and dispatches high-level
  * editor actions via the provided EventDispatcher.
  *
  * This listener interprets key presses and may dispatch the following events:
@@ -46,11 +46,22 @@ function getDirectionFromArrowKey(key: string): Direction | null {
  * - holding F9 reveals blocks hidden by `; @hidden`
  * - F10 toggles position offsetters directly via store mutation
  *
+ * @param element - Focusable editor element that owns the keyboard input.
  * @param events - Dispatcher used to emit editor actions in response to keyboard input.
  * @param store - State manager for direct feature flag toggling.
- * @returns A cleanup function that removes the keydown event listener from window.
+ * @returns A cleanup function that removes the keyboard event listeners.
  */
-export default function keyboardEvents(events: EventDispatcher, store: StateManager<State>): () => void {
+export default function keyboardEvents(
+	element: HTMLElement,
+	events: EventDispatcher,
+	store: StateManager<State>
+): () => void {
+	function hideTemporarilyRevealedCodeBlocks(): void {
+		if (store.getState().codeBlockRendering.showHiddenCodeBlocks) {
+			store.set('codeBlockRendering.showHiddenCodeBlocks', false);
+		}
+	}
+
 	function onKeydown(event: KeyboardEvent) {
 		const { key, metaKey, ctrlKey } = event;
 		const state = store.getState();
@@ -176,6 +187,9 @@ export default function keyboardEvents(events: EventDispatcher, store: StateMana
 
 		// Tab
 		if (key === 'Tab') {
+			if (state.editorMode !== 'edit') {
+				return;
+			}
 			event.preventDefault();
 			events.dispatch<InsertTextEvent>('insertText', { text: '\t' });
 			return;
@@ -203,17 +217,16 @@ export default function keyboardEvents(events: EventDispatcher, store: StateMana
 
 		event.preventDefault();
 
-		if (store.getState().codeBlockRendering.showHiddenCodeBlocks) {
-			store.set('codeBlockRendering.showHiddenCodeBlocks', false);
-		}
+		hideTemporarilyRevealedCodeBlocks();
 	}
 
-	window.addEventListener('keydown', onKeydown);
-	window.addEventListener('keyup', onKeyup);
+	element.addEventListener('keydown', onKeydown);
+	element.addEventListener('keyup', onKeyup);
+	element.addEventListener('blur', hideTemporarilyRevealedCodeBlocks);
 
-	// Return cleanup function
 	return () => {
-		window.removeEventListener('keydown', onKeydown);
-		window.removeEventListener('keyup', onKeyup);
+		element.removeEventListener('keydown', onKeydown);
+		element.removeEventListener('keyup', onKeyup);
+		element.removeEventListener('blur', hideTemporarilyRevealedCodeBlocks);
 	};
 }

--- a/packages/editor/packages/editor-core/src/events/pointerEvents.test.ts
+++ b/packages/editor/packages/editor-core/src/events/pointerEvents.test.ts
@@ -48,19 +48,16 @@ function createWheelEventLike(overrides: Partial<WheelEvent> = {}): WheelEvent {
 }
 
 describe('pointerEvents', () => {
-	const originalWindow = globalThis.window;
-	let mockWindow: MockEventTarget;
-	let mockElement: MockEventTarget & Pick<HTMLElement, 'clientWidth' | 'clientHeight'>;
+	let mockElement: MockEventTarget & Pick<HTMLElement, 'clientWidth' | 'clientHeight' | 'focus'>;
 	let events: EventDispatcher;
 	let state: State;
 
 	beforeEach(() => {
 		vi.useFakeTimers();
-		mockWindow = createMockEventTarget();
-		Object.assign(globalThis, { window: mockWindow });
 		mockElement = Object.assign(createMockEventTarget(), {
 			clientWidth: 640,
 			clientHeight: 480,
+			focus: vi.fn(),
 		});
 		events = {
 			on: vi.fn(),
@@ -76,14 +73,13 @@ describe('pointerEvents', () => {
 
 	afterEach(() => {
 		vi.useRealTimers();
-		Object.assign(globalThis, { window: originalWindow });
 	});
 
 	it('dispatches mouseup after wheel scrolling has paused', () => {
 		const cleanup = pointerEvents(mockElement as HTMLElement, events, state);
 		const wheelEvent = createWheelEventLike();
 
-		mockWindow.emit('wheel', wheelEvent);
+		mockElement.emit('wheel', wheelEvent);
 
 		expect(events.dispatch).toHaveBeenCalledWith('mousemove', {
 			x: 20,
@@ -113,9 +109,9 @@ describe('pointerEvents', () => {
 	it('resets the scroll-end timer on subsequent wheel events', () => {
 		const cleanup = pointerEvents(mockElement as HTMLElement, events, state);
 
-		mockWindow.emit('wheel', createWheelEventLike());
+		mockElement.emit('wheel', createWheelEventLike());
 		vi.advanceTimersByTime(100);
-		mockWindow.emit('wheel', createWheelEventLike({ deltaY: 7 }));
+		mockElement.emit('wheel', createWheelEventLike({ deltaY: 7 }));
 
 		vi.advanceTimersByTime(119);
 		expect(events.dispatch).not.toHaveBeenCalledWith('viewportscrollend', expect.anything());
@@ -133,13 +129,30 @@ describe('pointerEvents', () => {
 	it('removes listeners and clears the pending timer during cleanup', () => {
 		const cleanup = pointerEvents(mockElement as HTMLElement, events, state);
 
-		mockWindow.emit('wheel', createWheelEventLike());
+		mockElement.emit('wheel', createWheelEventLike());
 		cleanup();
 		vi.runAllTimers();
 
 		expect(events.dispatch).toHaveBeenCalledTimes(1);
 
-		mockWindow.emit('wheel', createWheelEventLike());
+		mockElement.emit('wheel', createWheelEventLike());
 		expect(events.dispatch).toHaveBeenCalledTimes(1);
+	});
+
+	it('focuses the owning canvas when it is pressed', () => {
+		const cleanup = pointerEvents(mockElement as HTMLElement, events, state);
+		const mouseEvent = {
+			type: 'mousedown',
+			offsetX: 10,
+			offsetY: 20,
+			buttons: 1,
+			altKey: false,
+			preventDefault: vi.fn(),
+		} as unknown as MouseEvent;
+
+		mockElement.emit('mousedown', mouseEvent);
+
+		expect(mockElement.focus).toHaveBeenCalledWith({ preventScroll: true });
+		cleanup();
 	});
 });

--- a/packages/editor/packages/editor-core/src/events/pointerEvents.ts
+++ b/packages/editor/packages/editor-core/src/events/pointerEvents.ts
@@ -20,6 +20,10 @@ export default function pointerEvents(element: HTMLElement, events: EventDispatc
 	};
 
 	function onMouseEvents(event: MouseEvent) {
+		if (event.type === 'mousedown') {
+			element.focus({ preventScroll: true });
+		}
+
 		const movementX = event.offsetX - prevEvent.offsetX;
 		const movementY = event.offsetY - prevEvent.offsetY;
 		prevEvent = event;
@@ -72,7 +76,7 @@ export default function pointerEvents(element: HTMLElement, events: EventDispatc
 	}
 
 	if (state.featureFlags.viewportDragging) {
-		window.addEventListener('wheel', onWheelEvents, { passive: false });
+		element.addEventListener('wheel', onWheelEvents, { passive: false });
 	}
 	element.addEventListener('mouseup', onMouseEvents);
 	element.addEventListener('mousedown', onMouseEvents);
@@ -85,7 +89,7 @@ export default function pointerEvents(element: HTMLElement, events: EventDispatc
 		}
 
 		if (state.featureFlags.viewportDragging) {
-			window.removeEventListener('wheel', onWheelEvents);
+			element.removeEventListener('wheel', onWheelEvents);
 		}
 		element.removeEventListener('mouseup', onMouseEvents);
 		element.removeEventListener('mousedown', onMouseEvents);

--- a/packages/editor/packages/editor-core/src/index.test.ts
+++ b/packages/editor/packages/editor-core/src/index.test.ts
@@ -182,6 +182,46 @@ describe('editor init', () => {
 		expect(disconnect).toHaveBeenCalledWith();
 	});
 
+	it('makes its canvas focusable and restores its previous tab index when disposed', async () => {
+		const { default: init } = await import('./index');
+		const { default: keyboardEvents } = await import('./events/keyboardEvents');
+		const { createEditorEnvironmentPluginManager } = await import('./editorEnvironmentPlugins/manager');
+		const canvas = {
+			width: 640,
+			height: 480,
+			clientWidth: 640,
+			clientHeight: 480,
+			tabIndex: -1,
+			hasAttribute: vi.fn(() => false),
+			removeAttribute: vi.fn(() => {
+				canvas.tabIndex = -1;
+			}),
+		} as unknown as HTMLCanvasElement;
+
+		const editor = await init(canvas, {
+			runtimeRegistry: {
+				WebWorkerRuntime: {
+					id: 'WebWorkerRuntime',
+					factory: () => () => {},
+				},
+			},
+			callbacks: {
+				loadSession: async () => null,
+			},
+		});
+
+		expect(canvas.tabIndex).toBe(0);
+		expect(keyboardEvents).toHaveBeenLastCalledWith(canvas, events, store);
+		expect(createEditorEnvironmentPluginManager).toHaveBeenLastCalledWith(
+			store,
+			events,
+			expect.objectContaining({ inputTarget: canvas })
+		);
+
+		editor.dispose();
+		expect(canvas.tabIndex).toBe(-1);
+	});
+
 	it('renders one fresh frame before exporting a canvas screenshot', async () => {
 		const { default: init } = await import('./index');
 		const { default: initState } = await import('@8f4e/editor-state');

--- a/packages/editor/packages/editor-core/src/index.ts
+++ b/packages/editor/packages/editor-core/src/index.ts
@@ -134,6 +134,12 @@ function toGraphicsInfoRecord(stats: RenderStats): InfoRecord {
 }
 
 export default async function init(canvas: HTMLCanvasElement, options: Options): Promise<Editor> {
+	const initialTabIndex = canvas.tabIndex;
+	const addedTabIndex = initialTabIndex < 0 && !canvas.hasAttribute('tabindex');
+	if (addedTabIndex) {
+		canvas.tabIndex = 0;
+	}
+
 	const { memoryViews, updateMemoryViews } = createMemoryViewManager(new ArrayBuffer(0));
 	const events = initEvents();
 	let currentMemoryRef: WebAssembly.Memory | null = null;
@@ -195,11 +201,12 @@ export default async function init(canvas: HTMLCanvasElement, options: Options):
 	});
 	const state = store.getState();
 	const cleanupPointer = pointerEvents(canvas, events, state);
-	const cleanupKeyboard = keyboardEvents(events, store);
+	const cleanupKeyboard = keyboardEvents(canvas, events, store);
 	const browserWindow = canvas.ownerDocument?.defaultView ?? globalThis.window;
 	const cleanupEditorEnvironmentPlugins = createEditorEnvironmentPluginManager(store, events, {
 		window: browserWindow as Window,
 		navigator: browserWindow?.navigator ?? globalThis.navigator,
+		inputTarget: canvas,
 		memoryViews,
 		services: pluginServices.services,
 	});
@@ -274,6 +281,9 @@ export default async function init(canvas: HTMLCanvasElement, options: Options):
 			cleanupPointer();
 			cleanupKeyboard();
 			cleanupEditorEnvironmentPlugins();
+			if (addedTabIndex && canvas.tabIndex === 0) {
+				canvas.removeAttribute('tabindex');
+			}
 		},
 		state,
 	};

--- a/packages/editor/packages/editor-website/src/index.html
+++ b/packages/editor/packages/editor-website/src/index.html
@@ -30,7 +30,7 @@
 </head>
 
 <body>
-	<canvas id="glcanvas"></canvas>
+	<canvas id="glcanvas" tabindex="0"></canvas>
 	<script src="./main.ts" type="module"></script>
 </body>
 

--- a/packages/editor/packages/editor-website/src/main.ts
+++ b/packages/editor/packages/editor-website/src/main.ts
@@ -6,4 +6,5 @@ if (!canvas) {
 	throw new Error('Editor canvas not found');
 }
 
+canvas.focus({ preventScroll: true });
 void mountDefaultEditor(canvas);


### PR DESCRIPTION
## Summary

- route editor keyboard events through the owning canvas instead of the window
- route keyboard-memory input through the same canvas target
- handle wheel input on the owning canvas and focus it on mouse press
- make canvases tabbable by default while preserving an explicit host tab index
- let Tab move between editors in view mode while retaining literal Tab insertion in edit mode
- have the single-editor website focus its canvas on startup

## Rationale

Window-level input listeners caused every mounted editor to process the same keyboard and wheel events. Canvas-scoped listeners use normal DOM focus and event targeting to select one editor without introducing another shared coordinator. The website keeps its existing immediate-typing behavior by choosing initial focus itself.

## Tests

- npx nx run-many --target=lint --projects=@8f4e/editor-core,@8f4e/editor-website
- npx nx run @8f4e/editor-core:typecheck
- npx nx run @8f4e/editor-core:test
- npx nx run @8f4e/editor-website:build