### PR TITLE
feat(editor-core): expose rendering lifecycle controls

### DIFF
--- a/packages/editor/packages/editor-core/packages/web-ui/src/index.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/index.test.ts
@@ -1,7 +1,7 @@
 import { createMockState } from '@8f4e/editor-state-testing';
 import { MemoryTypes, type PlannedMemoryDeclaration } from '@8f4e/language-spec';
 import type { WebUiRenderDataSource } from '@8f4e/web-ui-render-projection';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const renderDataSnapshot = { codeBlocks: new Map() };
 const renderData: WebUiRenderDataSource = { getSnapshot: () => renderDataSnapshot };
@@ -19,9 +19,6 @@ const mocks = vi.hoisted(() => {
 		},
 		setSpriteAtlas: vi.fn(),
 		drawSprite: vi.fn(),
-		render: vi.fn(),
-		pauseRendering: vi.fn(),
-		resumeRendering: vi.fn(),
 		renderFrame: vi.fn((drawFrame: () => void) => {
 			for (const hook of engine.hooks.preDraw) hook();
 			drawFrame();
@@ -57,6 +54,8 @@ const mocks = vi.hoisted(() => {
 		wireHighlighted: [0.4, 0.5, 0.6, 1] as const,
 	};
 	const resolveWireColors = vi.fn(() => wireColors);
+	const requestAnimationFrame = vi.fn(() => 23);
+	const cancelAnimationFrame = vi.fn();
 
 	return {
 		engine,
@@ -66,6 +65,8 @@ const mocks = vi.hoisted(() => {
 		postProcess,
 		wireColors,
 		resolveWireColors,
+		requestAnimationFrame,
+		cancelAnimationFrame,
 		// biome-ignore lint/complexity/useArrowFunction: Engine is constructed with new in the code under test.
 		Engine: vi.fn(function () {
 			engine.hooks.preDraw.length = 0;
@@ -172,7 +173,10 @@ function createSpriteData() {
 describe('web-ui init', () => {
 	beforeEach(() => {
 		vi.clearAllMocks();
+		vi.stubGlobal('requestAnimationFrame', mocks.requestAnimationFrame);
+		vi.stubGlobal('cancelAnimationFrame', mocks.cancelAnimationFrame);
 	});
+	afterEach(() => vi.unstubAllGlobals());
 
 	it('renders one frame with the current state on demand', async () => {
 		const { default: init } = await import('./index');
@@ -201,7 +205,7 @@ describe('web-ui init', () => {
 		expect(mocks.drawModeOverlay).toHaveBeenCalledWith(expect.anything(), frameState);
 	});
 
-	it('pauses and resumes the engine render loop', async () => {
+	it('pauses and resumes its animation frame loop idempotently', async () => {
 		const { default: init } = await import('./index');
 		const state = createMockState();
 		const memoryViews = {
@@ -214,12 +218,22 @@ describe('web-ui init', () => {
 			float64: new Float64Array(0),
 		};
 		const view = await init(state, renderData, {} as HTMLCanvasElement, memoryViews, createSpriteData());
+		expect(mocks.engine.renderFrame).toHaveBeenCalledOnce();
+		expect(mocks.requestAnimationFrame).toHaveBeenCalledOnce();
 
 		view.pauseRendering();
-		view.resumeRendering();
+		view.pauseRendering();
+		expect(mocks.cancelAnimationFrame).toHaveBeenCalledOnce();
+		expect(mocks.cancelAnimationFrame).toHaveBeenCalledWith(23);
 
-		expect(mocks.engine.pauseRendering).toHaveBeenCalledOnce();
-		expect(mocks.engine.resumeRendering).toHaveBeenCalledOnce();
+		view.resumeRendering();
+		view.resumeRendering();
+		expect(mocks.engine.renderFrame).toHaveBeenCalledTimes(2);
+		expect(mocks.requestAnimationFrame).toHaveBeenCalledTimes(2);
+
+		view.destroy();
+		expect(mocks.cancelAnimationFrame).toHaveBeenCalledTimes(2);
+		expect(mocks.engine.destroy).toHaveBeenCalledOnce();
 	});
 
 	it('re-resolves wire colors from the current theme when the atlas is loaded', async () => {
@@ -271,8 +285,6 @@ describe('web-ui init', () => {
 			onRenderStats,
 			renderStatsIntervalFrames: 2,
 		});
-
-		view.renderFrame();
 		expect(onRenderStats).not.toHaveBeenCalled();
 
 		view.renderFrame();
@@ -286,6 +298,9 @@ describe('web-ui init', () => {
 			spriteCount: 100,
 			uploadedInstanceBytes: 2000,
 		});
+
+		view.renderFrame();
+		expect(onRenderStats).toHaveBeenCalledTimes(1);
 		performanceNow.mockRestore();
 	});
 

--- a/packages/editor/packages/editor-core/packages/web-ui/src/index.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/index.test.ts
@@ -20,6 +20,8 @@ const mocks = vi.hoisted(() => {
 		setSpriteAtlas: vi.fn(),
 		drawSprite: vi.fn(),
 		render: vi.fn(),
+		pauseRendering: vi.fn(),
+		resumeRendering: vi.fn(),
 		renderFrame: vi.fn((drawFrame: () => void) => {
 			for (const hook of engine.hooks.preDraw) hook();
 			drawFrame();
@@ -197,6 +199,27 @@ describe('web-ui init', () => {
 		expect(mocks.resolveWireColors).toHaveBeenCalledWith(state.editorConfig.color);
 		expect(mocks.drawConnections).toHaveBeenCalledWith(mocks.lines, mocks.wireColors, frameState, memoryViews);
 		expect(mocks.drawModeOverlay).toHaveBeenCalledWith(expect.anything(), frameState);
+	});
+
+	it('pauses and resumes the engine render loop', async () => {
+		const { default: init } = await import('./index');
+		const state = createMockState();
+		const memoryViews = {
+			int8: new Int8Array(0),
+			int16: new Int16Array(0),
+			int32: new Int32Array(0),
+			uint8: new Uint8Array(0),
+			uint16: new Uint16Array(0),
+			float32: new Float32Array(0),
+			float64: new Float64Array(0),
+		};
+		const view = await init(state, renderData, {} as HTMLCanvasElement, memoryViews, createSpriteData());
+
+		view.pauseRendering();
+		view.resumeRendering();
+
+		expect(mocks.engine.pauseRendering).toHaveBeenCalledOnce();
+		expect(mocks.engine.resumeRendering).toHaveBeenCalledOnce();
 	});
 
 	it('re-resolves wire colors from the current theme when the atlas is loaded', async () => {

--- a/packages/editor/packages/editor-core/packages/web-ui/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/index.ts
@@ -166,7 +166,48 @@ export default async function init(
 		emitRenderStats(performance.now() - frameStartedAt);
 	});
 
-	engine.render(drawFrame);
+	let rendering = false;
+	let animationFrameRequest: number | null = null;
+	const renderNextFrame = () => {
+		animationFrameRequest = null;
+		if (!rendering) {
+			return;
+		}
+
+		try {
+			engine.renderFrame(drawFrame);
+		} catch (error) {
+			rendering = false;
+			throw error;
+		}
+
+		if (rendering) {
+			animationFrameRequest = requestAnimationFrame(renderNextFrame);
+		}
+	};
+	const pauseRendering = () => {
+		if (!rendering) {
+			return;
+		}
+
+		rendering = false;
+		if (animationFrameRequest !== null) {
+			cancelAnimationFrame(animationFrameRequest);
+			animationFrameRequest = null;
+		}
+	};
+	const resumeRendering = () => {
+		if (rendering) {
+			return;
+		}
+
+		rendering = true;
+		statsSampleStartTime = performance.now();
+		statsSampleStartFrameCount = renderedFrameCount;
+		renderNextFrame();
+	};
+
+	resumeRendering();
 
 	return {
 		resize: (width, height) => {
@@ -193,16 +234,13 @@ export default async function init(
 				background.clearEffect();
 			}
 		},
-		pauseRendering: () => {
-			engine.pauseRendering();
-		},
-		resumeRendering: () => {
-			engine.resumeRendering();
-		},
+		pauseRendering,
+		resumeRendering,
 		renderFrame: () => {
 			engine.renderFrame(drawFrame);
 		},
 		destroy: () => {
+			pauseRendering();
 			postProcess.destroy();
 			lines.destroy();
 			frameTextureLayer.destroy();

--- a/packages/editor/packages/editor-core/packages/web-ui/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/index.ts
@@ -65,6 +65,8 @@ export default async function init(
 	loadSpriteAtlas: (spriteData: SpriteData) => void;
 	loadPostProcessEffect: (effect: PostProcessEffect | null) => void;
 	loadBackgroundEffect: (effect: ShaderUnderlayEffect | null) => void;
+	pauseRendering: () => void;
+	resumeRendering: () => void;
 	renderFrame: () => void;
 	destroy: () => void;
 }> {
@@ -190,6 +192,12 @@ export default async function init(
 			} else {
 				background.clearEffect();
 			}
+		},
+		pauseRendering: () => {
+			engine.pauseRendering();
+		},
+		resumeRendering: () => {
+			engine.resumeRendering();
 		},
 		renderFrame: () => {
 			engine.renderFrame(drawFrame);

--- a/packages/editor/packages/editor-core/src/index.test.ts
+++ b/packages/editor/packages/editor-core/src/index.test.ts
@@ -35,6 +35,8 @@ const view = {
 	loadSpriteAtlas: vi.fn(),
 	loadPostProcessEffect: vi.fn(),
 	loadBackgroundEffect: vi.fn(),
+	pauseRendering: vi.fn(),
+	resumeRendering: vi.fn(),
 	renderFrame: vi.fn(),
 	destroy: vi.fn(),
 };
@@ -105,6 +107,8 @@ describe('editor init', () => {
 		store.set.mockClear();
 		store.dispose.mockClear();
 		view.resize.mockClear();
+		view.pauseRendering.mockClear();
+		view.resumeRendering.mockClear();
 		view.renderFrame.mockClear();
 		view.destroy.mockClear();
 		renderProjection.dispose.mockClear();
@@ -137,6 +141,21 @@ describe('editor init', () => {
 		expect(view.resize).toHaveBeenCalledWith(640, 480);
 		expect(view.renderFrame).toHaveBeenCalledOnce();
 		expect(view.resize.mock.invocationCallOrder[0]).toBeLessThan(view.renderFrame.mock.invocationCallOrder[0]);
+	});
+
+	it('exposes rendering lifecycle controls for this editor instance', async () => {
+		const { default: init } = await import('./index');
+		const canvas = { width: 640, height: 480 } as HTMLCanvasElement;
+		const editor = await init(canvas, {
+			runtimeRegistry: {},
+			callbacks: { loadSession: async () => null },
+		});
+
+		editor.pauseRendering();
+		editor.resumeRendering();
+
+		expect(view.pauseRendering).toHaveBeenCalledOnce();
+		expect(view.resumeRendering).toHaveBeenCalledOnce();
 	});
 
 	it('adapts to the canvas display size and stops observing when disposed', async () => {

--- a/packages/editor/packages/editor-core/src/index.ts
+++ b/packages/editor/packages/editor-core/src/index.ts
@@ -72,6 +72,8 @@ export { updateStateWithSpriteData } from './updateStateWithSpriteData';
 
 export interface Editor {
 	resize: (width: number, height: number) => void;
+	pauseRendering: () => void;
+	resumeRendering: () => void;
 	updateMemoryViews: (memoryRef: MemoryRef) => void;
 	getMemoryViews: () => MemoryViews;
 	dispose: () => void;
@@ -272,6 +274,8 @@ export default async function init(canvas: HTMLCanvasElement, options: EditorOpt
 
 	return {
 		resize,
+		pauseRendering: () => view.pauseRendering(),
+		resumeRendering: () => view.resumeRendering(),
 		updateMemoryViews: (memoryRef: MemoryRef) => {
 			currentMemoryRef = memoryRef instanceof WebAssembly.Memory ? memoryRef : null;
 			pluginServices.invalidateWasmExports();


### PR DESCRIPTION
## Summary

- move the editor animation-frame loop into Web UI, using `engine.renderFrame()` as the rendering primitive
- expose idempotent `pauseRendering()` and `resumeRendering()` controls on each editor instance
- cancel the pending frame when paused or disposed
- render immediately and restore exactly one loop when resumed
- add lifecycle and delegation tests at the Web UI and editor-core boundaries

## Rationale

Websites embedding multiple editors need an instance-local way to stop offscreen render loops without disposing the editor or stopping compilation, runtimes, audio, and state updates. Web UI now owns that lifecycle; `glugglugglug` remains unchanged.

## Tests

- `npx nx run-many --target=test --projects=@8f4e/web-ui,@8f4e/editor-core --output-style=static`
- `npx nx run-many --target=typecheck --projects=@8f4e/web-ui,@8f4e/editor-core,@8f4e/editor-default --output-style=static`
- Biome checks for all changed TypeScript files
- `git diff --check`