### PR TITLE
feat(editor-core): expose rendering resource release controls

### DIFF
--- a/packages/editor/packages/editor-core/README.md
+++ b/packages/editor/packages/editor-core/README.md
@@ -15,10 +15,16 @@ renderers can replace it.
 - Translate DOM input data into internal event payloads (coordinates, movement deltas, button state, canvas size).
 - Initialize the UI renderer with state and memory views, and forward resize and post-process events.
 - Observe the canvas's CSS dimensions and adapt the drawing buffer and editor viewport when its host resizes it.
-- Expose state access, memory view updates, and state machine callbacks as extension points.
+- Expose state access, memory view updates, rendering lifecycle controls, and state machine callbacks as extension
+  points.
 
 Wheel input pans the editor viewport and prevents page scrolling by default. Embedded hosts can set
 `captureWheel: false` when initializing the editor to leave wheel input and scrolling to the surrounding page.
+
+Hosts can pause rendering without releasing memory through `pauseRendering()`. `releaseRenderingResources()` also
+releases reloadable GPU textures and dynamic buffers while preserving the last frame in the canvas drawing buffer;
+`releaseRenderingResourcesAndDrawingBuffer()` additionally discards that drawing buffer. `resumeRendering()` restores
+either release level and applies any canvas resize that happened while resources were released.
 
 ## Docs
 

--- a/packages/editor/packages/editor-core/packages/web-ui/src/index.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/index.test.ts
@@ -25,6 +25,8 @@ const mocks = vi.hoisted(() => {
 			for (const hook of engine.hooks.postDraw) hook();
 		}),
 		resize: vi.fn(),
+		releaseRenderingMemory: vi.fn(),
+		restoreRenderingMemory: vi.fn(),
 		destroy: vi.fn(),
 	};
 	const background = {
@@ -38,15 +40,18 @@ const mocks = vi.hoisted(() => {
 		}),
 		uploadRgba8Texture: vi.fn(() => ({ texture: {}, width: 128, height: 128, filter: 'nearest' })),
 		drawTexture: vi.fn(),
+		releaseMemory: vi.fn(),
 		destroy: vi.fn(),
 	};
 	const lines = {
 		drawLine: vi.fn(),
+		releaseMemory: vi.fn(),
 		destroy: vi.fn(),
 	};
 	const postProcess = {
 		setEffect: vi.fn(),
 		clearEffect: vi.fn(),
+		releaseMemory: vi.fn(),
 		destroy: vi.fn(),
 	};
 	const wireColors = {
@@ -234,6 +239,69 @@ describe('web-ui init', () => {
 		view.destroy();
 		expect(mocks.cancelAnimationFrame).toHaveBeenCalledTimes(2);
 		expect(mocks.engine.destroy).toHaveBeenCalledOnce();
+	});
+
+	it('releases reloadable rendering resources while preserving the canvas drawing buffer', async () => {
+		const { default: init } = await import('./index');
+		const state = createMockState();
+		const memoryViews = {
+			int8: new Int8Array(0),
+			int16: new Int16Array(0),
+			int32: new Int32Array(0),
+			uint8: new Uint8Array(0),
+			uint16: new Uint16Array(0),
+			float32: new Float32Array(0),
+			float64: new Float64Array(0),
+		};
+		const canvas = { width: 640, height: 480 } as HTMLCanvasElement;
+		const view = await init(state, renderData, canvas, memoryViews, createSpriteData());
+
+		view.releaseRenderingResources();
+		view.releaseRenderingResources();
+
+		expect(mocks.cancelAnimationFrame).toHaveBeenCalledOnce();
+		expect(mocks.postProcess.releaseMemory).toHaveBeenCalledOnce();
+		expect(mocks.frameTextureLayer.releaseMemory).toHaveBeenCalledOnce();
+		expect(mocks.lines.releaseMemory).toHaveBeenCalledOnce();
+		expect(mocks.engine.releaseRenderingMemory).toHaveBeenCalledOnce();
+		expect(canvas).toEqual(expect.objectContaining({ width: 640, height: 480 }));
+
+		view.resumeRendering();
+		view.resumeRendering();
+
+		expect(mocks.engine.restoreRenderingMemory).toHaveBeenCalledOnce();
+		expect(mocks.engine.resize).not.toHaveBeenCalled();
+		expect(mocks.engine.renderFrame).toHaveBeenCalledTimes(2);
+	});
+
+	it('can also release the drawing buffer and apply the latest deferred size when resumed', async () => {
+		const { default: init } = await import('./index');
+		const state = createMockState();
+		const memoryViews = {
+			int8: new Int8Array(0),
+			int16: new Int16Array(0),
+			int32: new Int32Array(0),
+			uint8: new Uint8Array(0),
+			uint16: new Uint16Array(0),
+			float32: new Float32Array(0),
+			float64: new Float64Array(0),
+		};
+		const canvas = { width: 640, height: 480 } as HTMLCanvasElement;
+		const view = await init(state, renderData, canvas, memoryViews, createSpriteData());
+
+		view.releaseRenderingResourcesAndDrawingBuffer();
+		view.releaseRenderingResourcesAndDrawingBuffer();
+
+		expect(canvas).toEqual(expect.objectContaining({ width: 1, height: 1 }));
+		expect(view.resize(800, 600)).toBe(false);
+		expect(mocks.engine.resize).not.toHaveBeenCalled();
+
+		view.resumeRendering();
+
+		expect(mocks.engine.restoreRenderingMemory).toHaveBeenCalledOnce();
+		expect(mocks.engine.resize).toHaveBeenCalledOnce();
+		expect(mocks.engine.resize).toHaveBeenCalledWith(800, 600);
+		expect(mocks.engine.renderFrame).toHaveBeenCalledTimes(2);
 	});
 
 	it('re-resolves wire colors from the current theme when the atlas is loaded', async () => {

--- a/packages/editor/packages/editor-core/packages/web-ui/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/index.ts
@@ -61,11 +61,13 @@ export default async function init(
 	spriteData: SpriteData,
 	options: WebUiOptions = {}
 ): Promise<{
-	resize: (width: number, height: number) => void;
+	resize: (width: number, height: number) => boolean;
 	loadSpriteAtlas: (spriteData: SpriteData) => void;
 	loadPostProcessEffect: (effect: PostProcessEffect | null) => void;
 	loadBackgroundEffect: (effect: ShaderUnderlayEffect | null) => void;
 	pauseRendering: () => void;
+	releaseRenderingResources: () => void;
+	releaseRenderingResourcesAndDrawingBuffer: () => void;
 	resumeRendering: () => void;
 	renderFrame: () => void;
 	destroy: () => void;
@@ -84,6 +86,8 @@ export default async function init(
 	const renderStatsIntervalFrames = Math.max(1, Math.floor(options.renderStatsIntervalFrames ?? 60));
 	let viewportWidth = canvas.width;
 	let viewportHeight = canvas.height;
+	let appliedViewportWidth = canvas.width;
+	let appliedViewportHeight = canvas.height;
 	const getFrameTexture = options.getFrameTexture ?? (() => options.frameTexture);
 	let frameTextureKey = '';
 	let drawWasmFrameTexture: ((layer: RgbaTextureLayer) => void) | undefined;
@@ -167,6 +171,8 @@ export default async function init(
 	});
 
 	let rendering = false;
+	let renderingResourcesReleased = false;
+	let drawingBufferReleased = false;
 	let animationFrameRequest: number | null = null;
 	const renderNextFrame = () => {
 		animationFrameRequest = null;
@@ -196,11 +202,50 @@ export default async function init(
 			animationFrameRequest = null;
 		}
 	};
+	const releaseRenderingResources = () => {
+		pauseRendering();
+		if (renderingResourcesReleased) {
+			return;
+		}
+
+		postProcess.releaseMemory();
+		frameTextureLayer.releaseMemory();
+		lines.releaseMemory();
+		engine.releaseRenderingMemory();
+		renderingResourcesReleased = true;
+	};
+	const releaseRenderingResourcesAndDrawingBuffer = () => {
+		releaseRenderingResources();
+		if (drawingBufferReleased) {
+			return;
+		}
+
+		canvas.width = 1;
+		canvas.height = 1;
+		appliedViewportWidth = 1;
+		appliedViewportHeight = 1;
+		drawingBufferReleased = true;
+	};
+	const restoreRenderingResources = () => {
+		if (!renderingResourcesReleased) {
+			return;
+		}
+
+		engine.restoreRenderingMemory();
+		if (drawingBufferReleased || appliedViewportWidth !== viewportWidth || appliedViewportHeight !== viewportHeight) {
+			engine.resize(viewportWidth, viewportHeight);
+			appliedViewportWidth = viewportWidth;
+			appliedViewportHeight = viewportHeight;
+		}
+		renderingResourcesReleased = false;
+		drawingBufferReleased = false;
+	};
 	const resumeRendering = () => {
 		if (rendering) {
 			return;
 		}
 
+		restoreRenderingResources();
 		rendering = true;
 		statsSampleStartTime = performance.now();
 		statsSampleStartFrameCount = renderedFrameCount;
@@ -213,7 +258,13 @@ export default async function init(
 		resize: (width, height) => {
 			viewportWidth = width;
 			viewportHeight = height;
+			if (renderingResourcesReleased) {
+				return false;
+			}
 			engine.resize(width, height);
+			appliedViewportWidth = width;
+			appliedViewportHeight = height;
+			return true;
 		},
 		loadSpriteAtlas: spriteData => {
 			engine.setSpriteAtlas(spriteData.spriteAtlas.image, spriteData.spriteAtlas.lookup);
@@ -235,8 +286,11 @@ export default async function init(
 			}
 		},
 		pauseRendering,
+		releaseRenderingResources,
+		releaseRenderingResourcesAndDrawingBuffer,
 		resumeRendering,
 		renderFrame: () => {
+			restoreRenderingResources();
 			engine.renderFrame(drawFrame);
 		},
 		destroy: () => {

--- a/packages/editor/packages/editor-core/src/index.test.ts
+++ b/packages/editor/packages/editor-core/src/index.test.ts
@@ -31,11 +31,13 @@ const store = {
 };
 
 const view = {
-	resize: vi.fn(),
+	resize: vi.fn(() => true),
 	loadSpriteAtlas: vi.fn(),
 	loadPostProcessEffect: vi.fn(),
 	loadBackgroundEffect: vi.fn(),
 	pauseRendering: vi.fn(),
+	releaseRenderingResources: vi.fn(),
+	releaseRenderingResourcesAndDrawingBuffer: vi.fn(),
 	resumeRendering: vi.fn(),
 	renderFrame: vi.fn(),
 	destroy: vi.fn(),
@@ -108,6 +110,8 @@ describe('editor init', () => {
 		store.dispose.mockClear();
 		view.resize.mockClear();
 		view.pauseRendering.mockClear();
+		view.releaseRenderingResources.mockClear();
+		view.releaseRenderingResourcesAndDrawingBuffer.mockClear();
 		view.resumeRendering.mockClear();
 		view.renderFrame.mockClear();
 		view.destroy.mockClear();
@@ -152,10 +156,31 @@ describe('editor init', () => {
 		});
 
 		editor.pauseRendering();
+		editor.releaseRenderingResources();
+		editor.releaseRenderingResourcesAndDrawingBuffer();
 		editor.resumeRendering();
 
 		expect(view.pauseRendering).toHaveBeenCalledOnce();
+		expect(view.releaseRenderingResources).toHaveBeenCalledOnce();
+		expect(view.releaseRenderingResourcesAndDrawingBuffer).toHaveBeenCalledOnce();
 		expect(view.resumeRendering).toHaveBeenCalledOnce();
+	});
+
+	it('defers drawing when the view cannot apply a resize while rendering resources are released', async () => {
+		const { default: init } = await import('./index');
+		const canvas = { width: 640, height: 480 } as HTMLCanvasElement;
+		const editor = await init(canvas, {
+			runtimeRegistry: {},
+			callbacks: { loadSession: async () => null },
+		});
+
+		view.resize.mockReturnValueOnce(false);
+		view.renderFrame.mockClear();
+		editor.resize(800, 600);
+
+		expect(events.dispatch).toHaveBeenCalledWith('resize', { canvasWidth: 800, canvasHeight: 600 });
+		expect(view.resize).toHaveBeenLastCalledWith(800, 600);
+		expect(view.renderFrame).not.toHaveBeenCalled();
 	});
 
 	it('adapts to the canvas display size and stops observing when disposed', async () => {

--- a/packages/editor/packages/editor-core/src/index.ts
+++ b/packages/editor/packages/editor-core/src/index.ts
@@ -73,6 +73,10 @@ export { updateStateWithSpriteData } from './updateStateWithSpriteData';
 export interface Editor {
 	resize: (width: number, height: number) => void;
 	pauseRendering: () => void;
+	/** Releases reloadable GPU resources while preserving the canvas drawing buffer and its last rendered frame. */
+	releaseRenderingResources: () => void;
+	/** Releases reloadable GPU resources and the canvas drawing buffer. */
+	releaseRenderingResourcesAndDrawingBuffer: () => void;
 	resumeRendering: () => void;
 	updateMemoryViews: (memoryRef: MemoryRef) => void;
 	getMemoryViews: () => MemoryViews;
@@ -247,9 +251,11 @@ export default async function init(canvas: HTMLCanvasElement, options: EditorOpt
 	let currentCanvasSize: CanvasSize | null = null;
 	const resize = (width: number, height: number) => {
 		events.dispatch('resize', { canvasWidth: width, canvasHeight: height });
-		view.resize(width, height);
+		const resized = view.resize(width, height);
 		currentCanvasSize = { width, height };
-		view.renderFrame();
+		if (resized) {
+			view.renderFrame();
+		}
 	};
 	const initialCanvasSize = getCanvasDisplaySize(canvas) ?? {
 		width: canvas.width,
@@ -275,6 +281,8 @@ export default async function init(canvas: HTMLCanvasElement, options: EditorOpt
 	return {
 		resize,
 		pauseRendering: () => view.pauseRendering(),
+		releaseRenderingResources: () => view.releaseRenderingResources(),
+		releaseRenderingResourcesAndDrawingBuffer: () => view.releaseRenderingResourcesAndDrawingBuffer(),
 		resumeRendering: () => view.resumeRendering(),
 		updateMemoryViews: (memoryRef: MemoryRef) => {
 			currentMemoryRef = memoryRef instanceof WebAssembly.Memory ? memoryRef : null;

--- a/packages/editor/packages/editor-default/README.md
+++ b/packages/editor/packages/editor-default/README.md
@@ -15,8 +15,15 @@ const editor = await mountDefaultEditor(canvas, {
 });
 
 editor.state;
+editor.releaseRenderingResources();
+editor.resumeRendering();
 editor.dispose();
 ```
+
+`releaseRenderingResources()` pauses rendering and releases reloadable GPU textures and dynamic buffer storage while
+leaving the canvas drawing buffer—and therefore its last rendered frame—intact. For the lowest offscreen memory use,
+`releaseRenderingResourcesAndDrawingBuffer()` also discards the drawing buffer. `resumeRendering()` restores either
+release level, applies the latest canvas size, and renders immediately.
 
 The host controls the canvas's layout dimensions with CSS. The editor observes that rendered size and adapts its
 drawing buffer and UI automatically. Wheel input pans the editor and prevents page scrolling by default; embedded


### PR DESCRIPTION
## Summary
- expose `releaseRenderingResources()` on each editor instance while preserving the last canvas frame
- expose `releaseRenderingResourcesAndDrawingBuffer()` for the lowest offscreen GPU memory use
- restore resources and apply the latest deferred canvas size from `resumeRendering()`
- document the two release levels for `mountDefaultEditor()` consumers

## Rationale
Embedded pages can choose between keeping the last rendered frame visible and releasing the canvas drawing buffer as well. Both operations are instance-local and idempotent.

## Dependency
- andorthehood/glugglugglug#18

## Tests
- `npx nx run-many --target=test --projects=@8f4e/web-ui,@8f4e/editor-core --output-style=static`
- `npx nx run-many --target=typecheck --projects=glugglugglug,@8f4e/web-ui,@8f4e/editor-core,@8f4e/editor-default --output-style=static`
- `npx nx run @8f4e/editor-default:build --output-style=static`
- relevant Nx lint targets
- glugglugglug unit, build, typecheck, lint, and screenshot suites