### PR TITLE
fix(editor-state): ignore slow work after disposal

### DIFF
--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/browser-local-notes/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/browser-local-notes/effect.test.ts
@@ -18,6 +18,30 @@ function getEventHandler(events: ReturnType<typeof createMockEventDispatcherWith
 }
 
 describe('browser-local note placement', () => {
+	it('ignores local notes that finish loading after disposal', async () => {
+		let resolveNotes!: (notes: Array<{ code: string[] }>) => void;
+		const loadBrowserLocalNotes = vi.fn(
+			() =>
+				new Promise<Array<{ code: string[] }>>(resolve => {
+					resolveNotes = resolve;
+				})
+		);
+		const state = createMockState({
+			initialProjectState: { ...EMPTY_DEFAULT_PROJECT },
+			callbacks: { loadBrowserLocalNotes },
+		});
+		const store = createStateManager(state);
+		const events = createMockEventDispatcherWithVitest();
+		const dispose = browserLocalNotes(store, events);
+
+		const populatePromise = getPopulateHandler(events)();
+		dispose();
+		resolveNotes([{ code: ['note local.scratchpad', 'noteEnd'] }]);
+		await populatePromise;
+
+		expect(state.codeBlockRendering.codeBlocks).toEqual([]);
+	});
+
 	it('moves colliding browser-local notes to the first free y positions for their x span', async () => {
 		const existingTopBlock = createMockCodeBlock({
 			name: 'top',

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/browser-local-notes/effect.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/browser-local-notes/effect.ts
@@ -20,18 +20,25 @@ import {
 	serializeBrowserLocalNotes,
 } from './browserLocalNotes';
 
-export default function browserLocalNotes(store: StateManager<State>, events: EventDispatcher): void {
+export default function browserLocalNotes(store: StateManager<State>, events: EventDispatcher): () => void {
 	const state = store.getState();
 	let lastSavedBrowserLocalNotes = '';
 	let browserLocalNotesLoaded = false;
+	let disposed = false;
+	let loadGeneration = 0;
 
 	async function populateBrowserLocalNotes() {
-		if (!state.initialProjectState || !state.callbacks.loadBrowserLocalNotes) {
+		if (disposed || !state.initialProjectState || !state.callbacks.loadBrowserLocalNotes) {
 			return;
 		}
 
+		const generation = ++loadGeneration;
 		try {
 			const loadedBlocks = (await state.callbacks.loadBrowserLocalNotes()) ?? [];
+			if (disposed || generation !== loadGeneration) {
+				return;
+			}
+
 			const validBlocks = loadedBlocks.filter(block => isBrowserLocalNoteCode(block.code));
 			const browserLocalNotes = validBlocks.length > 0 ? validBlocks : [DEFAULT_BROWSER_LOCAL_NOTE];
 
@@ -103,12 +110,14 @@ export default function browserLocalNotes(store: StateManager<State>, events: Ev
 			store.set('codeBlockRendering.codeBlocks', state.codeBlockRendering.codeBlocks);
 			saveBrowserLocalNotes();
 		} catch (err) {
-			console.warn('Failed to load browser-local notes from storage:', err);
+			if (!disposed && generation === loadGeneration) {
+				console.warn('Failed to load browser-local notes from storage:', err);
+			}
 		}
 	}
 
 	function saveBrowserLocalNotes() {
-		if (!browserLocalNotesLoaded || !state.callbacks.saveBrowserLocalNotes) {
+		if (disposed || !browserLocalNotesLoaded || !state.callbacks.saveBrowserLocalNotes) {
 			return;
 		}
 
@@ -170,4 +179,21 @@ export default function browserLocalNotes(store: StateManager<State>, events: Ev
 		'codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code',
 		saveProgrammaticallyEditedBrowserLocalNoteWithoutCompilerTrigger
 	);
+
+	return () => {
+		disposed = true;
+		loadGeneration++;
+		events.off('projectCodeBlocksPopulated', populateBrowserLocalNotes);
+		events.off('deleteCodeBlock', saveAfterLocalNoteDelete);
+		events.off('deleteGroup', saveAfterGroupDelete);
+		store.unsubscribe('codeBlockRendering.selectedCodeBlock.code', saveSelectedBrowserLocalNote);
+		store.unsubscribe(
+			'codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code',
+			saveProgrammaticallyEditedBrowserLocalNote
+		);
+		store.unsubscribe(
+			'codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code',
+			saveProgrammaticallyEditedBrowserLocalNoteWithoutCompilerTrigger
+		);
+	};
 }

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/canvas-screenshot/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/canvas-screenshot/effect.test.ts
@@ -6,6 +6,36 @@ import { createMockEventDispatcherWithVitest } from '~/pureHelpers/testingUtils/
 import canvasScreenshot from './effect';
 
 describe('canvasScreenshot', () => {
+	it('does not restore screenshot flags after disposal while export is pending', async () => {
+		let finishExport!: () => void;
+		const exportCanvasScreenshot = vi.fn(
+			() =>
+				new Promise<void>(resolve => {
+					finishExport = resolve;
+				})
+		);
+		const state = createMockState({
+			callbacks: { exportCanvasScreenshot },
+			featureFlags: { modeOverlay: false, offscreenBlockArrows: true },
+		});
+		const store = createStateManager(state);
+		const events = createMockEventDispatcherWithVitest();
+		const dispose = canvasScreenshot(store, events);
+		const exportCallback = (events.on as unknown as MockInstance).mock.calls.find(
+			call => call[0] === 'exportCanvasScreenshot'
+		)![1];
+
+		const exportPromise = exportCallback();
+		dispose();
+		state.featureFlags.modeOverlay = true;
+		state.featureFlags.offscreenBlockArrows = false;
+		finishExport();
+		await exportPromise;
+
+		expect(state.featureFlags.modeOverlay).toBe(true);
+		expect(state.featureFlags.offscreenBlockArrows).toBe(false);
+	});
+
 	it('registers the screenshot export event handler', () => {
 		const state = createMockState();
 		const store = createStateManager(state);

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/canvas-screenshot/effect.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/canvas-screenshot/effect.ts
@@ -2,10 +2,15 @@ import type { EventDispatcher, State } from '@8f4e/editor-state-types';
 import type { StateManager } from '@8f4e/state-manager';
 import getExportBaseName from '../project-export/getExportBaseName';
 
-export default function canvasScreenshot(store: StateManager<State>, events: EventDispatcher): void {
+export default function canvasScreenshot(store: StateManager<State>, events: EventDispatcher): () => void {
 	const state = store.getState();
+	let disposed = false;
 
 	async function onExportCanvasScreenshot() {
+		if (disposed) {
+			return;
+		}
+
 		if (!state.callbacks.exportCanvasScreenshot) {
 			console.warn('No exportCanvasScreenshot callback provided');
 			return;
@@ -20,12 +25,21 @@ export default function canvasScreenshot(store: StateManager<State>, events: Eve
 			store.set('featureFlags.offscreenBlockArrows', false);
 			await state.callbacks.exportCanvasScreenshot(fileName);
 		} catch (error) {
-			console.error('Failed to export canvas screenshot:', error);
+			if (!disposed) {
+				console.error('Failed to export canvas screenshot:', error);
+			}
 		} finally {
-			store.set('featureFlags.modeOverlay', previousModeOverlay);
-			store.set('featureFlags.offscreenBlockArrows', previousOffscreenBlockArrows);
+			if (!disposed) {
+				store.set('featureFlags.modeOverlay', previousModeOverlay);
+				store.set('featureFlags.offscreenBlockArrows', previousOffscreenBlockArrows);
+			}
 		}
 	}
 
 	events.on('exportCanvasScreenshot', onExportCanvasScreenshot);
+
+	return () => {
+		disposed = true;
+		events.off('exportCanvasScreenshot', onExportCanvasScreenshot);
+	};
 }

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.test.ts
@@ -282,6 +282,29 @@ describe('codeBlockCreator - clipboard callbacks', () => {
 	});
 
 	describe('addCodeBlockBySlug with dependencies', () => {
+		it('ignores a module that finishes loading after disposal', async () => {
+			let resolveModule!: (source: string) => void;
+			mockState.callbacks.getModule = vi.fn(
+				() =>
+					new Promise(resolve => {
+						resolveModule = resolve;
+					})
+			);
+			mockState.callbacks.getModuleDependencies = vi.fn().mockResolvedValue(['dependency']);
+			const dispose = codeBlockCreator(store, mockEvents);
+			const addCodeBlockBySlug = (mockEvents.on as unknown as MockInstance).mock.calls.find(
+				call => call[0] === 'addCodeBlockBySlug'
+			)![1];
+
+			const addPromise = addCodeBlockBySlug({ codeBlockSlug: 'main', x: 100, y: 100 });
+			dispose();
+			resolveModule('module main\n\nmoduleEnd');
+			await addPromise;
+
+			expect(mockState.codeBlockRendering.codeBlocks).toEqual([]);
+			expect(mockState.callbacks.getModuleDependencies).not.toHaveBeenCalled();
+		});
+
 		it('should insert dependencies to the right of the requested module', async () => {
 			const mockGetModule = vi.fn();
 			mockGetModule.mockImplementation(async (slug: string) => {

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/effect.ts
@@ -126,8 +126,9 @@ function getEntryNameForNewModule(state: State, x: number, y: number, newEntry?:
 		: (findEntryNameAtPosition(state.codeBlockRendering.entryOutlines, x, y) ?? getUniqueEntryName(state));
 }
 
-export default function codeBlockCreator(store: StateManager<State>, events: EventDispatcher): void {
+export default function codeBlockCreator(store: StateManager<State>, events: EventDispatcher): () => void {
 	const state = store.getState();
+	let disposed = false;
 	async function onAddCodeBlock({
 		x,
 		y,
@@ -143,7 +144,7 @@ export default function codeBlockCreator(store: StateManager<State>, events: Eve
 		newEntry?: boolean;
 		code?: string[];
 	}) {
-		if (!state.featureFlags.editing) {
+		if (disposed || !state.featureFlags.editing) {
 			return;
 		}
 
@@ -167,6 +168,10 @@ export default function codeBlockCreator(store: StateManager<State>, events: Eve
 
 			try {
 				const clipboardText = await state.callbacks.readClipboardText();
+				if (disposed) {
+					return;
+				}
+
 				const parsedData = parseClipboardData(clipboardText);
 
 				if (parsedData.type === 'multi') {
@@ -308,6 +313,10 @@ export default function codeBlockCreator(store: StateManager<State>, events: Eve
 		x: number;
 		y: number;
 	}): Promise<void> {
+		if (disposed) {
+			return;
+		}
+
 		if (!state.callbacks.getModule) {
 			console.warn('No getCodeBlock callback provided');
 			return;
@@ -315,15 +324,25 @@ export default function codeBlockCreator(store: StateManager<State>, events: Eve
 
 		// Load the requested module
 		const requestedModuleCodeText = await state.callbacks.getModule(codeBlockSlug);
+		if (disposed) {
+			return;
+		}
 
 		// Add the requested module at the clicked position
 		const requestedCode = extractPublicBlockFromModuleSource(requestedModuleCodeText);
-		onAddCodeBlock({ code: requestedCode, x, y, isNew: false });
+		await onAddCodeBlock({ code: requestedCode, x, y, isNew: false });
+		if (disposed) {
+			return;
+		}
 
 		// If the module has dependencies, insert them to the right
 		const dependencies = state.callbacks.getModuleDependencies
 			? await state.callbacks.getModuleDependencies(codeBlockSlug)
 			: [];
+		if (disposed) {
+			return;
+		}
+
 		if (dependencies.length > 0) {
 			await insertDependencies({
 				dependencies,
@@ -333,6 +352,7 @@ export default function codeBlockCreator(store: StateManager<State>, events: Eve
 				clickY: y,
 				state,
 				onAddCodeBlock,
+				isCancelled: () => disposed,
 			});
 		}
 	}
@@ -342,4 +362,13 @@ export default function codeBlockCreator(store: StateManager<State>, events: Eve
 	events.on('copyCodeBlock', onCopyCodeBlock);
 	events.on('deleteCodeBlock', onDeleteCodeBlock);
 	events.on('toggleCodeBlockDisabled', onToggleCodeBlockDisabled);
+
+	return () => {
+		disposed = true;
+		events.off('addCodeBlockBySlug', onAddCodeBlockBySlug);
+		events.off('addCodeBlock', onAddCodeBlock);
+		events.off('copyCodeBlock', onCopyCodeBlock);
+		events.off('deleteCodeBlock', onDeleteCodeBlock);
+		events.off('toggleCodeBlockDisabled', onToggleCodeBlockDisabled);
+	};
 }

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/insertDependencies.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/codeBlockCreator/insertDependencies.ts
@@ -11,7 +11,8 @@ interface InsertDependenciesParams {
 	clickX: number;
 	clickY: number;
 	state: State;
-	onAddCodeBlock: (params: { code: string[]; x: number; y: number; isNew: boolean }) => void;
+	onAddCodeBlock: (params: { code: string[]; x: number; y: number; isNew: boolean }) => void | Promise<void>;
+	isCancelled?: () => boolean;
 }
 
 /**
@@ -28,6 +29,7 @@ export async function insertDependencies({
 	clickY,
 	state,
 	onAddCodeBlock,
+	isCancelled = () => false,
 }: InsertDependenciesParams): Promise<void> {
 	const vGrid = state.viewport.vGrid;
 	const gridGap = 4; // Fixed gap between modules in grid units
@@ -39,8 +41,15 @@ export async function insertDependencies({
 
 	// Insert dependencies from left to right
 	for (const dependencySlug of dependencies) {
+		if (isCancelled()) {
+			return;
+		}
+
 		try {
 			const dependencyCode = extractPublicBlockFromModuleSource(await getModule(dependencySlug));
+			if (isCancelled()) {
+				return;
+			}
 
 			// Get the module name and type from the dependency code
 			const dependencyModuleName = getCodeBlockNameFromSource(dependencyCode);
@@ -66,12 +75,19 @@ export async function insertDependencies({
 			const dependencyY = clickY;
 
 			// Add the dependency
-			onAddCodeBlock({ code: dependencyCode, x: dependencyX, y: dependencyY, isNew: false });
+			await onAddCodeBlock({ code: dependencyCode, x: dependencyX, y: dependencyY, isNew: false });
+			if (isCancelled()) {
+				return;
+			}
 
 			// Move position to the right for the next dependency
 			const dependencyGridWidth = getCodeBlockGridWidth(dependencyCode);
 			currentGridX += dependencyGridWidth + gridGap;
 		} catch (error) {
+			if (isCancelled()) {
+				return;
+			}
+
 			console.warn(`Failed to load dependency: ${dependencySlug}`, error);
 		}
 	}

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/menu/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/menu/effect.test.ts
@@ -1,12 +1,39 @@
 import type { State } from '@8f4e/editor-state-types';
 import createStateManager from '@8f4e/state-manager';
-import { describe, expect, it, type MockInstance } from 'vitest';
+import { describe, expect, it, type MockInstance, vi } from 'vitest';
 import { createMockState } from '~/pureHelpers/testingUtils/testUtils';
 
 import { createMockEventDispatcherWithVitest } from '~/pureHelpers/testingUtils/vitestTestUtils';
 import contextMenu from './effect';
 
 describe('contextMenu effect', () => {
+	it('ignores submenu data that finishes loading after disposal', async () => {
+		let resolveProjects!: (projects: Array<{ title: string; url: string; category: string }>) => void;
+		const state = createMockState({
+			callbacks: {
+				getListOfProjects: vi.fn(
+					() =>
+						new Promise(resolve => {
+							resolveProjects = resolve;
+						})
+				),
+				getProject: vi.fn(),
+			},
+		});
+		state.contextMenu.items = [{ title: 'Existing item' }];
+		const store = createStateManager(state as State);
+		const events = createMockEventDispatcherWithVitest();
+		const dispose = contextMenu(store, events);
+		const openSubMenu = (events.on as unknown as MockInstance).mock.calls.find(call => call[0] === 'openSubMenu')![1];
+
+		const openPromise = openSubMenu({ menu: 'projectMenu' });
+		dispose();
+		resolveProjects([{ title: 'Loaded project', url: 'loaded', category: 'Tests' }]);
+		await openPromise;
+
+		expect(state.contextMenu.items).toEqual([{ title: 'Existing item' }]);
+	});
+
 	it('anchors the menu in world coordinates and hit-tests it after viewport movement', async () => {
 		const state = createMockState({
 			viewport: {

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/menu/effect.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/menu/effect.ts
@@ -59,6 +59,10 @@ function getMenuViewportPosition(state: State): { x: number; y: number } {
 
 export default function contextMenu(store: StateManager<State>, events: EventDispatcher): () => void {
 	const state = store.getState();
+	let disposed = false;
+	let menuGeneration = 0;
+
+	const isCurrentMenu = (generation: number): boolean => !disposed && generation === menuGeneration;
 	const onMouseMove = (event: MouseEvent) => {
 		const { itemWidth } = state.contextMenu;
 		const { x, y } = getMenuViewportPosition(state);
@@ -72,6 +76,7 @@ export default function contextMenu(store: StateManager<State>, events: EventDis
 	};
 
 	const close = () => {
+		menuGeneration++;
 		events.off('mousedown', onMouseDown);
 		events.off('mousemove', onMouseMove);
 		state.contextMenu.open = false;
@@ -103,10 +108,11 @@ export default function contextMenu(store: StateManager<State>, events: EventDis
 	};
 
 	const onContextMenu = async (event: MouseEvent) => {
-		if (!state.featureFlags.contextMenu) {
+		if (disposed || !state.featureFlags.contextMenu) {
 			return;
 		}
 
+		const generation = ++menuGeneration;
 		const { x, y } = event;
 
 		state.contextMenu.highlightedItem = 0;
@@ -119,12 +125,12 @@ export default function contextMenu(store: StateManager<State>, events: EventDis
 
 		const codeBlock = findCodeBlockAtViewportCoordinates(state, x, y);
 
-		if (codeBlock) {
-			state.contextMenu.items = decorateMenu(await menus.moduleMenu(state));
-		} else {
-			state.contextMenu.items = decorateMenu(await menus.mainMenu(state));
+		const menuItems = codeBlock ? await menus.moduleMenu(state) : await menus.mainMenu(state);
+		if (!isCurrentMenu(generation)) {
+			return;
 		}
 
+		state.contextMenu.items = decorateMenu(menuItems);
 		state.contextMenu.itemWidth = getLongestMenuItem(state.contextMenu.items) * state.viewport.vGrid;
 
 		events.on('mousedown', onMouseDown);
@@ -132,36 +138,53 @@ export default function contextMenu(store: StateManager<State>, events: EventDis
 	};
 
 	const onOpenSubMenu = async (event: MenuEvent) => {
+		if (disposed) {
+			return;
+		}
+
+		const generation = ++menuGeneration;
 		const { menu, ...payload } = event;
 		state.contextMenu.menuStack.push({ menu, payload });
-		state.contextMenu.items = decorateMenu([
-			{ title: '< Back', action: 'menuBack' },
-			...(await (menus as Record<string, (state: State, payload?: unknown) => Promise<ContextMenuItem[]>>)[menu](
-				state,
-				payload
-			)),
-		]);
+		const menuItems = await (menus as Record<string, (state: State, payload?: unknown) => Promise<ContextMenuItem[]>>)[
+			menu
+		](state, payload);
+		if (!isCurrentMenu(generation)) {
+			return;
+		}
+
+		state.contextMenu.items = decorateMenu([{ title: '< Back', action: 'menuBack' }, ...menuItems]);
 		state.contextMenu.itemWidth = getLongestMenuItem(state.contextMenu.items) * state.viewport.vGrid;
 	};
 
 	const onMenuBack = async () => {
+		if (disposed) {
+			return;
+		}
+
+		const generation = ++menuGeneration;
 		state.contextMenu.menuStack.pop();
 		const entry = state.contextMenu.menuStack.pop();
 
 		if (!entry) {
-			state.contextMenu.items = decorateMenu(await menus.mainMenu(state));
+			const menuItems = await menus.mainMenu(state);
+			if (!isCurrentMenu(generation)) {
+				return;
+			}
+
+			state.contextMenu.items = decorateMenu(menuItems);
 			state.contextMenu.itemWidth = getLongestMenuItem(state.contextMenu.items) * state.viewport.vGrid;
 			return;
 		}
 
 		const { menu, payload } = entry;
-		state.contextMenu.items = decorateMenu([
-			{ title: '< Back', action: 'menuBack' },
-			...(await (menus as Record<string, (state: State, payload?: unknown) => Promise<ContextMenuItem[]>>)[menu](
-				state,
-				payload
-			)),
-		]);
+		const menuItems = await (menus as Record<string, (state: State, payload?: unknown) => Promise<ContextMenuItem[]>>)[
+			menu
+		](state, payload);
+		if (!isCurrentMenu(generation)) {
+			return;
+		}
+
+		state.contextMenu.items = decorateMenu([{ title: '< Back', action: 'menuBack' }, ...menuItems]);
 		state.contextMenu.itemWidth = getLongestMenuItem(state.contextMenu.items) * state.viewport.vGrid;
 	};
 
@@ -170,6 +193,10 @@ export default function contextMenu(store: StateManager<State>, events: EventDis
 	events.on('menuBack', onMenuBack);
 
 	return () => {
+		disposed = true;
+		close();
+		events.off('openSubMenu', onOpenSubMenu);
 		events.off('contextmenu', onContextMenu);
+		events.off('menuBack', onMenuBack);
 	};
 }

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/project-export/__tests__/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/project-export/__tests__/effect.test.ts
@@ -193,6 +193,28 @@ describe('projectExport', () => {
 	});
 
 	describe('saveSession', () => {
+		it('does not continue to quota loading when disposal happens during session save', async () => {
+			let finishSave!: () => void;
+			mockState.callbacks.saveSession = vi.fn(
+				() =>
+					new Promise<void>(resolve => {
+						finishSave = resolve;
+					})
+			);
+			mockState.callbacks.getStorageQuota = vi.fn().mockResolvedValue({ usedBytes: 1024, totalBytes: 10240 });
+			const dispose = projectExport(store, mockEvents);
+			const saveSessionCallback = (mockEvents.on as unknown as MockInstance).mock.calls.find(
+				call => call[0] === 'saveSession'
+			)![1];
+
+			const savePromise = saveSessionCallback();
+			dispose();
+			finishSave();
+			await savePromise;
+
+			expect(mockState.callbacks.getStorageQuota).not.toHaveBeenCalled();
+		});
+
 		it('should save session when saveSession callback is provided', async () => {
 			const mockSaveSession = vi.fn().mockResolvedValue(undefined);
 			const mockGetStorageQuota = vi.fn().mockResolvedValue({ usedBytes: 1024, totalBytes: 10240 });

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/project-export/effect.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/project-export/effect.ts
@@ -5,12 +5,18 @@ import getExportBaseName from './getExportBaseName';
 import { serializeProjectTo8f4e } from './serializeTo8f4e';
 import serializeToProject from './serializeToProject';
 
-export default function projectExport(store: StateManager<State>, events: EventDispatcher): void {
+export default function projectExport(store: StateManager<State>, events: EventDispatcher): () => void {
 	registerExportFileNameEditorConfigValidator(store);
 
 	const state = store.getState();
+	let disposed = false;
+	let saveGeneration = 0;
 
 	function onExportProject() {
+		if (disposed) {
+			return;
+		}
+
 		if (!state.callbacks.exportProject) {
 			console.warn('No exportProject callback provided');
 			return;
@@ -33,27 +39,35 @@ export default function projectExport(store: StateManager<State>, events: EventD
 	}
 
 	async function onSaveSession() {
-		if (!state.callbacks.saveSession) {
+		if (disposed || !state.callbacks.saveSession) {
 			return;
 		}
 
+		const generation = ++saveGeneration;
 		// Serialize current state to Project format
 		const projectToSave = serializeToProject(state);
 
 		// Use callbacks instead of localStorage
 		await state.callbacks.saveSession(projectToSave);
+		if (disposed || generation !== saveGeneration) {
+			return;
+		}
 
 		if (state.callbacks.getStorageQuota) {
 			const storageQuota = await state.callbacks.getStorageQuota();
-			if (storageQuota) {
+			if (!disposed && generation === saveGeneration && storageQuota) {
 				store.set('storageQuota', storageQuota);
 			}
 		}
 	}
 
 	function onExportWasm() {
+		if (disposed) {
+			return;
+		}
+
 		if (!state.callbacks.exportBinaryCode) {
-			console.warn('No exportProject callback provided');
+			console.warn('No exportBinaryCode callback provided');
 			return;
 		}
 
@@ -71,4 +85,19 @@ export default function projectExport(store: StateManager<State>, events: EventD
 	events.on('saveSession', onSaveSession);
 	events.on('exportProject', onExportProject);
 	events.on('exportWasm', onExportWasm);
+
+	return () => {
+		disposed = true;
+		saveGeneration++;
+		store.unsubscribe('codeBlockRendering.codeBlocks', onSaveSession);
+		store.unsubscribe('codeBlockRendering.selectedCodeBlock.code', onSaveSession);
+		store.unsubscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', onSaveSession);
+		store.unsubscribe(
+			'codeBlockRendering.selectedCodeBlockForProgrammaticEditWithoutCompilerTrigger.code',
+			onSaveSession
+		);
+		events.off('saveSession', onSaveSession);
+		events.off('exportProject', onExportProject);
+		events.off('exportWasm', onExportWasm);
+	};
 }

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/project-import/__tests__/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/project-import/__tests__/effect.test.ts
@@ -54,6 +54,28 @@ describe('projectImport', () => {
 	});
 
 	describe('Initial session loading', () => {
+		it('ignores a session that finishes loading after disposal', async () => {
+			let resolveSession!: (project: ProjectObjectModel) => void;
+			const loadedProject = { ...EMPTY_DEFAULT_PROJECT, code: ['loaded'] };
+			mockState.callbacks.loadSession = vi.fn(
+				() =>
+					new Promise(resolve => {
+						resolveSession = resolve;
+					})
+			);
+			const dispose = projectImport(store, mockEvents);
+			const loadSessionCallback = (mockEvents.on as unknown as MockInstance).mock.calls.find(
+				call => call[0] === 'loadSession'
+			)![1];
+
+			loadSessionCallback();
+			dispose();
+			resolveSession(loadedProject);
+			await Promise.resolve();
+
+			expect(mockState.initialProjectState).toBeUndefined();
+		});
+
 		it('should load empty project when loadSession callback is absent', async () => {
 			projectImport(store, mockEvents);
 			const onCalls = (mockEvents.on as unknown as MockInstance).mock.calls;

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/project-import/effect.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/project-import/effect.ts
@@ -5,28 +5,54 @@ import type { StateManager } from '@8f4e/state-manager';
 import { EMPTY_DEFAULT_PROJECT } from '~/features/project-import/emptyDefaultProject';
 import { error, warn } from '../logger/logger';
 
-export default function projectImport(store: StateManager<State>, events: EventDispatcher): void {
+export default function projectImport(store: StateManager<State>, events: EventDispatcher): () => void {
 	const state = store.getState();
+	let disposed = false;
+	let loadGeneration = 0;
+
+	function isCurrentLoad(generation: number): boolean {
+		return !disposed && generation === loadGeneration;
+	}
+
+	function commitLoadedProject(project: ProjectObjectModel, generation: number): void {
+		if (isCurrentLoad(generation)) {
+			store.set('initialProjectState', project);
+		}
+	}
 
 	function onLoadSession() {
+		if (disposed) {
+			return;
+		}
+
+		const generation = ++loadGeneration;
 		if (!state.callbacks.loadSession) {
-			loadProject({ project: EMPTY_DEFAULT_PROJECT });
+			commitLoadedProject(EMPTY_DEFAULT_PROJECT, generation);
 			return;
 		}
 
 		state.callbacks
 			.loadSession()
 			.then(localProject => {
-				loadProject({ project: localProject ?? EMPTY_DEFAULT_PROJECT });
+				commitLoadedProject(localProject ?? EMPTY_DEFAULT_PROJECT, generation);
 			})
 			.catch(err => {
+				if (!isCurrentLoad(generation)) {
+					return;
+				}
+
 				console.warn('Failed to load project from storage:', err);
 				warn(state, 'Failed to load project from storage');
-				loadProject({ project: EMPTY_DEFAULT_PROJECT });
+				commitLoadedProject(EMPTY_DEFAULT_PROJECT, generation);
 			});
 	}
 
 	async function loadProjectByUrl({ projectUrl }: { projectUrl: string }) {
+		if (disposed) {
+			return;
+		}
+
+		const generation = ++loadGeneration;
 		if (!state.callbacks.getProject) {
 			console.warn('No getProject callback provided');
 			warn(state, 'No getProject callback provided');
@@ -34,20 +60,36 @@ export default function projectImport(store: StateManager<State>, events: EventD
 		}
 		try {
 			const projectText = await state.callbacks.getProject(projectUrl);
+			if (!isCurrentLoad(generation)) {
+				return;
+			}
 			const project = parseProjectSource(projectText);
-			loadProject({ project });
+			commitLoadedProject(project, generation);
 		} catch (err) {
+			if (!isCurrentLoad(generation)) {
+				return;
+			}
+
 			console.error('Failed to load project by url:', err);
 			error(state, 'Failed to load project by url');
-			loadProject({ project: EMPTY_DEFAULT_PROJECT });
+			commitLoadedProject(EMPTY_DEFAULT_PROJECT, generation);
 		}
 	}
 
-	function loadProject({ project: newProject }: { project: ProjectObjectModel }) {
-		store.set('initialProjectState', newProject);
+	function loadProject({ project }: { project: ProjectObjectModel }) {
+		if (disposed) {
+			return;
+		}
+
+		commitLoadedProject(project, ++loadGeneration);
 	}
 
 	function onImportProject() {
+		if (disposed) {
+			return;
+		}
+
+		const generation = ++loadGeneration;
 		if (!state.callbacks.importProject) {
 			console.warn('No importProject callback provided');
 			warn(state, 'No importProject callback provided');
@@ -57,9 +99,13 @@ export default function projectImport(store: StateManager<State>, events: EventD
 		state.callbacks
 			.importProject()
 			.then(project => {
-				loadProject({ project });
+				commitLoadedProject(project, generation);
 			})
 			.catch(err => {
+				if (!isCurrentLoad(generation)) {
+					return;
+				}
+
 				console.error('Failed to load project from file:', err);
 				error(state, 'Failed to load project from file');
 			});
@@ -69,4 +115,13 @@ export default function projectImport(store: StateManager<State>, events: EventD
 	events.on('loadProject', loadProject);
 	events.on('loadProjectByUrl', loadProjectByUrl);
 	events.on('loadSession', onLoadSession);
+
+	return () => {
+		disposed = true;
+		loadGeneration++;
+		events.off('importProject', onImportProject);
+		events.off('loadProject', loadProject);
+		events.off('loadProjectByUrl', loadProjectByUrl);
+		events.off('loadSession', onLoadSession);
+	};
 }


### PR DESCRIPTION
## Summary

- ignore late results from slow host callbacks and dynamic loads after editor disposal
- cover project/session import, browser-local notes, screenshot export, session saving, async menus, clipboard reads, and module dependency loading
- prevent older project and menu loads from overwriting newer requests
- add focused regressions for all guarded completion paths

## Rationale

Slow host-provided promises can finish after an editor instance has been disposed. Their editor-owned continuations must become no-ops so a removed instance cannot mutate state, restore UI flags, or start follow-up work.

This follows the lifecycle cleanup merged in #911.

## Test notes

- npx nx run-many --target=test --projects=@8f4e/editor-state,@8f4e/editor-core
- npx nx run-many --target=typecheck --projects=@8f4e/editor-state,@8f4e/editor-core,@8f4e/editor-default,@8f4e/editor-website
- npx nx run @8f4e/editor-core:build
- npx nx run @8f4e/editor-core:lint
- pre-commit affected typecheck