### PR TITLE
fix(editor-core): isolate MIDI device listeners

### DIFF
--- a/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/midi/devices.test.ts
+++ b/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/midi/devices.test.ts
@@ -14,6 +14,40 @@ interface MIDIAccessMock {
 	inputs: Map<string, MIDIPortMock>;
 	outputs: Map<string, MIDIPortMock>;
 	onstatechange: ((event: unknown) => void) | null;
+	addEventListener: ReturnType<typeof vi.fn>;
+	removeEventListener: ReturnType<typeof vi.fn>;
+	dispatchStateChange: (event?: unknown) => void;
+}
+
+function createMIDIAccessMock({
+	inputs = new Map(),
+	outputs = new Map(),
+	onstatechange = null,
+}: Partial<Pick<MIDIAccessMock, 'inputs' | 'outputs' | 'onstatechange'>> = {}): MIDIAccessMock {
+	const stateChangeListeners = new Set<(event: unknown) => void>();
+	const access: MIDIAccessMock = {
+		inputs,
+		outputs,
+		onstatechange,
+		addEventListener: vi.fn((type: string, listener: (event: unknown) => void) => {
+			if (type === 'statechange') {
+				stateChangeListeners.add(listener);
+			}
+		}),
+		removeEventListener: vi.fn((type: string, listener: (event: unknown) => void) => {
+			if (type === 'statechange') {
+				stateChangeListeners.delete(listener);
+			}
+		}),
+		dispatchStateChange: (event = {}) => {
+			access.onstatechange?.(event);
+			for (const listener of stateChangeListeners) {
+				listener(event);
+			}
+		},
+	};
+
+	return access;
 }
 
 function createStore() {
@@ -41,7 +75,7 @@ describe('createMidiDeviceManager', () => {
 
 	it('commits available MIDI devices into state.info.midi', async () => {
 		const store = createStore();
-		const access: MIDIAccessMock = {
+		const access = createMIDIAccessMock({
 			inputs: new Map([
 				[
 					'input-a',
@@ -64,8 +98,7 @@ describe('createMidiDeviceManager', () => {
 					},
 				],
 			]),
-			onstatechange: null,
-		};
+		});
 		const requestMIDIAccess = vi.fn(async () => access as unknown as MIDIAccess);
 		const manager = createMidiDeviceManager({
 			store,
@@ -95,7 +128,7 @@ describe('createMidiDeviceManager', () => {
 			name: 'Disconnected output',
 			state: 'disconnected',
 		});
-		access.onstatechange?.({});
+		access.dispatchStateChange();
 
 		expect(store.getState().info.midi).toEqual({
 			'0': 'Keys (in)',
@@ -105,7 +138,7 @@ describe('createMidiDeviceManager', () => {
 		expect(manager.getInputPort('2')).toBe(access.inputs.get('input-b'));
 
 		access.inputs.get('input-a')!.state = 'disconnected';
-		access.onstatechange?.({});
+		access.dispatchStateChange();
 
 		expect(store.getState().info.midi).toEqual({
 			'1': 'Synth (out)',
@@ -115,7 +148,7 @@ describe('createMidiDeviceManager', () => {
 		expect(manager.getInputPort('2')).toBe(access.inputs.get('input-b'));
 
 		access.inputs.get('input-a')!.state = 'connected';
-		access.onstatechange?.({});
+		access.dispatchStateChange();
 
 		expect(store.getState().info.midi).toEqual({
 			'0': 'Keys (in)',
@@ -129,14 +162,12 @@ describe('createMidiDeviceManager', () => {
 		expect(store.getState().info.midi).toBeUndefined();
 	});
 
-	it('restores an existing MIDI statechange handler on cleanup', async () => {
+	it('leaves an existing MIDI statechange property handler untouched', async () => {
 		const store = createStore();
 		const previousStateChangeHandler = vi.fn();
-		const access: MIDIAccessMock = {
-			inputs: new Map(),
-			outputs: new Map(),
+		const access = createMIDIAccessMock({
 			onstatechange: previousStateChangeHandler,
-		};
+		});
 		const manager = createMidiDeviceManager({
 			store,
 			navigator: {
@@ -145,12 +176,46 @@ describe('createMidiDeviceManager', () => {
 		});
 
 		await flushPromises();
-		access.onstatechange?.('state-change');
+		access.dispatchStateChange('state-change');
 
 		expect(previousStateChangeHandler).toHaveBeenCalledWith('state-change');
+		expect(access.onstatechange).toBe(previousStateChangeHandler);
 
 		manager.dispose();
 
 		expect(access.onstatechange).toBe(previousStateChangeHandler);
+	});
+
+	it('keeps another manager subscribed when managers sharing MIDI access are disposed out of order', async () => {
+		const firstStore = createStore();
+		const secondStore = createStore();
+		const access = createMIDIAccessMock();
+		const navigator = {
+			requestMIDIAccess: vi.fn(async () => access as unknown as MIDIAccess),
+		} as unknown as Navigator;
+		const first = createMidiDeviceManager({ store: firstStore, navigator });
+		const second = createMidiDeviceManager({ store: secondStore, navigator });
+
+		await flushPromises();
+		access.inputs.set('input-a', { id: 'input-a', name: 'Keys', state: 'connected' });
+		access.dispatchStateChange();
+
+		expect(firstStore.getState().info.midi).toEqual({ '0': 'Keys (in)' });
+		expect(secondStore.getState().info.midi).toEqual({ '0': 'Keys (in)' });
+
+		first.dispose();
+		access.inputs.set('input-b', { id: 'input-b', name: 'Pads', state: 'connected' });
+		access.dispatchStateChange();
+
+		expect(firstStore.getState().info.midi).toBeUndefined();
+		expect(secondStore.getState().info.midi).toEqual({
+			'0': 'Keys (in)',
+			'1': 'Pads (in)',
+		});
+
+		second.dispose();
+
+		expect(access.addEventListener).toHaveBeenCalledTimes(2);
+		expect(access.removeEventListener).toHaveBeenCalledTimes(2);
 	});
 });

--- a/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/midi/devices.ts
+++ b/packages/editor/packages/editor-core/src/editorEnvironmentPlugins/midi/devices.ts
@@ -102,7 +102,6 @@ export default function createMidiDeviceManager({
 	};
 	let disposed = false;
 	let midiAccess: MIDIAccess | undefined;
-	let previousStateChangeHandler: MIDIAccess['onstatechange'] = null;
 
 	function setMidiInfo(info: InfoRecord | undefined): void {
 		store.set('info.midi', info);
@@ -115,6 +114,10 @@ export default function createMidiDeviceManager({
 
 		setMidiInfo(createMidiInfo(midiAccess, portRegistry));
 		onPortsChanged?.();
+	}
+
+	function onStateChange(): void {
+		updateMidiInfo();
 	}
 
 	if (typeof requestMIDIAccess !== 'function') {
@@ -139,11 +142,7 @@ export default function createMidiDeviceManager({
 			}
 
 			midiAccess = access;
-			previousStateChangeHandler = access.onstatechange;
-			access.onstatechange = event => {
-				previousStateChangeHandler?.call(access, event);
-				updateMidiInfo();
-			};
+			access.addEventListener('statechange', onStateChange);
 			updateMidiInfo();
 		})
 		.catch(() => {
@@ -157,9 +156,7 @@ export default function createMidiDeviceManager({
 		getInputPort: port => portRegistry.inputsByIndex.get(port),
 		dispose: () => {
 			disposed = true;
-			if (midiAccess) {
-				midiAccess.onstatechange = previousStateChangeHandler;
-			}
+			midiAccess?.removeEventListener('statechange', onStateChange);
 			portRegistry.inputsByIndex.clear();
 			portRegistry.indexesByKey.clear();
 			setMidiInfo(undefined);


### PR DESCRIPTION
## Summary

- subscribe each editor to MIDI device changes with its own statechange event listener
- remove only that editor instance's listener during disposal
- preserve existing MIDIAccess.onstatechange property handlers
- cover two managers sharing one MIDIAccess and disposing out of mount order

## Rationale

Browsers may return the same MIDIAccess object to multiple editor instances. Assigning its single onstatechange property made disposal order significant: disposing an older editor could remove a newer editor's device-change handler. Independent EventTarget listeners allow the editors to coexist safely.

## Validation

- npx nx run @8f4e/editor-core:test
- npx nx run @8f4e/editor-core:lint
- npx nx run @8f4e/editor-core:typecheck
- npx nx run @8f4e/editor-core:build
- git diff --check