### PR TITLE
feat(editor): show names on entry outlines

### DIFF
--- a/packages/editor/packages/editor-core/docs/color-paths.md
+++ b/packages/editor/packages/editor-core/docs/color-paths.md
@@ -15,6 +15,7 @@ Example:
 ## `text.*`
 
 - `text.lineNumber`
+- `text.entryName`
 - `text.arrow`
 - `text.instruction`
 - `text.codeComment`

--- a/packages/editor/packages/editor-core/packages/editor-state/src/features/color/editorConfig.test.ts
+++ b/packages/editor/packages/editor-core/packages/editor-state/src/features/color/editorConfig.test.ts
@@ -16,6 +16,7 @@ function entry(path: string, value: string): EditorConfigEntry {
 describe('color editor config', () => {
 	it('validates known color paths', () => {
 		expect(colorEditorConfigValidator.validate(entry('color.text.code', '#112233'))).toBeUndefined();
+		expect(colorEditorConfigValidator.validate(entry('color.text.entryName', '#abcdef'))).toBeUndefined();
 	});
 
 	it('reports unknown color paths with suggestions', () => {

--- a/packages/editor/packages/editor-core/packages/web-ui/packages/sprite-generator/src/defaultColorScheme.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/packages/sprite-generator/src/defaultColorScheme.ts
@@ -6,7 +6,7 @@ import type { ColorScheme } from './types.ts';
 const defaultColorScheme: ColorScheme = {
 	text: {
 		lineNumber: '#999999',
-		entryName: '#999999',
+		entryName: '#ffffff',
 		debugInfo: '#999999',
 		arrow: '#ffffff',
 		instruction: '#ffffff',

--- a/packages/editor/packages/editor-core/packages/web-ui/packages/sprite-generator/src/defaultColorScheme.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/packages/sprite-generator/src/defaultColorScheme.ts
@@ -6,6 +6,7 @@ import type { ColorScheme } from './types.ts';
 const defaultColorScheme: ColorScheme = {
 	text: {
 		lineNumber: '#999999',
+		entryName: '#999999',
 		debugInfo: '#999999',
 		arrow: '#ffffff',
 		instruction: '#ffffff',

--- a/packages/editor/packages/editor-core/packages/web-ui/packages/sprite-generator/src/types.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/packages/sprite-generator/src/types.ts
@@ -24,6 +24,7 @@ export type DrawingCommand =
 export interface ColorScheme {
 	text: {
 		lineNumber: string;
+		entryName: string;
 		debugInfo: string;
 		arrow: string;
 		instruction: string;

--- a/packages/editor/packages/editor-core/packages/web-ui/packages/sprite-generator/tests/colorScheme.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/packages/sprite-generator/tests/colorScheme.test.ts
@@ -15,11 +15,12 @@ describe('color scheme resolution', () => {
 
 	it('merges partial overrides with sprite-generator defaults', () => {
 		const colorScheme = resolveColorScheme({
-			text: { code: '#112233' },
+			text: { code: '#112233', entryName: '#fedcba' },
 			fill: { wire: 'rgba(1,2,3,0.4)' },
 		});
 
 		expect(colorScheme.text.code).toBe('#112233');
+		expect(colorScheme.text.entryName).toBe('#fedcba');
 		expect(colorScheme.fill.wire).toBe('rgba(1,2,3,0.4)');
 		expect(colorScheme.text.lineNumber).toBe(defaultColorScheme.text.lineNumber);
 		expect(colorScheme.fill.background).toBe(defaultColorScheme.fill.background);

--- a/packages/editor/packages/editor-core/packages/web-ui/packages/sprite-generator/tests/font.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/packages/sprite-generator/tests/font.test.ts
@@ -187,6 +187,7 @@ describe('font module', () => {
 
 			// Should include all text colors from color scheme
 			expect(colorValues).toContain(minimalColorScheme.text.lineNumber);
+			expect(colorValues).toContain(minimalColorScheme.text.entryName);
 			expect(colorValues).toContain(minimalColorScheme.text.instruction);
 			expect(colorValues).toContain(minimalColorScheme.text.code);
 			expect(colorValues).toContain(minimalColorScheme.text.numbers);
@@ -307,6 +308,7 @@ describe('font module', () => {
 
 			// Should have font lookups for all text color types
 			expect(lookups.fontLineNumber).toBeDefined();
+			expect(lookups.fontEntryName).toBeDefined();
 			expect(lookups.fontArrow).toBeDefined();
 			expect(lookups.fontInstruction).toBeDefined();
 			expect(lookups.fontCode).toBeDefined();

--- a/packages/editor/packages/editor-core/packages/web-ui/packages/sprite-generator/tests/types.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/packages/sprite-generator/tests/types.test.ts
@@ -96,6 +96,7 @@ describe('Types and Enums', () => {
 		it('should have all required text color properties', () => {
 			const textKeys = Object.keys(minimalColorScheme.text);
 			expect(textKeys).toContain('lineNumber');
+			expect(textKeys).toContain('entryName');
 			expect(textKeys).toContain('debugInfo');
 			expect(textKeys).toContain('instruction');
 			expect(textKeys).toContain('codeComment');

--- a/packages/editor/packages/editor-core/packages/web-ui/packages/sprite-generator/tests/utils/testFixtures.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/packages/sprite-generator/tests/utils/testFixtures.ts
@@ -6,6 +6,7 @@ import type { ColorScheme, Config } from '../../src/types';
 export const minimalColorScheme: ColorScheme = {
 	text: {
 		lineNumber: '#333333',
+		entryName: '#44ddff',
 		debugInfo: '#333333',
 		arrow: '#ffffff',
 		instruction: '#887ecb',

--- a/packages/editor/packages/editor-core/packages/web-ui/src/drawers/codeBlocks/drawEntryOutlines.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/drawers/codeBlocks/drawEntryOutlines.ts
@@ -27,7 +27,7 @@ export default function drawEntryOutlines(engine: DrawContext, state: State): vo
 		drawOutline(engine, outline, thickness, state.spriteLookups.fillColors.wire);
 		engine.drawText(
 			outline.topLeft.x + state.viewport.vGrid,
-			outline.topLeft.y + state.viewport.hGrid,
+			outline.topLeft.y,
 			outline.entryName,
 			state.spriteLookups.fontEntryName
 		);

--- a/packages/editor/packages/editor-core/packages/web-ui/src/drawers/codeBlocks/drawEntryOutlines.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/drawers/codeBlocks/drawEntryOutlines.ts
@@ -25,5 +25,11 @@ export default function drawEntryOutlines(engine: DrawContext, state: State): vo
 
 	for (const outline of state.codeBlockRendering.entryOutlines) {
 		drawOutline(engine, outline, thickness, state.spriteLookups.fillColors.wire);
+		engine.drawText(
+			outline.topLeft.x + state.viewport.vGrid,
+			outline.topLeft.y + state.viewport.hGrid,
+			outline.entryName,
+			state.spriteLookups.fontEntryName
+		);
 	}
 }

--- a/packages/editor/packages/editor-core/packages/web-ui/src/drawers/codeBlocks/index.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/drawers/codeBlocks/index.test.ts
@@ -105,6 +105,7 @@ describe('drawModules', () => {
 		const state = createMockState({
 			spriteLookups: {
 				fillColors: createSpriteIdLookupMock(),
+				fontEntryName: createSpriteIdLookupMock(),
 			} as never,
 			codeBlockRendering: {
 				codeBlocks: [],
@@ -158,6 +159,12 @@ describe('drawModules', () => {
 			'wire',
 			1,
 			80
+		);
+		expect((engine as unknown as { drawText: ReturnType<typeof vi.fn> }).drawText).toHaveBeenCalledWith(
+			16,
+			32,
+			'main',
+			state.spriteLookups?.fontEntryName
 		);
 	});
 

--- a/packages/editor/packages/editor-core/packages/web-ui/src/drawers/codeBlocks/index.test.ts
+++ b/packages/editor/packages/editor-core/packages/web-ui/src/drawers/codeBlocks/index.test.ts
@@ -162,7 +162,7 @@ describe('drawModules', () => {
 		);
 		expect((engine as unknown as { drawText: ReturnType<typeof vi.fn> }).drawText).toHaveBeenCalledWith(
 			16,
-			32,
+			16,
 			'main',
 			state.spriteLookups?.fontEntryName
 		);


### PR DESCRIPTION
## Summary

- render each execution entry name inside the top-left of its outline
- add a separately configurable color.text.entryName text color
- document the new color path and cover rendering, lookup generation, and validation

## Rationale

Entry outlines visually group their module blocks, but previously did not identify which execution entry each group represented.

## Tests

- npx nx run @8f4e/web-ui:test
- npx nx run @8f4e/sprite-generator:test
- npx nx run @8f4e/editor-state:test
- npx nx run @8f4e/editor-core:typecheck
- npx nx run @8f4e/editor-default:build