### PR TITLE
fix(8f4e-website): improve embedded editor loading

### DIFF
--- a/packages/8f4e-website/src/index.html
+++ b/packages/8f4e-website/src/index.html
@@ -28,6 +28,7 @@
 					id="editor"
 					tabindex="0"
 					aria-label="8f4e editor"
+					style="background-color: #069"
 					data-project-url="https://static.8f4e.com/example-projects/misc/landingPageDemo1.8f4e"
 				></canvas>
 				<div>
@@ -58,6 +59,7 @@
 					id="editor-pointers"
 					tabindex="0"
 					aria-label="Second 8f4e editor"
+					style="background-color: #096"
 					data-project-url="https://static.8f4e.com/example-projects/misc/landingPageDemo2.8f4e"
 				></canvas>
 				<div>
@@ -80,6 +82,7 @@
 					id="editor-reversed"
 					tabindex="0"
 					aria-label="Third 8f4e editor"
+					style="background-color: #609"
 					data-project-url="https://static.8f4e.com/example-projects/misc/landingPageDemo3.8f4e"
 				></canvas>
 				<div>
@@ -105,6 +108,7 @@
 					id="editor-centered"
 					tabindex="0"
 					aria-label="Fourth 8f4e editor"
+					style="background-color: #960"
 					data-project-url="https://static.8f4e.com/example-projects/misc/landingPageDemo4.8f4e"
 				></canvas>
 				<div>

--- a/packages/8f4e-website/src/main.ts
+++ b/packages/8f4e-website/src/main.ts
@@ -16,7 +16,7 @@ if (import.meta.env.DEV) {
 	}
 }
 
-const renderingReleaseDelayMs = 3_000;
+const renderingReleaseDelayMs = 2_000;
 const editorByCanvas = new Map<HTMLCanvasElement, DefaultEditorInstance>();
 const editorMountPromiseByCanvas = new Map<HTMLCanvasElement, Promise<DefaultEditorInstance>>();
 const renderingReleaseTimeoutByCanvas = new Map<HTMLCanvasElement, number>();
@@ -46,6 +46,7 @@ const renderingObserver = new IntersectionObserver(entries => {
 		if (entry.isIntersecting) {
 			editor?.resumeRendering();
 		} else {
+			editor?.pauseRendering();
 			const timeout = window.setTimeout(() => {
 				renderingReleaseTimeoutByCanvas.delete(canvas);
 				editor?.releaseRenderingResources();


### PR DESCRIPTION
## Summary
- pause each embedded editor immediately when it leaves the viewport
- release rendering resources after a two-second grace period
- give each editor a persistent backing layer using its project background color
- fade each transparent canvas in after its editor instance mounts
- respect reduced-motion preferences
- update glugglugglug to the transparent-canvas commit

## Rationale
The project-colored backing layer paints immediately while editor initialization proceeds. The transparent renderer avoids an intermediate black frame, and the mounted canvas fades smoothly over the matching color. Offscreen editors also stop their animation frame loops immediately while retaining resources briefly for fast scroll-back.

## Dependency
- https://github.com/andorthehood/glugglugglug/pull/19 — merged

## Tests
- npx nx run @8f4e/web-ui:test --skip-nx-cache -- --run src/index.test.ts
- npx nx run @8f4e/8f4e-website:lint
- npx nx run @8f4e/8f4e-website:typecheck
- npx nx run @8f4e/8f4e-website:build --skip-nx-cache
- glugglugglug unit, typecheck, and Chromium visual regression checks