### PR TITLE
fix(editor-state): align centered viewports to grid

### DIFF
--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/codeBlockNavigation/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/codeBlockNavigation/effect.test.ts
@@ -477,8 +477,8 @@ describe('codeBlockNavigation', () => {
 			goHome(state);
 
 			expect(state.codeBlockRendering.selectedCodeBlock).toBe(firstHome);
-			expect(state.viewport.x).toBe(50);
-			expect(state.viewport.y).toBe(50);
+			expect(state.viewport.x).toBe(48);
+			expect(state.viewport.y).toBe(48);
 		});
 
 		it('should honor home alignment hints when centering the viewport', () => {
@@ -506,8 +506,8 @@ describe('codeBlockNavigation', () => {
 			goHome(state);
 
 			expect(state.codeBlockRendering.selectedCodeBlock).toBe(homeBlock);
-			expect(state.viewport.x).toBe(50);
-			expect(state.viewport.y).toBe(100);
+			expect(state.viewport.x).toBe(48);
+			expect(state.viewport.y).toBe(96);
 		});
 
 		it('should dispatch viewportChanged after goHome changes the viewport', () => {

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/presentation/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/presentation/effect.test.ts
@@ -124,8 +124,8 @@ describe('presentation effect', () => {
 		vi.advanceTimersByTime(2000);
 		scheduledFrame?.(2016);
 		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[0]);
-		expect(state.viewport.x).toBe(10);
-		expect(state.viewport.y).toBe(140);
+		expect(state.viewport.x).toBe(8);
+		expect(state.viewport.y).toBe(144);
 
 		vi.advanceTimersByTime(3000);
 		scheduledFrame?.(5016);
@@ -134,8 +134,8 @@ describe('presentation effect', () => {
 		expect(state.presentation.totalStops).toBe(2);
 		expect(state.presentation.remainingMs).toBe(3000);
 		expect(state.presentation.deadlineAt).toBe(Date.now() + 3000);
-		expect(state.viewportAnimation.targetX).toBe(310);
-		expect(state.viewportAnimation.targetY).toBe(440);
+		expect(state.viewportAnimation.targetX).toBe(312);
+		expect(state.viewportAnimation.targetY).toBe(448);
 		expect(state.viewportAnimation.durationMs).toBe(2000);
 
 		cleanup();
@@ -205,14 +205,14 @@ describe('presentation effect', () => {
 
 		presentation(store, events);
 		store.set('editorMode', 'presentation');
-		expect(state.viewportAnimation.targetX).toBe(85);
+		expect(state.viewportAnimation.targetX).toBe(88);
 		expect(state.presentation.activeStopIndex).toBe(0);
 		expect(state.presentation.totalStops).toBe(2);
 
 		vi.advanceTimersByTime(5000);
 		scheduledFrame?.(5016);
 		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[1]);
-		expect(state.viewportAnimation.targetX).toBe(235);
+		expect(state.viewportAnimation.targetX).toBe(232);
 		expect(state.presentation.activeStopIndex).toBe(1);
 	});
 
@@ -279,14 +279,14 @@ describe('presentation effect', () => {
 
 		presentation(store, events);
 		store.set('editorMode', 'presentation');
-		expect(state.viewportAnimation.targetY).toBe(190);
+		expect(state.viewportAnimation.targetY).toBe(192);
 		expect(state.presentation.activeStopIndex).toBe(0);
 		expect(state.presentation.totalStops).toBe(2);
 
 		vi.advanceTimersByTime(5000);
 		scheduledFrame?.(5016);
 		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[1]);
-		expect(state.viewportAnimation.targetY).toBe(390);
+		expect(state.viewportAnimation.targetY).toBe(384);
 		expect(state.presentation.activeStopIndex).toBe(1);
 	});
 
@@ -360,15 +360,15 @@ describe('presentation effect', () => {
 		expect(state.presentation.activeStopIndex).toBe(1);
 		expect(state.presentation.totalStops).toBe(2);
 		expect(state.presentation.remainingMs).toBe(3000);
-		expect(state.viewportAnimation.targetX).toBe(310);
-		expect(state.viewportAnimation.targetY).toBe(440);
+		expect(state.viewportAnimation.targetX).toBe(312);
+		expect(state.viewportAnimation.targetY).toBe(448);
 
 		eventHandlers.get('previousPresentationStop')?.();
 		expect(state.codeBlockRendering.selectedCodeBlock).toBe(state.codeBlockRendering.codeBlocks[0]);
 		expect(state.presentation.activeStopIndex).toBe(0);
 		expect(state.presentation.remainingMs).toBe(5000);
-		expect(state.viewportAnimation.targetX).toBe(10);
-		expect(state.viewportAnimation.targetY).toBe(140);
+		expect(state.viewportAnimation.targetX).toBe(8);
+		expect(state.viewportAnimation.targetY).toBe(144);
 	});
 
 	it('restarts the current stop timer after a manual skip', () => {

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/viewport/centerViewportOnCodeBlock.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/viewport/centerViewportOnCodeBlock.test.ts
@@ -25,21 +25,21 @@ describe('centerViewportOnCodeBlock', () => {
 		const viewport = createMockViewport(0, 0, 800, 600);
 		const codeBlock = createMockCodeBlock(100, 100, 200, 100);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: -200, y: -150 });
+		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: -200, y: -144 });
 	});
 
 	it('returns the centered position for a block at the origin', () => {
 		const viewport = createMockViewport(0, 0, 400, 300);
 		const codeBlock = createMockCodeBlock(0, 0, 100, 100);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: -150, y: -100 });
+		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: -152, y: -96 });
 	});
 
 	it('returns the centered horizontal position for a wide block', () => {
 		const viewport = createMockViewport(0, 0, 800, 600);
 		const codeBlock = createMockCodeBlock(0, 0, 1000, 100);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock).x).toBe(100);
+		expect(centerViewportOnCodeBlock(viewport, codeBlock).x).toBe(104);
 	});
 
 	it('places the code block center on the left quarter of the viewport when aligned left', () => {
@@ -60,28 +60,28 @@ describe('centerViewportOnCodeBlock', () => {
 		const viewport = createMockViewport(0, 0, 800, 600);
 		const codeBlock = createMockCodeBlock(100, 200, 100, 100);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock, { alignment: 'top' }).y).toBe(100);
+		expect(centerViewportOnCodeBlock(viewport, codeBlock, { alignment: 'top' }).y).toBe(96);
 	});
 
 	it('places the code block center on the bottom quarter of the viewport when aligned bottom', () => {
 		const viewport = createMockViewport(0, 0, 800, 600);
 		const codeBlock = createMockCodeBlock(100, 200, 100, 100);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock, { alignment: 'bottom' }).y).toBe(-200);
+		expect(centerViewportOnCodeBlock(viewport, codeBlock, { alignment: 'bottom' }).y).toBe(-192);
 	});
 
 	it('centers a small block vertically when it fits in the viewport', () => {
 		const viewport = createMockViewport(0, 0, 800, 600);
 		const codeBlock = createMockCodeBlock(100, 200, 100, 100);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock).y).toBe(-50);
+		expect(centerViewportOnCodeBlock(viewport, codeBlock).y).toBe(-48);
 	});
 
 	it('adds 25% viewport-height top margin for large blocks, rounded to rows', () => {
 		const viewport = createMockViewport(0, 0, 800, 600);
 		const codeBlock = createMockCodeBlock(100, 100, 100, 800);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock).y).toBe(-44);
+		expect(centerViewportOnCodeBlock(viewport, codeBlock).y).toBe(-48);
 	});
 
 	it('keeps a rounded 25% viewport-height margin above a tall block at the origin', () => {
@@ -95,42 +95,42 @@ describe('centerViewportOnCodeBlock', () => {
 		const viewport = createMockViewport(0, 0, 800, 600);
 		const codeBlock = createMockCodeBlock(100, 200, 200, 100, 30, 40);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: -170, y: -10 });
+		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: -168, y: -16 });
 	});
 
 	it('applies the rounded 25% viewport-height top margin with offsetY for large blocks', () => {
 		const viewport = createMockViewport(0, 0, 800, 600);
 		const codeBlock = createMockCodeBlock(0, 100, 100, 800, 0, 50);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock).y).toBe(6);
+		expect(centerViewportOnCodeBlock(viewport, codeBlock).y).toBe(0);
 	});
 
 	it('handles zero-sized blocks', () => {
 		const viewport = createMockViewport(0, 0, 800, 600);
 		const codeBlock = createMockCodeBlock(100, 100, 0, 0);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: -300, y: -200 });
+		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: -296, y: -192 });
 	});
 
 	it('handles blocks with negative coordinates', () => {
 		const viewport = createMockViewport(0, 0, 800, 600);
 		const codeBlock = createMockCodeBlock(-200, -100, 100, 100);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: -550, y: -350 });
+		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: -552, y: -352 });
 	});
 
 	it('handles negative offsets', () => {
 		const viewport = createMockViewport(0, 0, 800, 600);
 		const codeBlock = createMockCodeBlock(100, 100, 100, 100, -20, -30);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: -270, y: -180 });
+		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: -272, y: -176 });
 	});
 
 	it('keeps the rounded 25% viewport-height margin for oversized blocks in a very small viewport', () => {
 		const viewport = createMockViewport(0, 0, 50, 50);
 		const codeBlock = createMockCodeBlock(100, 100, 100, 100);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: 125, y: 84 });
+		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: 128, y: 80 });
 	});
 
 	it('does not mutate the provided viewport object', () => {
@@ -143,41 +143,51 @@ describe('centerViewportOnCodeBlock', () => {
 		expect(viewport).toBe(originalViewport);
 		expect(viewport.x).toBe(999);
 		expect(viewport.y).toBe(888);
-		expect(nextViewport).toEqual({ x: -200, y: -150 });
+		expect(nextViewport).toEqual({ x: -200, y: -144 });
 	});
 
 	it('handles square viewport and square block', () => {
 		const viewport = createMockViewport(0, 0, 600, 600);
 		const codeBlock = createMockCodeBlock(400, 400, 200, 200);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: 200, y: 200 });
+		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: 200, y: 208 });
 	});
 
 	it('handles wide viewport and narrow block', () => {
 		const viewport = createMockViewport(0, 0, 1200, 400);
 		const codeBlock = createMockCodeBlock(100, 100, 50, 100);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock).x).toBe(-475);
+		expect(centerViewportOnCodeBlock(viewport, codeBlock).x).toBe(-472);
 	});
 
 	it('handles tall viewport and short block', () => {
 		const viewport = createMockViewport(0, 0, 400, 1000);
 		const codeBlock = createMockCodeBlock(100, 100, 100, 50);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock).y).toBe(-375);
+		expect(centerViewportOnCodeBlock(viewport, codeBlock).y).toBe(-368);
 	});
 
 	it('handles a typical desktop viewport', () => {
 		const viewport = createMockViewport(0, 0, 1920, 1080);
 		const codeBlock = createMockCodeBlock(500, 300, 400, 300);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: -260, y: -90 });
+		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: -256, y: -96 });
 	});
 
 	it('handles a mobile-sized viewport', () => {
 		const viewport = createMockViewport(0, 0, 375, 667);
 		const codeBlock = createMockCodeBlock(200, 200, 300, 400);
 
-		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: 163, y: 67 });
+		expect(centerViewportOnCodeBlock(viewport, codeBlock)).toEqual({ x: 160, y: 64 });
+	});
+
+	it('always returns coordinates aligned to the viewport grid', () => {
+		const viewport = createMockViewport(0, 0, 803, 607);
+		const codeBlock = createMockCodeBlock(103, 207, 197, 99, 3, 5);
+
+		const position = centerViewportOnCodeBlock(viewport, codeBlock);
+
+		expect(Math.abs(position.x % viewport.vGrid)).toBe(0);
+		expect(Math.abs(position.y % viewport.hGrid)).toBe(0);
 	});
 });

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/viewport/centerViewportOnCodeBlock.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/viewport/centerViewportOnCodeBlock.ts
@@ -1,4 +1,5 @@
 import type { Position, Viewport, ViewportBlockAlignment } from '@8f4e/editor-state-types';
+import roundToGrid from './roundToGrid';
 
 /**
  * Minimal positional data required for viewport centering
@@ -19,14 +20,14 @@ export interface CenterViewportOnCodeBlockOptions {
 /**
  * Calculates the viewport position needed to center a given code block, with optional viewport anchor hints.
  *
- * For blocks smaller than the viewport, perfect centering is achieved. For blocks
+ * For blocks smaller than the viewport, centering is rounded to the nearest grid lines. For blocks
  * larger than the viewport, the block is aligned near the top with a margin equal
  * to 25% of the viewport height, rounded to whole rows, while the bottom may
  * extend beyond the viewport.
  *
  * @param viewport - The viewport dimensions and grid sizing to center within
  * @param codeBlock - The code block to center on
- * @returns The viewport position that centers the code block
+ * @returns The nearest grid-aligned viewport position that centers the code block
  *
  * @remarks
  * **Centering Behavior:**
@@ -42,6 +43,7 @@ export interface CenterViewportOnCodeBlockOptions {
  * **Implementation Notes:**
  * - This function is pure and does not mutate the viewport parameter
  * - Coordinates use pixels, not grid units (grid conversion happens elsewhere)
+ * - The returned coordinates are rounded to the nearest grid lines
  * - Negative viewport coordinates are allowed (viewport can pan anywhere)
  */
 export default function centerViewportOnCodeBlock<T extends CodeBlockBounds>(
@@ -74,8 +76,7 @@ export default function centerViewportOnCodeBlock<T extends CodeBlockBounds>(
 				? oversizedBlockTop
 				: Math.min(blockTop, idealViewportY);
 
-	return {
-		x: Math.round(idealViewportX),
-		y: Math.round(constrainedViewportY),
-	};
+	const [x, y] = roundToGrid(idealViewportX, constrainedViewportY, viewport);
+
+	return { x, y };
 }


### PR DESCRIPTION
## Summary

- round code-block viewport centering to the nearest horizontal and vertical grid lines
- apply the same alignment to home navigation and presentation stops
- add an invariant test and update centering expectations

## Rationale

Code-block centering previously rounded to whole pixels, which could leave the viewport between editor grid lines. Reusing the viewport grid-rounding helper keeps every centered position aligned with vGrid and hGrid.

## Test notes

- npx nx run @8f4e/editor-state:test — 1,101 tests passed
- npx nx run @8f4e/editor-state:typecheck — passed
- pre-commit affected type-check — passed