### PR TITLE
feat(editor): allow disabling project opening

### DIFF
--- a/packages/8f4e-website/src/main.ts
+++ b/packages/8f4e-website/src/main.ts
@@ -10,6 +10,7 @@ const editorEntries = await Promise.all(
 		canvas,
 		editor: await mountDefaultEditor(canvas, {
 			captureWheel: false,
+			featureFlags: { projectOpening: false },
 			initialProjectUrl: canvas.dataset.projectUrl || undefined,
 			storage: window.localStorage,
 			storageNamespace: index === 0 ? '8f4e-website' : `8f4e-website-${index + 1}`,

--- a/packages/editor/packages/editor-core/packages/editor-state-testing/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state-testing/src/index.ts
@@ -220,6 +220,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			consoleOverlay: false,
 			positionOffsetters: true,
 			offscreenBlockArrows: true,
+			projectOpening: true,
 		},
 		editorMode: 'edit',
 		editorConfig: {},

--- a/packages/editor/packages/editor-core/packages/editor-state-types/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state-types/src/index.ts
@@ -252,6 +252,9 @@ export interface FeatureFlags {
 
 	/** Enable/disable arrows that point toward off-screen code blocks */
 	offscreenBlockArrows: boolean;
+
+	/** Enable/disable menu actions that open projects from disk or the project registry */
+	projectOpening: boolean;
 }
 
 /**

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/menu/menus/mainMenu.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/menu/menus/mainMenu.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { createMockState } from '~/pureHelpers/testingUtils/testUtils';
+import { mainMenu } from './mainMenu';
+
+describe('main menu', () => {
+	it('shows project-opening actions by default', async () => {
+		const items = await mainMenu(createMockState());
+
+		expect(items.some(item => item.action === 'importProject')).toBe(true);
+		expect(items.some(item => item.payload?.menu === 'projectMenu')).toBe(true);
+	});
+
+	it('hides project-opening actions when project opening is disabled', async () => {
+		const state = createMockState({
+			featureFlags: {
+				projectOpening: false,
+			},
+		});
+
+		const items = await mainMenu(state);
+
+		expect(items.some(item => item.action === 'importProject')).toBe(false);
+		expect(items.some(item => item.payload?.menu === 'projectMenu')).toBe(false);
+		expect(items.some(item => item.action === 'new')).toBe(true);
+		expect(items.some(item => item.action === 'exportProject')).toBe(true);
+	});
+});

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/menu/menus/mainMenu.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/menu/menus/mainMenu.ts
@@ -63,16 +63,26 @@ export const mainMenu: MenuGenerator = state => [
 		close: false,
 	},
 	{ divider: true },
-	...(state.featureFlags.editing ? [{ title: 'New Project', action: 'new', close: true }, { divider: true }] : []),
-	{ title: 'Open From Disk', action: 'importProject', close: true, disabled: !state.callbacks.importProject },
-	{
-		title: 'Open Project',
-		action: 'openSubMenu',
-		payload: { menu: 'projectMenu' },
-		close: false,
-		disabled: !state.callbacks.getListOfProjects,
-	},
-	{ divider: true },
+	...(state.featureFlags.editing ? [{ title: 'New Project', action: 'new', close: true }] : []),
+	...(state.featureFlags.editing && state.featureFlags.projectOpening ? [{ divider: true }] : []),
+	...(state.featureFlags.projectOpening
+		? [
+				{
+					title: 'Open From Disk',
+					action: 'importProject',
+					close: true,
+					disabled: !state.callbacks.importProject,
+				},
+				{
+					title: 'Open Project',
+					action: 'openSubMenu',
+					payload: { menu: 'projectMenu' },
+					close: false,
+					disabled: !state.callbacks.getListOfProjects,
+				},
+			]
+		: []),
+	...(state.featureFlags.editing || state.featureFlags.projectOpening ? [{ divider: true }] : []),
 	{ title: 'Export Project', action: 'exportProject', close: true, disabled: !state.callbacks.exportProject },
 	{
 		title: 'Export WebAssembly',

--- a/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/state/featureFlags.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/state/featureFlags.ts
@@ -17,6 +17,7 @@ export const defaultFeatureFlags: FeatureFlags = {
 	consoleOverlay: true,
 	positionOffsetters: true,
 	offscreenBlockArrows: true,
+	projectOpening: true,
 };
 
 /**

--- a/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
@@ -341,6 +341,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			consoleOverlay: false,
 			positionOffsetters: true,
 			offscreenBlockArrows: true,
+			projectOpening: true,
 		},
 		editorMode: 'edit',
 		editorConfig: {},

--- a/packages/editor/packages/editor-core/src/config/featureFlags.test.ts
+++ b/packages/editor/packages/editor-core/src/config/featureFlags.test.ts
@@ -37,6 +37,7 @@ describe('Feature Flags Configuration', () => {
 		expect(defaultFeatureFlags.modeToggling).toBe(true);
 		expect(defaultFeatureFlags.modeOverlay).toBe(true);
 		expect(defaultFeatureFlags.offscreenBlockArrows).toBe(true);
+		expect(defaultFeatureFlags.projectOpening).toBe(true);
 	});
 
 	test('validateFeatureFlags should preserve enabled flags when disabled flags are specified', () => {
@@ -54,6 +55,7 @@ describe('Feature Flags Configuration', () => {
 		expect(result.modeToggling).toBe(true);
 		expect(result.modeOverlay).toBe(true);
 		expect(result.offscreenBlockArrows).toBe(true);
+		expect(result.projectOpening).toBe(true);
 	});
 
 	test('validateFeatureFlags should preserve inactive editing unless explicitly enabled', () => {

--- a/packages/editor/packages/editor-core/src/config/featureFlags.ts
+++ b/packages/editor/packages/editor-core/src/config/featureFlags.ts
@@ -26,6 +26,7 @@ export const defaultFeatureFlags = {
 	consoleOverlay: true,
 	positionOffsetters: true,
 	offscreenBlockArrows: true,
+	projectOpening: true,
 };
 
 /**

--- a/packages/editor/packages/editor-core/src/integration/featureFlags.test.ts
+++ b/packages/editor/packages/editor-core/src/integration/featureFlags.test.ts
@@ -50,6 +50,7 @@ describe('Feature Flags Integration', () => {
 		expect(result).toHaveProperty('modeToggling');
 		expect(result).toHaveProperty('modeOverlay');
 		expect(result).toHaveProperty('offscreenBlockArrows');
+		expect(result).toHaveProperty('projectOpening');
 
 		// Should merge correctly
 		expect(result.contextMenu).toBe(false);
@@ -61,6 +62,7 @@ describe('Feature Flags Integration', () => {
 		expect(result.modeToggling).toBe(true);
 		expect(result.modeOverlay).toBe(true);
 		expect(result.offscreenBlockArrows).toBe(true);
+		expect(result.projectOpening).toBe(true);
 	});
 
 	test('should preserve defaults when no mode is configured through feature flags', () => {

--- a/packages/editor/packages/editor-default/src/index.ts
+++ b/packages/editor/packages/editor-default/src/index.ts
@@ -1,4 +1,4 @@
-import initEditor, { type Editor } from '@8f4e/editor-core';
+import initEditor, { type Editor, type EditorOptions } from '@8f4e/editor-core';
 import { createCompilerService } from './compiler-callback';
 import { getListOfModules, getModule, getModuleDependencies } from './examples/moduleRegistry';
 import { getListOfProjects, getProject } from './examples/projectRegistry';
@@ -19,6 +19,7 @@ export type DefaultEditorInstance = Editor;
 export interface DefaultEditorMountOptions {
 	/** Capture wheel gestures for viewport panning. Disable this for editors embedded in scrolling pages. */
 	captureWheel?: boolean;
+	featureFlags?: EditorOptions['featureFlags'];
 	initialProjectUrl?: string;
 	storage?: Storage;
 	storageNamespace?: string;
@@ -28,6 +29,7 @@ export async function mountDefaultEditor(
 	canvas: HTMLCanvasElement,
 	{
 		captureWheel,
+		featureFlags,
 		initialProjectUrl,
 		storage = localStorage,
 		storageNamespace = DEFAULT_STORAGE_NAMESPACE,
@@ -39,6 +41,7 @@ export async function mountDefaultEditor(
 	try {
 		editor = await initEditor(canvas, {
 			captureWheel,
+			featureFlags,
 			runtimeRegistry: createRuntimeRegistry(compilerService),
 			callbacks: {
 				getListOfModules,


### PR DESCRIPTION
## Summary
- add a `projectOpening` editor feature flag, enabled by default
- hide the Open From Disk and Open Project menu entries when disabled
- expose feature flags through `mountDefaultEditor`
- disable project opening on the 8f4e website while preserving URL-based initial project loading

## Rationale
Embedded editors can load a website-selected project without exposing UI for opening a different project.

## Tests
- `npx nx run-many --target=test --projects=@8f4e/editor-state,@8f4e/editor-core --output-style=static`
- `npx nx run-many --target=typecheck --projects=@8f4e/editor-state-types,@8f4e/editor-state-testing,@8f4e/editor-state,@8f4e/editor-core,@8f4e/editor-default,@8f4e/8f4e-website --output-style=static`
- pre-commit Biome and affected typecheck checks
- `git diff --check`