### PR TITLE
feat(editor-core): support initial editor mode

### DIFF
--- a/packages/8f4e-website/README.md
+++ b/packages/8f4e-website/README.md
@@ -1,7 +1,8 @@
 # 8f4e Website
 
 `@8f4e/8f4e-website` is a minimal product page with an embedded default editor. The website controls the canvas size
-and leaves wheel scrolling to the surrounding document.
+and leaves wheel scrolling to the surrounding document. Its embedded editors start in edit mode with mode switching
+disabled.
 
 From the workspace root:
 

--- a/packages/8f4e-website/src/main.ts
+++ b/packages/8f4e-website/src/main.ts
@@ -90,7 +90,13 @@ function mountEditor(canvas: HTMLCanvasElement, index: number): Promise<DefaultE
 
 	const mountPromise = mountDefaultEditor(canvas, {
 		captureWheel: false,
-		featureFlags: { browserLocalNotes: false, projectCreation: false, projectOpening: false },
+		featureFlags: {
+			browserLocalNotes: false,
+			modeToggling: false,
+			projectCreation: false,
+			projectOpening: false,
+		},
+		initialEditorMode: 'edit',
 		initialProjectUrl: canvas.dataset.projectUrl || undefined,
 		storage: window.localStorage,
 		storageNamespace: index === 0 ? '8f4e-website' : `8f4e-website-${index + 1}`,

--- a/packages/editor/packages/editor-core/packages/editor-state-types/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state-types/src/index.ts
@@ -236,7 +236,7 @@ export interface FeatureFlags {
 	/** Whether the editor is currently in an edit-enabled state. */
 	editing: boolean;
 
-	/** Enable/disable keyboard toggling between view/edit modes (e/Escape) */
+	/** Enable/disable keyboard switching into and out of edit mode, and into presentation mode. */
 	modeToggling: boolean;
 
 	/** Enable/disable the mode hint overlay at the top of the viewport */
@@ -271,6 +271,7 @@ export interface FeatureFlags {
 export type FeatureFlagsConfig = Partial<FeatureFlags>;
 
 export type EditorMode = 'view' | 'edit' | 'presentation';
+export type InitialEditorMode = Exclude<EditorMode, 'presentation'>;
 
 // Callbacks interface contains all callback functions (top-level public API)
 export interface Callbacks {
@@ -352,6 +353,8 @@ export interface Callbacks {
 // Options interface for editor initialization (top-level public API)
 export interface Options {
 	featureFlags?: FeatureFlagsConfig;
+	/** Mode used when the editor is initialized. */
+	initialEditorMode?: InitialEditorMode;
 	callbacks: Callbacks;
 	/**
 	 * Runtime registry mapping runtime IDs to runtime implementations.

--- a/packages/editor/packages/editor-core/packages/editor-state/src/index.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/index.test.ts
@@ -3,6 +3,20 @@ import initState from './index';
 import { createMockEventDispatcherWithVitest } from './pureHelpers/testingUtils/vitestTestUtils';
 
 describe('editor state lifecycle', () => {
+	it('initializes the requested editor mode and synchronizes editing', () => {
+		const events = createMockEventDispatcherWithVitest();
+		const store = initState(events, {
+			callbacks: { loadSession: async () => null },
+			initialEditorMode: 'edit',
+			runtimeRegistry: {},
+		});
+
+		expect(store.getState().editorMode).toBe('edit');
+		expect(store.getState().featureFlags.editing).toBe(true);
+
+		store.dispose();
+	});
+
 	it('enables browser-local notes by default and allows disabling them at initialization', () => {
 		const enabledEvents = createMockEventDispatcherWithVitest();
 		const enabledStore = initState(enabledEvents, {

--- a/packages/editor/packages/editor-core/packages/editor-state/src/index.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/index.ts
@@ -59,7 +59,11 @@ export {
 
 // Function to create default state
 export default function init(events: EventDispatcher, options: Options): StateManager<State> {
-	const featureFlags = validateFeatureFlags(options.featureFlags);
+	const initialEditorMode = options.initialEditorMode ?? (options.featureFlags?.editing ? 'edit' : 'view');
+	const featureFlags = validateFeatureFlags({
+		...options.featureFlags,
+		editing: initialEditorMode === 'edit',
+	});
 	type EffectCleanup = () => void;
 	const effectCleanups: EffectCleanup[] = [];
 	const registerEffect = (cleanup: void | EffectCleanup): void => {
@@ -72,6 +76,7 @@ export default function init(events: EventDispatcher, options: Options): StateMa
 	const baseState = {
 		...createDefaultState(),
 		callbacks: options.callbacks,
+		editorMode: initialEditorMode,
 		featureFlags,
 		runtimeRegistry: options.runtimeRegistry,
 		editorConfigSchemaContributions: options.editorConfigSchemaContributions ?? {},

--- a/packages/editor/packages/editor-core/src/events/keyboardEvents.test.ts
+++ b/packages/editor/packages/editor-core/src/events/keyboardEvents.test.ts
@@ -197,6 +197,19 @@ describe('keyboardEvents mode switching', () => {
 		cleanup();
 	});
 
+	it('does not leave edit mode when modeToggling is disabled', () => {
+		featureFlags.modeToggling = false;
+		editorMode = 'edit';
+		const cleanup = keyboardEvents(inputTarget as unknown as HTMLElement, events, store);
+		const event = createKeyboardEventLike('Escape');
+
+		inputTarget.emit('keydown', event);
+
+		expect(events.dispatch).not.toHaveBeenCalledWith('exitToViewMode');
+		expect(event.preventDefault as ReturnType<typeof vi.fn>).not.toHaveBeenCalled();
+		cleanup();
+	});
+
 	it('still exits presentation mode with Escape when modeToggling is disabled', () => {
 		featureFlags.modeToggling = false;
 		editorMode = 'presentation';

--- a/packages/editor/packages/editor-core/src/events/keyboardEvents.ts
+++ b/packages/editor/packages/editor-core/src/events/keyboardEvents.ts
@@ -66,8 +66,11 @@ export default function keyboardEvents(
 		const { key, metaKey, ctrlKey } = event;
 		const state = store.getState();
 
-		// Escape should always allow leaving non-view modes, even if mode toggling is disabled.
-		if (state.editorMode !== 'view' && key === 'Escape') {
+		// Presentation mode always retains an Escape route. Edit mode only exits when mode toggling is enabled.
+		if (
+			key === 'Escape' &&
+			(state.editorMode === 'presentation' || (state.editorMode === 'edit' && state.featureFlags.modeToggling))
+		) {
 			event.preventDefault();
 			events.dispatch('exitToViewMode');
 			return;

--- a/packages/editor/packages/editor-core/src/index.ts
+++ b/packages/editor/packages/editor-core/src/index.ts
@@ -3,6 +3,7 @@ import type {
 	Callbacks,
 	EditorConfigSchemaContributionRegistry,
 	InfoRecord,
+	InitialEditorMode,
 	RuntimeRegistry,
 	State,
 } from '@8f4e/editor-state-types';
@@ -56,6 +57,7 @@ export type {
 	EditorMode,
 	FeatureFlags,
 	FeatureFlagsConfig,
+	InitialEditorMode,
 	JSONSchemaLike,
 	Options,
 	ParsedDirectiveRecord,
@@ -86,6 +88,8 @@ export interface EditorOptions {
 	/** Capture wheel gestures for viewport panning. Disable this for editors embedded in scrolling pages. */
 	captureWheel?: boolean;
 	featureFlags?: Partial<State['featureFlags']>;
+	/** Mode used when the editor is initialized. */
+	initialEditorMode?: InitialEditorMode;
 	callbacks: Omit<
 		Callbacks,
 		'getWordFromMemory' | 'setWordInMemory' | 'readClipboardText' | 'writeClipboardText' | 'exportCanvasScreenshot'

--- a/packages/editor/packages/editor-default/README.md
+++ b/packages/editor/packages/editor-default/README.md
@@ -11,6 +11,7 @@ import { mountDefaultEditor } from '@8f4e/editor-default';
 
 const editor = await mountDefaultEditor(canvas, {
 	captureWheel: false,
+	initialEditorMode: 'edit',
 	storageNamespace: 'editor-a',
 });
 
@@ -19,6 +20,9 @@ editor.releaseRenderingResources();
 editor.resumeRendering();
 editor.dispose();
 ```
+
+Use `initialEditorMode: 'edit'` to start editing immediately. Set the `modeToggling` feature flag to `false` when the
+host should keep the editor in its initial mode.
 
 `releaseRenderingResources()` pauses rendering and releases reloadable GPU textures, dynamic buffer storage, and the
 canvas drawing buffer. `resumeRendering()` restores the resources, applies the latest canvas size, and renders

--- a/packages/editor/packages/editor-default/src/index.ts
+++ b/packages/editor/packages/editor-default/src/index.ts
@@ -20,6 +20,7 @@ export interface DefaultEditorMountOptions {
 	/** Capture wheel gestures for viewport panning. Disable this for editors embedded in scrolling pages. */
 	captureWheel?: boolean;
 	featureFlags?: EditorOptions['featureFlags'];
+	initialEditorMode?: EditorOptions['initialEditorMode'];
 	initialProjectUrl?: string;
 	storage?: Storage;
 	storageNamespace?: string;
@@ -30,6 +31,7 @@ export async function mountDefaultEditor(
 	{
 		captureWheel,
 		featureFlags,
+		initialEditorMode,
 		initialProjectUrl,
 		storage = localStorage,
 		storageNamespace = DEFAULT_STORAGE_NAMESPACE,
@@ -42,6 +44,7 @@ export async function mountDefaultEditor(
 		editor = await initEditor(canvas, {
 			captureWheel,
 			featureFlags,
+			initialEditorMode,
 			runtimeRegistry: createRuntimeRegistry(compilerService),
 			callbacks: {
 				getListOfModules,


### PR DESCRIPTION
## Summary

- add a typed `initialEditorMode` option across editor state, editor core, and the default editor composition
- start every editor embedded in the 8f4e website in edit mode
- use the existing `modeToggling` feature flag to lock those editors in edit mode while retaining Escape as a safety exit from presentation mode
- document the new mount option and website behavior

## Rationale

The product website should make its embedded examples immediately editable without changing the default behavior for other editor hosts. Keeping initial mode separate from feature flags also ensures the mode overlay, keyboard handling, and editing state agree from the first frame.

## Test notes

- `npx nx run-many --target=test --projects=@8f4e/editor-state,@8f4e/editor-core` — 155 files, 1,127 tests passed
- `npx nx run-many --targets=test,typecheck --projects=@8f4e/editor-default` — 40 tests passed; no type errors
- `npx nx run @8f4e/8f4e-website:build` — passed
- Biome formatting and staged-file type checks — passed

## Screenshots

Not included: this changes initial interaction state and intentionally hides the mode-switching overlay; it does not change the rendered editor layout.