### PR TITLE
feat!: rename stack directive and support known scalar values

### DIFF
--- a/docs/todos/398-add-compiler-peephole-arithmetic-strength-reduction.md
+++ b/docs/todos/398-add-compiler-peephole-arithmetic-strength-reduction.md
@@ -15,7 +15,7 @@ completed: null
 The compiler now has compile-time folding and stack-level integer metadata, but runtime arithmetic codegen still emits direct WebAssembly arithmetic operations even when the top stack operands prove a cheaper equivalent.
 
 - Compile-time expressions such as `16*2`, `SIZE/2`, and `sizeof(samples)*4` are already folded during semantic normalization.
-- `StackItem.knownIntegerValue` already tracks exact integer values when the compiler can prove them.
+- `StackItem.knownValue` already tracks exact scalar values when the compiler can prove them.
 - Integer arithmetic compilers preserve known values in stack metadata.
 - The generated runtime bytecode is not reduced: `mul.ts` still emits `I32_MUL`, and `div.ts` still emits `I32_DIV_S`.
 

--- a/docs/todos/425-split-stack-item-value-and-address.md
+++ b/docs/todos/425-split-stack-item-value-and-address.md
@@ -17,7 +17,7 @@ completed: null
 - numeric value type facts (`isInteger`, `isFloat64`)
 - optional address metadata (`address`)
 - optional pointee metadata (`pointeeBaseType`, `isPointingToPointer`, pointee memory fields)
-- optional numeric facts (`isNonZero`, `knownIntegerValue`)
+- optional numeric facts (`isNonZero`, `knownValue`)
 
 That makes the compiler rely on optional chaining in places where a previous phase already knows what kind of stack item it has. For example, memory access code repeatedly falls back with `address.address?.memoryIndex ?? 0` even though memory operations should consume an address-shaped stack item after stack analysis.
 
@@ -39,7 +39,7 @@ export interface StackValue {
 	kind: 'value';
 	valueType: 'int' | 'float' | 'float64';
 	isNonZero?: boolean;
-	knownIntegerValue?: number;
+	knownValue?: number;
 }
 
 export interface StackAddress {
@@ -48,7 +48,7 @@ export interface StackAddress {
 	address: AddressMetadata;
 	pointsTo?: PointeeMetadata;
 	isNonZero?: boolean;
-	knownIntegerValue?: number;
+	knownValue?: number;
 }
 ```
 

--- a/packages/compiler/packages/language-spec/src/semantic.ts
+++ b/packages/compiler/packages/language-spec/src/semantic.ts
@@ -234,8 +234,8 @@ export interface StackValue {
 	valueType: StackValueType;
 	/** A flag for the div operation to check if the divisor is zero. */
 	isNonZero?: boolean;
-	/** Exact integer value when the compiler can still prove it at this stack position. */
-	knownIntegerValue?: number;
+	/** Exact scalar value when the compiler can still prove it at this stack position. */
+	knownValue?: number;
 }
 
 /** Type and value facts known about one value that is proven to be a memory address. */
@@ -246,8 +246,8 @@ export interface StackAddress {
 	pointsTo?: PointeeMetadata;
 	/** A flag for the div operation to check if the divisor is zero. */
 	isNonZero?: boolean;
-	/** Exact integer value when the compiler can still prove it at this stack position. */
-	knownIntegerValue?: number;
+	/** Exact integer address when the compiler can still prove it at this stack position. */
+	knownValue?: number;
 }
 
 /** Type and value facts known about one item on the compiler analysis stack. */

--- a/packages/compiler/packages/sub-program/packages/semantic-utils/src/addressClamp.ts
+++ b/packages/compiler/packages/sub-program/packages/semantic-utils/src/addressClamp.ts
@@ -59,9 +59,9 @@ export function getClampedAddressStackItem(
 	const memoryIndex = range?.memoryIndex ?? (operand.kind === 'address' ? operand.address.memoryIndex : 0);
 	const memoryRegionName =
 		range?.memoryRegionName ?? (operand.kind === 'address' ? operand.address.memoryRegionName : undefined);
-	const knownIntegerValue = range
+	const knownValue = range
 		? clampKnownIntegerValue(
-				operand.knownIntegerValue,
+				operand.knownValue,
 				range.byteAddress,
 				range.byteAddress + Math.max(0, range.safeByteLength - accessByteWidth)
 			)
@@ -70,8 +70,8 @@ export function getClampedAddressStackItem(
 	return {
 		kind: 'address',
 		valueType: 'int',
-		isNonZero: knownIntegerValue !== undefined ? knownIntegerValue !== 0 : false,
-		...(knownIntegerValue !== undefined ? { knownIntegerValue } : {}),
+		isNonZero: knownValue !== undefined ? knownValue !== 0 : false,
+		...(knownValue !== undefined ? { knownValue } : {}),
 		...(operand.kind === 'address' && operand.pointsTo ? { pointsTo: { ...operand.pointsTo } } : {}),
 		address: {
 			...getMemoryRegionFields(memoryIndex, memoryRegionName),

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/analyzeInstruction.test.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/analyzeInstruction.test.ts
@@ -111,9 +111,33 @@ describe('analyzeInstruction', () => {
 		const facts = analyzeInstruction(line, context);
 
 		expect(facts.stackAnalysis.producedStackItems).toEqual([
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 7 },
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 7 },
 		]);
-		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 7 }]);
+		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 7 }]);
+	});
+
+	it('records float32 and float64 push values at their runtime precision', () => {
+		const context = createStackAnalyzerTestContext();
+		const float32Line = {
+			lineNumber: 1,
+			instruction: 'push',
+			arguments: [{ type: ArgumentType.LITERAL, value: Math.PI, isInteger: false }],
+		} as CompilerASTLine;
+		const float64Line = {
+			lineNumber: 2,
+			instruction: 'push',
+			arguments: [{ type: ArgumentType.LITERAL, value: Math.PI, isInteger: false, isFloat64: true }],
+		} as CompilerASTLine;
+
+		const float32Facts = analyzeInstruction(float32Line, context);
+		const float64Facts = analyzeInstruction(float64Line, context);
+
+		expect(float32Facts.stackAnalysis.producedStackItems).toEqual([
+			{ kind: 'value', valueType: 'float', isNonZero: true, knownValue: Math.fround(Math.PI) },
+		]);
+		expect(float64Facts.stackAnalysis.producedStackItems).toEqual([
+			{ kind: 'value', valueType: 'float64', isNonZero: true, knownValue: Math.PI },
+		]);
 	});
 
 	it('records map input and output kinds', () => {

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/abs.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/abs.ts
@@ -13,23 +13,23 @@ export function analyzeAbs(_line: CompilerASTLine, context: CompilationContext):
 	const consumed = consume(context, 1);
 	const operand = consumed[0];
 	const knownAbsValue =
-		operand.knownIntegerValue === undefined
+		operand.knownValue === undefined
 			? undefined
-			: operand.knownIntegerValue < 0
-				? (0 - operand.knownIntegerValue) | 0
-				: operand.knownIntegerValue;
+			: operand.knownValue < 0
+				? (0 - operand.knownValue) | 0
+				: operand.knownValue;
 	const knownIntegerMetadata =
 		knownAbsValue === undefined
 			? {}
 			: {
-					knownIntegerValue: knownAbsValue,
+					knownValue: knownAbsValue,
 					isNonZero: knownAbsValue !== 0,
 				};
 	const produced: Stack = [
 		operand.valueType === 'int'
 			? createStackValue('int', {
 					isNonZero: operand.isNonZero,
-					knownIntegerValue: knownIntegerMetadata.knownIntegerValue,
+					knownValue: knownIntegerMetadata.knownValue,
 				})
 			: createStackValue(operand.valueType === 'float64' ? 'float64' : 'float', { isNonZero: operand.isNonZero }),
 	];

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/and.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/and.ts
@@ -14,7 +14,7 @@ import { knownIntegerResult } from './shared';
 export function analyzeAnd(_line: CompilerASTLine, context: CompilationContext): InstructionAnalysisResult {
 	const consumed = consume(context, 2);
 	const integerMetadata = deriveKnownIntegerValue(consumed[0], consumed[1], (value1, value2) => value1 & value2);
-	const produced = [knownIntegerResult(integerMetadata.knownIntegerValue)];
+	const produced = [knownIntegerResult(integerMetadata.knownValue)];
 	produce(context, produced);
 	return { consumed, produced };
 }

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/or.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/or.ts
@@ -15,7 +15,7 @@ export function analyzeOr(_line: CompilerASTLine, context: CompilationContext): 
 	const consumed = consume(context, 2);
 	const integerMetadata = deriveKnownIntegerValue(consumed[0], consumed[1], (value1, value2) => value1 | value2);
 	const produced = [
-		knownIntegerResult(integerMetadata.knownIntegerValue, Boolean(consumed[0].isNonZero || consumed[1].isNonZero)),
+		knownIntegerResult(integerMetadata.knownValue, Boolean(consumed[0].isNonZero || consumed[1].isNonZero)),
 	];
 	produce(context, produced);
 	return { consumed, produced };

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/remainder.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/remainder.ts
@@ -27,7 +27,7 @@ export function analyzeRemainder(line: CompilerASTLine, context: CompilationCont
 
 		return (dividend % divisorValue) | 0;
 	});
-	const produced = [knownIntegerResult(integerMetadata.knownIntegerValue)];
+	const produced = [knownIntegerResult(integerMetadata.knownValue)];
 	produce(context, produced);
 	return { consumed, produced };
 }

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/shared.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/shared.ts
@@ -40,31 +40,31 @@ export function numericResult(
 			valueType: 'int',
 			address: integerMetadata.address,
 			...(integerMetadata.pointsTo ? { pointsTo: integerMetadata.pointsTo } : {}),
-			...(integerMetadata.knownIntegerValue !== undefined
+			...(integerMetadata.knownValue !== undefined
 				? {
-						knownIntegerValue: integerMetadata.knownIntegerValue,
-						isNonZero: integerMetadata.knownIntegerValue !== 0,
+						knownValue: integerMetadata.knownValue,
+						isNonZero: integerMetadata.knownValue !== 0,
 					}
 				: {}),
 		};
 	}
 
 	return createStackValue(valueType, {
-		isNonZero: integerMetadata.knownIntegerValue !== undefined ? integerMetadata.knownIntegerValue !== 0 : false,
-		knownIntegerValue: integerMetadata.knownIntegerValue,
+		isNonZero: integerMetadata.knownValue !== undefined ? integerMetadata.knownValue !== 0 : false,
+		knownValue: integerMetadata.knownValue,
 	});
 }
 
 /**
  * Builds an integer stack item from optional known integer metadata.
  *
- * @param knownIntegerValue - Known integer value to attach to the stack item.
+ * @param knownValue - Known integer value to attach to the stack item.
  * @param isNonZero - Whether the known integer value is known to be non-zero.
  * @returns The computed result.
  */
-export function knownIntegerResult(knownIntegerValue: number | undefined, isNonZero = false): StackItem {
+export function knownIntegerResult(knownValue: number | undefined, isNonZero = false): StackItem {
 	return createStackValue('int', {
-		isNonZero: knownIntegerValue !== undefined ? knownIntegerValue !== 0 : isNonZero,
-		knownIntegerValue,
+		isNonZero: knownValue !== undefined ? knownValue !== 0 : isNonZero,
+		knownValue,
 	});
 }

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/shiftLeft.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/shiftLeft.ts
@@ -18,7 +18,7 @@ export function analyzeShiftLeft(_line: CompilerASTLine, context: CompilationCon
 		consumed[1],
 		(value, shift) => (value << (shift & 31)) | 0
 	);
-	const produced = [knownIntegerResult(integerMetadata.knownIntegerValue)];
+	const produced = [knownIntegerResult(integerMetadata.knownValue)];
 	produce(context, produced);
 	return { consumed, produced };
 }

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/shiftRight.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/shiftRight.ts
@@ -14,7 +14,7 @@ import { knownIntegerResult } from './shared';
 export function analyzeShiftRight(_line: CompilerASTLine, context: CompilationContext): InstructionAnalysisResult {
 	const consumed = consume(context, 2);
 	const integerMetadata = deriveKnownIntegerValue(consumed[0], consumed[1], (value, shift) => value >> (shift & 31));
-	const produced = [knownIntegerResult(integerMetadata.knownIntegerValue)];
+	const produced = [knownIntegerResult(integerMetadata.knownValue)];
 	produce(context, produced);
 	return { consumed, produced };
 }

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/shiftRightUnsigned.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/shiftRightUnsigned.ts
@@ -17,7 +17,7 @@ export function analyzeShiftRightUnsigned(
 ): InstructionAnalysisResult {
 	const consumed = consume(context, 2);
 	const integerMetadata = deriveKnownIntegerValue(consumed[0], consumed[1], (value, shift) => value >>> (shift & 31));
-	const produced = [knownIntegerResult(integerMetadata.knownIntegerValue)];
+	const produced = [knownIntegerResult(integerMetadata.knownValue)];
 	produce(context, produced);
 	return { consumed, produced };
 }

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/xor.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/xor.ts
@@ -14,7 +14,7 @@ import { knownIntegerResult } from './shared';
 export function analyzeXor(_line: CompilerASTLine, context: CompilationContext): InstructionAnalysisResult {
 	const consumed = consume(context, 2);
 	const integerMetadata = deriveKnownIntegerValue(consumed[0], consumed[1], (value1, value2) => value1 ^ value2);
-	const produced = [knownIntegerResult(integerMetadata.knownIntegerValue)];
+	const produced = [knownIntegerResult(integerMetadata.knownValue)];
 	produce(context, produced);
 	return { consumed, produced };
 }

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/push.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/push.ts
@@ -63,6 +63,7 @@ function pushLiteralStackItems(line: SemanticPushLine, context: CompilationConte
 	}
 
 	const kind = resolveArgumentValueKind(argument);
+	const knownValue = kind === 'float32' ? Math.fround(argument.value) : argument.value;
 	const address = argument.address
 		? {
 				...argument.address,
@@ -72,8 +73,8 @@ function pushLiteralStackItems(line: SemanticPushLine, context: CompilationConte
 
 	return [
 		kindToStackItem(kind, {
-			isNonZero: argument.value !== 0,
-			...(argument.isInteger && Number.isInteger(argument.value) ? { knownIntegerValue: argument.value } : {}),
+			isNonZero: knownValue !== 0,
+			knownValue,
 			...(address ? { address, pointsTo: getAddressPointeeMetadata(context, address) } : {}),
 		}),
 	];

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/stack.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/stack.ts
@@ -9,13 +9,13 @@ import type { CompilationContext, Stack, StackItem, StackValueType } from '@8f4e
  */
 export function createStackValue(
 	valueType: StackValueType,
-	metadata: Pick<StackItem, 'isNonZero' | 'knownIntegerValue'> = {}
+	metadata: Pick<StackItem, 'isNonZero' | 'knownValue'> = {}
 ): StackItem {
 	return {
 		kind: 'value',
 		valueType,
 		...(metadata.isNonZero !== undefined ? { isNonZero: metadata.isNonZero } : {}),
-		...(metadata.knownIntegerValue !== undefined ? { knownIntegerValue: metadata.knownIntegerValue } : {}),
+		...(metadata.knownValue !== undefined ? { knownValue: metadata.knownValue } : {}),
 	};
 }
 

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/utils/knownIntegerValue.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/utils/knownIntegerValue.ts
@@ -13,18 +13,18 @@ export function deriveKnownIntegerValue(
 	operand2: StackItem,
 	operation: (operand1: number, operand2: number) => number | undefined
 ): Partial<StackItem> {
-	if (operand1.knownIntegerValue === undefined || operand2.knownIntegerValue === undefined) {
+	if (operand1.knownValue === undefined || operand2.knownValue === undefined) {
 		return {};
 	}
 
-	const knownIntegerValue = operation(operand1.knownIntegerValue, operand2.knownIntegerValue);
+	const knownValue = operation(operand1.knownValue, operand2.knownValue);
 
-	if (knownIntegerValue === undefined) {
+	if (knownValue === undefined) {
 		return {};
 	}
 
 	return {
-		knownIntegerValue,
-		isNonZero: knownIntegerValue !== 0,
+		knownValue,
+		isNonZero: knownValue !== 0,
 	};
 }

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/utils/pushValueKind.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/utils/pushValueKind.ts
@@ -13,7 +13,7 @@ export function resolveArgumentValueKind(argument: { isInteger: boolean; isFloat
 	return argument.isInteger ? 'int32' : 'float32';
 }
 
-type StackItemExtras = Pick<StackItem, 'isNonZero' | 'knownIntegerValue'> &
+type StackItemExtras = Pick<StackItem, 'isNonZero' | 'knownValue'> &
 	Partial<Pick<Extract<StackItem, { kind: 'address' }>, 'address' | 'pointsTo'>>;
 
 export function kindToStackItem(kind: PushValueKind, extras?: StackItemExtras): StackItem {
@@ -24,7 +24,7 @@ export function kindToStackItem(kind: PushValueKind, extras?: StackItemExtras): 
 			address: extras.address,
 			...(extras.pointsTo ? { pointsTo: extras.pointsTo } : {}),
 			...(extras.isNonZero !== undefined ? { isNonZero: extras.isNonZero } : {}),
-			...(extras.knownIntegerValue !== undefined ? { knownIntegerValue: extras.knownIntegerValue } : {}),
+			...(extras.knownValue !== undefined ? { knownValue: extras.knownValue } : {}),
 		};
 	}
 
@@ -32,6 +32,6 @@ export function kindToStackItem(kind: PushValueKind, extras?: StackItemExtras): 
 		kind: 'value',
 		valueType: kind === 'int32' ? 'int' : kind === 'float64' ? 'float64' : 'float',
 		...(extras?.isNonZero !== undefined ? { isNonZero: extras.isNonZero } : {}),
-		...(extras?.knownIntegerValue !== undefined ? { knownIntegerValue: extras.knownIntegerValue } : {}),
+		...(extras?.knownValue !== undefined ? { knownValue: extras.knownValue } : {}),
 	};
 }

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/utils/stackAddressMetadata.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/utils/stackAddressMetadata.ts
@@ -22,15 +22,15 @@ function shiftSafeRange(safeRange: MemoryAddressRange, byteOffset: number): Memo
  * @returns The computed result.
  */
 export function deriveAddStackMetadata(operand1: StackItem, operand2: StackItem): Partial<StackItem> {
-	const knownIntegerValue =
-		operand1.knownIntegerValue !== undefined && operand2.knownIntegerValue !== undefined
-			? operand1.knownIntegerValue + operand2.knownIntegerValue
+	const knownValue =
+		operand1.knownValue !== undefined && operand2.knownValue !== undefined
+			? operand1.knownValue + operand2.knownValue
 			: undefined;
 	const safeRange =
-		operand1.kind === 'address' && operand1.address.safeRange && operand2.knownIntegerValue !== undefined
-			? shiftSafeRange(operand1.address.safeRange, operand2.knownIntegerValue)
-			: operand2.kind === 'address' && operand2.address.safeRange && operand1.knownIntegerValue !== undefined
-				? shiftSafeRange(operand2.address.safeRange, operand1.knownIntegerValue)
+		operand1.kind === 'address' && operand1.address.safeRange && operand2.knownValue !== undefined
+			? shiftSafeRange(operand1.address.safeRange, operand2.knownValue)
+			: operand2.kind === 'address' && operand2.address.safeRange && operand1.knownValue !== undefined
+				? shiftSafeRange(operand2.address.safeRange, operand1.knownValue)
 				: undefined;
 	const clampRange =
 		(operand1.kind === 'address' ? (operand1.address.clampRange ?? operand1.address.safeRange) : undefined) ??
@@ -43,7 +43,7 @@ export function deriveAddStackMetadata(operand1: StackItem, operand2: StackItem)
 				: undefined;
 
 	return {
-		...(knownIntegerValue !== undefined ? { knownIntegerValue } : {}),
+		...(knownValue !== undefined ? { knownValue } : {}),
 		...(safeRange || clampRange
 			? {
 					kind: 'address',
@@ -70,20 +70,20 @@ export function deriveAddStackMetadata(operand1: StackItem, operand2: StackItem)
  * @returns The computed result.
  */
 export function deriveSubStackMetadata(operand1: StackItem, operand2: StackItem): Partial<StackItem> {
-	const knownIntegerValue =
-		operand1.knownIntegerValue !== undefined && operand2.knownIntegerValue !== undefined
-			? operand1.knownIntegerValue - operand2.knownIntegerValue
+	const knownValue =
+		operand1.knownValue !== undefined && operand2.knownValue !== undefined
+			? operand1.knownValue - operand2.knownValue
 			: undefined;
 	const safeRange =
-		operand1.kind === 'address' && operand1.address.safeRange && operand2.knownIntegerValue !== undefined
-			? shiftSafeRange(operand1.address.safeRange, -operand2.knownIntegerValue)
+		operand1.kind === 'address' && operand1.address.safeRange && operand2.knownValue !== undefined
+			? shiftSafeRange(operand1.address.safeRange, -operand2.knownValue)
 			: undefined;
 	const clampRange =
 		operand1.kind === 'address' ? (operand1.address.clampRange ?? operand1.address.safeRange) : undefined;
 	const pointsTo = operand1.kind === 'address' ? operand1.pointsTo : undefined;
 
 	return {
-		...(knownIntegerValue !== undefined ? { knownIntegerValue } : {}),
+		...(knownValue !== undefined ? { knownValue } : {}),
 		...(safeRange || clampRange
 			? {
 					kind: 'address',

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/tests/__snapshots__/analyzeStack.integration.test.ts.snap
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/tests/__snapshots__/analyzeStack.integration.test.ts.snap
@@ -67,7 +67,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 1,
+                "knownValue": 1,
                 "valueType": "int",
               },
             ],
@@ -80,7 +80,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 1,
+                "knownValue": 1,
                 "valueType": "int",
               },
             ],
@@ -105,7 +105,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 1,
+                "knownValue": 1,
                 "valueType": "int",
               },
             ],
@@ -132,7 +132,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 1,
+                "knownValue": 1,
                 "valueType": "int",
               },
             ],
@@ -282,7 +282,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 1,
+                "knownValue": 1,
                 "valueType": "int",
               },
             ],
@@ -295,7 +295,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 1,
+                "knownValue": 1,
                 "valueType": "int",
               },
             ],
@@ -321,7 +321,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 1,
+                "knownValue": 1,
                 "valueType": "int",
               },
             ],
@@ -348,7 +348,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 1,
+                "knownValue": 1,
                 "valueType": "int",
               },
             ],
@@ -456,7 +456,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -489,7 +489,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -539,7 +539,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -565,7 +565,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -591,7 +591,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -624,7 +624,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -654,7 +654,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -682,7 +682,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -701,7 +701,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 5,
+                "knownValue": 5,
                 "valueType": "int",
               },
             ],
@@ -709,7 +709,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 5,
+                "knownValue": 5,
                 "valueType": "int",
               },
             ],
@@ -722,7 +722,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 5,
+                "knownValue": 5,
                 "valueType": "int",
               },
             ],
@@ -742,7 +742,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 5,
+                "knownValue": 5,
                 "valueType": "int",
               },
             ],
@@ -798,7 +798,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -831,7 +831,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -871,7 +871,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -897,7 +897,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -923,7 +923,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -956,7 +956,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -988,7 +988,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -1016,7 +1016,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
                 },
                 "isNonZero": true,
                 "kind": "address",
-                "knownIntegerValue": 4,
+                "knownValue": 4,
                 "pointsTo": {
                   "baseType": "int",
                   "elementCount": 4,
@@ -1037,7 +1037,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 5,
+                "knownValue": 5,
                 "valueType": "int",
               },
             ],
@@ -1045,7 +1045,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 5,
+                "knownValue": 5,
                 "valueType": "int",
               },
             ],
@@ -1060,7 +1060,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 5,
+                "knownValue": 5,
                 "valueType": "int",
               },
             ],
@@ -1080,7 +1080,7 @@ exports[`analyzeStack integration > analyzes a sub-program-level module and func
               {
                 "isNonZero": true,
                 "kind": "value",
-                "knownIntegerValue": 5,
+                "knownValue": 5,
                 "valueType": "int",
               },
             ],

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/__snapshots__/push.test.ts.snap
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/__snapshots__/push.test.ts.snap
@@ -52,7 +52,7 @@ exports[`push instruction compiler > pushes a literal value 1`] = `
     {
       "isNonZero": true,
       "kind": "value",
-      "knownIntegerValue": 5,
+      "knownValue": 5,
       "valueType": "int",
     },
   ],
@@ -92,7 +92,7 @@ exports[`push instruction compiler > pushes a resolved literal value 1`] = `
     {
       "isNonZero": true,
       "kind": "value",
-      "knownIntegerValue": 42,
+      "knownValue": 42,
       "valueType": "int",
     },
   ],

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/add.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/add.test.ts
@@ -81,12 +81,12 @@ describe('add instruction compiler', () => {
 				kind: 'address',
 				valueType: 'int',
 				isNonZero: false,
-				knownIntegerValue: 0,
+				knownValue: 0,
 				address: {
 					safeRange: { source: 'memory-start', memoryIndex: 0, byteAddress: 0, safeByteLength: 128, memoryId: 'arr' },
 				},
 			},
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 4 }
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 4 }
 		);
 
 		analyzeAndCompileInstruction(
@@ -104,7 +104,7 @@ describe('add instruction compiler', () => {
 				kind: 'address',
 				valueType: 'int',
 				isNonZero: true,
-				knownIntegerValue: 4,
+				knownValue: 4,
 				address: {
 					memoryIndex: 0,
 					safeRange: { source: 'memory-start', memoryIndex: 0, byteAddress: 4, safeByteLength: 124, memoryId: 'arr' },
@@ -121,12 +121,12 @@ describe('add instruction compiler', () => {
 				kind: 'address',
 				valueType: 'int',
 				isNonZero: false,
-				knownIntegerValue: 0,
+				knownValue: 0,
 				address: {
 					safeRange: { source: 'memory-start', memoryIndex: 0, byteAddress: 0, safeByteLength: 128, memoryId: 'arr' },
 				},
 			},
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 1024 }
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 1024 }
 		);
 
 		analyzeAndCompileInstruction(
@@ -144,7 +144,7 @@ describe('add instruction compiler', () => {
 				kind: 'address',
 				valueType: 'int',
 				isNonZero: true,
-				knownIntegerValue: 1024,
+				knownValue: 1024,
 				address: {
 					memoryIndex: 0,
 					clampRange: { source: 'memory-start', memoryIndex: 0, byteAddress: 0, safeByteLength: 128, memoryId: 'arr' },

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/and.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/and.test.ts
@@ -50,8 +50,8 @@ describe('and instruction compiler', () => {
 	it('keeps known integer metadata when and-ing known integer operands', () => {
 		const context = createInstructionCompilerTestContext();
 		context.stack.push(
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 6 },
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 3 }
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 6 },
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 3 }
 		);
 
 		analyzeAndCompileInstruction(
@@ -64,6 +64,6 @@ describe('and instruction compiler', () => {
 			context
 		);
 
-		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 2 }]);
+		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 2 }]);
 	});
 });

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/clampAddress.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/clampAddress.test.ts
@@ -51,7 +51,7 @@ describe('clamp address instruction compilers', () => {
 			kind: 'address',
 			valueType: 'int',
 			isNonZero: true,
-			knownIntegerValue: 1024,
+			knownValue: 1024,
 			address: { clampRange: range },
 		});
 
@@ -62,7 +62,7 @@ describe('clamp address instruction compilers', () => {
 				kind: 'address',
 				valueType: 'int',
 				isNonZero: true,
-				knownIntegerValue: 128 - GLOBAL_ALIGNMENT_BOUNDARY,
+				knownValue: 128 - GLOBAL_ALIGNMENT_BOUNDARY,
 				address: {
 					memoryIndex: 0,
 					clampRange: range,
@@ -80,7 +80,7 @@ describe('clamp address instruction compilers', () => {
 			kind: 'address',
 			valueType: 'int',
 			isNonZero: true,
-			knownIntegerValue: 1024,
+			knownValue: 1024,
 			address: { clampRange: range },
 		});
 
@@ -91,7 +91,7 @@ describe('clamp address instruction compilers', () => {
 				kind: 'address',
 				valueType: 'int',
 				isNonZero: true,
-				knownIntegerValue: 127,
+				knownValue: 127,
 				address: {
 					memoryIndex: 0,
 					clampRange: range,
@@ -114,7 +114,7 @@ describe('clamp address instruction compilers', () => {
 			kind: 'address',
 			valueType: 'int',
 			isNonZero: true,
-			knownIntegerValue: -1,
+			knownValue: -1,
 			address: { clampRange: shiftedRange },
 		});
 
@@ -125,7 +125,7 @@ describe('clamp address instruction compilers', () => {
 				kind: 'address',
 				valueType: 'int',
 				isNonZero: true,
-				knownIntegerValue: 64,
+				knownValue: 64,
 				address: {
 					memoryIndex: 0,
 					clampRange: shiftedRange,
@@ -161,7 +161,7 @@ describe('clamp address instruction compilers', () => {
 				moduleName: 'osc',
 			},
 		});
-		context.stack.push({ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 999 });
+		context.stack.push({ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 999 });
 
 		analyzeAndCompileInstruction(clampModuleAddress, createLine('clampModuleAddress'), context);
 
@@ -170,7 +170,7 @@ describe('clamp address instruction compilers', () => {
 				kind: 'address',
 				valueType: 'int',
 				isNonZero: true,
-				knownIntegerValue: 92,
+				knownValue: 92,
 				address: {
 					memoryIndex: 0,
 					clampRange: {
@@ -190,7 +190,7 @@ describe('clamp address instruction compilers', () => {
 
 	it('clamps to the full global memory range', () => {
 		const context = createInstructionCompilerTestContext();
-		context.stack.push({ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 1024 });
+		context.stack.push({ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 1024 });
 
 		analyzeAndCompileInstruction(clampGlobalAddress, createLine('clampGlobalAddress'), context);
 

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/div.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/div.test.ts
@@ -97,8 +97,8 @@ describe('div instruction compiler', () => {
 	it('keeps known integer metadata when dividing known integer operands', () => {
 		const context = createInstructionCompilerTestContext();
 		context.stack.push(
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 8 },
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 4 }
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 8 },
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 4 }
 		);
 
 		analyzeAndCompileInstruction(
@@ -111,14 +111,14 @@ describe('div instruction compiler', () => {
 			context
 		);
 
-		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 2 }]);
+		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 2 }]);
 	});
 
 	it('marks known zero integer division results as zero', () => {
 		const context = createInstructionCompilerTestContext();
 		context.stack.push(
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 1 },
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 2 }
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 1 },
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 2 }
 		);
 
 		analyzeAndCompileInstruction(
@@ -131,6 +131,6 @@ describe('div instruction compiler', () => {
 			context
 		);
 
-		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: false, knownIntegerValue: 0 }]);
+		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: false, knownValue: 0 }]);
 	});
 });

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/mul.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/mul.test.ts
@@ -77,8 +77,8 @@ describe('mul instruction compiler', () => {
 	it('keeps known integer metadata when multiplying known integer operands', () => {
 		const context = createInstructionCompilerTestContext();
 		context.stack.push(
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 2 },
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 4 }
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 2 },
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 4 }
 		);
 
 		analyzeAndCompileInstruction(
@@ -91,6 +91,6 @@ describe('mul instruction compiler', () => {
 			context
 		);
 
-		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 8 }]);
+		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 8 }]);
 	});
 });

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/or.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/or.test.ts
@@ -31,8 +31,8 @@ describe('or instruction compiler', () => {
 	it('keeps known integer metadata when or-ing known integer operands', () => {
 		const context = createInstructionCompilerTestContext();
 		context.stack.push(
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 4 },
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 3 }
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 4 },
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 3 }
 		);
 
 		analyzeAndCompileInstruction(
@@ -45,6 +45,6 @@ describe('or instruction compiler', () => {
 			context
 		);
 
-		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 7 }]);
+		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 7 }]);
 	});
 });

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/remainder.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/remainder.test.ts
@@ -51,8 +51,8 @@ describe('remainder instruction compiler', () => {
 	it('keeps known integer metadata when taking the remainder of known integer operands', () => {
 		const context = createInstructionCompilerTestContext();
 		context.stack.push(
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 9 },
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 4 }
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 9 },
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 4 }
 		);
 
 		analyzeAndCompileInstruction(
@@ -65,6 +65,6 @@ describe('remainder instruction compiler', () => {
 			context
 		);
 
-		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 1 }]);
+		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 1 }]);
 	});
 });

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/shiftLeft.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/shiftLeft.test.ts
@@ -31,8 +31,8 @@ describe('shiftLeft instruction compiler', () => {
 	it('keeps known integer metadata when shifting known integer operands left', () => {
 		const context = createInstructionCompilerTestContext();
 		context.stack.push(
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 2 },
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 2 }
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 2 },
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 2 }
 		);
 
 		analyzeAndCompileInstruction(
@@ -45,6 +45,6 @@ describe('shiftLeft instruction compiler', () => {
 			context
 		);
 
-		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 8 }]);
+		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 8 }]);
 	});
 });

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/shiftRight.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/shiftRight.test.ts
@@ -31,8 +31,8 @@ describe('shiftRight instruction compiler', () => {
 	it('keeps known integer metadata when shifting known integer operands right', () => {
 		const context = createInstructionCompilerTestContext();
 		context.stack.push(
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: -8 },
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 1 }
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: -8 },
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 1 }
 		);
 
 		analyzeAndCompileInstruction(
@@ -45,6 +45,6 @@ describe('shiftRight instruction compiler', () => {
 			context
 		);
 
-		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: -4 }]);
+		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: -4 }]);
 	});
 });

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/shiftRightUnsigned.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/shiftRightUnsigned.test.ts
@@ -31,8 +31,8 @@ describe('shiftRightUnsigned instruction compiler', () => {
 	it('keeps known integer metadata when shifting known integer operands right as unsigned', () => {
 		const context = createInstructionCompilerTestContext();
 		context.stack.push(
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: -8 },
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 1 }
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: -8 },
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 1 }
 		);
 
 		analyzeAndCompileInstruction(
@@ -45,8 +45,6 @@ describe('shiftRightUnsigned instruction compiler', () => {
 			context
 		);
 
-		expect(context.stack).toEqual([
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 2147483644 },
-		]);
+		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 2147483644 }]);
 	});
 });

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/sub.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/sub.test.ts
@@ -81,12 +81,12 @@ describe('sub instruction compiler', () => {
 				kind: 'address',
 				valueType: 'int',
 				isNonZero: false,
-				knownIntegerValue: 0,
+				knownValue: 0,
 				address: {
 					safeRange: { source: 'memory-start', memoryIndex: 0, byteAddress: 0, safeByteLength: 128, memoryId: 'arr' },
 				},
 			},
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: -4 }
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: -4 }
 		);
 
 		analyzeAndCompileInstruction(
@@ -104,7 +104,7 @@ describe('sub instruction compiler', () => {
 				kind: 'address',
 				valueType: 'int',
 				isNonZero: true,
-				knownIntegerValue: 4,
+				knownValue: 4,
 				address: {
 					memoryIndex: 0,
 					safeRange: { source: 'memory-start', memoryIndex: 0, byteAddress: 4, safeByteLength: 124, memoryId: 'arr' },
@@ -121,12 +121,12 @@ describe('sub instruction compiler', () => {
 				kind: 'address',
 				valueType: 'int',
 				isNonZero: false,
-				knownIntegerValue: 0,
+				knownValue: 0,
 				address: {
 					safeRange: { source: 'memory-start', memoryIndex: 0, byteAddress: 0, safeByteLength: 128, memoryId: 'arr' },
 				},
 			},
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 4 }
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 4 }
 		);
 
 		analyzeAndCompileInstruction(
@@ -144,7 +144,7 @@ describe('sub instruction compiler', () => {
 				kind: 'address',
 				valueType: 'int',
 				isNonZero: true,
-				knownIntegerValue: -4,
+				knownValue: -4,
 				address: {
 					memoryIndex: 0,
 					clampRange: { source: 'memory-start', memoryIndex: 0, byteAddress: 0, safeByteLength: 128, memoryId: 'arr' },

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/utils/stackItem.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/utils/stackItem.ts
@@ -21,7 +21,7 @@ export function requireStackAddress(
 				valueType: 'int',
 				address: { memoryIndex: 0 },
 				...(item.isNonZero !== undefined ? { isNonZero: item.isNonZero } : {}),
-				...(item.knownIntegerValue !== undefined ? { knownIntegerValue: item.knownIntegerValue } : {}),
+				...(item.knownValue !== undefined ? { knownValue: item.knownValue } : {}),
 			};
 		}
 		throw getError(ErrorCode.TYPE_MISMATCH, line, context);
@@ -33,6 +33,6 @@ export function requireStackAddress(
 		address: item.address,
 		...(item.pointsTo ? { pointsTo: item.pointsTo } : {}),
 		...(item.isNonZero !== undefined ? { isNonZero: item.isNonZero } : {}),
-		...(item.knownIntegerValue !== undefined ? { knownIntegerValue: item.knownIntegerValue } : {}),
+		...(item.knownValue !== undefined ? { knownValue: item.knownValue } : {}),
 	};
 }

--- a/packages/compiler/packages/wasm-codegen/src/instructionCompilers/xor.test.ts
+++ b/packages/compiler/packages/wasm-codegen/src/instructionCompilers/xor.test.ts
@@ -31,8 +31,8 @@ describe('xor instruction compiler', () => {
 	it('keeps known integer metadata when xor-ing known integer operands', () => {
 		const context = createInstructionCompilerTestContext();
 		context.stack.push(
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 6 },
-			{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 3 }
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 6 },
+			{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 3 }
 		);
 
 		analyzeAndCompileInstruction(
@@ -45,6 +45,6 @@ describe('xor instruction compiler', () => {
 			context
 		);
 
-		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownIntegerValue: 5 }]);
+		expect(context.stack).toEqual([{ kind: 'value', valueType: 'int', isNonZero: true, knownValue: 5 }]);
 	});
 });

--- a/packages/compiler/packages/wasm-codegen/src/pushValueKind.ts
+++ b/packages/compiler/packages/wasm-codegen/src/pushValueKind.ts
@@ -43,7 +43,7 @@ export function valueKindToWasmType(
 	return kind === 'float32' ? WASM_TYPE_F32 : WASM_TYPE_I32;
 }
 
-type StackItemExtras = Pick<StackItem, 'isNonZero' | 'knownIntegerValue'> &
+type StackItemExtras = Pick<StackItem, 'isNonZero' | 'knownValue'> &
 	Partial<Pick<Extract<StackItem, { kind: 'address' }>, 'address' | 'pointsTo'>>;
 
 /**
@@ -61,7 +61,7 @@ export function kindToStackItem(kind: PushValueKind, extras?: StackItemExtras): 
 			address: extras.address,
 			...(extras.pointsTo ? { pointsTo: extras.pointsTo } : {}),
 			...(extras.isNonZero !== undefined ? { isNonZero: extras.isNonZero } : {}),
-			...(extras.knownIntegerValue !== undefined ? { knownIntegerValue: extras.knownIntegerValue } : {}),
+			...(extras.knownValue !== undefined ? { knownValue: extras.knownValue } : {}),
 		};
 	}
 
@@ -69,6 +69,6 @@ export function kindToStackItem(kind: PushValueKind, extras?: StackItemExtras): 
 		kind: 'value',
 		valueType: kind === 'int32' ? 'int' : kind === 'float64' ? 'float64' : 'float',
 		...(extras?.isNonZero !== undefined ? { isNonZero: extras.isNonZero } : {}),
-		...(extras?.knownIntegerValue !== undefined ? { knownIntegerValue: extras.knownIntegerValue } : {}),
+		...(extras?.knownValue !== undefined ? { knownValue: extras.knownValue } : {}),
 	};
 }

--- a/packages/compiler/packages/wasm-codegen/src/testUtils.ts
+++ b/packages/compiler/packages/wasm-codegen/src/testUtils.ts
@@ -233,13 +233,13 @@ function produce(context: CompilationContext, items: Stack): void {
 
 function createStackValue(
 	valueType: StackValueType,
-	metadata: Pick<StackItem, 'isNonZero' | 'knownIntegerValue'> = {}
+	metadata: Pick<StackItem, 'isNonZero' | 'knownValue'> = {}
 ): StackItem {
 	return {
 		kind: 'value',
 		valueType,
 		...(metadata.isNonZero !== undefined ? { isNonZero: metadata.isNonZero } : {}),
-		...(metadata.knownIntegerValue !== undefined ? { knownIntegerValue: metadata.knownIntegerValue } : {}),
+		...(metadata.knownValue !== undefined ? { knownValue: metadata.knownValue } : {}),
 	};
 }
 
@@ -334,12 +334,12 @@ function deriveKnownIntegerValue(
 	operand2: StackItem,
 	operation: (operand1: number, operand2: number) => number | undefined
 ): Partial<StackItem> {
-	if (operand1.knownIntegerValue === undefined || operand2.knownIntegerValue === undefined) {
+	if (operand1.knownValue === undefined || operand2.knownValue === undefined) {
 		return {};
 	}
 
-	const knownIntegerValue = operation(operand1.knownIntegerValue, operand2.knownIntegerValue);
-	return knownIntegerValue === undefined ? {} : { knownIntegerValue, isNonZero: knownIntegerValue !== 0 };
+	const knownValue = operation(operand1.knownValue, operand2.knownValue);
+	return knownValue === undefined ? {} : { knownValue, isNonZero: knownValue !== 0 };
 }
 
 function shiftSafeRange(safeRange: MemoryAddressRange, byteOffset: number): MemoryAddressRange | undefined {
@@ -355,15 +355,15 @@ function shiftSafeRange(safeRange: MemoryAddressRange, byteOffset: number): Memo
 }
 
 function deriveAddStackMetadata(operand1: StackItem, operand2: StackItem): Partial<StackItem> {
-	const knownIntegerValue =
-		operand1.knownIntegerValue !== undefined && operand2.knownIntegerValue !== undefined
-			? operand1.knownIntegerValue + operand2.knownIntegerValue
+	const knownValue =
+		operand1.knownValue !== undefined && operand2.knownValue !== undefined
+			? operand1.knownValue + operand2.knownValue
 			: undefined;
 	const safeRange =
-		operand1.kind === 'address' && operand1.address.safeRange && operand2.knownIntegerValue !== undefined
-			? shiftSafeRange(operand1.address.safeRange, operand2.knownIntegerValue)
-			: operand2.kind === 'address' && operand2.address.safeRange && operand1.knownIntegerValue !== undefined
-				? shiftSafeRange(operand2.address.safeRange, operand1.knownIntegerValue)
+		operand1.kind === 'address' && operand1.address.safeRange && operand2.knownValue !== undefined
+			? shiftSafeRange(operand1.address.safeRange, operand2.knownValue)
+			: operand2.kind === 'address' && operand2.address.safeRange && operand1.knownValue !== undefined
+				? shiftSafeRange(operand2.address.safeRange, operand1.knownValue)
 				: undefined;
 	const clampRange =
 		(operand1.kind === 'address' ? (operand1.address.clampRange ?? operand1.address.safeRange) : undefined) ??
@@ -376,7 +376,7 @@ function deriveAddStackMetadata(operand1: StackItem, operand2: StackItem): Parti
 				: undefined;
 
 	return {
-		...(knownIntegerValue !== undefined ? { knownIntegerValue } : {}),
+		...(knownValue !== undefined ? { knownValue } : {}),
 		...(safeRange || clampRange
 			? {
 					kind: 'address',
@@ -396,20 +396,20 @@ function deriveAddStackMetadata(operand1: StackItem, operand2: StackItem): Parti
 }
 
 function deriveSubStackMetadata(operand1: StackItem, operand2: StackItem): Partial<StackItem> {
-	const knownIntegerValue =
-		operand1.knownIntegerValue !== undefined && operand2.knownIntegerValue !== undefined
-			? operand1.knownIntegerValue - operand2.knownIntegerValue
+	const knownValue =
+		operand1.knownValue !== undefined && operand2.knownValue !== undefined
+			? operand1.knownValue - operand2.knownValue
 			: undefined;
 	const safeRange =
-		operand1.kind === 'address' && operand1.address.safeRange && operand2.knownIntegerValue !== undefined
-			? shiftSafeRange(operand1.address.safeRange, -operand2.knownIntegerValue)
+		operand1.kind === 'address' && operand1.address.safeRange && operand2.knownValue !== undefined
+			? shiftSafeRange(operand1.address.safeRange, -operand2.knownValue)
 			: undefined;
 	const clampRange =
 		operand1.kind === 'address' ? (operand1.address.clampRange ?? operand1.address.safeRange) : undefined;
 	const pointsTo = operand1.kind === 'address' ? operand1.pointsTo : undefined;
 
 	return {
-		...(knownIntegerValue !== undefined ? { knownIntegerValue } : {}),
+		...(knownValue !== undefined ? { knownValue } : {}),
 		...(safeRange || clampRange
 			? {
 					kind: 'address',
@@ -428,10 +428,10 @@ function deriveSubStackMetadata(operand1: StackItem, operand2: StackItem): Parti
 	} as Partial<StackItem>;
 }
 
-function knownIntegerResult(knownIntegerValue: number | undefined, isNonZero = false): StackItem {
+function knownIntegerResult(knownValue: number | undefined, isNonZero = false): StackItem {
 	return createStackValue('int', {
-		isNonZero: knownIntegerValue !== undefined ? knownIntegerValue !== 0 : isNonZero,
-		knownIntegerValue,
+		isNonZero: knownValue !== undefined ? knownValue !== 0 : isNonZero,
+		knownValue,
 	});
 }
 
@@ -450,18 +450,18 @@ function numericResult(
 			valueType: 'int',
 			address: integerMetadata.address!,
 			...(integerMetadata.pointsTo ? { pointsTo: integerMetadata.pointsTo } : {}),
-			...(integerMetadata.knownIntegerValue !== undefined
+			...(integerMetadata.knownValue !== undefined
 				? {
-						knownIntegerValue: integerMetadata.knownIntegerValue,
-						isNonZero: integerMetadata.knownIntegerValue !== 0,
+						knownValue: integerMetadata.knownValue,
+						isNonZero: integerMetadata.knownValue !== 0,
 					}
 				: {}),
 		};
 	}
 
 	return createStackValue(valueType, {
-		isNonZero: integerMetadata.knownIntegerValue !== undefined ? integerMetadata.knownIntegerValue !== 0 : false,
-		knownIntegerValue: integerMetadata.knownIntegerValue,
+		isNonZero: integerMetadata.knownValue !== undefined ? integerMetadata.knownValue !== 0 : false,
+		knownValue: integerMetadata.knownValue,
 	});
 }
 
@@ -536,7 +536,7 @@ function pushLiteralStackItems(line: CompilerASTLine, context: CompilationContex
 	return [
 		kindToStackItem(resolveArgumentValueKind(argument), {
 			isNonZero: argument.value !== 0,
-			...(argument.isInteger && Number.isInteger(argument.value) ? { knownIntegerValue: argument.value } : {}),
+			...(argument.isInteger && Number.isInteger(argument.value) ? { knownValue: argument.value } : {}),
 			...(address ? { address, pointsTo: getAddressPointeeMetadata(context, address) } : {}),
 		}),
 	];
@@ -836,34 +836,30 @@ function analyzeNumericBinaryForTest(line: CompilerASTLine, context: Compilation
 								),
 							]
 						: line.instruction === 'remainder'
-							? [knownIntegerResult(deriveKnownIntegerValue(left, right, (x, y) => (x % y) | 0).knownIntegerValue)]
+							? [knownIntegerResult(deriveKnownIntegerValue(left, right, (x, y) => (x % y) | 0).knownValue)]
 							: line.instruction === 'and'
-								? [knownIntegerResult(deriveKnownIntegerValue(left, right, (x, y) => x & y).knownIntegerValue)]
+								? [knownIntegerResult(deriveKnownIntegerValue(left, right, (x, y) => x & y).knownValue)]
 								: line.instruction === 'or'
 									? [
 											knownIntegerResult(
-												deriveKnownIntegerValue(left, right, (x, y) => x | y).knownIntegerValue,
+												deriveKnownIntegerValue(left, right, (x, y) => x | y).knownValue,
 												Boolean(left.isNonZero || right.isNonZero)
 											),
 										]
 									: line.instruction === 'xor'
-										? [knownIntegerResult(deriveKnownIntegerValue(left, right, (x, y) => x ^ y).knownIntegerValue)]
+										? [knownIntegerResult(deriveKnownIntegerValue(left, right, (x, y) => x ^ y).knownValue)]
 										: line.instruction === 'shiftLeft'
 											? [
 													knownIntegerResult(
-														deriveKnownIntegerValue(left, right, (x, y) => (x << (y & 31)) | 0).knownIntegerValue
+														deriveKnownIntegerValue(left, right, (x, y) => (x << (y & 31)) | 0).knownValue
 													),
 												]
 											: line.instruction === 'shiftRight'
-												? [
-														knownIntegerResult(
-															deriveKnownIntegerValue(left, right, (x, y) => x >> (y & 31)).knownIntegerValue
-														),
-													]
+												? [knownIntegerResult(deriveKnownIntegerValue(left, right, (x, y) => x >> (y & 31)).knownValue)]
 												: line.instruction === 'shiftRightUnsigned'
 													? [
 															knownIntegerResult(
-																deriveKnownIntegerValue(left, right, (x, y) => x >>> (y & 31)).knownIntegerValue
+																deriveKnownIntegerValue(left, right, (x, y) => x >>> (y & 31)).knownValue
 															),
 														]
 													: undefined;
@@ -881,16 +877,16 @@ function analyzeAbsForTest(_line: CompilerASTLine, context: CompilationContext):
 	const consumed = consume(context, 1);
 	const operand = consumed[0];
 	const knownAbsValue =
-		operand.knownIntegerValue === undefined
+		operand.knownValue === undefined
 			? undefined
-			: operand.knownIntegerValue < 0
-				? (0 - operand.knownIntegerValue) | 0
-				: operand.knownIntegerValue;
+			: operand.knownValue < 0
+				? (0 - operand.knownValue) | 0
+				: operand.knownValue;
 	const produced = [
 		operand.valueType === 'int'
 			? createStackValue('int', {
 					isNonZero: operand.isNonZero,
-					knownIntegerValue: knownAbsValue,
+					knownValue: knownAbsValue,
 				})
 			: createStackValue(operand.valueType === 'float64' ? 'float64' : 'float', { isNonZero: operand.isNonZero }),
 	];

--- a/packages/compiler/tests/compilerOptionsAndCache.test.ts
+++ b/packages/compiler/tests/compilerOptionsAndCache.test.ts
@@ -52,6 +52,40 @@ functionEnd int
 		]);
 	});
 
+	test('exposes resolved float constant values in stack analysis', async () => {
+		const source = `
+8f4e/v1
+
+entry main
+module floatConstants
+use values
+push FLOAT32
+drop
+push FLOAT64
+drop
+moduleEnd
+entryEnd
+
+constants values
+const FLOAT32 3.141592653589793
+const FLOAT64 3.141592653589793f64
+constantsEnd
+`;
+		const result = (
+			await compileFixtureProgramSource(source, {
+				includeStackAnalysis: true,
+			})
+		).compileResult;
+		const pushLines = result.compiledModules.floatConstants.stackAnalysis?.filter(line => line.instruction === 'push');
+
+		expect(pushLines?.[0]?.stackAnalysis.producedStackItems).toEqual([
+			{ kind: 'value', valueType: 'float', isNonZero: true, knownValue: Math.fround(Math.PI) },
+		]);
+		expect(pushLines?.[1]?.stackAnalysis.producedStackItems).toEqual([
+			{ kind: 'value', valueType: 'float64', isNonZero: true, knownValue: Math.PI },
+		]);
+	});
+
 	test('reuses cached AST entries when recompiling unchanged source', async () => {
 		const source = `
 8f4e/v1

--- a/packages/editor/packages/editor-core/docs/editor-directives.md
+++ b/packages/editor/packages/editor-core/docs/editor-directives.md
@@ -154,9 +154,10 @@ push 2
 push 3 ; @stack
 ```
 
-The example displays `[2, 3]`. Each stack item uses its statically known integer value when one is available; otherwise,
-it displays the analyzed type: `int`, `float`, `float64`, or `ptr`. For example, a stack whose first value is unknown and
-whose second value is known to be `3` displays `[int, 3]`. An empty stack displays `[]`.
+The example displays `[2, 3]`. Each stack item uses its statically known scalar value when one is available; otherwise,
+it displays the analyzed type: `int`, `float`, `float64`, or `ptr`. Float values use their WebAssembly runtime precision.
+For example, a stack whose first value is unknown and whose second value is known to be `3` displays `[int, 3]`. An
+empty stack displays `[]`.
 
 The standalone form is equivalent:
 

--- a/packages/editor/packages/editor-core/docs/editor-directives.md
+++ b/packages/editor/packages/editor-core/docs/editor-directives.md
@@ -22,7 +22,7 @@ Examples:
 
 ```txt
 ; @watch counter
-; @debug
+; @stack
 ; @plot &audioBuffer lengthMemory
 ; @button &gate0 0 1
 ; @config font ibmvga8x16
@@ -144,14 +144,14 @@ These modifiers can be combined when they make sense. For example:
 ; @watch buffer[3]
 ```
 
-### `@debug`
+### `@stack`
 
 Show the compiler's `stackAfter` analysis at a source location. A trailing directive shows the stack after the
 instruction on the same line. A standalone directive shows the stack after the preceding compiled instruction.
 
 ```txt
 push 2
-push 3 ; @debug
+push 3 ; @stack
 ```
 
 The example displays `[2, 3]`. Each stack item uses its statically known integer value when one is available; otherwise,
@@ -163,8 +163,10 @@ The standalone form is equivalent:
 ```txt
 push 2
 push 3
-; @debug
+; @stack
 ```
+
+Use `@s` as a shorthand alias for `@stack`.
 
 ### `@plot`
 

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/registry.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/registry.test.ts
@@ -14,7 +14,7 @@ describe('directive registry', () => {
 				'; @slider &gain 0 1 0.01',
 				'; @crossfade &dry &wet',
 				'; @info foo',
-				'; @debug',
+				'; @stack',
 				'; note',
 				'moduleEnd',
 			],
@@ -53,23 +53,23 @@ describe('directive registry', () => {
 				sourceLine: '; @info foo',
 			},
 			{
-				name: 'debug',
+				name: 'stack',
 				rawRow: 6,
 				args: [],
-				sourceLine: '; @debug',
+				sourceLine: '; @stack',
 			},
 		]);
 	});
 
 	it('parses trailing-comment directives only for plugins that allow them', () => {
 		const result = parseEditorDirectives(
-			['int foo 1 ; @watch', 'push 1 ; @debug', 'float out ; @meter', 'int bar 1 ; @plot buffer'],
+			['int foo 1 ; @watch', 'push 1 ; @stack', 'float out ; @meter', 'int bar 1 ; @plot buffer'],
 			directivePlugins
 		);
 
 		expect(result).toEqual([
 			{ name: 'watch', rawRow: 0, args: [], sourceLine: 'int foo 1 ; @watch' },
-			{ name: 'debug', rawRow: 1, args: [], sourceLine: 'push 1 ; @debug' },
+			{ name: 'stack', rawRow: 1, args: [], sourceLine: 'push 1 ; @stack' },
 			{ name: 'meter', rawRow: 2, args: [], sourceLine: 'float out ; @meter' },
 		]);
 	});
@@ -84,9 +84,12 @@ describe('directive registry', () => {
 	});
 
 	it('normalizes plugin aliases during parsing', () => {
-		const result = parseEditorDirectives(['; @w value'], directivePlugins);
+		const result = parseEditorDirectives(['; @w value', 'push 1 ; @s'], directivePlugins);
 
-		expect(result).toEqual([{ name: 'watch', rawRow: 0, args: ['value'], sourceLine: '; @w value' }]);
+		expect(result).toEqual([
+			{ name: 'watch', rawRow: 0, args: ['value'], sourceLine: '; @w value' },
+			{ name: 'stack', rawRow: 1, args: [], sourceLine: 'push 1 ; @s' },
+		]);
 	});
 
 	it('derives block state and layout in a single pass', () => {

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/registry.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/registry.ts
@@ -12,7 +12,6 @@ import alwaysOnTopDirective from './alwaysOnTop/plugin';
 import barsDirective from './bars/plugin';
 import buttonDirective from './button/plugin';
 import crossfadeDirective from './crossfade/plugin';
-import debugDirective from './debug/plugin';
 import disabledDirective from './disabled/plugin';
 import favoriteDirective from './favorite/plugin';
 import groupDirective from './group/plugin';
@@ -24,6 +23,7 @@ import meterDirective from './meter/plugin';
 import pianoDirective from './piano/plugin';
 import plotDirective from './plot/plugin';
 import sliderDirective from './slider/plugin';
+import stackDirective from './stack/plugin';
 import switchDirective from './switch/plugin';
 import { normalizeEditorDirectiveRecords } from './utils';
 import viewportDirective from './viewport/plugin';
@@ -51,7 +51,7 @@ export const directivePlugins: EditorDirectivePlugin[] = [
 	buttonDirective,
 	switchDirective,
 	watchDirective,
-	debugDirective,
+	stackDirective,
 	infoDirective,
 	disabledDirective,
 	homeDirective,

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/formatStack.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/formatStack.test.ts
@@ -1,15 +1,15 @@
 import type { Stack } from '@8f4e/language-spec';
 import { describe, expect, it } from 'vitest';
-import { formatDebugStack } from './formatStack';
+import { formatStack } from './formatStack';
 
-describe('debug directive stack formatting', () => {
+describe('stack directive formatting', () => {
 	it('shows known integer values without their types', () => {
 		const stack: Stack = [
 			{ kind: 'value', valueType: 'int', knownIntegerValue: 2 },
 			{ kind: 'value', valueType: 'int', knownIntegerValue: 3 },
 		];
 
-		expect(formatDebugStack(stack)).toBe('2, 3');
+		expect(formatStack(stack)).toBe('2, 3');
 	});
 
 	it('falls back to types for values without a known number', () => {
@@ -21,10 +21,10 @@ describe('debug directive stack formatting', () => {
 			{ kind: 'address', valueType: 'int', address: {} as never },
 		];
 
-		expect(formatDebugStack(stack)).toBe('int, 3, float, float64, ptr');
+		expect(formatStack(stack)).toBe('int, 3, float, float64, ptr');
 	});
 
 	it('formats an empty stack', () => {
-		expect(formatDebugStack([])).toBe('');
+		expect(formatStack([])).toBe('');
 	});
 });

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/formatStack.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/formatStack.test.ts
@@ -3,19 +3,20 @@ import { describe, expect, it } from 'vitest';
 import { formatStack } from './formatStack';
 
 describe('stack directive formatting', () => {
-	it('shows known integer values without their types', () => {
+	it('shows known scalar values without their types', () => {
 		const stack: Stack = [
-			{ kind: 'value', valueType: 'int', knownIntegerValue: 2 },
-			{ kind: 'value', valueType: 'int', knownIntegerValue: 3 },
+			{ kind: 'value', valueType: 'int', knownValue: 2 },
+			{ kind: 'value', valueType: 'float', knownValue: 3.5 },
+			{ kind: 'value', valueType: 'float64', knownValue: Math.PI },
 		];
 
-		expect(formatStack(stack)).toBe('2, 3');
+		expect(formatStack(stack)).toBe(`2, 3.5, ${Math.PI}`);
 	});
 
 	it('falls back to types for values without a known number', () => {
 		const stack: Stack = [
 			{ kind: 'value', valueType: 'int' },
-			{ kind: 'value', valueType: 'int', knownIntegerValue: 3 },
+			{ kind: 'value', valueType: 'int', knownValue: 3 },
 			{ kind: 'value', valueType: 'float' },
 			{ kind: 'value', valueType: 'float64' },
 			{ kind: 'address', valueType: 'int', address: {} as never },

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/formatStack.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/formatStack.ts
@@ -1,8 +1,8 @@
 import type { Stack, StackItem } from '@8f4e/language-spec';
 
 function formatStackItem(item: StackItem): string {
-	if (item.knownIntegerValue !== undefined) {
-		return String(item.knownIntegerValue);
+	if (item.knownValue !== undefined) {
+		return String(item.knownValue);
 	}
 
 	return item.kind === 'address' ? 'ptr' : item.valueType;

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/formatStack.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/formatStack.ts
@@ -9,6 +9,6 @@ function formatStackItem(item: StackItem): string {
 }
 
 /** Formats compiler stack facts for the inside of the debugger widget's brackets. */
-export function formatDebugStack(stack: Stack): string {
+export function formatStack(stack: Stack): string {
 	return stack.map(formatStackItem).join(', ');
 }

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/plugin.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/plugin.ts
@@ -1,19 +1,19 @@
 import { createDirectivePlugin } from '../utils';
-import { createDebugDirectiveWidgetContribution } from './resolve';
+import { createStackDirectiveWidgetContribution } from './resolve';
 
 export default createDirectivePlugin(
-	'debug',
+	'stack',
 	(directive, draft) => {
 		if (directive.args.length > 0) {
 			return;
 		}
 
 		draft.widgets.push(
-			createDebugDirectiveWidgetContribution({
+			createStackDirectiveWidgetContribution({
 				lineNumber: directive.rawRow,
 				isTrailing: !/^\s*;/.test(directive.sourceLine ?? ''),
 			})
 		);
 	},
-	{ allowTrailingComment: true }
+	{ aliases: ['s'], allowTrailingComment: true }
 );

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/resolve.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/resolve.test.ts
@@ -21,14 +21,14 @@ function createStackAnalysisLine(lineNumber: number, stackAfter: Stack): Compile
 	};
 }
 
-describe('debug directive widget resolution', () => {
+describe('stack directive widget resolution', () => {
 	let graphicData: CodeBlockGraphicData;
 	let state: State;
 
 	beforeEach(() => {
 		graphicData = createMockCodeBlock({
 			name: 'test-block',
-			code: ['module test-block', 'push 2', 'push 3', '; @debug', 'moduleEnd'],
+			code: ['module test-block', 'push 2', 'push 3', '; @stack', 'moduleEnd'],
 			blockType: 'module',
 			lineNumberColumnWidth: 1,
 			gaps: new Map(),
@@ -61,18 +61,29 @@ describe('debug directive widget resolution', () => {
 	it('renders known values from the preceding instruction for a standalone directive', () => {
 		runDirectiveResolution();
 
-		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'debug:3', text: '2, 3' }));
+		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'stack:3', text: '2, 3' }));
 	});
 
 	it('uses the same source line for a trailing directive', () => {
-		graphicData.code = ['module test-block', 'push 2 ; @debug', 'moduleEnd'];
+		graphicData.code = ['module test-block', 'push 2 ; @stack', 'moduleEnd'];
 		state.compiler.compiledModules['test-block']!.stackAnalysis = [
 			createStackAnalysisLine(1, [{ kind: 'value', valueType: 'int', knownIntegerValue: 2 }]),
 		];
 
 		runDirectiveResolution();
 
-		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'debug:1', text: '2' }));
+		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'stack:1', text: '2' }));
+	});
+
+	it('supports @s as a shorthand alias', () => {
+		graphicData.code = ['module test-block', 'push 2 ; @s', 'moduleEnd'];
+		state.compiler.compiledModules['test-block']!.stackAnalysis = [
+			createStackAnalysisLine(1, [{ kind: 'value', valueType: 'int', knownIntegerValue: 2 }]),
+		];
+
+		runDirectiveResolution();
+
+		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'stack:1', text: '2' }));
 	});
 
 	it('shows types when stack values are not statically known', () => {
@@ -85,7 +96,7 @@ describe('debug directive widget resolution', () => {
 
 		runDirectiveResolution();
 
-		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'debug:3', text: 'int, 3' }));
+		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'stack:3', text: 'int, 3' }));
 	});
 
 	it('renders an empty stack', () => {
@@ -93,13 +104,13 @@ describe('debug directive widget resolution', () => {
 
 		runDirectiveResolution();
 
-		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'debug:3', text: '' }));
+		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'stack:3', text: '' }));
 	});
 
 	it('resolves stack analysis for function blocks', () => {
 		graphicData = createMockCodeBlock({
 			name: 'helper',
-			code: ['function helper', 'push 3', '; @debug', 'functionEnd'],
+			code: ['function helper', 'push 3', '; @stack', 'functionEnd'],
 			blockType: 'function',
 			creationIndex: 42,
 		});
@@ -112,7 +123,7 @@ describe('debug directive widget resolution', () => {
 
 		runDirectiveResolution();
 
-		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'debug:2', text: '3' }));
+		expect(graphicData.widgets.debuggers).toContainEqual(expect.objectContaining({ id: 'stack:2', text: '3' }));
 	});
 
 	it('does not render when no matching stack analysis is available', () => {
@@ -124,7 +135,7 @@ describe('debug directive widget resolution', () => {
 	});
 
 	it('ignores unsupported arguments', () => {
-		graphicData.code = ['module test-block', 'push 2', '; @debug extra', 'moduleEnd'];
+		graphicData.code = ['module test-block', 'push 2', '; @stack extra', 'moduleEnd'];
 
 		runDirectiveResolution();
 

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/resolve.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/resolve.test.ts
@@ -42,8 +42,8 @@ describe('stack directive widget resolution', () => {
 					'test-block': {
 						stackAnalysis: [
 							createStackAnalysisLine(2, [
-								{ kind: 'value', valueType: 'int', knownIntegerValue: 2 },
-								{ kind: 'value', valueType: 'int', knownIntegerValue: 3 },
+								{ kind: 'value', valueType: 'int', knownValue: 2 },
+								{ kind: 'value', valueType: 'int', knownValue: 3 },
 							]),
 						],
 					},
@@ -67,7 +67,7 @@ describe('stack directive widget resolution', () => {
 	it('uses the same source line for a trailing directive', () => {
 		graphicData.code = ['module test-block', 'push 2 ; @stack', 'moduleEnd'];
 		state.compiler.compiledModules['test-block']!.stackAnalysis = [
-			createStackAnalysisLine(1, [{ kind: 'value', valueType: 'int', knownIntegerValue: 2 }]),
+			createStackAnalysisLine(1, [{ kind: 'value', valueType: 'int', knownValue: 2 }]),
 		];
 
 		runDirectiveResolution();
@@ -78,7 +78,7 @@ describe('stack directive widget resolution', () => {
 	it('supports @s as a shorthand alias', () => {
 		graphicData.code = ['module test-block', 'push 2 ; @s', 'moduleEnd'];
 		state.compiler.compiledModules['test-block']!.stackAnalysis = [
-			createStackAnalysisLine(1, [{ kind: 'value', valueType: 'int', knownIntegerValue: 2 }]),
+			createStackAnalysisLine(1, [{ kind: 'value', valueType: 'int', knownValue: 2 }]),
 		];
 
 		runDirectiveResolution();
@@ -90,7 +90,7 @@ describe('stack directive widget resolution', () => {
 		state.compiler.compiledModules['test-block']!.stackAnalysis = [
 			createStackAnalysisLine(2, [
 				{ kind: 'value', valueType: 'int' },
-				{ kind: 'value', valueType: 'int', knownIntegerValue: 3 },
+				{ kind: 'value', valueType: 'int', knownValue: 3 },
 			]),
 		];
 
@@ -117,7 +117,7 @@ describe('stack directive widget resolution', () => {
 		state.compiler.compiledFunctions = {
 			helper: {
 				ast: { projectBlockId: 42 },
-				stackAnalysis: [createStackAnalysisLine(1, [{ kind: 'value', valueType: 'int', knownIntegerValue: 3 }])],
+				stackAnalysis: [createStackAnalysisLine(1, [{ kind: 'value', valueType: 'int', knownValue: 3 }])],
 			},
 		} as never;
 

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/resolve.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/resolve.ts
@@ -4,9 +4,9 @@ import gapCalculator from '~/features/code-editing/gapCalculator';
 import { getTabStopsByLine, getVisualLineWidth } from '~/features/code-editing/tabLayout';
 import getCodeBlockModuleId from '~/pureHelpers/getCodeBlockModuleId';
 import { getCompiledFunctionForCodeBlock } from '../../../utils/getCompiledFunctionForCodeBlock';
-import { formatDebugStack } from './formatStack';
+import { formatStack } from './formatStack';
 
-interface DebugDirectiveData {
+interface StackDirectiveData {
 	lineNumber: number;
 	isTrailing: boolean;
 }
@@ -43,8 +43,8 @@ function findStackAnalysisLine(
 	return precedingLine;
 }
 
-function resolveDebugDirectiveWidget(
-	debug: DebugDirectiveData,
+function resolveStackDirectiveWidget(
+	stackDirective: StackDirectiveData,
 	graphicData: Parameters<DirectiveWidgetResolver>[0],
 	state: Parameters<DirectiveWidgetResolver>[1],
 	directiveState: DirectiveDerivedState
@@ -54,16 +54,21 @@ function resolveDebugDirectiveWidget(
 		return;
 	}
 
-	const stackAnalysisLine = findStackAnalysisLine(stackAnalysisLines, debug.lineNumber, debug.isTrailing);
+	const stackAnalysisLine = findStackAnalysisLine(
+		stackAnalysisLines,
+		stackDirective.lineNumber,
+		stackDirective.isTrailing
+	);
 	if (!stackAnalysisLine) {
 		return;
 	}
 
-	const displayRow = directiveState.displayModel.rawRowToDisplayRow[debug.lineNumber] ?? debug.lineNumber;
+	const displayRow =
+		directiveState.displayModel.rawRowToDisplayRow[stackDirective.lineNumber] ?? stackDirective.lineNumber;
 	const tabStopsByLine = getTabStopsByLine(graphicData.code);
 	const visualLineWidth = getVisualLineWidth(
-		graphicData.code[debug.lineNumber] || '',
-		tabStopsByLine[debug.lineNumber] || []
+		graphicData.code[stackDirective.lineNumber] || '',
+		tabStopsByLine[stackDirective.lineNumber] || []
 	);
 
 	graphicData.widgets.debuggers.push({
@@ -71,19 +76,21 @@ function resolveDebugDirectiveWidget(
 		height: state.viewport.hGrid,
 		x: state.viewport.vGrid * (3 + graphicData.lineNumberColumnWidth + visualLineWidth),
 		y: gapCalculator(displayRow, graphicData.gaps) * state.viewport.hGrid,
-		id: `debug:${debug.lineNumber}`,
+		id: `stack:${stackDirective.lineNumber}`,
 		showAddress: false,
 		showEndAddress: false,
 		bufferPointer: 0,
 		displayFormat: 'decimal',
-		text: formatDebugStack(stackAnalysisLine.stackAnalysis.stackAfter),
+		text: formatStack(stackAnalysisLine.stackAnalysis.stackAfter),
 	});
 }
 
-export function createDebugDirectiveWidgetContribution(debug: DebugDirectiveData): DirectiveWidgetContribution {
+export function createStackDirectiveWidgetContribution(
+	stackDirective: StackDirectiveData
+): DirectiveWidgetContribution {
 	return {
 		afterGraphicDataWidthCalculation: (graphicData, state, directiveState) => {
-			resolveDebugDirectiveWidget(debug, graphicData, state, directiveState);
+			resolveStackDirectiveWidget(stackDirective, graphicData, state, directiveState);
 		},
 	};
 }

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/tooltip/content.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/tooltip/content.test.ts
@@ -36,12 +36,12 @@ describe('selected line tooltip content', () => {
 				instruction: 'add',
 				stackAnalysis: {
 					stackBefore: [
-						{ kind: 'value', valueType: 'int', knownIntegerValue: 1 },
-						{ kind: 'value', valueType: 'int', knownIntegerValue: 2 },
+						{ kind: 'value', valueType: 'int', knownValue: 1 },
+						{ kind: 'value', valueType: 'int', knownValue: 2 },
 					],
 					consumedOperands: [
-						{ kind: 'value', valueType: 'int', knownIntegerValue: 1 },
-						{ kind: 'value', valueType: 'int', knownIntegerValue: 2 },
+						{ kind: 'value', valueType: 'int', knownValue: 1 },
+						{ kind: 'value', valueType: 'int', knownValue: 2 },
 					],
 					producedStackItems: [{ kind: 'value', valueType: 'int' }],
 					stackAfter: [{ kind: 'value', valueType: 'int' }],

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/tooltip/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/tooltip/effect.test.ts
@@ -30,12 +30,12 @@ describe('tooltip effect', () => {
 								instruction: 'add',
 								stackAnalysis: {
 									stackBefore: [
-										{ kind: 'value', valueType: 'int', knownIntegerValue: 1 },
-										{ kind: 'value', valueType: 'int', knownIntegerValue: 2 },
+										{ kind: 'value', valueType: 'int', knownValue: 1 },
+										{ kind: 'value', valueType: 'int', knownValue: 2 },
 									],
 									consumedOperands: [
-										{ kind: 'value', valueType: 'int', knownIntegerValue: 1 },
-										{ kind: 'value', valueType: 'int', knownIntegerValue: 2 },
+										{ kind: 'value', valueType: 'int', knownValue: 1 },
+										{ kind: 'value', valueType: 'int', knownValue: 2 },
 									],
 									producedStackItems: [{ kind: 'value', valueType: 'int' }],
 									stackAfter: [{ kind: 'value', valueType: 'int' }],
@@ -121,12 +121,12 @@ describe('tooltip effect', () => {
 								instruction: 'add',
 								stackAnalysis: {
 									stackBefore: [
-										{ kind: 'value', valueType: 'int', knownIntegerValue: 1 },
-										{ kind: 'value', valueType: 'int', knownIntegerValue: 2 },
+										{ kind: 'value', valueType: 'int', knownValue: 1 },
+										{ kind: 'value', valueType: 'int', knownValue: 2 },
 									],
 									consumedOperands: [
-										{ kind: 'value', valueType: 'int', knownIntegerValue: 1 },
-										{ kind: 'value', valueType: 'int', knownIntegerValue: 2 },
+										{ kind: 'value', valueType: 'int', knownValue: 1 },
+										{ kind: 'value', valueType: 'int', knownValue: 2 },
 									],
 									producedStackItems: [{ kind: 'value', valueType: 'int' }],
 									stackAfter: [{ kind: 'value', valueType: 'int' }],

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/tooltip/stackAnalysisTooltip.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/tooltip/stackAnalysisTooltip.test.ts
@@ -9,17 +9,17 @@ describe('stack analysis tooltip text', () => {
 			instruction: 'add',
 			stackAnalysis: {
 				stackBefore: [
-					{ kind: 'value', valueType: 'int', knownIntegerValue: 0 },
-					{ kind: 'value', valueType: 'int', knownIntegerValue: 1 },
-					{ kind: 'value', valueType: 'int', knownIntegerValue: 2 },
+					{ kind: 'value', valueType: 'int', knownValue: 0 },
+					{ kind: 'value', valueType: 'int', knownValue: 1 },
+					{ kind: 'value', valueType: 'int', knownValue: 2 },
 				],
 				consumedOperands: [
-					{ kind: 'value', valueType: 'int', knownIntegerValue: 1 },
-					{ kind: 'value', valueType: 'int', knownIntegerValue: 2 },
+					{ kind: 'value', valueType: 'int', knownValue: 1 },
+					{ kind: 'value', valueType: 'int', knownValue: 2 },
 				],
 				producedStackItems: [{ kind: 'value', valueType: 'int' }],
 				stackAfter: [
-					{ kind: 'value', valueType: 'int', knownIntegerValue: 0 },
+					{ kind: 'value', valueType: 'int', knownValue: 0 },
 					{ kind: 'value', valueType: 'int' },
 				],
 			},
@@ -36,6 +36,30 @@ describe('stack analysis tooltip text', () => {
 		]);
 	});
 
+	it('formats known float32 and float64 values', () => {
+		const stackAnalysisLine = {
+			lineNumber: 1,
+			instruction: 'push',
+			stackAnalysis: {
+				stackBefore: [],
+				consumedOperands: [],
+				producedStackItems: [
+					{ kind: 'value', valueType: 'float', knownValue: 3.5 },
+					{ kind: 'value', valueType: 'float64', knownValue: Math.PI },
+				],
+				stackAfter: [
+					{ kind: 'value', valueType: 'float', knownValue: 3.5 },
+					{ kind: 'value', valueType: 'float64', knownValue: Math.PI },
+				],
+			},
+		} as const;
+
+		expect(getStackAnalysisTooltipText(stackAnalysisLine)).toEqual([
+			'before []',
+			`after: [+float=3.5, +float64=${Math.PI}]`,
+		]);
+	});
+
 	it('formats long stack analysis as multiline blocks', () => {
 		const stackAnalysisLine = {
 			lineNumber: 6,
@@ -43,7 +67,7 @@ describe('stack analysis tooltip text', () => {
 			stackAnalysis: {
 				stackBefore: [
 					{ kind: 'value', valueType: 'int' },
-					{ kind: 'value', valueType: 'int', knownIntegerValue: 1234 },
+					{ kind: 'value', valueType: 'int', knownValue: 1234 },
 					{ kind: 'value', valueType: 'float' },
 					{ kind: 'address', valueType: 'int', address: { memoryIndex: 0 } },
 					{ kind: 'value', valueType: 'int' },
@@ -52,7 +76,7 @@ describe('stack analysis tooltip text', () => {
 				consumedOperands: [{ kind: 'value', valueType: 'int' }],
 				producedStackItems: [],
 				stackAfter: [
-					{ kind: 'value', valueType: 'int', knownIntegerValue: 1234 },
+					{ kind: 'value', valueType: 'int', knownValue: 1234 },
 					{ kind: 'value', valueType: 'float' },
 					{ kind: 'address', valueType: 'int', address: { memoryIndex: 0 } },
 					{ kind: 'value', valueType: 'int' },

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/tooltip/stackAnalysisTooltip.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/tooltip/stackAnalysisTooltip.ts
@@ -59,7 +59,7 @@ function getStackItemLabel(item: StackItem, marker?: StackItemMarker): string {
 		label = item.valueType;
 	}
 
-	const valueLabel = item.knownIntegerValue === undefined ? label : `${label}=${item.knownIntegerValue}`;
+	const valueLabel = item.knownValue === undefined ? label : `${label}=${item.knownValue}`;
 
 	if (marker === 'consumed') {
 		return `-${valueLabel}`;


### PR DESCRIPTION
## Summary

- rename the merged `@debug` directive to `@stack` and add `@s` as its shorthand alias
- generalize `StackItem.knownIntegerValue` to `StackItem.knownValue`
- retain known values for integer, `float`, and `float64` literal and resolved-constant pushes
- round `float` values with `Math.fround` so analysis matches WebAssembly `f32` precision
- display known floating-point values in both the stack tooltip and `@stack`

## Context

Follow-up to #921. That PR merged before these two later commits were pushed to its head branch, so this PR carries the missing changes from a fresh branch based on current `main`.

## Breaking change

`StackItem.knownIntegerValue` is replaced by `StackItem.knownValue`.

## Test notes

- affected Nx test matrix passed for language-spec (88), semantic-utils (21), stack-analyzer (23), wasm-codegen (233), compiler (241), and editor-state (1,112)
- compiler integration coverage verifies resolved `float` and `float64` constants
- editor coverage verifies `@stack`, `@s`, and floating-point tooltip/stack formatting
- pre-commit affected typechecks and Biome checks passed
