### PR TITLE
feat(editor-core)!: simplify rendering resource release

### DIFF
--- a/packages/8f4e-website/src/main.ts
+++ b/packages/8f4e-website/src/main.ts
@@ -26,7 +26,7 @@ const renderingObserver = new IntersectionObserver(entries => {
 		if (entry.isIntersecting) {
 			editor?.resumeRendering();
 		} else {
-			editor?.pauseRendering();
+			editor?.releaseRenderingResources();
 		}
 	}
 });

--- a/packages/editor/packages/editor-core/README.md
+++ b/packages/editor/packages/editor-core/README.md
@@ -22,9 +22,8 @@ Wheel input pans the editor viewport and prevents page scrolling by default. Emb
 `captureWheel: false` when initializing the editor to leave wheel input and scrolling to the surrounding page.
 
 Hosts can pause rendering without releasing memory through `pauseRendering()`. `releaseRenderingResources()` also
-releases reloadable GPU textures and dynamic buffers while preserving the last frame in the canvas drawing buffer;
-`releaseRenderingResourcesAndDrawingBuffer()` additionally discards that drawing buffer. `resumeRendering()` restores
-either release level and applies any canvas resize that happened while resources were released.
+releases reloadable GPU textures, dynamic buffers, and the canvas drawing buffer. `resumeRendering()` restores the
+resources and applies any canvas resize that happened while they were released.
 
 ## Docs
 

--- a/packages/editor/packages/editor-core/packages/web-ui/src/index.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/index.test.ts
@@ -241,7 +241,7 @@ describe('web-ui init', () => {
 		expect(mocks.engine.destroy).toHaveBeenCalledOnce();
 	});
 
-	it('releases reloadable rendering resources while preserving the canvas drawing buffer', async () => {
+	it('releases rendering resources and applies the latest deferred size when resumed', async () => {
 		const { default: init } = await import('./index');
 		const state = createMockState();
 		const memoryViews = {
@@ -264,34 +264,6 @@ describe('web-ui init', () => {
 		expect(mocks.frameTextureLayer.releaseMemory).toHaveBeenCalledOnce();
 		expect(mocks.lines.releaseMemory).toHaveBeenCalledOnce();
 		expect(mocks.engine.releaseRenderingMemory).toHaveBeenCalledOnce();
-		expect(canvas).toEqual(expect.objectContaining({ width: 640, height: 480 }));
-
-		view.resumeRendering();
-		view.resumeRendering();
-
-		expect(mocks.engine.restoreRenderingMemory).toHaveBeenCalledOnce();
-		expect(mocks.engine.resize).not.toHaveBeenCalled();
-		expect(mocks.engine.renderFrame).toHaveBeenCalledTimes(2);
-	});
-
-	it('can also release the drawing buffer and apply the latest deferred size when resumed', async () => {
-		const { default: init } = await import('./index');
-		const state = createMockState();
-		const memoryViews = {
-			int8: new Int8Array(0),
-			int16: new Int16Array(0),
-			int32: new Int32Array(0),
-			uint8: new Uint8Array(0),
-			uint16: new Uint16Array(0),
-			float32: new Float32Array(0),
-			float64: new Float64Array(0),
-		};
-		const canvas = { width: 640, height: 480 } as HTMLCanvasElement;
-		const view = await init(state, renderData, canvas, memoryViews, createSpriteData());
-
-		view.releaseRenderingResourcesAndDrawingBuffer();
-		view.releaseRenderingResourcesAndDrawingBuffer();
-
 		expect(canvas).toEqual(expect.objectContaining({ width: 1, height: 1 }));
 		expect(view.resize(800, 600)).toBe(false);
 		expect(mocks.engine.resize).not.toHaveBeenCalled();

--- a/packages/editor/packages/editor-core/packages/web-ui/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/index.ts
@@ -67,7 +67,6 @@ export default async function init(
 	loadBackgroundEffect: (effect: ShaderUnderlayEffect | null) => void;
 	pauseRendering: () => void;
 	releaseRenderingResources: () => void;
-	releaseRenderingResourcesAndDrawingBuffer: () => void;
 	resumeRendering: () => void;
 	renderFrame: () => void;
 	destroy: () => void;
@@ -86,8 +85,6 @@ export default async function init(
 	const renderStatsIntervalFrames = Math.max(1, Math.floor(options.renderStatsIntervalFrames ?? 60));
 	let viewportWidth = canvas.width;
 	let viewportHeight = canvas.height;
-	let appliedViewportWidth = canvas.width;
-	let appliedViewportHeight = canvas.height;
 	const getFrameTexture = options.getFrameTexture ?? (() => options.frameTexture);
 	let frameTextureKey = '';
 	let drawWasmFrameTexture: ((layer: RgbaTextureLayer) => void) | undefined;
@@ -172,7 +169,6 @@ export default async function init(
 
 	let rendering = false;
 	let renderingResourcesReleased = false;
-	let drawingBufferReleased = false;
 	let animationFrameRequest: number | null = null;
 	const renderNextFrame = () => {
 		animationFrameRequest = null;
@@ -213,18 +209,8 @@ export default async function init(
 		lines.releaseMemory();
 		engine.releaseRenderingMemory();
 		renderingResourcesReleased = true;
-	};
-	const releaseRenderingResourcesAndDrawingBuffer = () => {
-		releaseRenderingResources();
-		if (drawingBufferReleased) {
-			return;
-		}
-
 		canvas.width = 1;
 		canvas.height = 1;
-		appliedViewportWidth = 1;
-		appliedViewportHeight = 1;
-		drawingBufferReleased = true;
 	};
 	const restoreRenderingResources = () => {
 		if (!renderingResourcesReleased) {
@@ -232,13 +218,8 @@ export default async function init(
 		}
 
 		engine.restoreRenderingMemory();
-		if (drawingBufferReleased || appliedViewportWidth !== viewportWidth || appliedViewportHeight !== viewportHeight) {
-			engine.resize(viewportWidth, viewportHeight);
-			appliedViewportWidth = viewportWidth;
-			appliedViewportHeight = viewportHeight;
-		}
+		engine.resize(viewportWidth, viewportHeight);
 		renderingResourcesReleased = false;
-		drawingBufferReleased = false;
 	};
 	const resumeRendering = () => {
 		if (rendering) {
@@ -262,8 +243,6 @@ export default async function init(
 				return false;
 			}
 			engine.resize(width, height);
-			appliedViewportWidth = width;
-			appliedViewportHeight = height;
 			return true;
 		},
 		loadSpriteAtlas: spriteData => {
@@ -287,7 +266,6 @@ export default async function init(
 		},
 		pauseRendering,
 		releaseRenderingResources,
-		releaseRenderingResourcesAndDrawingBuffer,
 		resumeRendering,
 		renderFrame: () => {
 			restoreRenderingResources();

--- a/packages/editor/packages/editor-core/src/index.test.ts
+++ b/packages/editor/packages/editor-core/src/index.test.ts
@@ -37,7 +37,6 @@ const view = {
 	loadBackgroundEffect: vi.fn(),
 	pauseRendering: vi.fn(),
 	releaseRenderingResources: vi.fn(),
-	releaseRenderingResourcesAndDrawingBuffer: vi.fn(),
 	resumeRendering: vi.fn(),
 	renderFrame: vi.fn(),
 	destroy: vi.fn(),
@@ -111,7 +110,6 @@ describe('editor init', () => {
 		view.resize.mockClear();
 		view.pauseRendering.mockClear();
 		view.releaseRenderingResources.mockClear();
-		view.releaseRenderingResourcesAndDrawingBuffer.mockClear();
 		view.resumeRendering.mockClear();
 		view.renderFrame.mockClear();
 		view.destroy.mockClear();
@@ -157,12 +155,10 @@ describe('editor init', () => {
 
 		editor.pauseRendering();
 		editor.releaseRenderingResources();
-		editor.releaseRenderingResourcesAndDrawingBuffer();
 		editor.resumeRendering();
 
 		expect(view.pauseRendering).toHaveBeenCalledOnce();
 		expect(view.releaseRenderingResources).toHaveBeenCalledOnce();
-		expect(view.releaseRenderingResourcesAndDrawingBuffer).toHaveBeenCalledOnce();
 		expect(view.resumeRendering).toHaveBeenCalledOnce();
 	});
 

--- a/packages/editor/packages/editor-core/src/index.ts
+++ b/packages/editor/packages/editor-core/src/index.ts
@@ -73,10 +73,8 @@ export { updateStateWithSpriteData } from './updateStateWithSpriteData';
 export interface Editor {
 	resize: (width: number, height: number) => void;
 	pauseRendering: () => void;
-	/** Releases reloadable GPU resources while preserving the canvas drawing buffer and its last rendered frame. */
-	releaseRenderingResources: () => void;
 	/** Releases reloadable GPU resources and the canvas drawing buffer. */
-	releaseRenderingResourcesAndDrawingBuffer: () => void;
+	releaseRenderingResources: () => void;
 	resumeRendering: () => void;
 	updateMemoryViews: (memoryRef: MemoryRef) => void;
 	getMemoryViews: () => MemoryViews;
@@ -282,7 +280,6 @@ export default async function init(canvas: HTMLCanvasElement, options: EditorOpt
 		resize,
 		pauseRendering: () => view.pauseRendering(),
 		releaseRenderingResources: () => view.releaseRenderingResources(),
-		releaseRenderingResourcesAndDrawingBuffer: () => view.releaseRenderingResourcesAndDrawingBuffer(),
 		resumeRendering: () => view.resumeRendering(),
 		updateMemoryViews: (memoryRef: MemoryRef) => {
 			currentMemoryRef = memoryRef instanceof WebAssembly.Memory ? memoryRef : null;

--- a/packages/editor/packages/editor-default/README.md
+++ b/packages/editor/packages/editor-default/README.md
@@ -20,10 +20,9 @@ editor.resumeRendering();
 editor.dispose();
 ```
 
-`releaseRenderingResources()` pauses rendering and releases reloadable GPU textures and dynamic buffer storage while
-leaving the canvas drawing buffer—and therefore its last rendered frame—intact. For the lowest offscreen memory use,
-`releaseRenderingResourcesAndDrawingBuffer()` also discards the drawing buffer. `resumeRendering()` restores either
-release level, applies the latest canvas size, and renders immediately.
+`releaseRenderingResources()` pauses rendering and releases reloadable GPU textures, dynamic buffer storage, and the
+canvas drawing buffer. `resumeRendering()` restores the resources, applies the latest canvas size, and renders
+immediately.
 
 The host controls the canvas's layout dimensions with CSS. The editor observes that rendered size and adapts its
 drawing buffer and UI automatically. Wheel input pans the editor and prevents page scrolling by default; embedded


### PR DESCRIPTION
## Summary
- collapse the two editor release levels into a single `releaseRenderingResources()` API
- always release reloadable GPU resources and the canvas drawing buffer
- simplify deferred resize/restoration state now that only the deepest release exists
- release website editor resources only after they remain offscreen for three seconds
- cancel pending releases and resume immediately when an editor becomes visible

## Rationale
The deepest release restores quickly enough that retaining a second, lower-memory-saving mode adds API and lifecycle complexity without a practical benefit. Debouncing avoids resource churn during brief scroll transitions.

## Breaking change
`releaseRenderingResourcesAndDrawingBuffer()` is removed. `releaseRenderingResources()` now also discards the canvas drawing buffer.

## Tests
- `npx nx run-many --target=test --projects=@8f4e/web-ui,@8f4e/editor-core --output-style=static`
- `npx nx run @8f4e/8f4e-website:typecheck --output-style=static`
- affected-project type checks from the pre-commit hook