### PR TITLE
fix(editor-default): isolate editor persistence

### DIFF
--- a/packages/editor/packages/editor-default/README.md
+++ b/packages/editor/packages/editor-default/README.md
@@ -9,13 +9,22 @@ other browser hosts control when and where the editor starts.
 ```ts
 import { mountDefaultEditor } from '@8f4e/editor-default';
 
-await mountDefaultEditor(canvas);
+const editor = await mountDefaultEditor(canvas, {
+	storageNamespace: 'editor-a',
+});
+
+editor.state;
+editor.dispose();
 ```
 
 The host controls the canvas's layout dimensions with CSS. The editor observes that rendered size and adapts its
 drawing buffer and UI automatically.
 
 Each mounted editor owns its compiler worker, compiled memory and code-buffer state, and lazy runtime registry.
+It also owns persistence callbacks for its storage namespace. The default namespace is `editor`, which preserves the
+existing `project_editor` and `browserLocalNotes_editor` keys. Hosts mounting multiple editors should pass a stable,
+unique namespace for each editor. Hosts may also provide a custom `Storage` implementation or an
+`initialProjectUrl`; interpreting page URLs remains the host's responsibility.
 
 Build, test, and type-check it from the workspace root:
 

--- a/packages/editor/packages/editor-default/src/index.ts
+++ b/packages/editor/packages/editor-default/src/index.ts
@@ -5,18 +5,33 @@ import { getListOfProjects, getProject } from './examples/projectRegistry';
 import { createRuntimeRegistry } from './runtime-registry';
 import { resolveStdlibInclude } from './stdlib-resolver';
 import {
+	createStorageCallbacks,
 	exportBinaryCode,
 	exportCanvasScreenshot,
 	exportProject,
 	importProject,
-	loadBrowserLocalNotes,
-	loadSession,
-	saveBrowserLocalNotes,
-	saveSession,
 } from './storage-callbacks';
 
-export async function mountDefaultEditor(canvas: HTMLCanvasElement): Promise<Editor> {
+const DEFAULT_STORAGE_NAMESPACE = 'editor';
+
+export type DefaultEditorInstance = Editor;
+
+export interface DefaultEditorMountOptions {
+	initialProjectUrl?: string;
+	storage?: Storage;
+	storageNamespace?: string;
+}
+
+export async function mountDefaultEditor(
+	canvas: HTMLCanvasElement,
+	{
+		initialProjectUrl,
+		storage = localStorage,
+		storageNamespace = DEFAULT_STORAGE_NAMESPACE,
+	}: DefaultEditorMountOptions = {}
+): Promise<DefaultEditorInstance> {
 	const compilerService = createCompilerService();
+	const storageCallbacks = createStorageCallbacks({ storage, storageNamespace, initialProjectUrl });
 	let editor: Editor;
 	try {
 		editor = await initEditor(canvas, {
@@ -29,10 +44,7 @@ export async function mountDefaultEditor(canvas: HTMLCanvasElement): Promise<Edi
 				getProject,
 				resolveInclude: resolveStdlibInclude,
 				compileCode: (input, compilerOptions) => compilerService.compileCode(input, compilerOptions, editor),
-				loadSession,
-				saveSession,
-				loadBrowserLocalNotes,
-				saveBrowserLocalNotes,
+				...storageCallbacks,
 				importProject,
 				exportProject,
 				exportBinaryCode: fileName => exportBinaryCode(fileName, compilerService.getCodeBuffer()),
@@ -43,9 +55,6 @@ export async function mountDefaultEditor(canvas: HTMLCanvasElement): Promise<Edi
 		compilerService.dispose();
 		throw error;
 	}
-
-	// @ts-expect-error - Expose state for debugging purposes
-	window.state = editor.state;
 
 	return {
 		...editor,

--- a/packages/editor/packages/editor-default/src/storage-callbacks.test.ts
+++ b/packages/editor/packages/editor-default/src/storage-callbacks.test.ts
@@ -1,0 +1,80 @@
+import type { BrowserLocalNoteStorageBlock } from '@8f4e/editor-core';
+import type { ProjectObjectModel } from '@8f4e/language-spec';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createStorageCallbacks } from './storage-callbacks';
+
+const { parseProjectSource, getDefaultProjectUrl, getProject } = vi.hoisted(() => ({
+	parseProjectSource: vi.fn(),
+	getDefaultProjectUrl: vi.fn(),
+	getProject: vi.fn(),
+}));
+
+vi.mock('@8f4e/compiler', () => ({ parseProjectSource }));
+vi.mock('./examples/projectRegistry', () => ({ getDefaultProjectUrl, getProject }));
+
+function createMemoryStorage(): Storage {
+	const values = new Map<string, string>();
+
+	return {
+		get length() {
+			return values.size;
+		},
+		clear: () => values.clear(),
+		getItem: key => values.get(key) ?? null,
+		key: index => Array.from(values.keys())[index] ?? null,
+		removeItem: key => values.delete(key),
+		setItem: (key, value) => values.set(key, value),
+	};
+}
+
+describe('storage callbacks', () => {
+	beforeEach(() => {
+		parseProjectSource.mockReset();
+		getDefaultProjectUrl.mockReset();
+		getProject.mockReset();
+	});
+
+	it('isolates projects and browser-local notes by namespace', async () => {
+		const storage = createMemoryStorage();
+		const first = createStorageCallbacks({ storage, storageNamespace: 'first' });
+		const second = createStorageCallbacks({ storage, storageNamespace: 'second' });
+		const firstProject = { title: 'First' } as unknown as ProjectObjectModel;
+		const secondProject = { title: 'Second' } as unknown as ProjectObjectModel;
+		const firstNotes: BrowserLocalNoteStorageBlock[] = [{ code: ['note', 'first', 'noteEnd'] }];
+		const secondNotes: BrowserLocalNoteStorageBlock[] = [{ code: ['note', 'second', 'noteEnd'] }];
+
+		await first.saveSession(firstProject);
+		await second.saveSession(secondProject);
+		await first.saveBrowserLocalNotes(firstNotes);
+		await second.saveBrowserLocalNotes(secondNotes);
+
+		expect(storage.getItem('project_first')).toBe(JSON.stringify(firstProject));
+		expect(storage.getItem('project_second')).toBe(JSON.stringify(secondProject));
+		expect(storage.getItem('browserLocalNotes_first')).toBe(JSON.stringify(firstNotes));
+		expect(storage.getItem('browserLocalNotes_second')).toBe(JSON.stringify(secondNotes));
+		expect(await first.loadSession()).toEqual(firstProject);
+		expect(await second.loadSession()).toEqual(secondProject);
+		expect(await first.loadBrowserLocalNotes()).toEqual(firstNotes);
+		expect(await second.loadBrowserLocalNotes()).toEqual(secondNotes);
+	});
+
+	it('uses an initial project URL once before falling back to persisted state', async () => {
+		const storage = createMemoryStorage();
+		const persistedProject = { title: 'Persisted' } as unknown as ProjectObjectModel;
+		const initialProject = { title: 'Initial' } as unknown as ProjectObjectModel;
+		storage.setItem('project_editor', JSON.stringify(persistedProject));
+		getProject.mockResolvedValue('initial project source');
+		parseProjectSource.mockReturnValue(initialProject);
+		const callbacks = createStorageCallbacks({
+			storage,
+			storageNamespace: 'editor',
+			initialProjectUrl: 'https://example.com/initial.8f4e',
+		});
+
+		expect(await callbacks.loadSession()).toBe(initialProject);
+		expect(await callbacks.loadSession()).toEqual(persistedProject);
+		expect(getProject).toHaveBeenCalledOnce();
+		expect(getProject).toHaveBeenCalledWith('https://example.com/initial.8f4e');
+		expect(parseProjectSource).toHaveBeenCalledWith('initial project source');
+	});
+});

--- a/packages/editor/packages/editor-default/src/storage-callbacks.ts
+++ b/packages/editor/packages/editor-default/src/storage-callbacks.ts
@@ -3,71 +3,77 @@ import type { BrowserLocalNoteStorageBlock } from '@8f4e/editor-core';
 import type { ProjectObjectModel } from '@8f4e/language-spec';
 import { getDefaultProjectUrl, getProject } from './examples/projectRegistry';
 
-// Storage key constants
-const STORAGE_KEYS = {
-	PROJECT: 'project_editor',
-	BROWSER_LOCAL_NOTES: 'browserLocalNotes_editor',
-} as const;
-
-// Implementation of storage callbacks using localStorage
-export async function loadSession(): Promise<ProjectObjectModel | null> {
-	try {
-		const projectUrlFromQuery = new URLSearchParams(location.search).get('projectUrl') || '';
-		if (projectUrlFromQuery) {
-			const url = new URL(window.location.href);
-			url.searchParams.delete('projectUrl');
-			const cleanUrl = `${url.pathname}${url.search}${url.hash}`;
-			window.history.replaceState({}, '', cleanUrl);
-
-			console.log('Loading project from query param:', projectUrlFromQuery);
-			return parseProjectSource(await getProject(projectUrlFromQuery));
-		}
-
-		const stored = localStorage.getItem(STORAGE_KEYS.PROJECT);
-		if (stored) {
-			console.log('Loading project from localStorage');
-			return JSON.parse(stored);
-		}
-
-		const defaultProjectUrl = await getDefaultProjectUrl();
-		if (defaultProjectUrl) {
-			console.log(`Loading default project: ${defaultProjectUrl}`);
-			return parseProjectSource(await getProject(defaultProjectUrl));
-		}
-
-		return null;
-	} catch (error) {
-		console.error('Failed to load project from localStorage:', error);
-		return null;
-	}
+interface StorageCallbacksOptions {
+	storage: Storage;
+	storageNamespace: string;
+	initialProjectUrl?: string;
 }
 
-export async function saveSession(project: ProjectObjectModel): Promise<void> {
-	try {
-		localStorage.setItem(STORAGE_KEYS.PROJECT, JSON.stringify(project));
-	} catch (error) {
-		console.error('Failed to save project to localStorage:', error);
-		throw error;
-	}
+function createStorageKeys(namespace: string) {
+	return {
+		project: `project_${namespace}`,
+		browserLocalNotes: `browserLocalNotes_${namespace}`,
+	};
 }
 
-export async function loadBrowserLocalNotes(): Promise<BrowserLocalNoteStorageBlock[] | null> {
-	try {
-		const stored = localStorage.getItem(STORAGE_KEYS.BROWSER_LOCAL_NOTES);
-		return stored ? JSON.parse(stored) : null;
-	} catch (error) {
-		console.error('Failed to load browser-local notes from localStorage:', error);
-		return null;
-	}
-}
+export function createStorageCallbacks({ storage, storageNamespace, initialProjectUrl }: StorageCallbacksOptions) {
+	const storageKeys = createStorageKeys(storageNamespace);
+	let pendingInitialProjectUrl = initialProjectUrl;
 
-export async function saveBrowserLocalNotes(blocks: BrowserLocalNoteStorageBlock[]): Promise<void> {
-	try {
-		localStorage.setItem(STORAGE_KEYS.BROWSER_LOCAL_NOTES, JSON.stringify(blocks));
-	} catch (error) {
-		console.error('Failed to save browser-local notes to localStorage:', error);
-		throw error;
-	}
+	return {
+		async loadSession(): Promise<ProjectObjectModel | null> {
+			try {
+				const projectUrl = pendingInitialProjectUrl;
+				pendingInitialProjectUrl = undefined;
+				if (projectUrl) {
+					console.log('Loading initial project:', projectUrl);
+					return parseProjectSource(await getProject(projectUrl));
+				}
+
+				const stored = storage.getItem(storageKeys.project);
+				if (stored) {
+					console.log(`Loading project from storage namespace "${storageNamespace}"`);
+					return JSON.parse(stored);
+				}
+
+				const defaultProjectUrl = await getDefaultProjectUrl();
+				if (defaultProjectUrl) {
+					console.log(`Loading default project: ${defaultProjectUrl}`);
+					return parseProjectSource(await getProject(defaultProjectUrl));
+				}
+
+				return null;
+			} catch (error) {
+				console.error('Failed to load editor session:', error);
+				return null;
+			}
+		},
+		async saveSession(project: ProjectObjectModel): Promise<void> {
+			try {
+				storage.setItem(storageKeys.project, JSON.stringify(project));
+			} catch (error) {
+				console.error('Failed to save project to storage:', error);
+				throw error;
+			}
+		},
+		async loadBrowserLocalNotes(): Promise<BrowserLocalNoteStorageBlock[] | null> {
+			try {
+				const stored = storage.getItem(storageKeys.browserLocalNotes);
+				return stored ? JSON.parse(stored) : null;
+			} catch (error) {
+				console.error('Failed to load browser-local notes from storage:', error);
+				return null;
+			}
+		},
+		async saveBrowserLocalNotes(blocks: BrowserLocalNoteStorageBlock[]): Promise<void> {
+			try {
+				storage.setItem(storageKeys.browserLocalNotes, JSON.stringify(blocks));
+			} catch (error) {
+				console.error('Failed to save browser-local notes to storage:', error);
+				throw error;
+			}
+		},
+	};
 }
 
 export async function importProject(): Promise<ProjectObjectModel> {

--- a/packages/editor/packages/editor-website/src/main.ts
+++ b/packages/editor/packages/editor-website/src/main.ts
@@ -14,5 +14,11 @@ if (initialProjectUrl) {
 }
 
 canvas.focus({ preventScroll: true });
-const editor = await mountDefaultEditor(canvas, { initialProjectUrl });
+const editor = await mountDefaultEditor(canvas, {
+	initialProjectUrl,
+	storage: window.localStorage,
+	storageNamespace: 'editor',
+});
 Object.assign(window, { state: editor.state });
+
+import.meta.hot?.dispose(() => editor.dispose());

--- a/packages/editor/packages/editor-website/src/main.ts
+++ b/packages/editor/packages/editor-website/src/main.ts
@@ -6,5 +6,13 @@ if (!canvas) {
 	throw new Error('Editor canvas not found');
 }
 
+const url = new URL(window.location.href);
+const initialProjectUrl = url.searchParams.get('projectUrl') || undefined;
+if (initialProjectUrl) {
+	url.searchParams.delete('projectUrl');
+	window.history.replaceState({}, '', `${url.pathname}${url.search}${url.hash}`);
+}
+
 canvas.focus({ preventScroll: true });
-void mountDefaultEditor(canvas);
+const editor = await mountDefaultEditor(canvas, { initialProjectUrl });
+Object.assign(window, { state: editor.state });


### PR DESCRIPTION
## Summary

- return a typed editor instance from mountDefaultEditor and accept per-mount options
- isolate saved projects and browser-local notes with stable storage namespaces
- move projectUrl parsing, history cleanup, persistence selection, and the window.state debug hook into editor-website
- dispose the mounted editor during Vite hot-module replacement
- cover namespace isolation and one-shot initial project loading with unit tests

## Rationale

The reusable default composition should adapt and manage its own editor instance without owning page-level URL, storage-selection, lifecycle, or global-window policy. Per-mount persistence prevents multiple editors on one page from sharing saved state, while the default editor namespace preserves the existing storage keys.

## Validation

- npx nx run-many --target=lint --projects=@8f4e/editor-default,@8f4e/editor-website
- npx nx run @8f4e/editor-default:typecheck
- npx nx run @8f4e/editor-default:test
- npx nx run @8f4e/editor-website:build
- git diff --check