### PR TITLE
fix(editor-core): dispose editor lifecycle resources

### DIFF
--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/edit-history/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/edit-history/effect.test.ts
@@ -1,0 +1,33 @@
+import createStateManager from '@8f4e/state-manager';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createMockCodeBlock, createMockState } from '../../pureHelpers/testingUtils/testUtils';
+import { createMockEventDispatcherWithVitest } from '../../pureHelpers/testingUtils/vitestTestUtils';
+import historyTracking from './effect';
+
+describe('history tracking effect', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('cancels a pending history snapshot when disposed', async () => {
+		const state = createMockState({
+			featureFlags: { historyTracking: true },
+		});
+		state.codeBlockRendering.selectedCodeBlock = createMockCodeBlock({
+			code: ['function main', 'functionEnd'],
+		});
+		const store = createStateManager(state);
+		const events = createMockEventDispatcherWithVitest();
+		const dispose = historyTracking(store, events);
+
+		store.set('codeBlockRendering.selectedCodeBlock.code', ['function main', 'functionEnd']);
+		dispose?.();
+		await vi.advanceTimersByTimeAsync(1000);
+
+		expect(state.historyStack).toEqual([]);
+	});
+});

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/edit-history/effect.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/edit-history/effect.ts
@@ -3,7 +3,7 @@ import type { StateManager } from '@8f4e/state-manager';
 
 import serializeToProject from '../project-export/serializeToProject';
 
-export default function historyTracking(store: StateManager<State>, events: EventDispatcher): void {
+export default function historyTracking(store: StateManager<State>, events: EventDispatcher): void | (() => void) {
 	const state = store.getState();
 	if (!state.featureFlags.historyTracking) {
 		return;
@@ -67,4 +67,14 @@ export default function historyTracking(store: StateManager<State>, events: Even
 	store.subscribe('codeBlockRendering.selectedCodeBlock.code', onCodeChange);
 	events.on('undo', undo);
 	events.on('redo', redo);
+
+	return () => {
+		if (saveTimeout) {
+			clearTimeout(saveTimeout);
+			saveTimeout = null;
+		}
+		store.unsubscribe('codeBlockRendering.selectedCodeBlock.code', onCodeChange);
+		events.off('undo', undo);
+		events.off('redo', redo);
+	};
 }

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/program-compiler/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/program-compiler/effect.test.ts
@@ -243,6 +243,20 @@ describe('program compiler effect', () => {
 		expect(mockState.editorConfigValidators.recompileDebounceDelay).toBe(recompileDebounceDelayEditorConfigValidator);
 	});
 
+	it('cancels a scheduled compilation when disposed', async () => {
+		const dispose = compilerEffect(store);
+		const programmaticChangeCall = subscribeSpy.mock.calls.find(
+			call => call[0] === 'codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code'
+		);
+		expect(programmaticChangeCall).toBeDefined();
+
+		programmaticChangeCall![1]();
+		dispose();
+		await vi.advanceTimersByTimeAsync(500);
+
+		expect(mockCompileCode).not.toHaveBeenCalled();
+	});
+
 	it('passes the includes collection and resolver to the compiler callback', async () => {
 		mockCompileCode.mockResolvedValue({
 			codeBuffer: new Uint8Array([0x00]),

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/program-compiler/effect.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/program-compiler/effect.ts
@@ -10,9 +10,10 @@ import { DEFAULT_RECOMPILE_DEBOUNCE_DELAY, registerRecompileDebounceDelayEditorC
 
 const includesBlockType = documentBlockInstructionByType.includes.type;
 
-export default function compiler(store: StateManager<State>) {
+export default function compiler(store: StateManager<State>): () => void {
 	const state = store.getState();
 	registerRecompileDebounceDelayEditorConfigValidator(store);
+	let disposed = false;
 
 	const scheduleRecompile = debounceTrailing(
 		onRecompile,
@@ -27,6 +28,10 @@ export default function compiler(store: StateManager<State>) {
 	}
 
 	async function onForceCompile() {
+		if (disposed) {
+			return;
+		}
+
 		scheduleRecompile.cancel();
 		const compilationStart = performance.now();
 
@@ -49,6 +54,9 @@ export default function compiler(store: StateManager<State>) {
 				...compilerOptions,
 				...(state.callbacks.resolveInclude ? { resolveInclude: state.callbacks.resolveInclude } : {}),
 			});
+			if (disposed) {
+				return;
+			}
 			const compilationTimeMs = performance.now() - compilationStart;
 			const memoryUsagePercent =
 				result.allocatedMemoryBytes === 0
@@ -85,6 +93,10 @@ export default function compiler(store: StateManager<State>) {
 			log(state, 'Compilation succeeded in ' + compilationTimeMs.toFixed(2) + 'ms', 'Compiler');
 			console.log('[Compiler] Compilation succeeded with config:', compilerOptions);
 		} catch (error) {
+			if (disposed) {
+				return;
+			}
+
 			log(state, 'Compilation failed', 'Compiler');
 
 			store.set('compiler.isCompiling', false);
@@ -106,6 +118,10 @@ export default function compiler(store: StateManager<State>) {
 	}
 
 	function onRecompile() {
+		if (disposed) {
+			return;
+		}
+
 		store.set('codeErrors.compilationErrors', []);
 
 		if (!state.callbacks.compileCode) {
@@ -115,7 +131,7 @@ export default function compiler(store: StateManager<State>) {
 		onForceCompile();
 	}
 
-	store.subscribe('codeBlockRendering.selectedCodeBlock.code', () => {
+	const onSelectedCodeChanged = () => {
 		if (state.codeBlockRendering.selectedCodeBlock?.disabled) {
 			return;
 		}
@@ -126,13 +142,24 @@ export default function compiler(store: StateManager<State>) {
 			return;
 		}
 		scheduleRecompile();
-	});
-	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', () => {
+	};
+	const onProgrammaticCodeChanged = () => {
 		const blockType = state.codeBlockRendering.selectedCodeBlockForProgrammaticEdit?.blockType;
 		if (!isCompilableBlockType(blockType) && blockType !== includesBlockType) {
 			return;
 		}
 		scheduleRecompile();
-	});
+	};
+
+	store.subscribe('codeBlockRendering.selectedCodeBlock.code', onSelectedCodeChanged);
+	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', onProgrammaticCodeChanged);
 	store.subscribe('featureFlags.codeLineSelection', scheduleRecompile);
+
+	return () => {
+		disposed = true;
+		scheduleRecompile.cancel();
+		store.unsubscribe('codeBlockRendering.selectedCodeBlock.code', onSelectedCodeChanged);
+		store.unsubscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', onProgrammaticCodeChanged);
+		store.unsubscribe('featureFlags.codeLineSelection', scheduleRecompile);
+	};
 }

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/runtime/__tests__/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/runtime/__tests__/effect.test.ts
@@ -157,5 +157,36 @@ describe('Runtime System', () => {
 
 			expect(webWorkerRuntimeFactory).not.toHaveBeenCalled();
 		});
+
+		it('destroys the active runtime and stops reacting after disposal', async () => {
+			const audioDestroyer = vi.fn();
+			const webWorkerRuntimeFactory = vi.fn(() => () => {});
+			const state = createMockState({
+				editorConfig: { runtime: 'AudioWorkletRuntime' },
+				runtimeRegistry: {
+					AudioWorkletRuntime: {
+						id: 'AudioWorkletRuntime',
+						factory: vi.fn(() => audioDestroyer),
+					},
+					WebWorkerRuntime: {
+						id: 'WebWorkerRuntime',
+						factory: webWorkerRuntimeFactory,
+					},
+				},
+			});
+			const store = createStateManager(state);
+			const events = createMockEventDispatcherWithVitest();
+			const dispose = runtimeEffect(store, events);
+
+			store.set('compiler.isCompiling', true);
+			store.set('compiler.isCompiling', false);
+			await new Promise(resolve => setTimeout(resolve, 10));
+			dispose();
+			store.set('editorConfig.runtime', 'WebWorkerRuntime');
+			await new Promise(resolve => setTimeout(resolve, 10));
+
+			expect(audioDestroyer).toHaveBeenCalledOnce();
+			expect(webWorkerRuntimeFactory).not.toHaveBeenCalled();
+		});
 	});
 });

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/runtime/effect.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/runtime/effect.ts
@@ -8,7 +8,7 @@ import {
 	resolveSelectedRuntimeId,
 } from './editorConfig';
 
-export default async function runtime(store: StateManager<State>, events: EventDispatcher) {
+export default function runtime(store: StateManager<State>, events: EventDispatcher): () => void {
 	registerRuntimeSelectionEditorConfigValidator(store);
 
 	const state = store.getState();
@@ -16,9 +16,10 @@ export default async function runtime(store: StateManager<State>, events: EventD
 	let runtimeDestroyer: null | (() => void) = null;
 	let onlineRuntime: null | string = null;
 	let isInitializing = false;
+	let disposed = false;
 
 	async function initOrDestroyOrUpdateRuntime() {
-		if (isInitializing) {
+		if (disposed || isInitializing) {
 			log(state, 'Runtime is already initializing, skipping...', 'Runtime');
 			return;
 		}
@@ -81,6 +82,10 @@ export default async function runtime(store: StateManager<State>, events: EventD
 	}
 
 	function onRuntimeSelectionChanged() {
+		if (disposed) {
+			return;
+		}
+
 		syncRuntimeEditorConfigSchemaContributions();
 
 		if (state.compiler.isCompiling) {
@@ -94,4 +99,18 @@ export default async function runtime(store: StateManager<State>, events: EventD
 	store.subscribeToValue('compiler.isCompiling', false, initOrDestroyOrUpdateRuntime);
 	store.subscribe('editorConfig.runtime', onRuntimeSelectionChanged);
 	store.subscribe('runtimeRegistry', onRuntimeSelectionChanged);
+
+	return () => {
+		if (disposed) {
+			return;
+		}
+
+		disposed = true;
+		store.unsubscribe('compiler.isCompiling', initOrDestroyOrUpdateRuntime);
+		store.unsubscribe('editorConfig.runtime', onRuntimeSelectionChanged);
+		store.unsubscribe('runtimeRegistry', onRuntimeSelectionChanged);
+		runtimeDestroyer?.();
+		runtimeDestroyer = null;
+		onlineRuntime = null;
+	};
 }

--- a/packages/editor/packages/editor-core/packages/editor-state/src/index.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/index.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import initState from './index';
+import { createMockEventDispatcherWithVitest } from './pureHelpers/testingUtils/vitestTestUtils';
+
+describe('editor state lifecycle', () => {
+	it('disposes initialized effects and their active runtime exactly once', async () => {
+		const runtimeDestroyer = vi.fn();
+		const runtimeFactory = vi.fn(() => runtimeDestroyer);
+		const events = createMockEventDispatcherWithVitest();
+		const store = initState(events, {
+			callbacks: { loadSession: async () => null },
+			runtimeRegistry: {
+				TestRuntime: {
+					id: 'TestRuntime',
+					factory: runtimeFactory,
+				},
+			},
+		});
+
+		store.getState().editorConfig.runtime = 'TestRuntime';
+		store.set('compiler.isCompiling', false);
+		await Promise.resolve();
+		store.dispose();
+		store.dispose();
+
+		expect(runtimeFactory).toHaveBeenCalledOnce();
+		expect(runtimeDestroyer).toHaveBeenCalledOnce();
+	});
+});

--- a/packages/editor/packages/editor-core/packages/editor-state/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/index.ts
@@ -60,6 +60,13 @@ export {
 // Function to create default state
 export default function init(events: EventDispatcher, options: Options): StateManager<State> {
 	const featureFlags = validateFeatureFlags(options.featureFlags);
+	type EffectCleanup = () => void;
+	const effectCleanups: EffectCleanup[] = [];
+	const registerEffect = (cleanup: void | EffectCleanup): void => {
+		if (cleanup) {
+			effectCleanups.push(cleanup);
+		}
+	};
 
 	// Create base state
 	const baseState = {
@@ -74,58 +81,80 @@ export default function init(events: EventDispatcher, options: Options): StateMa
 
 	const state = store.getState();
 
-	font(store);
-	color(store);
-	registerEditorConfigSchemaContributionsValidator(store);
-	projectExport(store, events);
-	canvasScreenshot(store, events);
-	dialog(store, events);
-	binaryAssetLoadingDialog(store, events);
+	registerEffect(font(store));
+	registerEffect(color(store));
+	registerEffect(registerEditorConfigSchemaContributionsValidator(store));
+	registerEffect(projectExport(store, events));
+	registerEffect(canvasScreenshot(store, events));
+	registerEffect(dialog(store, events));
+	registerEffect(binaryAssetLoadingDialog(store, events));
 
-	runtime(store, events);
-	editorMode(store, events);
-	presentation(store, events);
-	projectImport(store, events);
-	codeBlockDragger(store, events);
-	codeBlockNavigation(store, events);
-	_switch(state, events);
-	button(state, events);
-	slider(store, events);
-	sliderDefaultSaver(store, events);
-	memoryConnectionRemover(store, events);
-	crossfade(store, events);
-	pianoKeyboard(store, events);
-	viewport(store, events);
-	contextMenu(store, events);
-	codeBlockCreator(store, events);
-	skipExecutionToggler(store, events);
-	groupSkipExecutionToggler(store, events);
-	groupNonstickToggler(store, events);
-	groupCopier(store, events);
-	favoriteToggler(store, events);
-	groupRemover(store, events);
-	groupUngroupper(store, events);
-	groupDeleter(store, events);
-	projectGroupNavigation(store, events);
-	parsedDirectivesUpdater(store);
-	autoEnvConstants(store); // Must run after codeBlockCreator to ensure env block is created
-	blockTypeUpdater(store); // Must run before compiler to classify blocks first
-	shaderEffectsDeriver(store, events); // Must run after blockTypeUpdater to derive shader effects
-	globalEditorDirectivesEffect(store);
-	compiler(store);
-	codeBlockRendering(store, events);
-	viewportDirectiveEffect(store, events);
-	entryOutlines(store);
-	browserLocalNotes(store, events);
-	codeEditing(store, events);
-	tooltip(store);
-	historyTracking(store, events);
+	registerEffect(runtime(store, events));
+	registerEffect(editorMode(store, events));
+	registerEffect(presentation(store, events));
+	registerEffect(projectImport(store, events));
+	registerEffect(codeBlockDragger(store, events));
+	registerEffect(codeBlockNavigation(store, events));
+	registerEffect(_switch(state, events));
+	registerEffect(button(state, events));
+	registerEffect(slider(store, events));
+	registerEffect(sliderDefaultSaver(store, events));
+	registerEffect(memoryConnectionRemover(store, events));
+	registerEffect(crossfade(store, events));
+	registerEffect(pianoKeyboard(store, events));
+	registerEffect(viewport(store, events));
+	registerEffect(contextMenu(store, events));
+	registerEffect(codeBlockCreator(store, events));
+	registerEffect(skipExecutionToggler(store, events));
+	registerEffect(groupSkipExecutionToggler(store, events));
+	registerEffect(groupNonstickToggler(store, events));
+	registerEffect(groupCopier(store, events));
+	registerEffect(favoriteToggler(store, events));
+	registerEffect(groupRemover(store, events));
+	registerEffect(groupUngroupper(store, events));
+	registerEffect(groupDeleter(store, events));
+	registerEffect(projectGroupNavigation(store, events));
+	registerEffect(parsedDirectivesUpdater(store));
+	registerEffect(autoEnvConstants(store)); // Must run after codeBlockCreator to ensure env block is created
+	registerEffect(blockTypeUpdater(store)); // Must run before compiler to classify blocks first
+	registerEffect(shaderEffectsDeriver(store, events)); // Must run after blockTypeUpdater to derive shader effects
+	registerEffect(globalEditorDirectivesEffect(store));
+	registerEffect(compiler(store));
+	registerEffect(codeBlockRendering(store, events));
+	registerEffect(viewportDirectiveEffect(store, events));
+	registerEffect(entryOutlines(store));
+	registerEffect(browserLocalNotes(store, events));
+	registerEffect(codeEditing(store, events));
+	registerEffect(tooltip(store));
+	registerEffect(historyTracking(store, events));
 
-	events.on('consoleLog', event => {
+	const onConsoleLog = (event: unknown) => {
 		console.log(event);
-	});
+	};
+	events.on('consoleLog', onConsoleLog);
+	registerEffect(() => events.off('consoleLog', onConsoleLog));
 
-	return store;
+	const disposeSubscriptions = store.dispose;
+	let disposed = false;
+	return {
+		...store,
+		dispose: () => {
+			if (disposed) {
+				return;
+			}
+
+			disposed = true;
+			for (let index = effectCleanups.length - 1; index >= 0; index--) {
+				try {
+					effectCleanups[index]();
+				} catch (error) {
+					console.error('Failed to dispose editor state effect:', error);
+				}
+			}
+			effectCleanups.length = 0;
+			disposeSubscriptions();
+		},
+	};
 }
 
 export { navigateToCodeBlockInDirection } from './features/code-blocks/features/codeBlockNavigation/effect';

--- a/packages/editor/packages/editor-core/packages/state-manager/src/index.test.ts
+++ b/packages/editor/packages/editor-core/packages/state-manager/src/index.test.ts
@@ -354,6 +354,23 @@ describe('StateManager', () => {
 		});
 	});
 
+	describe('dispose', () => {
+		it('removes every subscription and is idempotent', () => {
+			const nameCallback = vi.fn();
+			const ageCallback = vi.fn();
+			stateManager.subscribe('name', nameCallback);
+			stateManager.subscribeToValue('age', 31, ageCallback);
+
+			stateManager.dispose();
+			stateManager.dispose();
+			stateManager.set('name', 'Jane Doe');
+			stateManager.set('age', 31);
+
+			expect(nameCallback).not.toHaveBeenCalled();
+			expect(ageCallback).not.toHaveBeenCalled();
+		});
+	});
+
 	describe('integration', () => {
 		it('should handle complex state updates with multiple subscriptions', () => {
 			const nameCallback = vi.fn();

--- a/packages/editor/packages/editor-core/packages/state-manager/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/state-manager/src/index.ts
@@ -17,6 +17,7 @@ export interface StateManager<State> {
 		callback: (value: PathValue<State, P>) => void
 	) => Subscription<State, P>;
 	unsubscribe: <P extends Path<State>>(selector: P, callback: (value: PathValue<State, P>) => void) => void;
+	dispose: () => void;
 }
 
 function createStateManager<State>(state: State): StateManager<State> {
@@ -33,6 +34,7 @@ function createStateManager<State>(state: State): StateManager<State> {
 		subscribe,
 		subscribeToValue,
 		unsubscribe,
+		dispose: () => subscriptions.clear(),
 	};
 }
 

--- a/packages/editor/packages/editor-core/src/events/index.test.ts
+++ b/packages/editor/packages/editor-core/src/events/index.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest';
+import createEventDispatcher from './index';
+
+describe('event dispatcher', () => {
+	it('removes every subscription when disposed', () => {
+		const events = createEventDispatcher();
+		const first = vi.fn();
+		const second = vi.fn();
+		events.on('first', first);
+		events.on('second', second);
+
+		events.dispose();
+		events.dispose();
+		events.dispatch('first');
+		events.dispatch('second');
+
+		expect(first).not.toHaveBeenCalled();
+		expect(second).not.toHaveBeenCalled();
+	});
+});

--- a/packages/editor/packages/editor-core/src/events/index.ts
+++ b/packages/editor/packages/editor-core/src/events/index.ts
@@ -10,10 +10,14 @@ export interface EventDispatcher {
 	dispatch: <T>(eventName: string, eventObject?: T) => void;
 }
 
+interface DisposableEventDispatcher extends EventDispatcher {
+	dispose: () => void;
+}
+
 // Re-export event types from shared package
 export type { InternalKeyboardEvent, InternalMouseEvent } from '@8f4e/editor-state-types';
 
-export default function events(): EventDispatcher {
+export default function events(): DisposableEventDispatcher {
 	const subscriptions: Record<string, EventHandler<unknown>[]> = {};
 
 	function on<T>(eventName: string, callback: EventHandler<T>): void {
@@ -42,5 +46,11 @@ export default function events(): EventDispatcher {
 		}
 	}
 
-	return { on, off, dispatch };
+	function dispose(): void {
+		for (const handlers of Object.values(subscriptions)) {
+			handlers.length = 0;
+		}
+	}
+
+	return { on, off, dispatch, dispose };
 }

--- a/packages/editor/packages/editor-core/src/index.test.ts
+++ b/packages/editor/packages/editor-core/src/index.test.ts
@@ -4,6 +4,7 @@ const events = {
 	dispatch: vi.fn(),
 	on: vi.fn(),
 	off: vi.fn(),
+	dispose: vi.fn(),
 };
 
 const storeState: {
@@ -26,6 +27,7 @@ const store = {
 			};
 		}
 	}),
+	dispose: vi.fn(),
 };
 
 const view = {
@@ -42,6 +44,8 @@ const renderProjection = {
 	refresh: vi.fn(),
 	dispose: vi.fn(),
 };
+
+const cleanupSpriteSheet = vi.fn();
 
 vi.mock('@8f4e/web-ui-render-projection', () => ({
 	createWebUiRenderProjection: vi.fn(() => renderProjection),
@@ -84,7 +88,7 @@ vi.mock('./editorEnvironmentPlugins/manager', () => ({
 }));
 
 vi.mock('./spriteSheetManager', () => ({
-	createSpriteSheetManager: vi.fn(),
+	createSpriteSheetManager: vi.fn(() => cleanupSpriteSheet),
 }));
 
 vi.mock('./updateStateWithSpriteData', () => ({
@@ -96,10 +100,15 @@ describe('editor init', () => {
 		events.dispatch.mockClear();
 		events.on.mockClear();
 		events.off.mockClear();
+		events.dispose.mockClear();
 		store.getState.mockClear();
 		store.set.mockClear();
+		store.dispose.mockClear();
 		view.resize.mockClear();
 		view.renderFrame.mockClear();
+		view.destroy.mockClear();
+		renderProjection.dispose.mockClear();
+		cleanupSpriteSheet.mockClear();
 		storeState.editorConfig = {};
 		storeState.info = {};
 	});
@@ -220,6 +229,24 @@ describe('editor init', () => {
 
 		editor.dispose();
 		expect(canvas.tabIndex).toBe(-1);
+	});
+
+	it('disposes state, events, sprite subscriptions, projection, and view exactly once', async () => {
+		const { default: init } = await import('./index');
+		const canvas = { width: 640, height: 480 } as HTMLCanvasElement;
+		const editor = await init(canvas, {
+			runtimeRegistry: {},
+			callbacks: { loadSession: async () => null },
+		});
+
+		editor.dispose();
+		editor.dispose();
+
+		expect(cleanupSpriteSheet).toHaveBeenCalledOnce();
+		expect(renderProjection.dispose).toHaveBeenCalledOnce();
+		expect(store.dispose).toHaveBeenCalledOnce();
+		expect(events.dispose).toHaveBeenCalledOnce();
+		expect(view.destroy).toHaveBeenCalledOnce();
 	});
 
 	it('renders one fresh frame before exporting a canvas screenshot', async () => {

--- a/packages/editor/packages/editor-core/src/index.ts
+++ b/packages/editor/packages/editor-core/src/index.ts
@@ -231,7 +231,7 @@ export default async function init(canvas: HTMLCanvasElement, options: Options):
 		},
 	});
 
-	createSpriteSheetManager(store, view, events);
+	const cleanupSpriteSheet = createSpriteSheetManager(store, view, events);
 
 	events.on<PostProcessEffect | null>('loadPostProcessEffect', effect => {
 		view.loadPostProcessEffect(effect);
@@ -265,6 +265,7 @@ export default async function init(canvas: HTMLCanvasElement, options: Options):
 	resize(initialCanvasSize.width, initialCanvasSize.height);
 	resizeObserver?.observe(canvas);
 	events.dispatch('loadSession');
+	let disposed = false;
 
 	return {
 		resize,
@@ -275,12 +276,29 @@ export default async function init(canvas: HTMLCanvasElement, options: Options):
 		},
 		getMemoryViews: () => memoryViews,
 		dispose: () => {
-			resizeObserver?.disconnect();
-			view.destroy();
-			renderProjection.dispose();
-			cleanupPointer();
-			cleanupKeyboard();
-			cleanupEditorEnvironmentPlugins();
+			if (disposed) {
+				return;
+			}
+
+			disposed = true;
+			const cleanups = [
+				() => resizeObserver?.disconnect(),
+				cleanupPointer,
+				cleanupKeyboard,
+				cleanupEditorEnvironmentPlugins,
+				cleanupSpriteSheet,
+				() => renderProjection.dispose(),
+				() => store.dispose(),
+				() => events.dispose(),
+				() => view.destroy(),
+			];
+			for (const cleanup of cleanups) {
+				try {
+					cleanup();
+				} catch (error) {
+					console.error('Failed to dispose editor resource:', error);
+				}
+			}
 			if (addedTabIndex && canvas.tabIndex === 0) {
 				canvas.removeAttribute('tabindex');
 			}

--- a/packages/editor/packages/editor-core/src/spriteSheetManager.test.ts
+++ b/packages/editor/packages/editor-core/src/spriteSheetManager.test.ts
@@ -1,0 +1,56 @@
+import type { State } from '@8f4e/editor-state-types';
+import type { StateManager } from '@8f4e/state-manager';
+import type { SpriteData } from '@8f4e/web-ui';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createSpriteSheetManager } from './spriteSheetManager';
+
+const { generateSprite } = vi.hoisted(() => ({ generateSprite: vi.fn() }));
+
+vi.mock('@8f4e/sprite-generator', () => ({ default: generateSprite }));
+
+function deferred<T>() {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>(resolvePromise => {
+		resolve = resolvePromise;
+	});
+	return { promise, resolve };
+}
+
+describe('sprite sheet manager', () => {
+	beforeEach(() => {
+		generateSprite.mockReset();
+	});
+
+	it('unsubscribes and ignores sprite generation that finishes after disposal', async () => {
+		const state = {
+			editorConfig: { font: 'terminus8x16', color: {} },
+		} as unknown as State;
+		const subscriptions = new Map<string, () => Promise<void>>();
+		const store = {
+			getState: () => state,
+			subscribe: vi.fn((selector: string, callback: () => Promise<void>) => subscriptions.set(selector, callback)),
+			unsubscribe: vi.fn((selector: string, callback: () => Promise<void>) => {
+				if (subscriptions.get(selector) === callback) {
+					subscriptions.delete(selector);
+				}
+			}),
+		} as unknown as StateManager<State>;
+		const view = { loadSpriteAtlas: vi.fn() };
+		const events = { dispatch: vi.fn() };
+		const pendingSprite = deferred<SpriteData>();
+		generateSprite.mockReturnValueOnce(pendingSprite.promise);
+		const dispose = createSpriteSheetManager(store, view, events as never);
+
+		const rerender = subscriptions.get('editorConfig.font');
+		expect(rerender).toBeDefined();
+		const rerenderPromise = rerender?.() as Promise<void>;
+		dispose();
+		pendingSprite.resolve({} as SpriteData);
+		await rerenderPromise;
+
+		expect(store.unsubscribe).toHaveBeenCalledWith('editorConfig.font', rerender);
+		expect(store.unsubscribe).toHaveBeenCalledWith('editorConfig.color', expect.any(Function));
+		expect(view.loadSpriteAtlas).not.toHaveBeenCalled();
+		expect(events.dispatch).not.toHaveBeenCalled();
+	});
+});

--- a/packages/editor/packages/editor-core/src/spriteSheetManager.ts
+++ b/packages/editor/packages/editor-core/src/spriteSheetManager.ts
@@ -16,13 +16,19 @@ export function createSpriteSheetManager(
 	store: StateManager<State>,
 	view: SpriteSheetView,
 	events: EventDispatcher
-): void {
+): () => void {
 	const state = store.getState();
+	let disposed = false;
+	let generation = 0;
 	const rerenderSpriteSheet = async () => {
+		const currentGeneration = ++generation;
 		const spriteData = await generateSprite({
 			font: state.editorConfig.font,
 			colorScheme: state.editorConfig.color,
 		});
+		if (disposed || currentGeneration !== generation) {
+			return;
+		}
 
 		view.loadSpriteAtlas(spriteData);
 
@@ -34,4 +40,15 @@ export function createSpriteSheetManager(
 
 	store.subscribe('editorConfig.font', rerenderSpriteSheet);
 	store.subscribe('editorConfig.color', rerenderSpriteSheet);
+
+	return () => {
+		if (disposed) {
+			return;
+		}
+
+		disposed = true;
+		generation++;
+		store.unsubscribe('editorConfig.font', rerenderSpriteSheet);
+		store.unsubscribe('editorConfig.color', rerenderSpriteSheet);
+	};
 }


### PR DESCRIPTION
## Summary

- make editor disposal idempotent and clean up core systems in dependency-safe order
- aggregate editor-state effect cleanup and clear state and event subscriptions
- stop active runtimes and cancel pending compiler and history work
- unsubscribe sprite-sheet updates and ignore generation results that arrive after disposal
- ignore late results from slow host callbacks and dynamic loads for project/session import, browser-local notes, screenshot export, session saving, async menus, clipboard reads, and module dependencies
- prevent older project and menu loads from overwriting newer requests
- preserve the existing public EventDispatcher contract

## Rationale

Unmounted editor instances kept internal subscriptions, timers, event handlers, and runtime resources alive. That made repeated mounting unsafe and could allow disposed instances to react to later work. Slow host-provided promises can still finish after disposal, so their editor-owned continuations now become no-ops.

## Test notes

- npx nx run-many --target=test --projects=@8f4e/state-manager,@8f4e/editor-state,@8f4e/editor-core
- npx nx run-many --target=typecheck --projects=@8f4e/state-manager,@8f4e/editor-state,@8f4e/editor-core
- npx nx run-many --target=typecheck --projects=@8f4e/runtime-main-thread,@8f4e/runtime-web-worker,@8f4e/runtime-audio-worklet,@8f4e/editor-default,@8f4e/editor-website
- npx nx run @8f4e/editor-core:build
- npx nx run @8f4e/editor-core:lint
- pre-commit affected typecheck