### PR TITLE
fix(8f4e-website): fade in embedded editors

### DIFF
--- a/packages/8f4e-website/src/index.html
+++ b/packages/8f4e-website/src/index.html
@@ -24,14 +24,15 @@
 			</p>
 
 			<section class="editor-row">
-				<canvas
-					id="editor"
-					tabindex="0"
-					aria-label="8f4e editor"
-					style="background-color: #069"
-					data-project-url="https://static.8f4e.com/example-projects/misc/landingPageDemo1.8f4e"
-				></canvas>
-				<div>
+				<div class="editor-frame" style="background-color: #069">
+					<canvas
+						id="editor"
+						tabindex="0"
+						aria-label="8f4e editor"
+						data-project-url="https://static.8f4e.com/example-projects/misc/landingPageDemo1.8f4e"
+					></canvas>
+				</div>
+				<div class="editor-copy">
 					<p>
 						Stack-oriented programming means that instead of using variables, instructions take their operands from a
 						stack and push their results back onto the same stack for the next instruction to consume.
@@ -55,14 +56,15 @@
 			</section>
 
 			<section class="editor-row editor-row--reversed">
-				<canvas
-					id="editor-pointers"
-					tabindex="0"
-					aria-label="Second 8f4e editor"
-					style="background-color: #096"
-					data-project-url="https://static.8f4e.com/example-projects/misc/landingPageDemo2.8f4e"
-				></canvas>
-				<div>
+				<div class="editor-frame" style="background-color: #096">
+					<canvas
+						id="editor-pointers"
+						tabindex="0"
+						aria-label="Second 8f4e editor"
+						data-project-url="https://static.8f4e.com/example-projects/misc/landingPageDemo2.8f4e"
+					></canvas>
+				</div>
+				<div class="editor-copy">
 					<p>
 						Pointers are represented as wires in the editor, making it possible to see which memory item each pointer
 						refers to. Because raw pointers can address any location in the program's memory, these visual connections
@@ -78,14 +80,15 @@
 			</section>
 
 			<section class="editor-row">
-				<canvas
-					id="editor-reversed"
-					tabindex="0"
-					aria-label="Third 8f4e editor"
-					style="background-color: #609"
-					data-project-url="https://static.8f4e.com/example-projects/misc/landingPageDemo3.8f4e"
-				></canvas>
-				<div>
+				<div class="editor-frame" style="background-color: #609">
+					<canvas
+						id="editor-reversed"
+						tabindex="0"
+						aria-label="Third 8f4e editor"
+						data-project-url="https://static.8f4e.com/example-projects/misc/landingPageDemo3.8f4e"
+					></canvas>
+				</div>
+				<div class="editor-copy">
 					<p>
 						All memory items are laid out sequentially in memory, so variables declared one after another occupy adjacent
 						memory locations.
@@ -104,14 +107,15 @@
 			</section>
 
 			<section class="editor-row editor-row--reversed">
-				<canvas
-					id="editor-centered"
-					tabindex="0"
-					aria-label="Fourth 8f4e editor"
-					style="background-color: #960"
-					data-project-url="https://static.8f4e.com/example-projects/misc/landingPageDemo4.8f4e"
-				></canvas>
-				<div>
+				<div class="editor-frame" style="background-color: #960">
+					<canvas
+						id="editor-centered"
+						tabindex="0"
+						aria-label="Fourth 8f4e editor"
+						data-project-url="https://static.8f4e.com/example-projects/misc/landingPageDemo4.8f4e"
+					></canvas>
+				</div>
+				<div class="editor-copy">
 					<p>
 						UI elements such as sliders, switches and plots can be added directly
 						to modules, making it possible to shape and inspect the sound while the program is running.

--- a/packages/8f4e-website/src/main.ts
+++ b/packages/8f4e-website/src/main.ts
@@ -20,6 +20,7 @@ const renderingReleaseDelayMs = 2_000;
 const editorByCanvas = new Map<HTMLCanvasElement, DefaultEditorInstance>();
 const editorMountPromiseByCanvas = new Map<HTMLCanvasElement, Promise<DefaultEditorInstance>>();
 const renderingReleaseTimeoutByCanvas = new Map<HTMLCanvasElement, number>();
+const revealAnimationFrameByCanvas = new Map<HTMLCanvasElement, number>();
 const editors: DefaultEditorInstance[] = [];
 let disposed = false;
 
@@ -32,6 +33,31 @@ function syncEditors(): void {
 			return editor ? [editor] : [];
 		})
 	);
+}
+
+function revealEditorAfterFirstProjectFrame(canvas: HTMLCanvasElement, editor: DefaultEditorInstance): void {
+	const waitForProject = () => {
+		if (disposed) {
+			return;
+		}
+
+		if (!editor.state.initialProjectState) {
+			revealAnimationFrameByCanvas.set(canvas, window.requestAnimationFrame(waitForProject));
+			return;
+		}
+
+		revealAnimationFrameByCanvas.set(
+			canvas,
+			window.requestAnimationFrame(() => {
+				revealAnimationFrameByCanvas.delete(canvas);
+				if (!disposed) {
+					canvas.classList.add('editor-ready');
+				}
+			})
+		);
+	};
+
+	waitForProject();
 }
 
 const renderingObserver = new IntersectionObserver(entries => {
@@ -76,7 +102,7 @@ function mountEditor(canvas: HTMLCanvasElement, index: number): Promise<DefaultE
 			}
 
 			editorByCanvas.set(canvas, editor);
-			canvas.classList.add('editor-mounted');
+			revealEditorAfterFirstProjectFrame(canvas, editor);
 			syncEditors();
 			renderingObserver.observe(canvas);
 			if (index === 0) {
@@ -125,6 +151,10 @@ import.meta.hot?.dispose(() => {
 		window.clearTimeout(timeout);
 	}
 	renderingReleaseTimeoutByCanvas.clear();
+	for (const animationFrame of revealAnimationFrameByCanvas.values()) {
+		window.cancelAnimationFrame(animationFrame);
+	}
+	revealAnimationFrameByCanvas.clear();
 	for (const editor of editors) {
 		editor.dispose();
 	}

--- a/packages/8f4e-website/src/main.ts
+++ b/packages/8f4e-website/src/main.ts
@@ -76,6 +76,7 @@ function mountEditor(canvas: HTMLCanvasElement, index: number): Promise<DefaultE
 			}
 
 			editorByCanvas.set(canvas, editor);
+			canvas.classList.add('editor-mounted');
 			syncEditors();
 			renderingObserver.observe(canvas);
 			if (index === 0) {

--- a/packages/8f4e-website/src/styles.css
+++ b/packages/8f4e-website/src/styles.css
@@ -90,23 +90,35 @@ main > img {
 	grid-template-areas: "copy editor";
 }
 
-.editor-row > canvas {
+.editor-frame {
 	grid-area: editor;
-	display: block;
 	width: 100%;
 	height: clamp(500px, 70vh, 700px);
 	background: #000;
-	image-rendering: pixelated;
-	outline: none;
-	cursor: pointer;
 }
 
-.editor-row > div {
+.editor-frame > canvas {
+	display: block;
+	width: 100%;
+	height: 100%;
+	background: transparent;
+	image-rendering: pixelated;
+	outline: none;
+	opacity: 0;
+	cursor: pointer;
+	transition: opacity 250ms ease-out;
+}
+
+.editor-frame > canvas.editor-mounted {
+	opacity: 1;
+}
+
+.editor-copy {
 	grid-area: copy;
 	padding-right: 2rem;
 }
 
-.editor-row--reversed > div {
+.editor-row--reversed > .editor-copy {
 	padding-right: 0;
 	padding-left: 2rem;
 }
@@ -171,13 +183,19 @@ footer ul {
 			"copy";
 	}
 
-	.editor-row > div,
-	.editor-row--reversed > div {
+	.editor-copy,
+	.editor-row--reversed > .editor-copy {
 		padding-right: 2rem;
 		padding-left: 2rem;
 	}
 
 	footer {
 		grid-template-columns: 1fr;
+	}
+}
+
+@media (prefers-reduced-motion: reduce) {
+	.editor-frame > canvas {
+		transition: none;
 	}
 }

--- a/packages/8f4e-website/src/styles.css
+++ b/packages/8f4e-website/src/styles.css
@@ -109,7 +109,7 @@ main > img {
 	transition: opacity 250ms ease-out;
 }
 
-.editor-frame > canvas.editor-mounted {
+.editor-frame > canvas.editor-ready {
 	opacity: 1;
 }
 


### PR DESCRIPTION
## Summary
- keep each project color visible as a CSS-backed frame while its embedded editor loads
- fade the canvas in with opacity once the project is loaded and has had a frame to render
- respect reduced-motion preferences

## Rationale
This avoids a visual blink during editor startup while preserving the fast CSS background as progressive enhancement. The fade is owned by the product website and only begins once rendered editor content is ready.

Follow-up to #927.

## Testing
- `npx nx run @8f4e/8f4e-website:lint`
- `npx nx run @8f4e/8f4e-website:typecheck`
- `npx nx run @8f4e/8f4e-website:build`
