### PR TITLE
feat(editor): allow disabling project creation

### DIFF
--- a/packages/8f4e-website/src/main.ts
+++ b/packages/8f4e-website/src/main.ts
@@ -10,7 +10,7 @@ const editorEntries = await Promise.all(
 		canvas,
 		editor: await mountDefaultEditor(canvas, {
 			captureWheel: false,
-			featureFlags: { projectOpening: false },
+			featureFlags: { projectCreation: false, projectOpening: false },
 			initialProjectUrl: canvas.dataset.projectUrl || undefined,
 			storage: window.localStorage,
 			storageNamespace: index === 0 ? '8f4e-website' : `8f4e-website-${index + 1}`,

--- a/packages/editor/packages/editor-core/packages/editor-state-testing/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state-testing/src/index.ts
@@ -221,6 +221,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			positionOffsetters: true,
 			offscreenBlockArrows: true,
 			projectOpening: true,
+			projectCreation: true,
 		},
 		editorMode: 'edit',
 		editorConfig: {},

--- a/packages/editor/packages/editor-core/packages/editor-state-types/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state-types/src/index.ts
@@ -255,6 +255,9 @@ export interface FeatureFlags {
 
 	/** Enable/disable menu actions that open projects from disk or the project registry */
 	projectOpening: boolean;
+
+	/** Enable/disable the menu action that creates a new project */
+	projectCreation: boolean;
 }
 
 /**

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/menu/menus/mainMenu.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/menu/menus/mainMenu.test.ts
@@ -24,4 +24,31 @@ describe('main menu', () => {
 		expect(items.some(item => item.action === 'new')).toBe(true);
 		expect(items.some(item => item.action === 'exportProject')).toBe(true);
 	});
+
+	it('hides the new-project action when project creation is disabled', async () => {
+		const state = createMockState({
+			featureFlags: {
+				projectCreation: false,
+			},
+		});
+
+		const items = await mainMenu(state);
+
+		expect(items.some(item => item.action === 'new')).toBe(false);
+		expect(items.some(item => item.action === 'importProject')).toBe(true);
+		expect(items.some(item => item.action === 'exportProject')).toBe(true);
+	});
+
+	it('does not add adjacent dividers when project actions are disabled', async () => {
+		const state = createMockState({
+			featureFlags: {
+				projectCreation: false,
+				projectOpening: false,
+			},
+		});
+
+		const items = await mainMenu(state);
+
+		expect(items.some((item, index) => item.divider && items[index + 1]?.divider)).toBe(false);
+	});
 });

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/menu/menus/mainMenu.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/menu/menus/mainMenu.ts
@@ -63,8 +63,12 @@ export const mainMenu: MenuGenerator = state => [
 		close: false,
 	},
 	{ divider: true },
-	...(state.featureFlags.editing ? [{ title: 'New Project', action: 'new', close: true }] : []),
-	...(state.featureFlags.editing && state.featureFlags.projectOpening ? [{ divider: true }] : []),
+	...(state.featureFlags.editing && state.featureFlags.projectCreation
+		? [{ title: 'New Project', action: 'new', close: true }]
+		: []),
+	...(state.featureFlags.editing && state.featureFlags.projectCreation && state.featureFlags.projectOpening
+		? [{ divider: true }]
+		: []),
 	...(state.featureFlags.projectOpening
 		? [
 				{
@@ -82,7 +86,9 @@ export const mainMenu: MenuGenerator = state => [
 				},
 			]
 		: []),
-	...(state.featureFlags.editing || state.featureFlags.projectOpening ? [{ divider: true }] : []),
+	...((state.featureFlags.editing && state.featureFlags.projectCreation) || state.featureFlags.projectOpening
+		? [{ divider: true }]
+		: []),
 	{ title: 'Export Project', action: 'exportProject', close: true, disabled: !state.callbacks.exportProject },
 	{
 		title: 'Export WebAssembly',

--- a/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/state/featureFlags.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/state/featureFlags.ts
@@ -18,6 +18,7 @@ export const defaultFeatureFlags: FeatureFlags = {
 	positionOffsetters: true,
 	offscreenBlockArrows: true,
 	projectOpening: true,
+	projectCreation: true,
 };
 
 /**

--- a/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
@@ -342,6 +342,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			positionOffsetters: true,
 			offscreenBlockArrows: true,
 			projectOpening: true,
+			projectCreation: true,
 		},
 		editorMode: 'edit',
 		editorConfig: {},

--- a/packages/editor/packages/editor-core/src/config/featureFlags.test.ts
+++ b/packages/editor/packages/editor-core/src/config/featureFlags.test.ts
@@ -38,6 +38,7 @@ describe('Feature Flags Configuration', () => {
 		expect(defaultFeatureFlags.modeOverlay).toBe(true);
 		expect(defaultFeatureFlags.offscreenBlockArrows).toBe(true);
 		expect(defaultFeatureFlags.projectOpening).toBe(true);
+		expect(defaultFeatureFlags.projectCreation).toBe(true);
 	});
 
 	test('validateFeatureFlags should preserve enabled flags when disabled flags are specified', () => {
@@ -56,6 +57,7 @@ describe('Feature Flags Configuration', () => {
 		expect(result.modeOverlay).toBe(true);
 		expect(result.offscreenBlockArrows).toBe(true);
 		expect(result.projectOpening).toBe(true);
+		expect(result.projectCreation).toBe(true);
 	});
 
 	test('validateFeatureFlags should preserve inactive editing unless explicitly enabled', () => {

--- a/packages/editor/packages/editor-core/src/config/featureFlags.ts
+++ b/packages/editor/packages/editor-core/src/config/featureFlags.ts
@@ -27,6 +27,7 @@ export const defaultFeatureFlags = {
 	positionOffsetters: true,
 	offscreenBlockArrows: true,
 	projectOpening: true,
+	projectCreation: true,
 };
 
 /**

--- a/packages/editor/packages/editor-core/src/integration/featureFlags.test.ts
+++ b/packages/editor/packages/editor-core/src/integration/featureFlags.test.ts
@@ -51,6 +51,7 @@ describe('Feature Flags Integration', () => {
 		expect(result).toHaveProperty('modeOverlay');
 		expect(result).toHaveProperty('offscreenBlockArrows');
 		expect(result).toHaveProperty('projectOpening');
+		expect(result).toHaveProperty('projectCreation');
 
 		// Should merge correctly
 		expect(result.contextMenu).toBe(false);
@@ -63,6 +64,7 @@ describe('Feature Flags Integration', () => {
 		expect(result.modeOverlay).toBe(true);
 		expect(result.offscreenBlockArrows).toBe(true);
 		expect(result.projectOpening).toBe(true);
+		expect(result.projectCreation).toBe(true);
 	});
 
 	test('should preserve defaults when no mode is configured through feature flags', () => {


### PR DESCRIPTION
## Summary
- add a `projectCreation` editor feature flag, enabled by default
- hide the New Project menu action when project creation is disabled
- keep menu separators tidy when project creation and opening are both disabled
- disable project creation on the 8f4e website

## Rationale
Embedded editors can load their website-selected project without exposing UI that replaces it with a newly created project.

## Tests
- `npx nx run-many --target=test --projects=@8f4e/editor-state,@8f4e/editor-core --output-style=static`
- `npx nx run-many --target=typecheck --projects=@8f4e/editor-state-types,@8f4e/editor-state-testing,@8f4e/editor-state,@8f4e/editor-core,@8f4e/editor-default,@8f4e/8f4e-website --output-style=static`
- pre-commit Biome and affected typecheck checks
- `git diff --check`