### PR TITLE
fix(editor-state): prevent duplicate browser-local notes

### DIFF
--- a/packages/8f4e-website/src/main.ts
+++ b/packages/8f4e-website/src/main.ts
@@ -52,7 +52,7 @@ function mountEditor(canvas: HTMLCanvasElement, index: number): Promise<DefaultE
 
 	const mountPromise = mountDefaultEditor(canvas, {
 		captureWheel: false,
-		featureFlags: { projectCreation: false, projectOpening: false },
+		featureFlags: { browserLocalNotes: false, projectCreation: false, projectOpening: false },
 		initialProjectUrl: canvas.dataset.projectUrl || undefined,
 		storage: window.localStorage,
 		storageNamespace: index === 0 ? '8f4e-website' : `8f4e-website-${index + 1}`,

--- a/packages/editor/packages/editor-core/packages/editor-state-testing/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state-testing/src/index.ts
@@ -222,6 +222,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			offscreenBlockArrows: true,
 			projectOpening: true,
 			projectCreation: true,
+			browserLocalNotes: true,
 		},
 		editorMode: 'edit',
 		editorConfig: {},

--- a/packages/editor/packages/editor-core/packages/editor-state-types/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state-types/src/index.ts
@@ -258,6 +258,9 @@ export interface FeatureFlags {
 
 	/** Enable/disable the menu action that creates a new project */
 	projectCreation: boolean;
+
+	/** Enable/disable loading and persisting browser-local note blocks */
+	browserLocalNotes: boolean;
 }
 
 /**

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/browser-local-notes/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/browser-local-notes/effect.test.ts
@@ -1,3 +1,4 @@
+import type { BrowserLocalNoteStorageBlock } from '@8f4e/editor-state-types';
 import createStateManager from '@8f4e/state-manager';
 import { describe, expect, it, vi } from 'vitest';
 import { EMPTY_DEFAULT_PROJECT } from '~/features/project-import/emptyDefaultProject';
@@ -18,6 +19,98 @@ function getEventHandler(events: ReturnType<typeof createMockEventDispatcherWith
 }
 
 describe('browser-local note placement', () => {
+	it('does not load or persist browser-local notes when the feature flag is disabled', () => {
+		const loadBrowserLocalNotes = vi.fn(async () => []);
+		const saveBrowserLocalNotes = vi.fn(async () => undefined);
+		const localNote = createMockCodeBlock({ code: ['note local.editorConfig', '; config', 'noteEnd'] });
+		const state = createMockState({
+			initialProjectState: { ...EMPTY_DEFAULT_PROJECT },
+			featureFlags: { browserLocalNotes: false },
+			callbacks: {
+				loadBrowserLocalNotes,
+				saveBrowserLocalNotes,
+			},
+			codeBlockRendering: {
+				codeBlocks: [localNote],
+				selectedCodeBlock: localNote,
+			},
+		});
+		const store = createStateManager(state);
+		const events = createMockEventDispatcherWithVitest();
+
+		browserLocalNotes(store, events);
+		localNote.code = ['note local.editorConfig', '; changed', 'noteEnd'];
+		store.set('codeBlockRendering.selectedCodeBlock.code', localNote.code);
+
+		expect(events.on).not.toHaveBeenCalled();
+		expect(loadBrowserLocalNotes).not.toHaveBeenCalled();
+		expect(saveBrowserLocalNotes).not.toHaveBeenCalled();
+	});
+
+	it('coalesces overlapping browser-local note population for the same project', async () => {
+		const storedBlocks: BrowserLocalNoteStorageBlock[] = [
+			{
+				code: ['note local.editorConfig', '; config', 'noteEnd'],
+				gridCoordinates: { x: 0, y: 0 },
+			},
+		];
+		let resolveFirstLoad: ((blocks: BrowserLocalNoteStorageBlock[]) => void) | undefined;
+		const firstLoad = new Promise<BrowserLocalNoteStorageBlock[]>(resolve => {
+			resolveFirstLoad = resolve;
+		});
+		const loadBrowserLocalNotes = vi.fn(() => firstLoad);
+		const state = createMockState({
+			initialProjectState: { ...EMPTY_DEFAULT_PROJECT },
+			callbacks: {
+				loadBrowserLocalNotes,
+			},
+		});
+		const store = createStateManager(state);
+		const events = createMockEventDispatcherWithVitest();
+
+		browserLocalNotes(store, events);
+		const populateBrowserLocalNotes = getPopulateHandler(events);
+		const firstPopulation = populateBrowserLocalNotes();
+		const secondPopulation = populateBrowserLocalNotes();
+		resolveFirstLoad?.(storedBlocks);
+		await Promise.all([firstPopulation, secondPopulation]);
+
+		expect(loadBrowserLocalNotes).toHaveBeenCalledOnce();
+		expect(state.codeBlockRendering.codeBlocks).toHaveLength(1);
+		expect(state.codeBlockRendering.codeBlocks[0].code[0]).toBe('note local.editorConfig');
+	});
+
+	it('clears rendered browser-local note leftovers before population', async () => {
+		const state = createMockState({
+			initialProjectState: { ...EMPTY_DEFAULT_PROJECT },
+			callbacks: {
+				loadBrowserLocalNotes: vi.fn(async () => [
+					{
+						code: ['note local.scratchpad', '; current', 'noteEnd'],
+						gridCoordinates: { x: 10, y: 10 },
+					},
+				]),
+			},
+			codeBlockRendering: {
+				codeBlocks: [
+					createMockCodeBlock({ code: ['module projectBlock', 'moduleEnd'] }),
+					createMockCodeBlock({ code: ['note local.editorConfig', '; leftover', 'noteEnd'] }),
+					createMockCodeBlock({ code: ['note local.editorConfig', '; duplicate leftover', 'noteEnd'] }),
+				],
+			},
+		});
+		const store = createStateManager(state);
+		const events = createMockEventDispatcherWithVitest();
+
+		browserLocalNotes(store, events);
+		await getPopulateHandler(events)();
+
+		expect(state.codeBlockRendering.codeBlocks.map(block => block.code[0])).toEqual([
+			'module projectBlock',
+			'note local.scratchpad',
+		]);
+	});
+
 	it('moves colliding browser-local notes to the first free y positions for their x span', async () => {
 		const existingTopBlock = createMockCodeBlock({
 			name: 'top',
@@ -173,6 +266,29 @@ describe('browser-local note placement', () => {
 });
 
 describe('browser-local note persistence', () => {
+	it('does not write loaded browser-local notes back to storage', async () => {
+		const saveBrowserLocalNotes = vi.fn(async () => undefined);
+		const state = createMockState({
+			initialProjectState: { ...EMPTY_DEFAULT_PROJECT },
+			callbacks: {
+				loadBrowserLocalNotes: vi.fn(async () => [
+					{
+						code: ['note local.editorConfig', '; config', 'noteEnd'],
+						gridCoordinates: { x: 0, y: 0 },
+					},
+				]),
+				saveBrowserLocalNotes,
+			},
+		});
+		const store = createStateManager(state);
+		const events = createMockEventDispatcherWithVitest();
+
+		browserLocalNotes(store, events);
+		await getPopulateHandler(events)();
+
+		expect(saveBrowserLocalNotes).not.toHaveBeenCalled();
+	});
+
 	it('does not save an empty local note list before local notes are populated for a project', () => {
 		const saveBrowserLocalNotes = vi.fn(async () => undefined);
 		const state = createMockState({
@@ -227,6 +343,7 @@ describe('browser-local note persistence', () => {
 				code: ['module projectOnly', 'moduleEnd'],
 			}),
 		]);
+		state.initialProjectState = { ...EMPTY_DEFAULT_PROJECT };
 		expect(saveBrowserLocalNotes).not.toHaveBeenCalled();
 
 		await populateBrowserLocalNotes();

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/browser-local-notes/effect.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/browser-local-notes/effect.ts
@@ -21,21 +21,45 @@ import {
 } from './browserLocalNotes';
 
 export default function browserLocalNotes(store: StateManager<State>, events: EventDispatcher): void {
+	type ProjectState = NonNullable<State['initialProjectState']>;
+
 	const state = store.getState();
+	if (!state.featureFlags.browserLocalNotes) {
+		return;
+	}
+
 	let lastSavedBrowserLocalNotes = '';
 	let browserLocalNotesLoaded = false;
+	let populatedProject: ProjectState | undefined;
+	let populationInProgress: { project: ProjectState; promise: Promise<void> } | undefined;
 
-	async function populateBrowserLocalNotes() {
-		if (!state.initialProjectState || !state.callbacks.loadBrowserLocalNotes) {
-			return;
+	function populateBrowserLocalNotes(): Promise<void> {
+		const project = state.initialProjectState;
+		if (!project || !state.callbacks.loadBrowserLocalNotes || project === populatedProject) {
+			return Promise.resolve();
 		}
 
+		if (populationInProgress?.project === project) {
+			return populationInProgress.promise;
+		}
+
+		browserLocalNotesLoaded = false;
+		const population = loadBrowserLocalNotesForProject(project);
+		populationInProgress = { project, promise: population };
+		return population;
+	}
+
+	async function loadBrowserLocalNotesForProject(project: ProjectState): Promise<void> {
 		try {
-			const loadedBlocks = (await state.callbacks.loadBrowserLocalNotes()) ?? [];
+			const loadedBlocks = (await state.callbacks.loadBrowserLocalNotes?.()) ?? [];
+			if (state.initialProjectState !== project) {
+				return;
+			}
+
 			const validBlocks = loadedBlocks.filter(block => isBrowserLocalNoteCode(block.code));
 			const browserLocalNotes = validBlocks.length > 0 ? validBlocks : [DEFAULT_BROWSER_LOCAL_NOTE];
 
-			const nextCodeBlocks = [...state.codeBlockRendering.codeBlocks];
+			const nextCodeBlocks = state.codeBlockRendering.codeBlocks.filter(block => !isBrowserLocalNoteBlock(block));
 			const occupiedBounds: GridBounds[] = nextCodeBlocks
 				.filter(existingCodeBlock => existingCodeBlock.viewportAnchor === undefined)
 				.map(existingCodeBlock => getCodeBlockGridBounds(existingCodeBlock, state.viewport));
@@ -101,9 +125,14 @@ export default function browserLocalNotes(store: StateManager<State>, events: Ev
 			browserLocalNotesLoaded = true;
 			replaceCodeBlocksInPlace(state.codeBlockRendering.codeBlocks, nextCodeBlocks);
 			store.set('codeBlockRendering.codeBlocks', state.codeBlockRendering.codeBlocks);
-			saveBrowserLocalNotes();
+			lastSavedBrowserLocalNotes = JSON.stringify(serializeBrowserLocalNotes(state.codeBlockRendering.codeBlocks));
+			populatedProject = project;
 		} catch (err) {
 			console.warn('Failed to load browser-local notes from storage:', err);
+		} finally {
+			if (populationInProgress?.project === project) {
+				populationInProgress = undefined;
+			}
 		}
 	}
 

--- a/packages/editor/packages/editor-core/packages/editor-state/src/index.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/index.test.ts
@@ -3,6 +3,28 @@ import initState from './index';
 import { createMockEventDispatcherWithVitest } from './pureHelpers/testingUtils/vitestTestUtils';
 
 describe('editor state lifecycle', () => {
+	it('enables browser-local notes by default and allows disabling them at initialization', () => {
+		const enabledEvents = createMockEventDispatcherWithVitest();
+		const enabledStore = initState(enabledEvents, {
+			callbacks: { loadSession: async () => null },
+			runtimeRegistry: {},
+		});
+		const disabledEvents = createMockEventDispatcherWithVitest();
+		const disabledStore = initState(disabledEvents, {
+			callbacks: { loadSession: async () => null },
+			runtimeRegistry: {},
+			featureFlags: { browserLocalNotes: false },
+		});
+
+		expect(enabledStore.getState().featureFlags.browserLocalNotes).toBe(true);
+		expect(enabledEvents.on).toHaveBeenCalledWith('projectCodeBlocksPopulated', expect.any(Function));
+		expect(disabledStore.getState().featureFlags.browserLocalNotes).toBe(false);
+		expect(disabledEvents.on).not.toHaveBeenCalledWith('projectCodeBlocksPopulated', expect.any(Function));
+
+		enabledStore.dispose();
+		disabledStore.dispose();
+	});
+
 	it('disposes initialized effects and their active runtime exactly once', async () => {
 		const runtimeDestroyer = vi.fn();
 		const runtimeFactory = vi.fn(() => runtimeDestroyer);

--- a/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/state/featureFlags.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/state/featureFlags.ts
@@ -19,6 +19,7 @@ export const defaultFeatureFlags: FeatureFlags = {
 	offscreenBlockArrows: true,
 	projectOpening: true,
 	projectCreation: true,
+	browserLocalNotes: true,
 };
 
 /**

--- a/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
@@ -343,6 +343,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			offscreenBlockArrows: true,
 			projectOpening: true,
 			projectCreation: true,
+			browserLocalNotes: true,
 		},
 		editorMode: 'edit',
 		editorConfig: {},

--- a/packages/editor/packages/editor-core/src/config/featureFlags.test.ts
+++ b/packages/editor/packages/editor-core/src/config/featureFlags.test.ts
@@ -39,6 +39,13 @@ describe('Feature Flags Configuration', () => {
 		expect(defaultFeatureFlags.offscreenBlockArrows).toBe(true);
 		expect(defaultFeatureFlags.projectOpening).toBe(true);
 		expect(defaultFeatureFlags.projectCreation).toBe(true);
+		expect(defaultFeatureFlags.browserLocalNotes).toBe(true);
+	});
+
+	test('validateFeatureFlags should allow disabling browser-local notes', () => {
+		const result = validateFeatureFlags({ browserLocalNotes: false });
+
+		expect(result.browserLocalNotes).toBe(false);
 	});
 
 	test('validateFeatureFlags should preserve enabled flags when disabled flags are specified', () => {

--- a/packages/editor/packages/editor-core/src/config/featureFlags.ts
+++ b/packages/editor/packages/editor-core/src/config/featureFlags.ts
@@ -28,6 +28,7 @@ export const defaultFeatureFlags = {
 	offscreenBlockArrows: true,
 	projectOpening: true,
 	projectCreation: true,
+	browserLocalNotes: true,
 };
 
 /**

--- a/packages/editor/packages/editor-core/src/integration/featureFlags.test.ts
+++ b/packages/editor/packages/editor-core/src/integration/featureFlags.test.ts
@@ -52,6 +52,7 @@ describe('Feature Flags Integration', () => {
 		expect(result).toHaveProperty('offscreenBlockArrows');
 		expect(result).toHaveProperty('projectOpening');
 		expect(result).toHaveProperty('projectCreation');
+		expect(result).toHaveProperty('browserLocalNotes');
 
 		// Should merge correctly
 		expect(result.contextMenu).toBe(false);
@@ -65,6 +66,7 @@ describe('Feature Flags Integration', () => {
 		expect(result.offscreenBlockArrows).toBe(true);
 		expect(result.projectOpening).toBe(true);
 		expect(result.projectCreation).toBe(true);
+		expect(result.browserLocalNotes).toBe(true);
 	});
 
 	test('should preserve defaults when no mode is configured through feature flags', () => {


### PR DESCRIPTION
## Summary

- populate browser-local notes once per project and coalesce overlapping population events
- remove rendered local-note leftovers and avoid writing unchanged loaded state back to storage
- add the enabled-by-default `browserLocalNotes` feature flag
- disable browser-local notes in the embedded 8f4e website editors

## Rationale

Nested project-state updates could start overlapping asynchronous browser-local-note loads. Each completion appended another editor-config note, allowing the block to multiply. The new population lifecycle is idempotent per project and can be disabled for embedded editor instances.

## Test notes

- `npx nx run @8f4e/editor-state:test` — 1,122 tests passed
- focused editor-core feature-flag tests — 16 tests passed
- `npx nx run @8f4e/editor-core:typecheck`
- `npx nx run @8f4e/editor-default:typecheck`
- `npx nx run @8f4e/8f4e-website:build`