### PR TITLE
feat(editor-core): add configurable dialog buttons

### DIFF
--- a/packages/editor/packages/editor-core/packages/editor-state-testing/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state-testing/src/index.ts
@@ -251,6 +251,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			wrappedText: [''],
 			title: '',
 			buttons: [],
+			highlightedButton: Infinity,
 			width: 0,
 			height: 0,
 			x: 0,

--- a/packages/editor/packages/editor-core/packages/editor-state-types/src/features/dialog/types.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state-types/src/features/dialog/types.ts
@@ -1,8 +1,13 @@
+import type { Position, Size } from '../../shared/types';
+
 export interface DialogButton {
 	title: string;
-	action: string;
+	action?: string;
 	payload?: unknown;
+	close?: boolean;
 }
+
+export type DialogButtonState = DialogButton & Position & Size;
 
 export interface DialogContent {
 	id: string;
@@ -11,8 +16,10 @@ export interface DialogContent {
 	buttons: DialogButton[];
 }
 
-export interface DialogState extends DialogContent {
+export interface DialogState extends Omit<DialogContent, 'buttons'> {
 	wrappedText: string[];
+	buttons: DialogButtonState[];
+	highlightedButton: number;
 	width: number;
 	height: number;
 	x: number;

--- a/packages/editor/packages/editor-core/packages/editor-state-types/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state-types/src/index.ts
@@ -40,7 +40,7 @@ import type {
 	TypedValueKind,
 } from './features/code-blocks/types';
 import type { InsertTextEvent, MoveCaretEvent, NavigateCodeBlockEvent } from './features/code-editing/types';
-import type { DialogButton, DialogContent, DialogState } from './features/dialog/types';
+import type { DialogButton, DialogButtonState, DialogContent, DialogState } from './features/dialog/types';
 import type {
 	EditorConfig,
 	EditorConfigSchemaContributionRegistry,
@@ -105,6 +105,7 @@ export type {
 	Crossfade,
 	Debugger,
 	DialogButton,
+	DialogButtonState,
 	DialogContent,
 	DialogState,
 	EventDispatcher,

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/effect.test.ts
@@ -1,4 +1,4 @@
-import type { State } from '@8f4e/editor-state-types';
+import type { InternalMouseEvent, State } from '@8f4e/editor-state-types';
 import createStateManager from '@8f4e/state-manager';
 import { describe, expect, it, type MockInstance } from 'vitest';
 import { createMockState } from '~/pureHelpers/testingUtils/testUtils';
@@ -23,7 +23,7 @@ describe('dialog effect', () => {
 			callback(event);
 		}
 
-		return { emit, onResize };
+		return { emit, events, onResize };
 	}
 
 	it('uses the minimum dialog width when half the viewport is too narrow', () => {
@@ -148,5 +148,104 @@ describe('dialog effect', () => {
 
 		expect(state.dialogStack).toEqual([]);
 		expect(state.dialog.id).toBe('');
+	});
+
+	it('lays out and activates dialog buttons while blocking pointer propagation', () => {
+		const state = createMockState({
+			dialogStack: [
+				{
+					id: 'confirmation',
+					text: 'Continue?',
+					title: 'Confirm',
+					buttons: [{ title: 'Cancel' }, { title: 'Grant', action: 'confirmAction', payload: { id: 42 } }],
+				},
+			],
+			viewport: {
+				width: 1280,
+				height: 768,
+				vGrid: 8,
+				hGrid: 16,
+			},
+		});
+		const { emit, events } = setup(state);
+
+		expect(state.dialog.height).toBe(112);
+		expect(state.dialog.buttons).toEqual([
+			{ title: 'Cancel', x: 504, y: 80, width: 64, height: 16 },
+			{ title: 'Grant', action: 'confirmAction', payload: { id: 42 }, x: 576, y: 80, width: 56, height: 16 },
+		]);
+
+		const pointerEvent: InternalMouseEvent = {
+			x: state.dialog.x + state.dialog.buttons[1].x + 1,
+			y: state.dialog.y + state.dialog.buttons[1].y + 1,
+			movementX: 0,
+			movementY: 0,
+			buttons: 1,
+			stopPropagation: false,
+			canvasWidth: 1280,
+			canvasHeight: 768,
+			altKey: false,
+		};
+
+		emit('mousemove', pointerEvent);
+		expect(state.dialog.highlightedButton).toBe(1);
+		expect(pointerEvent.stopPropagation).toBe(true);
+
+		pointerEvent.stopPropagation = false;
+		emit('mousedown', pointerEvent);
+
+		expect(pointerEvent.stopPropagation).toBe(true);
+		expect(state.dialogStack).toEqual([]);
+		expect(events.dispatch).toHaveBeenCalledWith('confirmAction', { id: 42 });
+	});
+
+	it('blocks clicks outside dialog buttons without closing the dialog', () => {
+		const state = createMockState({
+			dialogStack: [
+				{
+					id: 'loading',
+					text: 'Please wait',
+					title: 'Loading',
+					buttons: [],
+				},
+			],
+		});
+		const { emit, events } = setup(state);
+		const pointerEvent = {
+			x: 0,
+			y: 0,
+			stopPropagation: false,
+		} as InternalMouseEvent;
+
+		emit('mousedown', pointerEvent);
+
+		expect(pointerEvent.stopPropagation).toBe(true);
+		expect(state.dialogStack).toHaveLength(1);
+		expect(events.dispatch).not.toHaveBeenCalled();
+	});
+
+	it('keeps the dialog open when a button opts out of closing it', () => {
+		const state = createMockState({
+			dialogStack: [
+				{
+					id: 'retry-dialog',
+					text: 'Try again?',
+					title: 'Retry',
+					buttons: [{ title: 'Retry', action: 'retryAction', close: false }],
+				},
+			],
+		});
+		const { emit, events } = setup(state);
+		const button = state.dialog.buttons[0];
+		const pointerEvent = {
+			x: state.dialog.x + button.x + 1,
+			y: state.dialog.y + button.y + 1,
+			stopPropagation: false,
+		} as InternalMouseEvent;
+
+		emit('mousedown', pointerEvent);
+
+		expect(state.dialogStack).toHaveLength(1);
+		expect(events.dispatch).toHaveBeenCalledWith('retryAction', undefined);
 	});
 });

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/effect.test.ts
@@ -171,8 +171,8 @@ describe('dialog effect', () => {
 
 		expect(state.dialog.height).toBe(144);
 		expect(state.dialog.buttons).toEqual([
-			{ title: 'Cancel', x: 472, y: 80, width: 80, height: 48 },
-			{ title: 'Allow', action: 'confirmAction', payload: { id: 42 }, x: 560, y: 80, width: 72, height: 48 },
+			{ title: 'Cancel', x: 408, y: 80, width: 112, height: 48 },
+			{ title: 'Allow', action: 'confirmAction', payload: { id: 42 }, x: 528, y: 80, width: 104, height: 48 },
 		]);
 
 		const pointerEvent: InternalMouseEvent = {

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/effect.test.ts
@@ -157,7 +157,7 @@ describe('dialog effect', () => {
 					id: 'confirmation',
 					text: 'Continue?',
 					title: 'Confirm',
-					buttons: [{ title: 'Cancel' }, { title: 'Grant', action: 'confirmAction', payload: { id: 42 } }],
+					buttons: [{ title: 'Cancel' }, { title: 'Allow', action: 'confirmAction', payload: { id: 42 } }],
 				},
 			],
 			viewport: {
@@ -172,7 +172,7 @@ describe('dialog effect', () => {
 		expect(state.dialog.height).toBe(144);
 		expect(state.dialog.buttons).toEqual([
 			{ title: 'Cancel', x: 472, y: 80, width: 80, height: 48 },
-			{ title: 'Grant', action: 'confirmAction', payload: { id: 42 }, x: 560, y: 80, width: 72, height: 48 },
+			{ title: 'Allow', action: 'confirmAction', payload: { id: 42 }, x: 560, y: 80, width: 72, height: 48 },
 		]);
 
 		const pointerEvent: InternalMouseEvent = {

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/effect.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/effect.test.ts
@@ -169,10 +169,10 @@ describe('dialog effect', () => {
 		});
 		const { emit, events } = setup(state);
 
-		expect(state.dialog.height).toBe(112);
+		expect(state.dialog.height).toBe(144);
 		expect(state.dialog.buttons).toEqual([
-			{ title: 'Cancel', x: 504, y: 80, width: 64, height: 16 },
-			{ title: 'Grant', action: 'confirmAction', payload: { id: 42 }, x: 576, y: 80, width: 56, height: 16 },
+			{ title: 'Cancel', x: 472, y: 80, width: 80, height: 48 },
+			{ title: 'Grant', action: 'confirmAction', payload: { id: 42 }, x: 560, y: 80, width: 72, height: 48 },
 		]);
 
 		const pointerEvent: InternalMouseEvent = {

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/effect.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/effect.ts
@@ -44,7 +44,8 @@ export default function dialog(store: StateManager<State>, events: EventDispatch
 			state.viewport.hGrid
 		);
 		const roundedDialogHeight =
-			(wrappedText.length + buttonLayout.rowCount + DIALOG_VERTICAL_GRID_CELLS_WITHOUT_TEXT) * state.viewport.hGrid;
+			(wrappedText.length + buttonLayout.heightInGridRows + DIALOG_VERTICAL_GRID_CELLS_WITHOUT_TEXT) *
+			state.viewport.hGrid;
 
 		state.dialog.id = visibleDialog.id;
 		state.dialog.text = visibleDialog.text;

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/effect.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/effect.ts
@@ -1,7 +1,8 @@
-import type { DialogContent, EventDispatcher, State } from '@8f4e/editor-state-types';
+import type { DialogContent, EventDispatcher, InternalMouseEvent, State } from '@8f4e/editor-state-types';
 import type { StateManager } from '@8f4e/state-manager';
 import roundToGrid from '~/features/viewport/roundToGrid';
 import wrapText from '../code-blocks/utils/wrapText';
+import layoutButtons from './layoutButtons';
 
 const DIALOG_MIN_WIDTH_GRID_CELLS = 64;
 const DIALOG_MAX_WIDTH_GRID_CELLS = 96;
@@ -9,7 +10,7 @@ const DIALOG_VERTICAL_GRID_CELLS_WITHOUT_TEXT = 5;
 
 type RemoveDialogEvent = string | { id: string };
 
-export default function dialog(store: StateManager<State>, events: EventDispatcher): void {
+export default function dialog(store: StateManager<State>, events: EventDispatcher): () => void {
 	const state = store.getState();
 
 	function syncVisibleDialog() {
@@ -21,6 +22,7 @@ export default function dialog(store: StateManager<State>, events: EventDispatch
 			state.dialog.wrappedText = [''];
 			state.dialog.title = '';
 			state.dialog.buttons = [];
+			state.dialog.highlightedButton = Infinity;
 			state.dialog.width = 0;
 			state.dialog.height = 0;
 			state.dialog.x = 0;
@@ -34,12 +36,21 @@ export default function dialog(store: StateManager<State>, events: EventDispatch
 		);
 		const [roundedDialogWidth] = roundToGrid(dialogWidth, 0, state.viewport);
 		const wrappedText = wrapText(visibleDialog.text, Math.floor(roundedDialogWidth / state.viewport.vGrid) - 2);
-		const roundedDialogHeight = (wrappedText.length + DIALOG_VERTICAL_GRID_CELLS_WITHOUT_TEXT) * state.viewport.hGrid;
+		const buttonLayout = layoutButtons(
+			visibleDialog.buttons,
+			roundedDialogWidth,
+			wrappedText.length,
+			state.viewport.vGrid,
+			state.viewport.hGrid
+		);
+		const roundedDialogHeight =
+			(wrappedText.length + buttonLayout.rowCount + DIALOG_VERTICAL_GRID_CELLS_WITHOUT_TEXT) * state.viewport.hGrid;
 
 		state.dialog.id = visibleDialog.id;
 		state.dialog.text = visibleDialog.text;
 		state.dialog.title = visibleDialog.title;
-		state.dialog.buttons = visibleDialog.buttons;
+		state.dialog.buttons = buttonLayout.buttons;
+		state.dialog.highlightedButton = Infinity;
 		state.dialog.width = roundedDialogWidth;
 		state.dialog.height = roundedDialogHeight;
 
@@ -67,11 +78,83 @@ export default function dialog(store: StateManager<State>, events: EventDispatch
 		);
 	}
 
+	function findButtonAtCoordinates(x: number, y: number): number {
+		const dialogX = x - state.dialog.x;
+		const dialogY = y - state.dialog.y;
+
+		return state.dialog.buttons.findIndex(
+			button =>
+				dialogX >= button.x &&
+				dialogX < button.x + button.width &&
+				dialogY >= button.y &&
+				dialogY < button.y + button.height
+		);
+	}
+
+	function onMouseMove(event: InternalMouseEvent): void {
+		if (state.dialogStack.length === 0) {
+			return;
+		}
+
+		const buttonIndex = findButtonAtCoordinates(event.x, event.y);
+		state.dialog.highlightedButton = buttonIndex === -1 ? Infinity : buttonIndex;
+		event.stopPropagation = true;
+	}
+
+	function onMouseDown(event: InternalMouseEvent): void {
+		if (state.dialogStack.length === 0) {
+			return;
+		}
+
+		const buttonIndex = findButtonAtCoordinates(event.x, event.y);
+		const button = state.dialog.buttons[buttonIndex];
+		event.stopPropagation = true;
+
+		if (!button) {
+			return;
+		}
+
+		const dialogId = state.dialog.id;
+		if (button.close !== false) {
+			removeDialog({ id: dialogId });
+		}
+
+		if (button.action) {
+			events.dispatch(button.action, button.payload);
+		}
+	}
+
+	function blockPointerEvent(event: InternalMouseEvent): void {
+		if (state.dialogStack.length > 0) {
+			event.stopPropagation = true;
+		}
+	}
+
+	function clearDialogs(): void {
+		store.set('dialogStack', []);
+	}
+
 	store.subscribe('dialogStack', syncVisibleDialog);
 	events.on('resize', syncVisibleDialog);
 	events.on('addDialog', addDialog);
 	events.on('removeDialog', removeDialog);
-	events.on('clearDialogs', () => store.set('dialogStack', []));
+	events.on('clearDialogs', clearDialogs);
+	events.on('mousemove', onMouseMove);
+	events.on('mousedown', onMouseDown);
+	events.on('mouseup', blockPointerEvent);
+	events.on('contextmenu', blockPointerEvent);
 
 	syncVisibleDialog();
+
+	return () => {
+		store.unsubscribe('dialogStack', syncVisibleDialog);
+		events.off('resize', syncVisibleDialog);
+		events.off('addDialog', addDialog);
+		events.off('removeDialog', removeDialog);
+		events.off('clearDialogs', clearDialogs);
+		events.off('mousemove', onMouseMove);
+		events.off('mousedown', onMouseDown);
+		events.off('mouseup', blockPointerEvent);
+		events.off('contextmenu', blockPointerEvent);
+	};
 }

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/layoutButtons.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/layoutButtons.ts
@@ -1,0 +1,70 @@
+import type { DialogButton, DialogButtonState } from '@8f4e/editor-state-types';
+
+const BUTTON_HORIZONTAL_PADDING_GRID_CELLS = 1;
+const BUTTON_GAP_GRID_CELLS = 1;
+
+interface ButtonLayout {
+	buttons: DialogButtonState[];
+	rowCount: number;
+}
+
+interface MeasuredButton extends DialogButton {
+	width: number;
+}
+
+export default function layoutButtons(
+	buttons: DialogButton[],
+	dialogWidth: number,
+	textLineCount: number,
+	vGrid: number,
+	hGrid: number
+): ButtonLayout {
+	if (buttons.length === 0) {
+		return { buttons: [], rowCount: 0 };
+	}
+
+	const availableWidth = dialogWidth - 2 * vGrid;
+	const buttonGap = BUTTON_GAP_GRID_CELLS * vGrid;
+	const maximumTitleLength = Math.max(0, Math.floor(availableWidth / vGrid) - 2 * BUTTON_HORIZONTAL_PADDING_GRID_CELLS);
+	const measuredButtons: MeasuredButton[] = buttons.map(button => {
+		const title = button.title.slice(0, maximumTitleLength);
+		return {
+			...button,
+			title,
+			width: (title.length + 2 * BUTTON_HORIZONTAL_PADDING_GRID_CELLS) * vGrid,
+		};
+	});
+	const rows: MeasuredButton[][] = [];
+
+	for (const button of measuredButtons) {
+		const row = rows[rows.length - 1];
+		const occupiedWidth = row?.reduce((width, item) => width + item.width, 0) ?? 0;
+		const gapsWidth = row ? row.length * buttonGap : 0;
+
+		if (!row || (row.length > 0 && occupiedWidth + gapsWidth + button.width > availableWidth)) {
+			rows.push([button]);
+			continue;
+		}
+
+		row.push(button);
+	}
+
+	const laidOutButtons = rows.flatMap((row, rowIndex) => {
+		const rowWidth = row.reduce((width, button) => width + button.width, 0) + (row.length - 1) * buttonGap;
+		let x = dialogWidth - vGrid - rowWidth;
+		const y = (textLineCount + 4 + rowIndex) * hGrid;
+
+		return row.map(button => {
+			const layout: DialogButtonState = {
+				...button,
+				x,
+				y,
+				height: hGrid,
+			};
+			x += button.width + buttonGap;
+			return layout;
+		});
+	});
+
+	return { buttons: laidOutButtons, rowCount: rows.length };
+}

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/layoutButtons.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/layoutButtons.ts
@@ -1,11 +1,12 @@
 import type { DialogButton, DialogButtonState } from '@8f4e/editor-state-types';
 
-const BUTTON_HORIZONTAL_PADDING_GRID_CELLS = 1;
+const BUTTON_HORIZONTAL_PADDING_GRID_CELLS = 2;
+const BUTTON_HEIGHT_GRID_CELLS = 3;
 const BUTTON_GAP_GRID_CELLS = 1;
 
 interface ButtonLayout {
 	buttons: DialogButtonState[];
-	rowCount: number;
+	heightInGridRows: number;
 }
 
 interface MeasuredButton extends DialogButton {
@@ -20,7 +21,7 @@ export default function layoutButtons(
 	hGrid: number
 ): ButtonLayout {
 	if (buttons.length === 0) {
-		return { buttons: [], rowCount: 0 };
+		return { buttons: [], heightInGridRows: 0 };
 	}
 
 	const availableWidth = dialogWidth - 2 * vGrid;
@@ -52,19 +53,19 @@ export default function layoutButtons(
 	const laidOutButtons = rows.flatMap((row, rowIndex) => {
 		const rowWidth = row.reduce((width, button) => width + button.width, 0) + (row.length - 1) * buttonGap;
 		let x = dialogWidth - vGrid - rowWidth;
-		const y = (textLineCount + 4 + rowIndex) * hGrid;
+		const y = (textLineCount + 4 + rowIndex * BUTTON_HEIGHT_GRID_CELLS) * hGrid;
 
 		return row.map(button => {
 			const layout: DialogButtonState = {
 				...button,
 				x,
 				y,
-				height: hGrid,
+				height: BUTTON_HEIGHT_GRID_CELLS * hGrid,
 			};
 			x += button.width + buttonGap;
 			return layout;
 		});
 	});
 
-	return { buttons: laidOutButtons, rowCount: rows.length };
+	return { buttons: laidOutButtons, heightInGridRows: rows.length * BUTTON_HEIGHT_GRID_CELLS };
 }

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/layoutButtons.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/dialog/layoutButtons.ts
@@ -1,6 +1,6 @@
 import type { DialogButton, DialogButtonState } from '@8f4e/editor-state-types';
 
-const BUTTON_HORIZONTAL_PADDING_GRID_CELLS = 2;
+const BUTTON_HORIZONTAL_PADDING_GRID_CELLS = 4;
 const BUTTON_HEIGHT_GRID_CELLS = 3;
 const BUTTON_GAP_GRID_CELLS = 1;
 

--- a/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/state/createDefaultState.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/state/createDefaultState.ts
@@ -97,6 +97,7 @@ export default function createDefaultState() {
 			wrappedText: [''],
 			title: '',
 			buttons: [],
+			highlightedButton: Infinity,
 			width: 0,
 			height: 0,
 			x: 0,

--- a/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/pureHelpers/testingUtils/testUtils.ts
@@ -372,6 +372,7 @@ export function createMockState(overrides: DeepPartial<State> = {}): State {
 			wrappedText: [''],
 			title: '',
 			buttons: [],
+			highlightedButton: Infinity,
 			width: 0,
 			height: 0,
 			x: 0,

--- a/packages/editor/packages/editor-core/packages/web-ui/src/drawers/dialog.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/drawers/dialog.test.ts
@@ -1,0 +1,64 @@
+import { createMockState } from '@8f4e/editor-state-testing';
+import { describe, expect, it, type vi } from 'vitest';
+import { createDrawContextMock, createSpriteIdLookupMock } from '../__tests__/rendering';
+import drawDialog from './dialog';
+
+describe('drawDialog', () => {
+	it('draws a highlighted dialog button', () => {
+		const engine = createDrawContextMock();
+		const state = createMockState({
+			dialogStack: [{ id: 'permission', title: 'Permission', text: 'Allow audio?', buttons: [] }],
+			dialog: {
+				id: 'permission',
+				title: 'Permission',
+				text: 'Allow audio?',
+				wrappedText: ['Allow audio?'],
+				buttons: [
+					{
+						title: 'Grant',
+						action: 'grantAudioPermission',
+						x: 448,
+						y: 80,
+						width: 56,
+						height: 16,
+					},
+				],
+				highlightedButton: 0,
+				x: 64,
+				y: 320,
+				width: 512,
+				height: 112,
+			},
+			viewport: {
+				width: 640,
+				height: 768,
+				vGrid: 8,
+				hGrid: 16,
+			},
+			spriteLookups: {
+				fillColors: createSpriteIdLookupMock(),
+				fontCode: createSpriteIdLookupMock(),
+				fontDialogTitle: createSpriteIdLookupMock(),
+				fontDialogText: createSpriteIdLookupMock(),
+				fontMenuItemText: createSpriteIdLookupMock(),
+				fontMenuItemTextHighlighted: createSpriteIdLookupMock(),
+			} as never,
+		});
+
+		drawDialog(engine, state);
+
+		expect((engine as unknown as { drawSprite: ReturnType<typeof vi.fn> }).drawSprite).toHaveBeenCalledWith(
+			448,
+			80,
+			'menuItemBackgroundHighlighted',
+			56,
+			16
+		);
+		expect((engine as unknown as { drawText: ReturnType<typeof vi.fn> }).drawText).toHaveBeenCalledWith(
+			448,
+			80,
+			'[Grant]',
+			state.spriteLookups?.fontMenuItemTextHighlighted
+		);
+	});
+});

--- a/packages/editor/packages/editor-core/packages/web-ui/src/drawers/dialog.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/drawers/dialog.test.ts
@@ -4,7 +4,7 @@ import { createDrawContextMock, createSpriteIdLookupMock } from '../__tests__/re
 import drawDialog from './dialog';
 
 describe('drawDialog', () => {
-	it('draws a highlighted dialog button', () => {
+	it('draws a white dialog button with black text and grid padding', () => {
 		const engine = createDrawContextMock();
 		const state = createMockState({
 			dialogStack: [{ id: 'permission', title: 'Permission', text: 'Allow audio?', buttons: [] }],
@@ -17,13 +17,13 @@ describe('drawDialog', () => {
 					{
 						title: 'Grant',
 						action: 'grantAudioPermission',
-						x: 448,
+						x: 432,
 						y: 80,
-						width: 56,
-						height: 16,
+						width: 72,
+						height: 48,
 					},
 				],
-				highlightedButton: 0,
+				highlightedButton: Infinity,
 				x: 64,
 				y: 320,
 				width: 512,
@@ -48,16 +48,16 @@ describe('drawDialog', () => {
 		drawDialog(engine, state);
 
 		expect((engine as unknown as { drawSprite: ReturnType<typeof vi.fn> }).drawSprite).toHaveBeenCalledWith(
-			448,
+			432,
 			80,
 			'menuItemBackgroundHighlighted',
-			56,
-			16
+			72,
+			48
 		);
 		expect((engine as unknown as { drawText: ReturnType<typeof vi.fn> }).drawText).toHaveBeenCalledWith(
 			448,
-			80,
-			'[Grant]',
+			96,
+			'Grant',
 			state.spriteLookups?.fontMenuItemTextHighlighted
 		);
 	});

--- a/packages/editor/packages/editor-core/packages/web-ui/src/drawers/dialog.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/drawers/dialog.test.ts
@@ -17,9 +17,9 @@ describe('drawDialog', () => {
 					{
 						title: 'Allow',
 						action: 'grantAudioPermission',
-						x: 432,
+						x: 400,
 						y: 80,
-						width: 72,
+						width: 104,
 						height: 48,
 					},
 				],
@@ -48,14 +48,14 @@ describe('drawDialog', () => {
 		drawDialog(engine, state);
 
 		expect((engine as unknown as { drawSprite: ReturnType<typeof vi.fn> }).drawSprite).toHaveBeenCalledWith(
-			432,
+			400,
 			80,
 			'menuItemBackgroundHighlighted',
-			72,
+			104,
 			48
 		);
 		expect((engine as unknown as { drawText: ReturnType<typeof vi.fn> }).drawText).toHaveBeenCalledWith(
-			448,
+			432,
 			96,
 			'Allow',
 			state.spriteLookups?.fontMenuItemTextHighlighted

--- a/packages/editor/packages/editor-core/packages/web-ui/src/drawers/dialog.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/drawers/dialog.test.ts
@@ -15,7 +15,7 @@ describe('drawDialog', () => {
 				wrappedText: ['Allow audio?'],
 				buttons: [
 					{
-						title: 'Grant',
+						title: 'Allow',
 						action: 'grantAudioPermission',
 						x: 432,
 						y: 80,
@@ -57,7 +57,7 @@ describe('drawDialog', () => {
 		expect((engine as unknown as { drawText: ReturnType<typeof vi.fn> }).drawText).toHaveBeenCalledWith(
 			448,
 			96,
-			'Grant',
+			'Allow',
 			state.spriteLookups?.fontMenuItemTextHighlighted
 		);
 	});

--- a/packages/editor/packages/editor-core/packages/web-ui/src/drawers/dialog.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/drawers/dialog.ts
@@ -2,7 +2,7 @@ import type { State } from '@8f4e/editor-state-types';
 import type { DrawContext } from '../drawContext';
 
 const DIALOG_CORNER = '+';
-const BUTTON_HORIZONTAL_PADDING_GRID_CELLS = 2;
+const BUTTON_HORIZONTAL_PADDING_GRID_CELLS = 4;
 const BUTTON_VERTICAL_PADDING_GRID_CELLS = 1;
 
 export default function drawDialog(engine: DrawContext, state: State): void {

--- a/packages/editor/packages/editor-core/packages/web-ui/src/drawers/dialog.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/drawers/dialog.ts
@@ -2,6 +2,8 @@ import type { State } from '@8f4e/editor-state-types';
 import type { DrawContext } from '../drawContext';
 
 const DIALOG_CORNER = '+';
+const BUTTON_HORIZONTAL_PADDING_GRID_CELLS = 2;
+const BUTTON_VERTICAL_PADDING_GRID_CELLS = 1;
 
 export default function drawDialog(engine: DrawContext, state: State): void {
 	if (state.dialogStack.length === 0 || !state.spriteLookups) {
@@ -35,21 +37,18 @@ export default function drawDialog(engine: DrawContext, state: State): void {
 
 	for (let i = 0; i < state.dialog.buttons.length; i++) {
 		const button = state.dialog.buttons[i];
-		const isHighlighted = i === state.dialog.highlightedButton;
 		engine.drawSprite(
 			button.x,
 			button.y,
-			isHighlighted
-				? state.spriteLookups.fillColors.menuItemBackgroundHighlighted
-				: state.spriteLookups.fillColors.menuItemBackground,
+			state.spriteLookups.fillColors.menuItemBackgroundHighlighted,
 			button.width,
 			button.height
 		);
 		engine.drawText(
-			button.x,
-			button.y,
-			`[${button.title}]`,
-			isHighlighted ? state.spriteLookups.fontMenuItemTextHighlighted : state.spriteLookups.fontMenuItemText
+			button.x + BUTTON_HORIZONTAL_PADDING_GRID_CELLS * state.viewport.vGrid,
+			button.y + BUTTON_VERTICAL_PADDING_GRID_CELLS * state.viewport.hGrid,
+			button.title,
+			state.spriteLookups.fontMenuItemTextHighlighted
 		);
 	}
 

--- a/packages/editor/packages/editor-core/packages/web-ui/src/drawers/dialog.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/drawers/dialog.ts
@@ -33,5 +33,25 @@ export default function drawDialog(engine: DrawContext, state: State): void {
 		engine.drawText(state.viewport.vGrid, textY, state.dialog.wrappedText[i], state.spriteLookups.fontDialogText);
 	}
 
+	for (let i = 0; i < state.dialog.buttons.length; i++) {
+		const button = state.dialog.buttons[i];
+		const isHighlighted = i === state.dialog.highlightedButton;
+		engine.drawSprite(
+			button.x,
+			button.y,
+			isHighlighted
+				? state.spriteLookups.fillColors.menuItemBackgroundHighlighted
+				: state.spriteLookups.fillColors.menuItemBackground,
+			button.width,
+			button.height
+		);
+		engine.drawText(
+			button.x,
+			button.y,
+			`[${button.title}]`,
+			isHighlighted ? state.spriteLookups.fontMenuItemTextHighlighted : state.spriteLookups.fontMenuItemText
+		);
+	}
+
 	engine.endGroup();
 }

--- a/packages/editor/packages/editor-core/packages/web-ui/src/index.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/index.test.ts
@@ -210,6 +210,30 @@ describe('web-ui init', () => {
 		expect(mocks.drawModeOverlay).toHaveBeenCalledWith(expect.anything(), frameState);
 	});
 
+	it('hides wires while a dialog is visible and restores them when it closes', async () => {
+		const { default: init } = await import('./index');
+		const state = createMockState({
+			dialogStack: [{ id: 'permission', title: 'Permission', text: 'Allow audio?', buttons: [] }],
+		});
+		const memoryViews = {
+			int8: new Int8Array(0),
+			int16: new Int16Array(0),
+			int32: new Int32Array(0),
+			uint8: new Uint8Array(0),
+			uint16: new Uint16Array(0),
+			float32: new Float32Array(0),
+			float64: new Float64Array(0),
+		};
+		const view = await init(state, renderData, {} as HTMLCanvasElement, memoryViews, createSpriteData());
+
+		expect(mocks.drawConnections).not.toHaveBeenCalled();
+
+		state.dialogStack = [];
+		view.renderFrame();
+
+		expect(mocks.drawConnections).toHaveBeenCalledWith(mocks.lines, mocks.wireColors, state, memoryViews);
+	});
+
 	it('pauses and resumes its animation frame loop idempotently', async () => {
 		const { default: init } = await import('./index');
 		const state = createMockState();

--- a/packages/editor/packages/editor-core/packages/web-ui/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/index.ts
@@ -158,7 +158,9 @@ export default async function init(
 	const drawFrame = () => {
 		drawBackground(draw, state);
 		drawCodeBlocks(draw, state, memoryViews, renderData.getSnapshot());
-		drawConnections(lines, wireColors, state, memoryViews);
+		if (state.dialogStack.length === 0) {
+			drawConnections(lines, wireColors, state, memoryViews);
+		}
 		drawContextMenu(draw, state);
 		drawModeOverlay(draw, state);
 		drawDialog(draw, state);

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
@@ -164,7 +164,7 @@ describe('AudioWorklet runtime config', () => {
 		expect(events.dispatch).toHaveBeenCalledWith('addDialog', {
 			id: 'audio-worklet-permission',
 			title: 'Audio Permission',
-			text: 'Audio playback requires your permission. Select Allow to start the program.',
+			text: 'This project uses AudioWorklet for audio playback and requires your permission to start. Select Allow to start the program. If you do nothing, the program will not start.',
 			buttons: [{ title: 'Allow', action: 'grantAudioPermission' }],
 		});
 		expect(events.on).toHaveBeenCalledWith('grantAudioPermission', expect.any(Function));

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
@@ -164,7 +164,7 @@ describe('AudioWorklet runtime config', () => {
 		expect(events.dispatch).toHaveBeenCalledWith('addDialog', {
 			id: 'audio-worklet-permission',
 			title: 'Audio Permission',
-			text: 'This project uses the AudioWorklet runtime. Select Allow to start the program with audio playback.',
+			text: 'Audio playback requires your permission. Select Allow to start the program.',
 			buttons: [{ title: 'Allow', action: 'grantAudioPermission' }],
 		});
 		expect(events.on).toHaveBeenCalledWith('grantAudioPermission', expect.any(Function));

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
@@ -164,7 +164,7 @@ describe('AudioWorklet runtime config', () => {
 		expect(events.dispatch).toHaveBeenCalledWith('addDialog', {
 			id: 'audio-worklet-permission',
 			title: 'Audio Permission',
-			text: 'This project uses AudioWorklet for audio playback and requires your permission to start. Select Allow to start the program. If you do nothing, the program will not start.',
+			text: "This project uses AudioWorklet for audio playback and requires your permission to start. Select Allow to start the program, or choose to do nothing; then the program won't start.",
 			buttons: [{ title: 'Allow', action: 'grantAudioPermission' }],
 		});
 		expect(events.on).toHaveBeenCalledWith('grantAudioPermission', expect.any(Function));

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
@@ -1,7 +1,12 @@
-import type { State } from '@8f4e/editor-core';
+import type { EventDispatcher, State } from '@8f4e/editor-core';
 import createStateManager from '@8f4e/state-manager';
-import { describe, expect, it } from 'vitest';
-import { createAudioWorkletRuntimeDef, getAudioInputBuffers, getAudioOutputBuffers } from './runtimeDef';
+import { describe, expect, it, vi } from 'vitest';
+import {
+	audioWorkletRuntimeFactory,
+	createAudioWorkletRuntimeDef,
+	getAudioInputBuffers,
+	getAudioOutputBuffers,
+} from './runtimeDef';
 import { storeAudioWorkletRuntimeValues } from './runtimeValues';
 
 describe('storeAudioWorkletRuntimeValues', () => {
@@ -137,5 +142,36 @@ describe('AudioWorklet runtime config', () => {
 			{ audioBufferWordAddress: 24, output: 0, channel: 1 },
 		]);
 		expect(getAudioInputBuffers(state)).toEqual([{ audioBufferWordAddress: 16, input: 0, channel: 0 }]);
+	});
+
+	it('requests audio permission through a Grant dialog button', () => {
+		const state = createState();
+		const store = createStateManager(state);
+		const events: EventDispatcher = {
+			on: vi.fn(),
+			off: vi.fn(),
+			dispatch: vi.fn(),
+		};
+
+		const cleanup = audioWorkletRuntimeFactory(
+			store,
+			events,
+			() => new Uint8Array(),
+			() => null,
+			'worklet.js'
+		);
+
+		expect(events.dispatch).toHaveBeenCalledWith('addDialog', {
+			id: 'audio-worklet-permission',
+			title: 'Audio Permission',
+			text: 'This project uses the AudioWorklet runtime. Select Grant to start the program with audio playback.',
+			buttons: [{ title: 'Grant', action: 'grantAudioPermission' }],
+		});
+		expect(events.on).toHaveBeenCalledWith('grantAudioPermission', expect.any(Function));
+		expect(events.on).not.toHaveBeenCalledWith('mousedown', expect.any(Function));
+
+		cleanup();
+
+		expect(events.off).toHaveBeenCalledWith('grantAudioPermission', expect.any(Function));
 	});
 });

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
@@ -144,7 +144,7 @@ describe('AudioWorklet runtime config', () => {
 		expect(getAudioInputBuffers(state)).toEqual([{ audioBufferWordAddress: 16, input: 0, channel: 0 }]);
 	});
 
-	it('requests audio permission through a Grant dialog button', () => {
+	it('requests audio permission through an Allow dialog button', () => {
 		const state = createState();
 		const store = createStateManager(state);
 		const events: EventDispatcher = {
@@ -164,8 +164,8 @@ describe('AudioWorklet runtime config', () => {
 		expect(events.dispatch).toHaveBeenCalledWith('addDialog', {
 			id: 'audio-worklet-permission',
 			title: 'Audio Permission',
-			text: 'This project uses the AudioWorklet runtime. Select Grant to start the program with audio playback.',
-			buttons: [{ title: 'Grant', action: 'grantAudioPermission' }],
+			text: 'This project uses the AudioWorklet runtime. Select Allow to start the program with audio playback.',
+			buttons: [{ title: 'Allow', action: 'grantAudioPermission' }],
 		});
 		expect(events.on).toHaveBeenCalledWith('grantAudioPermission', expect.any(Function));
 		expect(events.on).not.toHaveBeenCalledWith('mousedown', expect.any(Function));

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
@@ -279,7 +279,9 @@ export function audioWorkletRuntimeFactory(
 	}
 
 	if (!audioContext) {
-		showAudioPermissionDialog('Audio playback requires your permission. Select Allow to start the program.');
+		showAudioPermissionDialog(
+			'This project uses AudioWorklet for audio playback and requires your permission to start. Select Allow to start the program. If you do nothing, the program will not start.'
+		);
 	}
 
 	return () => {

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
@@ -13,6 +13,7 @@ import type { StateManager } from '@8f4e/state-manager';
 import { AUDIO_WORKLET_RUNTIME_ID, storeAudioWorkletRuntimeValues } from './runtimeValues';
 
 const AUDIO_PERMISSION_DIALOG_ID = 'audio-worklet-permission';
+const GRANT_AUDIO_PERMISSION_ACTION = 'grantAudioPermission';
 const AUDIO_BUFFER_SIZE = 128;
 const AUDIO_BUFFER_ADDRESS_SCHEMA = {
 	format: 'memory-address',
@@ -132,7 +133,7 @@ export function audioWorkletRuntimeFactory(
 			id: AUDIO_PERMISSION_DIALOG_ID,
 			text,
 			title: 'Audio Permission',
-			buttons: [{ title: 'OK', action: 'close' }],
+			buttons: [{ title: 'Grant', action: GRANT_AUDIO_PERMISSION_ACTION }],
 		});
 	}
 
@@ -238,7 +239,7 @@ export function audioWorkletRuntimeFactory(
 
 	store.subscribeToValue('compiler.isCompiling', false, syncCodeAndSettingsWithRuntime);
 	store.subscribe('editorConfig.audioRuntime', onEditorConfigChanged);
-	events.on('mousedown', initAudioContext);
+	events.on(GRANT_AUDIO_PERMISSION_ACTION, initAudioContext);
 
 	function tearDownAudioContext() {
 		if (mediaStreamSource) {
@@ -269,9 +270,7 @@ export function audioWorkletRuntimeFactory(
 		const desiredSampleRate = getSampleRate(state.editorConfig);
 		if (audioContext.sampleRate !== desiredSampleRate) {
 			tearDownAudioContext();
-			showAudioPermissionDialog(
-				'Sample rate changed. Click anywhere to restart audio playback at the new sample rate.'
-			);
+			showAudioPermissionDialog('Sample rate changed. Select Grant to restart audio playback at the new sample rate.');
 			return;
 		}
 
@@ -281,14 +280,14 @@ export function audioWorkletRuntimeFactory(
 
 	if (!audioContext) {
 		showAudioPermissionDialog(
-			'This project is using the AudioWorklet runtime, to start the program with audio playback, please click anywhere on the screen to continue.'
+			'This project uses the AudioWorklet runtime. Select Grant to start the program with audio playback.'
 		);
 	}
 
 	return () => {
 		store.unsubscribe('compiler.isCompiling', syncCodeAndSettingsWithRuntime);
 		store.unsubscribe('editorConfig.audioRuntime', onEditorConfigChanged);
-		events.off('mousedown', initAudioContext);
+		events.off(GRANT_AUDIO_PERMISSION_ACTION, initAudioContext);
 
 		tearDownAudioContext();
 		hideAudioPermissionDialog();

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
@@ -133,7 +133,7 @@ export function audioWorkletRuntimeFactory(
 			id: AUDIO_PERMISSION_DIALOG_ID,
 			text,
 			title: 'Audio Permission',
-			buttons: [{ title: 'Grant', action: GRANT_AUDIO_PERMISSION_ACTION }],
+			buttons: [{ title: 'Allow', action: GRANT_AUDIO_PERMISSION_ACTION }],
 		});
 	}
 
@@ -270,7 +270,7 @@ export function audioWorkletRuntimeFactory(
 		const desiredSampleRate = getSampleRate(state.editorConfig);
 		if (audioContext.sampleRate !== desiredSampleRate) {
 			tearDownAudioContext();
-			showAudioPermissionDialog('Sample rate changed. Select Grant to restart audio playback at the new sample rate.');
+			showAudioPermissionDialog('Sample rate changed. Select Allow to restart audio playback at the new sample rate.');
 			return;
 		}
 
@@ -280,7 +280,7 @@ export function audioWorkletRuntimeFactory(
 
 	if (!audioContext) {
 		showAudioPermissionDialog(
-			'This project uses the AudioWorklet runtime. Select Grant to start the program with audio playback.'
+			'This project uses the AudioWorklet runtime. Select Allow to start the program with audio playback.'
 		);
 	}
 

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
@@ -279,9 +279,7 @@ export function audioWorkletRuntimeFactory(
 	}
 
 	if (!audioContext) {
-		showAudioPermissionDialog(
-			'This project uses the AudioWorklet runtime. Select Allow to start the program with audio playback.'
-		);
+		showAudioPermissionDialog('Audio playback requires your permission. Select Allow to start the program.');
 	}
 
 	return () => {

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
@@ -280,7 +280,7 @@ export function audioWorkletRuntimeFactory(
 
 	if (!audioContext) {
 		showAudioPermissionDialog(
-			'This project uses AudioWorklet for audio playback and requires your permission to start. Select Allow to start the program. If you do nothing, the program will not start.'
+			"This project uses AudioWorklet for audio playback and requires your permission to start. Select Allow to start the program, or choose to do nothing; then the program won't start."
 		);
 	}
 


### PR DESCRIPTION
## Summary

- add declarative, canvas-rendered dialog buttons with grid-aligned wrapping
- render large white buttons with black labels and one-row/four-column grid padding
- dispatch configured button actions and payloads, closing dialogs by default while supporting persistent actions
- make open dialogs block pointer input and hide editor wires until the dialog closes
- replace click-anywhere audio activation with an explicit Allow button

## Rationale

Dialog content already carried button definitions, but the editor did not lay them out, render them, or handle their interaction. This completes that internal event-driven path without adding keyboard behavior or exposing a public dialog API.

## Test notes

- `npx nx run-many --target=test --projects=@8f4e/editor-state,@8f4e/web-ui,@8f4e/runtime-audio-worklet`
- `npx nx run @8f4e/editor-default:build`
- pre-commit affected type checks and Biome checks