### PR TITLE
fix: propagate and format known float values

### DIFF
--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/analyzeInstruction.test.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/analyzeInstruction.test.ts
@@ -140,6 +140,55 @@ describe('analyzeInstruction', () => {
 		]);
 	});
 
+	it.each([
+		['add', 3.2, 1.1, Math.fround(Math.fround(3.2) + Math.fround(1.1))],
+		['sub', 3.2, 1.1, Math.fround(Math.fround(3.2) - Math.fround(1.1))],
+		['mul', 3.2, 2, Math.fround(Math.fround(3.2) * Math.fround(2))],
+		['div', 3.2, 2, Math.fround(Math.fround(3.2) / Math.fround(2))],
+	] as const)('propagates known float32 values through %s', (instruction, left, right, expected) => {
+		const context = createStackAnalyzerTestContext({
+			stack: [
+				{ kind: 'value', valueType: 'float', isNonZero: left !== 0, knownValue: Math.fround(left) },
+				{ kind: 'value', valueType: 'float', isNonZero: right !== 0, knownValue: Math.fround(right) },
+			],
+		});
+		const line = { lineNumber: 1, instruction, arguments: [] } as CompilerASTLine;
+
+		const facts = analyzeInstruction(line, context);
+
+		expect(facts.stackAnalysis.producedStackItems).toEqual([
+			{ kind: 'value', valueType: 'float', isNonZero: expected !== 0, knownValue: expected },
+		]);
+	});
+
+	it('propagates known float64 division and absolute values', () => {
+		const divisionContext = createStackAnalyzerTestContext({
+			stack: [
+				{ kind: 'value', valueType: 'float64', isNonZero: true, knownValue: 3.2 },
+				{ kind: 'value', valueType: 'float64', isNonZero: true, knownValue: 2 },
+			],
+		});
+		const absContext = createStackAnalyzerTestContext({
+			stack: [{ kind: 'value', valueType: 'float', isNonZero: true, knownValue: Math.fround(-3.2) }],
+		});
+
+		const divisionFacts = analyzeInstruction(
+			{ lineNumber: 1, instruction: 'div', arguments: [] } as CompilerASTLine,
+			divisionContext
+		);
+		const absFacts = analyzeInstruction(
+			{ lineNumber: 1, instruction: 'abs', arguments: [] } as CompilerASTLine,
+			absContext
+		);
+
+		expect(divisionFacts.stackAnalysis.producedStackItems).toEqual([
+			{ kind: 'value', valueType: 'float64', isNonZero: true, knownValue: 1.6 },
+		]);
+		expect(absFacts.stackAnalysis.producedStackItems).toEqual([
+			{ kind: 'value', valueType: 'float', isNonZero: true, knownValue: Math.fround(3.2) },
+		]);
+	});
+
 	it('records map input and output kinds', () => {
 		const mapBlock: MapBlockStackFrame = {
 			blockType: BlockType.MAP,

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/abs.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/abs.ts
@@ -3,7 +3,7 @@ import { consume, createStackValue, produce } from '../stack';
 import type { InstructionAnalysisResult } from '../types';
 
 /**
- * Analyzes `abs` stack effects and known integer propagation.
+ * Analyzes `abs` stack effects and known-value propagation.
  *
  * @param _line - Unused source AST line kept for handler signature consistency.
  * @param context - Compilation context used by the operation.
@@ -15,23 +15,18 @@ export function analyzeAbs(_line: CompilerASTLine, context: CompilationContext):
 	const knownAbsValue =
 		operand.knownValue === undefined
 			? undefined
-			: operand.knownValue < 0
-				? (0 - operand.knownValue) | 0
-				: operand.knownValue;
-	const knownIntegerMetadata =
-		knownAbsValue === undefined
-			? {}
-			: {
-					knownValue: knownAbsValue,
-					isNonZero: knownAbsValue !== 0,
-				};
+			: operand.valueType === 'int'
+				? operand.knownValue < 0
+					? (0 - operand.knownValue) | 0
+					: operand.knownValue
+				: Math.abs(operand.knownValue);
+	const runtimeKnownValue =
+		operand.valueType === 'float' && knownAbsValue !== undefined ? Math.fround(knownAbsValue) : knownAbsValue;
 	const produced: Stack = [
-		operand.valueType === 'int'
-			? createStackValue('int', {
-					isNonZero: operand.isNonZero,
-					knownValue: knownIntegerMetadata.knownValue,
-				})
-			: createStackValue(operand.valueType === 'float64' ? 'float64' : 'float', { isNonZero: operand.isNonZero }),
+		createStackValue(operand.valueType, {
+			isNonZero: runtimeKnownValue !== undefined ? runtimeKnownValue !== 0 : operand.isNonZero,
+			knownValue: runtimeKnownValue,
+		}),
 	];
 	produce(context, produced);
 	return { consumed, produced };

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/add.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/add.ts
@@ -13,7 +13,12 @@ import { numericResult } from './shared';
  */
 export function analyzeAdd(_line: CompilerASTLine, context: CompilationContext): InstructionAnalysisResult {
 	const consumed = consume(context, 2);
-	const produced = [numericResult(consumed[0], consumed[1], deriveAddStackMetadata)];
+	const produced = [
+		numericResult(consumed[0], consumed[1], {
+			calculateKnownValue: (left, right) => left + right,
+			deriveIntegerMetadata: deriveAddStackMetadata,
+		}),
+	];
 	produce(context, produced);
 	return { consumed, produced };
 }

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/div.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/div.ts
@@ -6,7 +6,7 @@ import type { InstructionAnalysisResult } from '../types';
 import { numericResult } from './shared';
 
 /**
- * Analyzes `div` stack effects, known integer propagation, and zero-divisor failures.
+ * Analyzes `div` stack effects, known-value propagation, and zero-divisor failures.
  *
  * @param line - Source AST line being processed.
  * @param context - Compilation context used by the operation.
@@ -21,15 +21,17 @@ export function analyzeDiv(line: CompilerASTLine, context: CompilationContext): 
 	}
 
 	const produced = [
-		numericResult(consumed[0], right, (left, divisor) =>
-			deriveKnownIntegerValue(left, divisor, (dividend, divisorValue) => {
-				if (dividend === BASE_TYPE_METADATA.int.min && divisorValue === -1) {
-					return undefined;
-				}
+		numericResult(consumed[0], right, {
+			calculateKnownValue: (dividend, divisor) => dividend / divisor,
+			deriveIntegerMetadata: (left, divisor) =>
+				deriveKnownIntegerValue(left, divisor, (dividend, divisorValue) => {
+					if (dividend === BASE_TYPE_METADATA.int.min && divisorValue === -1) {
+						return undefined;
+					}
 
-				return Math.trunc(dividend / divisorValue) | 0;
-			})
-		),
+					return Math.trunc(dividend / divisorValue) | 0;
+				}),
+		}),
 	];
 	produce(context, produced);
 	return { consumed, produced };

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/mul.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/mul.ts
@@ -5,7 +5,7 @@ import type { InstructionAnalysisResult } from '../types';
 import { numericResult } from './shared';
 
 /**
- * Analyzes `mul` stack effects and known integer propagation.
+ * Analyzes `mul` stack effects and known-value propagation.
  *
  * @param _line - Unused source AST line kept for handler signature consistency.
  * @param context - Compilation context used by the operation.
@@ -14,9 +14,11 @@ import { numericResult } from './shared';
 export function analyzeMul(_line: CompilerASTLine, context: CompilationContext): InstructionAnalysisResult {
 	const consumed = consume(context, 2);
 	const produced = [
-		numericResult(consumed[0], consumed[1], (left, right) =>
-			deriveKnownIntegerValue(left, right, (value1, value2) => Math.imul(value1, value2))
-		),
+		numericResult(consumed[0], consumed[1], {
+			calculateKnownValue: (left, right) => left * right,
+			deriveIntegerMetadata: (left, right) =>
+				deriveKnownIntegerValue(left, right, (value1, value2) => Math.imul(value1, value2)),
+		}),
 	];
 	produce(context, produced);
 	return { consumed, produced };

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/shared.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/shared.ts
@@ -2,6 +2,11 @@ import type { StackAnalysisNumericValueKind, StackItem, StackValueType } from '@
 import { areAllOperandsFloat64, areAllOperandsIntegers } from '@8f4e/semantic-utils';
 import { createStackValue } from '../stack';
 
+interface NumericResultOptions {
+	calculateKnownValue: (left: number, right: number) => number;
+	deriveIntegerMetadata?: (left: StackItem, right: StackItem) => Partial<StackItem>;
+}
+
 /**
  * Resolves two numeric operands to the concrete value kind used by downstream codegen.
  *
@@ -22,17 +27,13 @@ export function getNumericOperandKind(left: StackItem, right: StackItem): StackA
  *
  * @param left - Left stack operand.
  * @param right - Right stack operand.
- * @param deriveIntegerMetadata - Callback that derives integer metadata for the result.
+ * @param options - Integer metadata and known floating-point value derivation.
  * @returns The computed result.
  */
-export function numericResult(
-	left: StackItem,
-	right: StackItem,
-	deriveIntegerMetadata?: (left: StackItem, right: StackItem) => Partial<StackItem>
-): StackItem {
+export function numericResult(left: StackItem, right: StackItem, options: NumericResultOptions): StackItem {
 	const numericOperandKind = getNumericOperandKind(left, right);
 	const isInteger = numericOperandKind === 'int32';
-	const integerMetadata = isInteger ? (deriveIntegerMetadata?.(left, right) ?? {}) : {};
+	const integerMetadata = isInteger ? (options.deriveIntegerMetadata?.(left, right) ?? {}) : {};
 	const valueType: StackValueType = isInteger ? 'int' : numericOperandKind === 'float64' ? 'float64' : 'float';
 	if (isInteger && 'kind' in integerMetadata && integerMetadata.kind === 'address' && integerMetadata.address) {
 		return {
@@ -48,10 +49,16 @@ export function numericResult(
 				: {}),
 		};
 	}
+	const knownValue = isInteger
+		? integerMetadata.knownValue
+		: left.knownValue !== undefined && right.knownValue !== undefined
+			? options.calculateKnownValue(left.knownValue, right.knownValue)
+			: undefined;
+	const runtimeKnownValue = valueType === 'float' && knownValue !== undefined ? Math.fround(knownValue) : knownValue;
 
 	return createStackValue(valueType, {
-		isNonZero: integerMetadata.knownValue !== undefined ? integerMetadata.knownValue !== 0 : false,
-		knownValue: integerMetadata.knownValue,
+		isNonZero: runtimeKnownValue !== undefined ? runtimeKnownValue !== 0 : false,
+		knownValue: runtimeKnownValue,
 	});
 }
 

--- a/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/sub.ts
+++ b/packages/compiler/packages/sub-program/packages/stack-analyzer/src/instructionAnalyzers/numeric/sub.ts
@@ -13,7 +13,12 @@ import { numericResult } from './shared';
  */
 export function analyzeSub(_line: CompilerASTLine, context: CompilationContext): InstructionAnalysisResult {
 	const consumed = consume(context, 2);
-	const produced = [numericResult(consumed[0], consumed[1], deriveSubStackMetadata)];
+	const produced = [
+		numericResult(consumed[0], consumed[1], {
+			calculateKnownValue: (left, right) => left - right,
+			deriveIntegerMetadata: deriveSubStackMetadata,
+		}),
+	];
 	produce(context, produced);
 	return { consumed, produced };
 }

--- a/packages/compiler/tests/compilerOptionsAndCache.test.ts
+++ b/packages/compiler/tests/compilerOptionsAndCache.test.ts
@@ -60,8 +60,12 @@ entry main
 module floatConstants
 use values
 push FLOAT32
+push 2.0
+div
 drop
 push FLOAT64
+push 2f64
+div
 drop
 moduleEnd
 entryEnd
@@ -77,12 +81,19 @@ constantsEnd
 			})
 		).compileResult;
 		const pushLines = result.compiledModules.floatConstants.stackAnalysis?.filter(line => line.instruction === 'push');
+		const divLines = result.compiledModules.floatConstants.stackAnalysis?.filter(line => line.instruction === 'div');
 
 		expect(pushLines?.[0]?.stackAnalysis.producedStackItems).toEqual([
 			{ kind: 'value', valueType: 'float', isNonZero: true, knownValue: Math.fround(Math.PI) },
 		]);
-		expect(pushLines?.[1]?.stackAnalysis.producedStackItems).toEqual([
+		expect(pushLines?.[2]?.stackAnalysis.producedStackItems).toEqual([
 			{ kind: 'value', valueType: 'float64', isNonZero: true, knownValue: Math.PI },
+		]);
+		expect(divLines?.[0]?.stackAnalysis.producedStackItems).toEqual([
+			{ kind: 'value', valueType: 'float', isNonZero: true, knownValue: Math.fround(Math.fround(Math.PI) / 2) },
+		]);
+		expect(divLines?.[1]?.stackAnalysis.producedStackItems).toEqual([
+			{ kind: 'value', valueType: 'float64', isNonZero: true, knownValue: Math.PI / 2 },
 		]);
 	});
 

--- a/packages/editor/packages/editor-core/docs/editor-directives.md
+++ b/packages/editor/packages/editor-core/docs/editor-directives.md
@@ -155,9 +155,9 @@ push 3 ; @stack
 ```
 
 The example displays `[2, 3]`. Each stack item uses its statically known scalar value when one is available; otherwise,
-it displays the analyzed type: `int`, `float`, `float64`, or `ptr`. Float values use their WebAssembly runtime precision.
-For example, a stack whose first value is unknown and whose second value is known to be `3` displays `[int, 3]`. An
-empty stack displays `[]`.
+it displays the analyzed type: `int`, `float`, `float64`, or `ptr`. Float values use their WebAssembly runtime precision
+and display as the shortest decimal that round-trips to the same `f32` value. For example, a stack whose first value is
+unknown and whose second value is known to be `3` displays `[int, 3]`. An empty stack displays `[]`.
 
 The standalone form is equivalent:
 

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/formatStack.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/formatStack.test.ts
@@ -6,11 +6,11 @@ describe('stack directive formatting', () => {
 	it('shows known scalar values without their types', () => {
 		const stack: Stack = [
 			{ kind: 'value', valueType: 'int', knownValue: 2 },
-			{ kind: 'value', valueType: 'float', knownValue: 3.5 },
+			{ kind: 'value', valueType: 'float', knownValue: Math.fround(3.2) },
 			{ kind: 'value', valueType: 'float64', knownValue: Math.PI },
 		];
 
-		expect(formatStack(stack)).toBe(`2, 3.5, ${Math.PI}`);
+		expect(formatStack(stack)).toBe(`2, 3.2, ${Math.PI}`);
 	});
 
 	it('falls back to types for values without a known number', () => {

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/formatStack.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/code-blocks/features/directives/stack/formatStack.ts
@@ -1,8 +1,10 @@
 import type { Stack, StackItem } from '@8f4e/language-spec';
+import { formatKnownStackValue } from '~/shared/formatKnownStackValue';
 
 function formatStackItem(item: StackItem): string {
-	if (item.knownValue !== undefined) {
-		return String(item.knownValue);
+	const knownValue = formatKnownStackValue(item);
+	if (knownValue !== undefined) {
+		return knownValue;
 	}
 
 	return item.kind === 'address' ? 'ptr' : item.valueType;

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/tooltip/stackAnalysisTooltip.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/tooltip/stackAnalysisTooltip.test.ts
@@ -44,11 +44,11 @@ describe('stack analysis tooltip text', () => {
 				stackBefore: [],
 				consumedOperands: [],
 				producedStackItems: [
-					{ kind: 'value', valueType: 'float', knownValue: 3.5 },
+					{ kind: 'value', valueType: 'float', knownValue: Math.fround(3.2) },
 					{ kind: 'value', valueType: 'float64', knownValue: Math.PI },
 				],
 				stackAfter: [
-					{ kind: 'value', valueType: 'float', knownValue: 3.5 },
+					{ kind: 'value', valueType: 'float', knownValue: Math.fround(3.2) },
 					{ kind: 'value', valueType: 'float64', knownValue: Math.PI },
 				],
 			},
@@ -56,7 +56,7 @@ describe('stack analysis tooltip text', () => {
 
 		expect(getStackAnalysisTooltipText(stackAnalysisLine)).toEqual([
 			'before []',
-			`after: [+float=3.5, +float64=${Math.PI}]`,
+			`after: [+float=3.2, +float64=${Math.PI}]`,
 		]);
 	});
 

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/tooltip/stackAnalysisTooltip.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/tooltip/stackAnalysisTooltip.ts
@@ -1,4 +1,5 @@
 import type { CompiledStackAnalysisLine, Stack, StackItem } from '@8f4e/language-spec';
+import { formatKnownStackValue } from '~/shared/formatKnownStackValue';
 import { maxInlineStackItemCount } from './constants';
 import type { TooltipHighlightRange, TooltipHighlightTarget } from './types';
 
@@ -59,7 +60,8 @@ function getStackItemLabel(item: StackItem, marker?: StackItemMarker): string {
 		label = item.valueType;
 	}
 
-	const valueLabel = item.knownValue === undefined ? label : `${label}=${item.knownValue}`;
+	const knownValue = formatKnownStackValue(item);
+	const valueLabel = knownValue === undefined ? label : `${label}=${knownValue}`;
 
 	if (marker === 'consumed') {
 		return `-${valueLabel}`;

--- a/packages/editor/packages/editor-core/packages/editor-state/src/shared/formatKnownStackValue.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/shared/formatKnownStackValue.test.ts
@@ -1,0 +1,23 @@
+import type { StackItem } from '@8f4e/language-spec';
+import { describe, expect, it } from 'vitest';
+import { formatKnownStackValue } from './formatKnownStackValue';
+
+function float32(value: number): StackItem {
+	return { kind: 'value', valueType: 'float', knownValue: Math.fround(value) };
+}
+
+describe('formatKnownStackValue', () => {
+	it.each([
+		[3.2, '3.2'],
+		[3.1, '3.1'],
+		[Math.PI, '3.1415927'],
+	])('formats the shortest decimal that round-trips to float32 %s', (value, expected) => {
+		expect(formatKnownStackValue(float32(value))).toBe(expected);
+	});
+
+	it('preserves float64 precision', () => {
+		expect(formatKnownStackValue({ kind: 'value', valueType: 'float64', knownValue: 3.141592653589793 })).toBe(
+			'3.141592653589793'
+		);
+	});
+});

--- a/packages/editor/packages/editor-core/packages/editor-state/src/shared/formatKnownStackValue.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/shared/formatKnownStackValue.ts
@@ -1,0 +1,29 @@
+import type { StackItem } from '@8f4e/language-spec';
+
+function formatFloat32(value: number): string {
+	const runtimeValue = Math.fround(value);
+	if (!Number.isFinite(runtimeValue)) {
+		return String(runtimeValue);
+	}
+	if (Object.is(runtimeValue, -0)) {
+		return '-0';
+	}
+
+	for (let precision = 1; precision <= 9; precision++) {
+		const candidate = Number(runtimeValue.toPrecision(precision));
+		if (Object.is(Math.fround(candidate), runtimeValue)) {
+			return String(candidate);
+		}
+	}
+
+	return String(runtimeValue);
+}
+
+/** Formats a known stack value without exposing insignificant float32 representation noise. */
+export function formatKnownStackValue(item: StackItem): string | undefined {
+	if (item.knownValue === undefined) {
+		return undefined;
+	}
+
+	return item.valueType === 'float' ? formatFloat32(item.knownValue) : String(item.knownValue);
+}


### PR DESCRIPTION
## Summary

- format known f32 stack values using the shortest decimal that round-trips to the same runtime value
- propagate known float and float64 values through add, sub, mul, div, and abs
- round f32 results after each analyzed operation to match WebAssembly runtime behavior
- share the formatter between the @stack directive and stack-analysis tooltip

## Rationale

This removes representation noise such as `3.200000047683716` while retaining the exact analyzed f32 value, and lets float division show a calculated value instead of only `float`.

Follow-up to #922.

## Tests

- `npx nx run @8f4e/stack-analyzer:test` (28 tests)
- `npx nx run @8f4e/compiler:test` (241 tests)
- `npx nx run @8f4e/editor-state:test` (1,116 tests)
- affected typechecks run by the pre-commit hook