### PR TITLE
fix(editor-default): reuse host audio contexts across editors

### DIFF
--- a/docs/shared-editor-audio.md
+++ b/docs/shared-editor-audio.md
@@ -1,0 +1,22 @@
+# Shared audio contexts for embedded editors
+
+`mountDefaultEditor(canvas, { sharedAudioContext })` accepts an optional browser `AudioContext` owned by the host page.
+The AudioWorklet runtime borrows it when its sample rate matches the project's `audioRuntime.sampleRate` (48 kHz by
+default). A closed context or a different sample rate falls back to a context created and owned by that runtime.
+Omitting the option preserves independent contexts and the existing Allow dialog.
+
+The 8f4e website supplies one 48 kHz context per page. The first matching audio project's Allow button resumes it
+directly during the user interaction. Later matching projects start automatically while the context is running,
+including projects mounted after another editor has been disposed. Already mounted matching runtimes waiting for
+permission also start when the shared context begins running. Sharing does not select or mute editors; hosts that
+need exclusive playback should dispose the previous editor, as the examples gallery does.
+
+Each editor retains its own worklet node, compiled program, and memory. The worklet module is loaded once per context
+and URL. Disposing an editor stops its processor and microphone tracks and disconnects its nodes. It closes only a
+context it created itself, leaving a borrowed context available for the next editor. The host should close the shared
+context when it no longer needs it; the website closes it on development module disposal, and full page navigation
+releases the document's context.
+
+Projects requesting a different rate use their own context and Allow flow. Switching back to 48 kHz reuses the
+shared context if it is still running. Sharing does not survive a full page navigation, grant microphone permission,
+or prevent browser/device interruptions from suspending audio.

--- a/packages/8f4e-website/src/examples/main.ts
+++ b/packages/8f4e-website/src/examples/main.ts
@@ -1,4 +1,5 @@
 import { type DefaultEditorInstance, mountDefaultEditor } from '@8f4e/editor-default';
+import { sharedAudioContext } from '../shared-audio-context';
 import { getExampleId, withExampleId } from './example-url';
 import { projectCategories } from './projects';
 
@@ -129,6 +130,7 @@ function selectExample(id: string | null, retry = false): void {
 		};
 		try {
 			const editor = await mountDefaultEditor(canvas, {
+				sharedAudioContext,
 				captureWheel: true,
 				featureFlags: {
 					browserLocalNotes: false,

--- a/packages/8f4e-website/src/main.ts
+++ b/packages/8f4e-website/src/main.ts
@@ -1,4 +1,5 @@
 import { type DefaultEditorInstance, mountDefaultEditor } from '@8f4e/editor-default';
+import { sharedAudioContext } from './shared-audio-context';
 
 const canvases = Array.from(document.querySelectorAll<HTMLCanvasElement>('.editor-row canvas'));
 if (canvases.length === 0) {
@@ -89,6 +90,7 @@ function mountEditor(canvas: HTMLCanvasElement, index: number): Promise<DefaultE
 	}
 
 	const mountPromise = mountDefaultEditor(canvas, {
+		sharedAudioContext,
 		captureWheel: false,
 		featureFlags: {
 			browserLocalNotes: false,

--- a/packages/8f4e-website/src/shared-audio-context.ts
+++ b/packages/8f4e-website/src/shared-audio-context.ts
@@ -1,0 +1,7 @@
+// The page owns this context so it survives editor disposal and gallery selections.
+// The first audio project's Allow button resumes it from a user gesture.
+export const sharedAudioContext = new AudioContext({ sampleRate: 48000, latencyHint: 'interactive' });
+
+import.meta.hot?.dispose(() => {
+	void sharedAudioContext.close();
+});

--- a/packages/editor/packages/editor-default/src/index.ts
+++ b/packages/editor/packages/editor-default/src/index.ts
@@ -17,6 +17,8 @@ const DEFAULT_STORAGE_NAMESPACE = 'editor';
 export type DefaultEditorInstance = Editor;
 
 export interface DefaultEditorMountOptions {
+	/** Borrow this context when its sample rate matches the project. The host owns its lifetime. */
+	sharedAudioContext?: AudioContext;
 	/** Capture wheel gestures for viewport panning. Disable this for editors embedded in scrolling pages. */
 	captureWheel?: boolean;
 	featureFlags?: EditorOptions['featureFlags'];
@@ -29,6 +31,7 @@ export interface DefaultEditorMountOptions {
 export async function mountDefaultEditor(
 	canvas: HTMLCanvasElement,
 	{
+		sharedAudioContext,
 		captureWheel,
 		featureFlags,
 		initialEditorMode,
@@ -45,7 +48,7 @@ export async function mountDefaultEditor(
 			captureWheel,
 			featureFlags,
 			initialEditorMode,
-			runtimeRegistry: createRuntimeRegistry(compilerService),
+			runtimeRegistry: createRuntimeRegistry(compilerService, sharedAudioContext),
 			callbacks: {
 				getListOfModules,
 				getModule,

--- a/packages/editor/packages/editor-default/src/runtime-registry.ts
+++ b/packages/editor/packages/editor-default/src/runtime-registry.ts
@@ -67,7 +67,10 @@ function createLazyRuntimeEntry(
  * Runtimes are lazy-loaded on first selection. Each runtime starts with a minimal stub schema
  * and replaces it with the full schema after loading.
  */
-export function createRuntimeRegistry({ getCodeBuffer, getMemory }: CompilerArtifacts): RuntimeRegistry {
+export function createRuntimeRegistry(
+	{ getCodeBuffer, getMemory }: CompilerArtifacts,
+	sharedAudioContext?: AudioContext
+): RuntimeRegistry {
 	return {
 		WebWorkerRuntime: createLazyRuntimeEntry(
 			'WebWorkerRuntime',
@@ -98,7 +101,7 @@ export function createRuntimeRegistry({ getCodeBuffer, getMemory }: CompilerArti
 					import('@8f4e/runtime-audio-worklet/runtime-def'),
 					import('@8f4e/runtime-audio-worklet/worklet?url'),
 				]);
-				return createAudioWorkletRuntimeDef(getCodeBuffer, getMemory, audioWorkletUrl);
+				return createAudioWorkletRuntimeDef(getCodeBuffer, getMemory, audioWorkletUrl, sharedAudioContext);
 			}
 		),
 	};

--- a/packages/editor/packages/runtime-audio-worklet/src/index.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/index.ts
@@ -5,6 +5,13 @@ class Main extends AudioWorkletProcessor {
 		super(...args);
 
 		this.port.onmessage = async event => {
+			if (event.data.type === 'dispose') {
+				this.disposed = true;
+				this.buffer = () => {};
+				this.memoryBuffer = new Float32Array(0);
+				this.port.close();
+				return;
+			}
 			if (event.data.type === 'init') {
 				this.init(
 					event.data.memoryRef,
@@ -23,6 +30,9 @@ class Main extends AudioWorkletProcessor {
 		audioInputBuffers: { channel: number; input: number; audioBufferWordAddress: number }[]
 	) {
 		const { memoryBuffer, buffer } = await createModule(memoryRef, codeBuffer);
+		if (this.disposed) {
+			return;
+		}
 
 		this.audioOutputBuffers = audioOutputBuffers;
 		this.audioInputBuffers = audioInputBuffers;
@@ -41,6 +51,7 @@ class Main extends AudioWorkletProcessor {
 	buffer: CallableFunction = () => {
 		return;
 	};
+	private disposed = false;
 
 	memoryBuffer: Float32Array = new Float32Array(128).fill(0);
 	audioOutputBuffers = [] as { channel: number; output: number; audioBufferWordAddress: number }[];
@@ -68,6 +79,9 @@ class Main extends AudioWorkletProcessor {
 	}
 
 	process(inputs: Float32Array[][], outputs: Float32Array[][]) {
+		if (this.disposed) {
+			return false;
+		}
 		this.reportAudioBufferSize(inputs, outputs);
 
 		for (let i = 0; i < this.audioInputBuffers.length; i++) {

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
@@ -1,6 +1,6 @@
 import type { EventDispatcher, State } from '@8f4e/editor-core';
 import createStateManager from '@8f4e/state-manager';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
 	audioWorkletRuntimeFactory,
 	createAudioWorkletRuntimeDef,
@@ -25,6 +25,235 @@ describe('storeAudioWorkletRuntimeValues', () => {
 			audioBufferSize: 128,
 			sampleRate: 48000,
 		});
+	});
+});
+
+describe('AudioWorklet context lifetime', () => {
+	class MockContext {
+		state = 'suspended';
+		sampleRate: number;
+		destination = {};
+		listeners = new Set<() => void>();
+		audioWorklet = { addModule: vi.fn(async () => {}) };
+		resume = vi.fn(async () => {
+			this.state = 'running';
+			for (const listener of this.listeners) listener();
+		});
+		close = vi.fn(async () => {
+			this.state = 'closed';
+		});
+		createMediaStreamSource = vi.fn(() => ({ connect: vi.fn(), disconnect: vi.fn() }));
+		constructor({ sampleRate = 48000 } = {}) {
+			this.sampleRate = sampleRate;
+		}
+		addEventListener(_type: string, listener: () => void) {
+			this.listeners.add(listener);
+		}
+		removeEventListener(_type: string, listener: () => void) {
+			this.listeners.delete(listener);
+		}
+	}
+
+	class MockWorklet {
+		port = { postMessage: vi.fn(), close: vi.fn(), onmessage: null };
+		connect = vi.fn();
+		disconnect = vi.fn();
+	}
+
+	let contexts: MockContext[];
+	let worklets: MockWorklet[];
+	let workletContexts: MockContext[];
+	let cleanups: (() => void)[];
+
+	beforeEach(() => {
+		contexts = [];
+		worklets = [];
+		workletContexts = [];
+		cleanups = [];
+		vi.stubGlobal(
+			'AudioContext',
+			class extends MockContext {
+				constructor(options: { sampleRate: number }) {
+					super(options);
+					contexts.push(this);
+				}
+			}
+		);
+		vi.stubGlobal(
+			'AudioWorkletNode',
+			class extends MockWorklet {
+				constructor(context: MockContext) {
+					super();
+					worklets.push(this);
+					workletContexts.push(context);
+				}
+			}
+		);
+	});
+
+	afterEach(() => {
+		for (const cleanup of cleanups) cleanup();
+		vi.unstubAllGlobals();
+		vi.restoreAllMocks();
+	});
+
+	function mount(sharedAudioContext?: MockContext, sampleRate = 48000, input = false) {
+		const state = {
+			editorConfig: { audioRuntime: { sampleRate, ...(input ? { audioInBufferLAddress: 0 } : {}) } },
+			compiler: { isCompiling: false },
+		} as unknown as State;
+		const store = createStateManager(state);
+		const handlers = new Map<string, () => Promise<void>>();
+		const events = {
+			on: vi.fn((name: string, handler: () => Promise<void>) => handlers.set(name, handler)),
+			off: vi.fn((name: string) => handlers.delete(name)),
+			dispatch: vi.fn(),
+		} as unknown as EventDispatcher;
+		const cleanup = audioWorkletRuntimeFactory(
+			store,
+			events,
+			() => new Uint8Array(),
+			() => new WebAssembly.Memory({ initial: 1 }),
+			'worklet.js',
+			sharedAudioContext
+		);
+		cleanups.push(cleanup);
+		return {
+			cleanup,
+			store,
+			events,
+			allow: () => handlers.get('grantAudioPermission')!(),
+		};
+	}
+
+	it('activates the supplied context in the Allow handler and reuses it after disposal', async () => {
+		const shared = new MockContext();
+		const first = mount(shared);
+		expect(first.events.dispatch).toHaveBeenCalledWith('addDialog', expect.anything());
+		const activation = first.allow();
+		expect(shared.resume).toHaveBeenCalledOnce();
+		await activation;
+		const firstNode = worklets[0];
+		first.cleanup();
+		expect(firstNode.port.postMessage).toHaveBeenCalledWith({ type: 'dispose' });
+		expect(firstNode.disconnect).toHaveBeenCalledOnce();
+		expect(shared.close).not.toHaveBeenCalled();
+		expect(shared.listeners.size).toBe(0);
+
+		const second = mount(shared);
+		await vi.waitFor(() => expect(worklets).toHaveLength(2));
+		expect(second.events.dispatch).not.toHaveBeenCalledWith('addDialog', expect.anything());
+		expect(contexts).toHaveLength(0);
+		expect(workletContexts).toEqual([shared, shared]);
+		expect(worklets[1]).not.toBe(firstNode);
+		expect(shared.audioWorklet.addModule).toHaveBeenCalledOnce();
+		expect(shared.resume).toHaveBeenCalledOnce();
+	});
+
+	it('shares an in-flight module load and starts waiting editors when the context runs', async () => {
+		const shared = new MockContext();
+		const loading = Promise.withResolvers<void>();
+		shared.audioWorklet.addModule.mockReturnValue(loading.promise);
+		const first = mount(shared);
+		const second = mount(shared);
+		const activation = first.allow();
+		expect(shared.audioWorklet.addModule).toHaveBeenCalledOnce();
+		expect(worklets).toHaveLength(0);
+		loading.resolve();
+		await activation;
+		await vi.waitFor(() => expect(worklets).toHaveLength(2));
+		expect(second.events.dispatch).toHaveBeenCalledWith('removeDialog', { id: 'audio-worklet-permission' });
+	});
+
+	it('creates and closes a private context when the project needs another rate', async () => {
+		const shared = new MockContext();
+		shared.state = 'running';
+		const editor = mount(shared, 44100);
+		expect(editor.events.dispatch).toHaveBeenCalledWith('addDialog', expect.anything());
+		await editor.allow();
+		expect(contexts[0].sampleRate).toBe(44100);
+		expect(workletContexts).toEqual([contexts[0]]);
+		expect(shared.audioWorklet.addModule).not.toHaveBeenCalled();
+		editor.cleanup();
+		expect(contexts[0].close).toHaveBeenCalledOnce();
+		expect(shared.close).not.toHaveBeenCalled();
+	});
+
+	it.each(['omitted', 'closed'])('uses a private context when the supplied context is %s', async kind => {
+		const shared = new MockContext();
+		shared.state = 'closed';
+		const editor = mount(kind === 'closed' ? shared : undefined);
+		await editor.allow();
+		expect(contexts).toHaveLength(1);
+		editor.cleanup();
+		expect(contexts[0].close).toHaveBeenCalledOnce();
+	});
+
+	it('returns to the running shared context after a sample rate change', async () => {
+		const shared = new MockContext();
+		const editor = mount(shared);
+		await editor.allow();
+		editor.store.set('editorConfig.audioRuntime', { sampleRate: 44100 });
+		expect(worklets[0].disconnect).toHaveBeenCalledOnce();
+		expect(shared.close).not.toHaveBeenCalled();
+		await editor.allow();
+		editor.events.dispatch = vi.fn();
+		editor.store.set('editorConfig.audioRuntime', { sampleRate: 48000 });
+		await vi.waitFor(() => expect(worklets).toHaveLength(3));
+		expect(contexts[0].close).toHaveBeenCalledOnce();
+		expect(workletContexts).toEqual([shared, contexts[0], shared]);
+		expect(editor.events.dispatch).not.toHaveBeenCalledWith('addDialog', expect.anything());
+	});
+
+	it('does not attach a disposed editor when module loading finishes late', async () => {
+		const shared = new MockContext();
+		const loading = Promise.withResolvers<void>();
+		shared.audioWorklet.addModule.mockReturnValue(loading.promise);
+		const editor = mount(shared);
+		const activation = editor.allow();
+		editor.cleanup();
+		loading.resolve();
+		await activation;
+		expect(worklets).toHaveLength(0);
+		expect(shared.close).not.toHaveBeenCalled();
+		mount(shared);
+		await vi.waitFor(() => expect(worklets).toHaveLength(1));
+		expect(shared.audioWorklet.addModule).toHaveBeenCalledOnce();
+	});
+
+	it('stops a microphone obtained after disposal without reconnecting its worklet', async () => {
+		const shared = new MockContext();
+		const stop = vi.fn();
+		const microphone = Promise.withResolvers<{ getTracks: () => { stop: typeof stop }[] }>();
+		const getUserMedia = vi.fn(() => microphone.promise);
+		vi.stubGlobal('navigator', { mediaDevices: { getUserMedia } });
+		const editor = mount(shared, 48000, true);
+		const activation = editor.allow();
+		await vi.waitFor(() => expect(getUserMedia).toHaveBeenCalledOnce());
+		editor.cleanup();
+		microphone.resolve({ getTracks: () => [{ stop }] });
+		await activation;
+		expect(stop).toHaveBeenCalledOnce();
+		expect(shared.createMediaStreamSource).not.toHaveBeenCalled();
+		expect(worklets[0].connect).not.toHaveBeenCalled();
+	});
+
+	it('allows a failed worklet load to be retried without closing the shared context', async () => {
+		vi.spyOn(console, 'error').mockImplementation(() => {});
+		const shared = new MockContext();
+		shared.audioWorklet.addModule.mockRejectedValueOnce(new Error('Network error'));
+		const editor = mount(shared);
+		await editor.allow();
+		expect(editor.events.dispatch).toHaveBeenCalledWith(
+			'addDialog',
+			expect.objectContaining({
+				text: 'Audio could not start. Select Allow to try again.',
+			})
+		);
+		await editor.allow();
+		expect(worklets).toHaveLength(1);
+		expect(shared.audioWorklet.addModule).toHaveBeenCalledTimes(2);
+		expect(shared.close).not.toHaveBeenCalled();
 	});
 });
 

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
@@ -15,6 +15,37 @@ import { AUDIO_WORKLET_RUNTIME_ID, storeAudioWorkletRuntimeValues } from './runt
 const AUDIO_PERMISSION_DIALOG_ID = 'audio-worklet-permission';
 const GRANT_AUDIO_PERMISSION_ACTION = 'grantAudioPermission';
 const AUDIO_BUFFER_SIZE = 128;
+const AUDIO_PERMISSION_TEXT =
+	"This project uses AudioWorklet for audio playback and requires your permission to start. Select Allow to start the program, or choose to do nothing; then the program won't start.";
+
+/** Host-side context operations used for sharing, without requiring DOM types in the worklet build. */
+export interface SharedAudioContext {
+	readonly sampleRate: number;
+	readonly state: string;
+	resume(): Promise<void>;
+	audioWorklet: { addModule(url: string): Promise<void> };
+	addEventListener(type: 'statechange', listener: () => void): void;
+	removeEventListener(type: 'statechange', listener: () => void): void;
+}
+
+const workletModules = new WeakMap<SharedAudioContext, Map<string, Promise<void>>>();
+
+function loadWorklet(context: SharedAudioContext, url: string): Promise<void> {
+	let modules = workletModules.get(context);
+	if (!modules) {
+		modules = new Map();
+		workletModules.set(context, modules);
+	}
+	let loading = modules.get(url);
+	if (!loading) {
+		loading = context.audioWorklet.addModule(url).catch(error => {
+			modules.delete(url);
+			throw error;
+		});
+		modules.set(url, loading);
+	}
+	return loading;
+}
 const AUDIO_BUFFER_ADDRESS_SCHEMA = {
 	format: 'memory-address',
 	anyOf: [
@@ -119,7 +150,8 @@ export function audioWorkletRuntimeFactory(
 	events: EventDispatcher,
 	getCodeBuffer: () => Uint8Array,
 	getMemory: () => WebAssembly.Memory | null,
-	audioWorkletUrl: string
+	audioWorkletUrl: string,
+	sharedAudioContext?: SharedAudioContext
 ) {
 	const state = store.getState();
 	// Using any types for Web Audio API types that aren't available in worker context during build
@@ -127,6 +159,16 @@ export function audioWorkletRuntimeFactory(
 	let audioWorklet: any | null = null;
 	let mediaStream: any | null = null;
 	let mediaStreamSource: any | null = null;
+	let disposed = false;
+	let generation = 0;
+	let inputRevision = 0;
+
+	function getSharedAudioContext() {
+		return sharedAudioContext?.state !== 'closed' &&
+			sharedAudioContext?.sampleRate === getSampleRate(state.editorConfig)
+			? sharedAudioContext
+			: undefined;
+	}
 
 	function showAudioPermissionDialog(text: string) {
 		events.dispatch('addDialog', {
@@ -164,6 +206,7 @@ export function audioWorkletRuntimeFactory(
 	}
 
 	async function syncAudioInputSource() {
+		const revision = ++inputRevision;
 		if (!audioContext || !audioWorklet) {
 			return;
 		}
@@ -187,7 +230,12 @@ export function audioWorkletRuntimeFactory(
 
 		try {
 			// @ts-expect-error - navigator.mediaDevices not available in worker context during build
-			mediaStream = await navigator.mediaDevices.getUserMedia({ audio: true });
+			const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+			if (disposed || revision !== inputRevision) {
+				stream.getTracks().forEach((track: any) => track.stop());
+				return;
+			}
+			mediaStream = stream;
 			mediaStreamSource = audioContext.createMediaStreamSource(mediaStream);
 			mediaStreamSource.connect(audioWorklet);
 		} catch (error) {
@@ -196,52 +244,78 @@ export function audioWorkletRuntimeFactory(
 	}
 
 	async function initAudioContext() {
-		if (audioContext) {
+		if (disposed || audioContext) {
 			return;
 		}
 		hideAudioPermissionDialog();
+		const currentGeneration = ++generation;
 
-		// @ts-expect-error - AudioContext not available in worker context during build
-		audioContext = new AudioContext({
-			sampleRate: getSampleRate(state.editorConfig),
-			latencyHint: 'interactive',
-		});
-
-		await audioContext.audioWorklet.addModule(audioWorkletUrl);
-		// @ts-expect-error - AudioWorkletNode not available in worker context during build
-		audioWorklet = new AudioWorkletNode(audioContext, 'worklet', {
-			outputChannelCount: [2],
-			numberOfOutputs: 1,
-			numberOfInputs: 1, // Specify the number of inputs
-			channelCount: 1,
-			channelCountMode: 'explicit',
-		});
-
-		audioWorklet.port.onmessage = (event: { data: unknown }) => {
-			const { data } = event;
-			const typedData = data as any;
-			switch (typedData.type) {
-				case 'initialized':
-					events.dispatch('runtimeInitialized', typedData.payload);
-					break;
-				case 'runtimeValues':
-					storeAudioWorkletRuntimeValues(store, state, typedData.payload);
-					break;
+		try {
+			audioContext = getSharedAudioContext();
+			if (!audioContext) {
+				// @ts-expect-error - AudioContext not available in worker context during build
+				audioContext = new AudioContext({
+					sampleRate: getSampleRate(state.editorConfig),
+					latencyHint: 'interactive',
+				});
 			}
-		};
 
-		await syncAudioInputSource();
+			// Resume synchronously in the Allow handler, before loading the worklet can consume the user gesture.
+			await Promise.all([
+				audioContext.state === 'running' ? Promise.resolve() : audioContext.resume(),
+				loadWorklet(audioContext, audioWorkletUrl),
+			]);
+			if (disposed || currentGeneration !== generation) {
+				return;
+			}
+			// @ts-expect-error - AudioWorkletNode not available in worker context during build
+			audioWorklet = new AudioWorkletNode(audioContext, 'worklet', {
+				outputChannelCount: [2],
+				numberOfOutputs: 1,
+				numberOfInputs: 1, // Specify the number of inputs
+				channelCount: 1,
+				channelCountMode: 'explicit',
+			});
 
-		audioWorklet.connect(audioContext.destination);
+			audioWorklet.port.onmessage = (event: { data: unknown }) => {
+				const { data } = event;
+				const typedData = data as any;
+				switch (typedData.type) {
+					case 'initialized':
+						events.dispatch('runtimeInitialized', typedData.payload);
+						break;
+					case 'runtimeValues':
+						storeAudioWorkletRuntimeValues(store, state, typedData.payload);
+						break;
+				}
+			};
 
-		syncCodeAndSettingsWithRuntime();
+			await syncAudioInputSource();
+			if (disposed || currentGeneration !== generation) {
+				return;
+			}
+
+			audioWorklet.connect(audioContext.destination);
+
+			syncCodeAndSettingsWithRuntime();
+		} catch (error) {
+			if (disposed || currentGeneration !== generation) {
+				return;
+			}
+			tearDownAudioContext();
+			console.error('Error starting audio:', error);
+			showAudioPermissionDialog('Audio could not start. Select Allow to try again.');
+		}
 	}
 
 	store.subscribeToValue('compiler.isCompiling', false, syncCodeAndSettingsWithRuntime);
 	store.subscribe('editorConfig.audioRuntime', onEditorConfigChanged);
 	events.on(GRANT_AUDIO_PERMISSION_ACTION, initAudioContext);
+	sharedAudioContext?.addEventListener('statechange', onSharedContextStateChanged);
 
 	function tearDownAudioContext() {
+		++generation;
+		++inputRevision;
 		if (mediaStreamSource) {
 			mediaStreamSource.disconnect();
 			mediaStreamSource = null;
@@ -253,24 +327,30 @@ export function audioWorkletRuntimeFactory(
 		}
 
 		if (audioWorklet) {
+			audioWorklet.port.postMessage({ type: 'dispose' });
+			audioWorklet.port.onmessage = null;
+			audioWorklet.port.close();
 			audioWorklet.disconnect();
 			audioWorklet = null;
 		}
 
 		if (audioContext) {
-			audioContext.close();
+			if (audioContext !== sharedAudioContext) {
+				void audioContext.close();
+			}
 			audioContext = null;
 		}
 	}
 
 	function onEditorConfigChanged() {
 		if (!audioContext) {
+			startOrRequestAudio();
 			return;
 		}
 		const desiredSampleRate = getSampleRate(state.editorConfig);
 		if (audioContext.sampleRate !== desiredSampleRate) {
 			tearDownAudioContext();
-			showAudioPermissionDialog('Sample rate changed. Select Allow to restart audio playback at the new sample rate.');
+			startOrRequestAudio('Sample rate changed. Select Allow to restart audio playback at the new sample rate.');
 			return;
 		}
 
@@ -278,16 +358,28 @@ export function audioWorkletRuntimeFactory(
 		syncCodeAndSettingsWithRuntime();
 	}
 
-	if (!audioContext) {
-		showAudioPermissionDialog(
-			"This project uses AudioWorklet for audio playback and requires your permission to start. Select Allow to start the program, or choose to do nothing; then the program won't start."
-		);
+	function onSharedContextStateChanged() {
+		if (!disposed && !audioContext && getSharedAudioContext()?.state === 'running') {
+			void initAudioContext();
+		}
 	}
 
+	function startOrRequestAudio(text = AUDIO_PERMISSION_TEXT) {
+		if (getSharedAudioContext()?.state === 'running') {
+			void initAudioContext();
+		} else {
+			showAudioPermissionDialog(text);
+		}
+	}
+
+	startOrRequestAudio();
+
 	return () => {
+		disposed = true;
 		store.unsubscribe('compiler.isCompiling', syncCodeAndSettingsWithRuntime);
 		store.unsubscribe('editorConfig.audioRuntime', onEditorConfigChanged);
 		events.off(GRANT_AUDIO_PERMISSION_ACTION, initAudioContext);
+		sharedAudioContext?.removeEventListener('statechange', onSharedContextStateChanged);
 
 		tearDownAudioContext();
 		hideAudioPermissionDialog();
@@ -301,7 +393,8 @@ export function audioWorkletRuntimeFactory(
 export function createAudioWorkletRuntimeDef(
 	getCodeBuffer: () => Uint8Array,
 	getMemory: () => WebAssembly.Memory | null,
-	audioWorkletUrl: string
+	audioWorkletUrl: string,
+	sharedAudioContext?: SharedAudioContext
 ): RuntimeRegistryEntry {
 	return {
 		id: AUDIO_WORKLET_RUNTIME_ID,
@@ -311,7 +404,7 @@ export function createAudioWorkletRuntimeDef(
 			`const AUDIO_BUFFER_SIZE ${AUDIO_BUFFER_SIZE}`,
 		],
 		factory: (store: StateManager<State>, events: EventDispatcher) => {
-			return audioWorkletRuntimeFactory(store, events, getCodeBuffer, getMemory, audioWorkletUrl);
+			return audioWorkletRuntimeFactory(store, events, getCodeBuffer, getMemory, audioWorkletUrl, sharedAudioContext);
 		},
 	};
 }

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
@@ -160,7 +160,20 @@ export function audioWorkletRuntimeFactory(
 	let mediaStream: any | null = null;
 	let mediaStreamSource: any | null = null;
 	let disposed = false;
+	/**
+	 * Identifies the current audio initialization attempt. Incremented when initialization
+	 * starts and when the audio setup is torn down. After each await, initialization checks
+	 * its captured value so an old attempt cannot attach nodes or tear down a newer setup.
+	 * This also handles sample-rate changes while the editor itself remains alive.
+	 */
 	let generation = 0;
+	/**
+	 * Identifies the latest microphone synchronization request. Incremented on every input
+	 * sync and audio teardown. If getUserMedia resolves with an older revision, its tracks
+	 * are stopped instead of connected. This is separate from generation because input
+	 * settings can change without restarting the audio context. The pending browser request
+	 * is not cancelled; only its outdated result is discarded.
+	 */
 	let inputRevision = 0;
 
 	function getSharedAudioContext() {


### PR DESCRIPTION
## Summary

Switching gallery examples currently destroys the previous editor's audio context, so each audio example asks the user to allow playback again. The homepage and examples gallery now supply a shared 48 kHz context that survives editor disposal. After the first Allow click, matching projects reuse that running context without another prompt.

The default editor accepts an optional `sharedAudioContext`. Projects requesting a different sample rate, or receiving a closed context, retain their own context and Allow flow. Editors mounted without this option retain independent contexts.

## Implementation

- Keep worklet nodes, compiled programs, and memory separate for each editor, and cache worklet module loading per context and URL.
- Stop disposed processors and disconnect their nodes while closing only contexts owned by the editor.
- Guard asynchronous initialization and microphone acquisition against disposal and sample-rate changes; allow failed worklet loads to be retried.
- Document ownership, sample-rate fallback, and the page-lifetime boundary in `docs/shared-editor-audio.md`.

## Validation

- Runtime and default-editor tests: 57 passed.
- Runtime and default-editor type checks passed.
- Product website production build and its type check passed.
- Chrome browser check with user activation required: initial Allow click, successive 48 kHz editors without another click, stopped processing after disposal, 44.1 kHz fallback, and return to the shared 48 kHz context all passed.
- Safari has not been tested.
