### PR TITLE
fix(8f4e-website): manage offscreen editor resources

### DIFF
--- a/packages/8f4e-website/src/main.ts
+++ b/packages/8f4e-website/src/main.ts
@@ -1,27 +1,29 @@
-import { mountDefaultEditor } from '@8f4e/editor-default';
+import { type DefaultEditorInstance, mountDefaultEditor } from '@8f4e/editor-default';
 
-const canvases = document.querySelectorAll<HTMLCanvasElement>('.editor-row canvas');
+const canvases = Array.from(document.querySelectorAll<HTMLCanvasElement>('.editor-row canvas'));
 if (canvases.length === 0) {
 	throw new Error('Editor canvases not found');
 }
 
-const editorEntries = await Promise.all(
-	Array.from(canvases, async (canvas, index) => ({
-		canvas,
-		editor: await mountDefaultEditor(canvas, {
-			captureWheel: false,
-			featureFlags: { projectCreation: false, projectOpening: false },
-			initialProjectUrl: canvas.dataset.projectUrl || undefined,
-			storage: window.localStorage,
-			storageNamespace: index === 0 ? '8f4e-website' : `8f4e-website-${index + 1}`,
-		}),
-	}))
-);
-const editors = editorEntries.map(({ editor }) => editor);
-
-const editorByCanvas = new Map(editorEntries.map(({ canvas, editor }) => [canvas, editor]));
 const renderingReleaseDelayMs = 3_000;
+const editorMountRootMargin = '200px 0px';
+const editorByCanvas = new Map<HTMLCanvasElement, DefaultEditorInstance>();
+const editorMountPromiseByCanvas = new Map<HTMLCanvasElement, Promise<DefaultEditorInstance>>();
 const renderingReleaseTimeoutByCanvas = new Map<HTMLCanvasElement, number>();
+const editors: DefaultEditorInstance[] = [];
+let disposed = false;
+
+function syncEditors(): void {
+	editors.splice(
+		0,
+		editors.length,
+		...canvases.flatMap(canvas => {
+			const editor = editorByCanvas.get(canvas);
+			return editor ? [editor] : [];
+		})
+	);
+}
+
 const renderingObserver = new IntersectionObserver(entries => {
 	for (const entry of entries) {
 		const canvas = entry.target as HTMLCanvasElement;
@@ -42,15 +44,73 @@ const renderingObserver = new IntersectionObserver(entries => {
 		}
 	}
 });
-for (const canvas of canvases) {
-	renderingObserver.observe(canvas);
+
+function mountEditor(canvas: HTMLCanvasElement, index: number): Promise<DefaultEditorInstance> {
+	const pendingMount = editorMountPromiseByCanvas.get(canvas);
+	if (pendingMount) {
+		return pendingMount;
+	}
+
+	const mountPromise = mountDefaultEditor(canvas, {
+		captureWheel: false,
+		featureFlags: { projectCreation: false, projectOpening: false },
+		initialProjectUrl: canvas.dataset.projectUrl || undefined,
+		storage: window.localStorage,
+		storageNamespace: index === 0 ? '8f4e-website' : `8f4e-website-${index + 1}`,
+	})
+		.then(editor => {
+			if (disposed) {
+				editor.dispose();
+				return editor;
+			}
+
+			editorByCanvas.set(canvas, editor);
+			syncEditors();
+			renderingObserver.observe(canvas);
+			if (index === 0) {
+				Object.assign(window, { editor, state: editor.state });
+			}
+			return editor;
+		})
+		.catch(error => {
+			editorMountPromiseByCanvas.delete(canvas);
+			throw error;
+		});
+
+	editorMountPromiseByCanvas.set(canvas, mountPromise);
+	return mountPromise;
 }
 
-const [editor] = editors;
+const canvasIndex = new Map(canvases.map((canvas, index) => [canvas, index]));
+const mountingObserver = new IntersectionObserver(
+	entries => {
+		for (const entry of entries) {
+			if (!entry.isIntersecting) {
+				continue;
+			}
 
-Object.assign(window, { editor, editors, state: editor.state });
+			const canvas = entry.target as HTMLCanvasElement;
+			const index = canvasIndex.get(canvas);
+			if (index === undefined) {
+				continue;
+			}
+
+			void mountEditor(canvas, index)
+				.then(() => mountingObserver.unobserve(canvas))
+				.catch(error => console.error('Failed to mount editor:', error));
+		}
+	},
+	{ rootMargin: editorMountRootMargin }
+);
+for (const canvas of canvases) {
+	mountingObserver.observe(canvas);
+}
+
+Object.assign(window, { editors });
 
 import.meta.hot?.dispose(() => {
+	disposed = true;
+	mountingObserver.disconnect();
 	renderingObserver.disconnect();
 	for (const timeout of renderingReleaseTimeoutByCanvas.values()) {
 		window.clearTimeout(timeout);
@@ -59,4 +119,6 @@ import.meta.hot?.dispose(() => {
 	for (const editor of editors) {
 		editor.dispose();
 	}
+	editors.length = 0;
+	editorByCanvas.clear();
 });

--- a/packages/8f4e-website/src/main.ts
+++ b/packages/8f4e-website/src/main.ts
@@ -20,13 +20,25 @@ const editorEntries = await Promise.all(
 const editors = editorEntries.map(({ editor }) => editor);
 
 const editorByCanvas = new Map(editorEntries.map(({ canvas, editor }) => [canvas, editor]));
+const renderingReleaseDelayMs = 3_000;
+const renderingReleaseTimeoutByCanvas = new Map<HTMLCanvasElement, number>();
 const renderingObserver = new IntersectionObserver(entries => {
 	for (const entry of entries) {
-		const editor = editorByCanvas.get(entry.target as HTMLCanvasElement);
+		const canvas = entry.target as HTMLCanvasElement;
+		const editor = editorByCanvas.get(canvas);
+		const pendingRelease = renderingReleaseTimeoutByCanvas.get(canvas);
+		if (pendingRelease !== undefined) {
+			window.clearTimeout(pendingRelease);
+			renderingReleaseTimeoutByCanvas.delete(canvas);
+		}
 		if (entry.isIntersecting) {
 			editor?.resumeRendering();
 		} else {
-			editor?.releaseRenderingResources();
+			const timeout = window.setTimeout(() => {
+				renderingReleaseTimeoutByCanvas.delete(canvas);
+				editor?.releaseRenderingResources();
+			}, renderingReleaseDelayMs);
+			renderingReleaseTimeoutByCanvas.set(canvas, timeout);
 		}
 	}
 });
@@ -40,6 +52,10 @@ Object.assign(window, { editor, editors, state: editor.state });
 
 import.meta.hot?.dispose(() => {
 	renderingObserver.disconnect();
+	for (const timeout of renderingReleaseTimeoutByCanvas.values()) {
+		window.clearTimeout(timeout);
+	}
+	renderingReleaseTimeoutByCanvas.clear();
 	for (const editor of editors) {
 		editor.dispose();
 	}

--- a/packages/8f4e-website/src/main.ts
+++ b/packages/8f4e-website/src/main.ts
@@ -6,7 +6,6 @@ if (canvases.length === 0) {
 }
 
 const renderingReleaseDelayMs = 3_000;
-const editorMountRootMargin = '200px 0px';
 const editorByCanvas = new Map<HTMLCanvasElement, DefaultEditorInstance>();
 const editorMountPromiseByCanvas = new Map<HTMLCanvasElement, Promise<DefaultEditorInstance>>();
 const renderingReleaseTimeoutByCanvas = new Map<HTMLCanvasElement, number>();
@@ -82,26 +81,23 @@ function mountEditor(canvas: HTMLCanvasElement, index: number): Promise<DefaultE
 }
 
 const canvasIndex = new Map(canvases.map((canvas, index) => [canvas, index]));
-const mountingObserver = new IntersectionObserver(
-	entries => {
-		for (const entry of entries) {
-			if (!entry.isIntersecting) {
-				continue;
-			}
-
-			const canvas = entry.target as HTMLCanvasElement;
-			const index = canvasIndex.get(canvas);
-			if (index === undefined) {
-				continue;
-			}
-
-			void mountEditor(canvas, index)
-				.then(() => mountingObserver.unobserve(canvas))
-				.catch(error => console.error('Failed to mount editor:', error));
+const mountingObserver = new IntersectionObserver(entries => {
+	for (const entry of entries) {
+		if (!entry.isIntersecting) {
+			continue;
 		}
-	},
-	{ rootMargin: editorMountRootMargin }
-);
+
+		const canvas = entry.target as HTMLCanvasElement;
+		const index = canvasIndex.get(canvas);
+		if (index === undefined) {
+			continue;
+		}
+
+		void mountEditor(canvas, index)
+			.then(() => mountingObserver.unobserve(canvas))
+			.catch(error => console.error('Failed to mount editor:', error));
+	}
+});
 for (const canvas of canvases) {
 	mountingObserver.observe(canvas);
 }


### PR DESCRIPTION
## Summary
- lazy-mount each embedded editor only when its canvas enters the viewport
- retain mounted editors in DOM order and preserve the browser debug handles as instances become available
- wait until a mounted editor remains offscreen for three seconds before releasing rendering resources
- cancel pending releases and resume immediately when an editor becomes visible
- safely dispose editors whose asynchronous mount completes during hot reload cleanup

## Rationale
Initially offscreen editors no longer create their WebGL allocations during page startup. The release debounce avoids allocation churn during brief scroll transitions.

## Tests
- `npx nx run @8f4e/8f4e-website:typecheck --output-style=static`
- affected-project type checks from the pre-commit hook