### PR TITLE
feat!: add stack directive with known scalar values

### DIFF
--- a/packages/editor/packages/editor-core/docs/editor-directives.md
+++ b/packages/editor/packages/editor-core/docs/editor-directives.md
@@ -22,6 +22,7 @@ Examples:
 
 ```txt
 ; @watch counter
+; @debug
 ; @plot &audioBuffer lengthMemory
 ; @button &gate0 0 1
 ; @config font ibmvga8x16
@@ -141,6 +142,28 @@ These modifiers can be combined when they make sense. For example:
 ; @watch *out
 ; @watch otherModule:value
 ; @watch buffer[3]
+```
+
+### `@debug`
+
+Show the compiler's `stackAfter` analysis at a source location. A trailing directive shows the stack after the
+instruction on the same line. A standalone directive shows the stack after the preceding compiled instruction.
+
+```txt
+push 2
+push 3 ; @debug
+```
+
+The example displays `[2, 3]`. Each stack item uses its statically known integer value when one is available; otherwise,
+it displays the analyzed type: `int`, `float`, `float64`, or `ptr`. For example, a stack whose first value is unknown and
+whose second value is known to be `3` displays `[int, 3]`. An empty stack displays `[]`.
+
+The standalone form is equivalent:
+
+```txt
+push 2
+push 3
+; @debug
 ```
 
 ### `@plot`

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/debug/formatStack.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/debug/formatStack.test.ts
@@ -1,0 +1,30 @@
+import type { Stack } from '@8f4e/language-spec';
+import { describe, expect, it } from 'vitest';
+import { formatDebugStack } from './formatStack';
+
+describe('debug directive stack formatting', () => {
+	it('shows known integer values without their types', () => {
+		const stack: Stack = [
+			{ kind: 'value', valueType: 'int', knownIntegerValue: 2 },
+			{ kind: 'value', valueType: 'int', knownIntegerValue: 3 },
+		];
+
+		expect(formatDebugStack(stack)).toBe('2, 3');
+	});
+
+	it('falls back to types for values without a known number', () => {
+		const stack: Stack = [
+			{ kind: 'value', valueType: 'int' },
+			{ kind: 'value', valueType: 'int', knownIntegerValue: 3 },
+			{ kind: 'value', valueType: 'float' },
+			{ kind: 'value', valueType: 'float64' },
+			{ kind: 'address', valueType: 'int', address: {} as never },
+		];
+
+		expect(formatDebugStack(stack)).toBe('int, 3, float, float64, ptr');
+	});
+
+	it('formats an empty stack', () => {
+		expect(formatDebugStack([])).toBe('');
+	});
+});

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/debug/formatStack.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/debug/formatStack.ts
@@ -1,0 +1,14 @@
+import type { Stack, StackItem } from '@8f4e/language-spec';
+
+function formatStackItem(item: StackItem): string {
+	if (item.knownIntegerValue !== undefined) {
+		return String(item.knownIntegerValue);
+	}
+
+	return item.kind === 'address' ? 'ptr' : item.valueType;
+}
+
+/** Formats compiler stack facts for the inside of the debugger widget's brackets. */
+export function formatDebugStack(stack: Stack): string {
+	return stack.map(formatStackItem).join(', ');
+}

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/debug/plugin.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/debug/plugin.ts
@@ -1,0 +1,19 @@
+import { createDirectivePlugin } from '../utils';
+import { createDebugDirectiveWidgetContribution } from './resolve';
+
+export default createDirectivePlugin(
+	'debug',
+	(directive, draft) => {
+		if (directive.args.length > 0) {
+			return;
+		}
+
+		draft.widgets.push(
+			createDebugDirectiveWidgetContribution({
+				lineNumber: directive.rawRow,
+				isTrailing: !/^\s*;/.test(directive.sourceLine ?? ''),
+			})
+		);
+	},
+	{ allowTrailingComment: true }
+);

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/debug/resolve.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/debug/resolve.test.ts
@@ -1,0 +1,133 @@
+import type { CodeBlockGraphicData, State } from '@8f4e/editor-state-types';
+import type { CompiledStackAnalysisLine, Stack } from '@8f4e/language-spec';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+	createMockCodeBlock,
+	createMockState,
+	deriveDirectiveStateForMockCodeBlock,
+} from '~/pureHelpers/testingUtils/testUtils';
+import { runAfterGraphicDataWidthCalculation, runBeforeGraphicDataWidthCalculation } from '../registry';
+
+function createStackAnalysisLine(lineNumber: number, stackAfter: Stack): CompiledStackAnalysisLine {
+	return {
+		lineNumber,
+		instruction: 'test',
+		stackAnalysis: {
+			stackBefore: [],
+			stackAfter,
+			consumedOperands: [],
+			producedStackItems: [],
+		},
+	};
+}
+
+describe('debug directive widget resolution', () => {
+	let graphicData: CodeBlockGraphicData;
+	let state: State;
+
+	beforeEach(() => {
+		graphicData = createMockCodeBlock({
+			name: 'test-block',
+			code: ['module test-block', 'push 2', 'push 3', '; @debug', 'moduleEnd'],
+			blockType: 'module',
+			lineNumberColumnWidth: 1,
+			gaps: new Map(),
+		});
+		state = createMockState({
+			codeBlockRendering: {
+				viewport: { vGrid: 10, hGrid: 20 },
+			},
+			compiler: {
+				compiledModules: {
+					'test-block': {
+						stackAnalysis: [
+							createStackAnalysisLine(2, [
+								{ kind: 'value', valueType: 'int', knownIntegerValue: 2 },
+								{ kind: 'value', valueType: 'int', knownIntegerValue: 3 },
+							]),
+						],
+					},
+				},
+			},
+		});
+	});
+
+	function runDirectiveResolution(): void {
+		const directiveState = deriveDirectiveStateForMockCodeBlock(graphicData);
+		runBeforeGraphicDataWidthCalculation(graphicData, state, directiveState);
+		runAfterGraphicDataWidthCalculation(graphicData, state, directiveState);
+	}
+
+	it('renders known values from the preceding instruction for a standalone directive', () => {
+		runDirectiveResolution();
+
+		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'debug:3', text: '2, 3' }));
+	});
+
+	it('uses the same source line for a trailing directive', () => {
+		graphicData.code = ['module test-block', 'push 2 ; @debug', 'moduleEnd'];
+		state.compiler.compiledModules['test-block']!.stackAnalysis = [
+			createStackAnalysisLine(1, [{ kind: 'value', valueType: 'int', knownIntegerValue: 2 }]),
+		];
+
+		runDirectiveResolution();
+
+		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'debug:1', text: '2' }));
+	});
+
+	it('shows types when stack values are not statically known', () => {
+		state.compiler.compiledModules['test-block']!.stackAnalysis = [
+			createStackAnalysisLine(2, [
+				{ kind: 'value', valueType: 'int' },
+				{ kind: 'value', valueType: 'int', knownIntegerValue: 3 },
+			]),
+		];
+
+		runDirectiveResolution();
+
+		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'debug:3', text: 'int, 3' }));
+	});
+
+	it('renders an empty stack', () => {
+		state.compiler.compiledModules['test-block']!.stackAnalysis = [createStackAnalysisLine(2, [])];
+
+		runDirectiveResolution();
+
+		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'debug:3', text: '' }));
+	});
+
+	it('resolves stack analysis for function blocks', () => {
+		graphicData = createMockCodeBlock({
+			name: 'helper',
+			code: ['function helper', 'push 3', '; @debug', 'functionEnd'],
+			blockType: 'function',
+			creationIndex: 42,
+		});
+		state.compiler.compiledFunctions = {
+			helper: {
+				ast: { projectBlockId: 42 },
+				stackAnalysis: [createStackAnalysisLine(1, [{ kind: 'value', valueType: 'int', knownIntegerValue: 3 }])],
+			},
+		} as never;
+
+		runDirectiveResolution();
+
+		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'debug:2', text: '3' }));
+	});
+
+	it('does not render when no matching stack analysis is available', () => {
+		state.compiler.compiledModules['test-block']!.stackAnalysis = [];
+
+		runDirectiveResolution();
+
+		expect(graphicData.widgets.debuggers).toEqual([]);
+	});
+
+	it('ignores unsupported arguments', () => {
+		graphicData.code = ['module test-block', 'push 2', '; @debug extra', 'moduleEnd'];
+
+		runDirectiveResolution();
+
+		expect(graphicData.widgets.debuggers).toEqual([]);
+	});
+});

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/debug/resolve.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/debug/resolve.ts
@@ -1,0 +1,89 @@
+import type { DirectiveDerivedState, DirectiveWidgetContribution, State } from '@8f4e/editor-state-types';
+import type { CompiledStackAnalysisLine } from '@8f4e/language-spec';
+import gapCalculator from '~/features/code-editing/gapCalculator';
+import { getTabStopsByLine, getVisualLineWidth } from '~/features/code-editing/tabLayout';
+import getCodeBlockModuleId from '~/pureHelpers/getCodeBlockModuleId';
+import { getCompiledFunctionForCodeBlock } from '../../../utils/getCompiledFunctionForCodeBlock';
+import { formatDebugStack } from './formatStack';
+
+interface DebugDirectiveData {
+	lineNumber: number;
+	isTrailing: boolean;
+}
+
+type DirectiveWidgetResolver = NonNullable<DirectiveWidgetContribution['afterGraphicDataWidthCalculation']>;
+
+function getStackAnalysisLines(
+	graphicData: Parameters<DirectiveWidgetResolver>[0],
+	state: State
+): CompiledStackAnalysisLine[] | undefined {
+	if (graphicData.blockType === 'function') {
+		return getCompiledFunctionForCodeBlock(graphicData, state)?.stackAnalysis;
+	}
+
+	return state.compiler.compiledModules[getCodeBlockModuleId(graphicData)]?.stackAnalysis;
+}
+
+function findStackAnalysisLine(
+	lines: CompiledStackAnalysisLine[],
+	lineNumber: number,
+	isTrailing: boolean
+): CompiledStackAnalysisLine | undefined {
+	if (isTrailing) {
+		return lines.find(line => line.lineNumber === lineNumber);
+	}
+
+	let precedingLine: CompiledStackAnalysisLine | undefined;
+	for (const line of lines) {
+		if (line.lineNumber >= lineNumber) {
+			break;
+		}
+		precedingLine = line;
+	}
+	return precedingLine;
+}
+
+function resolveDebugDirectiveWidget(
+	debug: DebugDirectiveData,
+	graphicData: Parameters<DirectiveWidgetResolver>[0],
+	state: Parameters<DirectiveWidgetResolver>[1],
+	directiveState: DirectiveDerivedState
+): void {
+	const stackAnalysisLines = getStackAnalysisLines(graphicData, state);
+	if (!stackAnalysisLines) {
+		return;
+	}
+
+	const stackAnalysisLine = findStackAnalysisLine(stackAnalysisLines, debug.lineNumber, debug.isTrailing);
+	if (!stackAnalysisLine) {
+		return;
+	}
+
+	const displayRow = directiveState.displayModel.rawRowToDisplayRow[debug.lineNumber] ?? debug.lineNumber;
+	const tabStopsByLine = getTabStopsByLine(graphicData.code);
+	const visualLineWidth = getVisualLineWidth(
+		graphicData.code[debug.lineNumber] || '',
+		tabStopsByLine[debug.lineNumber] || []
+	);
+
+	graphicData.widgets.debuggers.push({
+		width: state.viewport.vGrid * 2,
+		height: state.viewport.hGrid,
+		x: state.viewport.vGrid * (3 + graphicData.lineNumberColumnWidth + visualLineWidth),
+		y: gapCalculator(displayRow, graphicData.gaps) * state.viewport.hGrid,
+		id: `debug:${debug.lineNumber}`,
+		showAddress: false,
+		showEndAddress: false,
+		bufferPointer: 0,
+		displayFormat: 'decimal',
+		text: formatDebugStack(stackAnalysisLine.stackAnalysis.stackAfter),
+	});
+}
+
+export function createDebugDirectiveWidgetContribution(debug: DebugDirectiveData): DirectiveWidgetContribution {
+	return {
+		afterGraphicDataWidthCalculation: (graphicData, state, directiveState) => {
+			resolveDebugDirectiveWidget(debug, graphicData, state, directiveState);
+		},
+	};
+}

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/registry.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/registry.test.ts
@@ -14,6 +14,7 @@ describe('directive registry', () => {
 				'; @slider &gain 0 1 0.01',
 				'; @crossfade &dry &wet',
 				'; @info foo',
+				'; @debug',
 				'; note',
 				'moduleEnd',
 			],
@@ -51,18 +52,25 @@ describe('directive registry', () => {
 				args: ['foo'],
 				sourceLine: '; @info foo',
 			},
+			{
+				name: 'debug',
+				rawRow: 6,
+				args: [],
+				sourceLine: '; @debug',
+			},
 		]);
 	});
 
 	it('parses trailing-comment directives only for plugins that allow them', () => {
 		const result = parseEditorDirectives(
-			['int foo 1 ; @watch', 'float out ; @meter', 'int bar 1 ; @plot buffer'],
+			['int foo 1 ; @watch', 'push 1 ; @debug', 'float out ; @meter', 'int bar 1 ; @plot buffer'],
 			directivePlugins
 		);
 
 		expect(result).toEqual([
 			{ name: 'watch', rawRow: 0, args: [], sourceLine: 'int foo 1 ; @watch' },
-			{ name: 'meter', rawRow: 1, args: [], sourceLine: 'float out ; @meter' },
+			{ name: 'debug', rawRow: 1, args: [], sourceLine: 'push 1 ; @debug' },
+			{ name: 'meter', rawRow: 2, args: [], sourceLine: 'float out ; @meter' },
 		]);
 	});
 

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/registry.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/registry.ts
@@ -12,6 +12,7 @@ import alwaysOnTopDirective from './alwaysOnTop/plugin';
 import barsDirective from './bars/plugin';
 import buttonDirective from './button/plugin';
 import crossfadeDirective from './crossfade/plugin';
+import debugDirective from './debug/plugin';
 import disabledDirective from './disabled/plugin';
 import favoriteDirective from './favorite/plugin';
 import groupDirective from './group/plugin';
@@ -50,6 +51,7 @@ export const directivePlugins: EditorDirectivePlugin[] = [
 	buttonDirective,
 	switchDirective,
 	watchDirective,
+	debugDirective,
 	infoDirective,
 	disabledDirective,
 	homeDirective,

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/program-compiler/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/program-compiler/effect.test.ts
@@ -154,7 +154,7 @@ describe('program compiler effect', () => {
 		});
 	});
 
-	it('disables stack analysis when code line selection is disabled', async () => {
+	it('includes stack analysis when code line selection is disabled', async () => {
 		mockState.featureFlags.codeLineSelection = false;
 		mockCompileCode.mockResolvedValue({
 			codeBuffer: new Uint8Array([0x00]),
@@ -172,82 +172,6 @@ describe('program compiler effect', () => {
 		await triggerProgrammaticCompile();
 
 		expect(mockCompileCode).toHaveBeenCalledWith(
-			expect.objectContaining({
-				modules: expect.any(Array),
-				constants: expect.any(Array),
-				functions: expect.any(Array),
-				prototypes: expect.any(Array),
-			}),
-			{
-				startingMemoryWordAddress: 0,
-				includeStackAnalysis: false,
-			}
-		);
-	});
-
-	it('includes stack analysis for @debug directives when code line selection is disabled', async () => {
-		mockState.featureFlags.codeLineSelection = false;
-		mockState.codeBlockRendering.rootCodeBlocks[0]!.code = ['function helper', 'push 1', '; @debug', 'functionEnd'];
-		mockCompileCode.mockResolvedValue({
-			codeBuffer: new Uint8Array([0x00]),
-			compiledModules: {},
-			compiledFunctions: {},
-			requiredMemoryBytes: 0,
-			allocatedMemoryBytes: 65536,
-			astCacheStats: { hits: 0, misses: 0 },
-			hasWasmInstanceBeenReset: false,
-			memoryAction: { action: 'reused' },
-			initOnlyReran: false,
-			byteCodeSize: 1,
-		});
-
-		await triggerProgrammaticCompile();
-
-		expect(mockCompileCode).toHaveBeenCalledWith(expect.any(Object), {
-			startingMemoryWordAddress: 0,
-			includeStackAnalysis: true,
-		});
-	});
-
-	it('recompiles when code line selection changes so stack analysis follows the feature flag', async () => {
-		mockCompileCode.mockResolvedValue({
-			codeBuffer: new Uint8Array([0x00]),
-			compiledModules: {},
-			compiledFunctions: {},
-			requiredMemoryBytes: 0,
-			allocatedMemoryBytes: 65536,
-			astCacheStats: { hits: 0, misses: 0 },
-			hasWasmInstanceBeenReset: false,
-			memoryAction: { action: 'reused' },
-			initOnlyReran: false,
-			byteCodeSize: 1,
-		});
-		compilerEffect(store);
-		const featureFlagChangeCall = subscribeSpy.mock.calls.find(call => call[0] === 'featureFlags.codeLineSelection');
-		expect(featureFlagChangeCall).toBeDefined();
-
-		mockState.featureFlags.codeLineSelection = false;
-		featureFlagChangeCall![1]();
-		await vi.advanceTimersByTimeAsync(500);
-
-		expect(mockCompileCode).toHaveBeenCalledWith(
-			expect.objectContaining({
-				modules: expect.any(Array),
-				constants: expect.any(Array),
-				functions: expect.any(Array),
-				prototypes: expect.any(Array),
-			}),
-			{
-				startingMemoryWordAddress: 0,
-				includeStackAnalysis: false,
-			}
-		);
-
-		mockState.featureFlags.codeLineSelection = true;
-		featureFlagChangeCall![1]();
-		await vi.advanceTimersByTimeAsync(500);
-
-		expect(mockCompileCode).toHaveBeenLastCalledWith(
 			expect.objectContaining({
 				modules: expect.any(Array),
 				constants: expect.any(Array),

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/program-compiler/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/program-compiler/effect.test.ts
@@ -185,6 +185,30 @@ describe('program compiler effect', () => {
 		);
 	});
 
+	it('includes stack analysis for @debug directives when code line selection is disabled', async () => {
+		mockState.featureFlags.codeLineSelection = false;
+		mockState.codeBlockRendering.rootCodeBlocks[0]!.code = ['function helper', 'push 1', '; @debug', 'functionEnd'];
+		mockCompileCode.mockResolvedValue({
+			codeBuffer: new Uint8Array([0x00]),
+			compiledModules: {},
+			compiledFunctions: {},
+			requiredMemoryBytes: 0,
+			allocatedMemoryBytes: 65536,
+			astCacheStats: { hits: 0, misses: 0 },
+			hasWasmInstanceBeenReset: false,
+			memoryAction: { action: 'reused' },
+			initOnlyReran: false,
+			byteCodeSize: 1,
+		});
+
+		await triggerProgrammaticCompile();
+
+		expect(mockCompileCode).toHaveBeenCalledWith(expect.any(Object), {
+			startingMemoryWordAddress: 0,
+			includeStackAnalysis: true,
+		});
+	});
+
 	it('recompiles when code line selection changes so stack analysis follows the feature flag', async () => {
 		mockCompileCode.mockResolvedValue({
 			codeBuffer: new Uint8Array([0x00]),

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/program-compiler/effect.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/program-compiler/effect.ts
@@ -1,23 +1,14 @@
-import type { CodeBlockGraphicData, InfoRecord, State } from '@8f4e/editor-state-types';
+import type { InfoRecord, State } from '@8f4e/editor-state-types';
 import type { CompilerDiagnostic } from '@8f4e/language-spec';
 import { documentBlockInstructionByType, WASM_MEMORY_PAGE_SIZE } from '@8f4e/language-spec';
 import type { StateManager } from '@8f4e/state-manager';
 import { isCompilableBlockType } from '@8f4e/tokenizer';
 import debounceTrailing from '../../pureHelpers/debounceTrailing';
-import { parseBlockDirectives } from '../code-blocks/utils/parseBlockDirectives';
 import { log } from '../logger/logger';
 import convertGraphicDataToProjectStructure from '../project-export/serializeCodeBlocks';
 import { DEFAULT_RECOMPILE_DEBOUNCE_DELAY, registerRecompileDebounceDelayEditorConfigValidator } from './editorConfig';
 
 const includesBlockType = documentBlockInstructionByType.includes.type;
-
-function hasDebugDirective(codeBlocks: CodeBlockGraphicData[]): boolean {
-	return codeBlocks.some(
-		codeBlock =>
-			parseBlockDirectives(codeBlock.code).some(directive => directive.name === 'debug') ||
-			(codeBlock.nestedProjectCodeBlocks !== undefined && hasDebugDirective(codeBlock.nestedProjectCodeBlocks))
-	);
-}
 
 export default function compiler(store: StateManager<State>): () => void {
 	const state = store.getState();
@@ -56,8 +47,7 @@ export default function compiler(store: StateManager<State>): () => void {
 
 			const compilerOptions = {
 				startingMemoryWordAddress: 0,
-				includeStackAnalysis:
-					state.featureFlags.codeLineSelection || hasDebugDirective(state.codeBlockRendering.rootCodeBlocks),
+				includeStackAnalysis: true,
 			};
 			const project = convertGraphicDataToProjectStructure(state.codeBlockRendering.rootCodeBlocks);
 			const result = await state.callbacks.compileCode(project, {
@@ -163,13 +153,11 @@ export default function compiler(store: StateManager<State>): () => void {
 
 	store.subscribe('codeBlockRendering.selectedCodeBlock.code', onSelectedCodeChanged);
 	store.subscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', onProgrammaticCodeChanged);
-	store.subscribe('featureFlags.codeLineSelection', scheduleRecompile);
 
 	return () => {
 		disposed = true;
 		scheduleRecompile.cancel();
 		store.unsubscribe('codeBlockRendering.selectedCodeBlock.code', onSelectedCodeChanged);
 		store.unsubscribe('codeBlockRendering.selectedCodeBlockForProgrammaticEdit.code', onProgrammaticCodeChanged);
-		store.unsubscribe('featureFlags.codeLineSelection', scheduleRecompile);
 	};
 }

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/program-compiler/effect.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/program-compiler/effect.ts
@@ -1,14 +1,23 @@
-import type { InfoRecord, State } from '@8f4e/editor-state-types';
+import type { CodeBlockGraphicData, InfoRecord, State } from '@8f4e/editor-state-types';
 import type { CompilerDiagnostic } from '@8f4e/language-spec';
 import { documentBlockInstructionByType, WASM_MEMORY_PAGE_SIZE } from '@8f4e/language-spec';
 import type { StateManager } from '@8f4e/state-manager';
 import { isCompilableBlockType } from '@8f4e/tokenizer';
 import debounceTrailing from '../../pureHelpers/debounceTrailing';
+import { parseBlockDirectives } from '../code-blocks/utils/parseBlockDirectives';
 import { log } from '../logger/logger';
 import convertGraphicDataToProjectStructure from '../project-export/serializeCodeBlocks';
 import { DEFAULT_RECOMPILE_DEBOUNCE_DELAY, registerRecompileDebounceDelayEditorConfigValidator } from './editorConfig';
 
 const includesBlockType = documentBlockInstructionByType.includes.type;
+
+function hasDebugDirective(codeBlocks: CodeBlockGraphicData[]): boolean {
+	return codeBlocks.some(
+		codeBlock =>
+			parseBlockDirectives(codeBlock.code).some(directive => directive.name === 'debug') ||
+			(codeBlock.nestedProjectCodeBlocks !== undefined && hasDebugDirective(codeBlock.nestedProjectCodeBlocks))
+	);
+}
 
 export default function compiler(store: StateManager<State>): () => void {
 	const state = store.getState();
@@ -47,7 +56,8 @@ export default function compiler(store: StateManager<State>): () => void {
 
 			const compilerOptions = {
 				startingMemoryWordAddress: 0,
-				includeStackAnalysis: state.featureFlags.codeLineSelection,
+				includeStackAnalysis:
+					state.featureFlags.codeLineSelection || hasDebugDirective(state.codeBlockRendering.rootCodeBlocks),
 			};
 			const project = convertGraphicDataToProjectStructure(state.codeBlockRendering.rootCodeBlocks);
 			const result = await state.callbacks.compileCode(project, {

--- a/packages/editor/packages/editor-core/packages/web-ui/src/drawers/codeBlocks/widgets/debuggers.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/drawers/codeBlocks/widgets/debuggers.test.ts
@@ -1,0 +1,48 @@
+import { createMockCodeBlock, createMockState } from '@8f4e/editor-state-testing';
+import { describe, expect, it, type vi } from 'vitest';
+import { createDrawContextMock, createSpriteIdLookupMock } from '../../../__tests__/rendering';
+import type { MemoryViews } from '../../../types';
+import drawDebuggers from './debuggers';
+
+function createMemoryViews(): MemoryViews {
+	return {
+		int8: new Int8Array(4),
+		int16: new Int16Array(2),
+		int32: new Int32Array(1),
+		uint8: new Uint8Array(4),
+		uint16: new Uint16Array(2),
+		float32: new Float32Array(1),
+		float64: new Float64Array(0),
+	};
+}
+
+describe('drawDebuggers', () => {
+	it('adds one pair of brackets around compiler stack text', () => {
+		const engine = createDrawContextMock();
+		const state = createMockState({
+			viewport: { vGrid: 8, hGrid: 16 },
+			spriteLookups: {
+				fontCode: createSpriteIdLookupMock(),
+				fontNumbers: createSpriteIdLookupMock(),
+			} as never,
+		});
+		const codeBlock = createMockCodeBlock({
+			widgets: {
+				debuggers: [
+					{
+						x: 5,
+						y: 7,
+						text: '2, 3',
+					},
+				],
+			} as never,
+		});
+
+		drawDebuggers(engine, state, codeBlock, createMemoryViews());
+
+		const drawText = (engine as unknown as { drawText: ReturnType<typeof vi.fn> }).drawText;
+		expect(drawText).toHaveBeenNthCalledWith(1, 5, 7, '[', state.spriteLookups?.fontCode);
+		expect(drawText).toHaveBeenNthCalledWith(2, 13, 7, '2, 3', state.spriteLookups?.fontNumbers);
+		expect(drawText).toHaveBeenNthCalledWith(3, 45, 7, ']', state.spriteLookups?.fontCode);
+	});
+});


### PR DESCRIPTION
## Summary

- add an `@stack` editor directive that renders compiler `stackAfter` analysis beside source code
- add `@s` as a shorthand alias for `@stack`
- generalize `StackItem.knownIntegerValue` to `StackItem.knownValue`
- retain known values for integer, `float`, and `float64` literal and resolved-constant pushes
- round `float` values with `Math.fround` so displayed analysis matches WebAssembly `f32` precision
- show known scalar values directly and fall back to `int`, `float`, `float64`, or `ptr`
- support trailing directives on the same instruction and standalone directives after an instruction
- always request the compiler stack-analysis metadata used by line selection and `@stack`

## Rationale

This exposes the compiler's existing stack facts without adding runtime instrumentation or hidden memory writes. It reuses the existing debugger text widget and preserves normal compiled program behavior. Stack analysis is already enabled for the normal editor configuration, so keeping it unconditional avoids directive scanning and an unnecessary feature-flag recompilation path.

Generalizing the known-value field also lets both the existing tooltip and `@stack` display resolved floating-point constants instead of falling back to their types.

## Breaking change

`StackItem.knownIntegerValue` is replaced by `StackItem.knownValue`.

## Test notes

- affected Nx test matrix passed for language-spec (88), semantic-utils (21), stack-analyzer (23), wasm-codegen (233), compiler (241), and editor-state (1,112)
- compiler integration coverage verifies resolved `float` and `float64` constants
- editor coverage verifies floating-point tooltip and `@stack` formatting
- `npx nx run @8f4e/web-ui:test -- --run src/drawers/codeBlocks/widgets/debuggers.test.ts` — 56 tests passed
- pre-commit affected typechecks and Biome checks passed

## UI verification

The renderer test verifies a single bracket pair, so stack content `2, 3` is displayed as `[2, 3]`.
