### PR TITLE
feat(runtime): make entry exports configurable

### DIFF
--- a/packages/editor/packages/editor-core/docs/editor-directives.md
+++ b/packages/editor/packages/editor-core/docs/editor-directives.md
@@ -848,9 +848,14 @@ paths such as:
 
 ```txt
 ; @config audioRuntime.sampleRate 48000
+; @config audioRuntime.entry buffer
 ; @config audioRuntime.audioOutBufferLAddress audioout:buffer
 ; @config workerRuntime.sampleRate 50
+; @config workerRuntime.entry main
 ```
+
+`audioRuntime.entry` selects the exported entry called for each audio processing block and defaults to `buffer`.
+`workerRuntime.entry` selects the exported entry called at the configured worker sample rate and defaults to `main`.
 
 These roots are owned by their contributing package, not by the editor config type.
 

--- a/packages/editor/packages/runtime-audio-worklet/src/createModule.test.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/createModule.test.ts
@@ -24,10 +24,10 @@ describe('createModule', () => {
 
 		const result = await createModule(new WebAssembly.Memory({ initial: 1 }), new Uint8Array());
 
-		expect(result.entry).toBe(buffer);
+		expect(result.buffer).toBe(buffer);
 	});
 
-	it('returns the configured entry function', async () => {
+	it('returns the configured export as the buffer function', async () => {
 		const alternate = vi.fn();
 		mockInstantiation({
 			main: vi.fn(),
@@ -38,10 +38,10 @@ describe('createModule', () => {
 
 		const result = await createModule(new WebAssembly.Memory({ initial: 1 }), new Uint8Array(), 'alternate');
 
-		expect(result.entry).toBe(alternate);
+		expect(result.buffer).toBe(alternate);
 	});
 
-	it('returns an empty entry function when the export is missing', async () => {
+	it('returns an empty buffer function when the export is missing', async () => {
 		mockInstantiation({
 			main: vi.fn(),
 			initDefaults: vi.fn(),
@@ -49,7 +49,7 @@ describe('createModule', () => {
 
 		const result = await createModule(new WebAssembly.Memory({ initial: 1 }), new Uint8Array());
 
-		expect(result.entry).toBeTypeOf('function');
-		expect(() => result.entry()).not.toThrow();
+		expect(result.buffer).toBeTypeOf('function');
+		expect(() => result.buffer()).not.toThrow();
 	});
 });

--- a/packages/editor/packages/runtime-audio-worklet/src/createModule.test.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/createModule.test.ts
@@ -14,7 +14,7 @@ describe('createModule', () => {
 		vi.restoreAllMocks();
 	});
 
-	it('returns the exported buffer function when present', async () => {
+	it('returns the exported buffer function by default', async () => {
 		const buffer = vi.fn();
 		mockInstantiation({
 			main: vi.fn(),
@@ -24,10 +24,24 @@ describe('createModule', () => {
 
 		const result = await createModule(new WebAssembly.Memory({ initial: 1 }), new Uint8Array());
 
-		expect(result.buffer).toBe(buffer);
+		expect(result.entry).toBe(buffer);
 	});
 
-	it('returns an empty buffer function when the export is missing', async () => {
+	it('returns the configured entry function', async () => {
+		const alternate = vi.fn();
+		mockInstantiation({
+			main: vi.fn(),
+			initDefaults: vi.fn(),
+			buffer: vi.fn(),
+			alternate,
+		});
+
+		const result = await createModule(new WebAssembly.Memory({ initial: 1 }), new Uint8Array(), 'alternate');
+
+		expect(result.entry).toBe(alternate);
+	});
+
+	it('returns an empty entry function when the export is missing', async () => {
 		mockInstantiation({
 			main: vi.fn(),
 			initDefaults: vi.fn(),
@@ -35,7 +49,7 @@ describe('createModule', () => {
 
 		const result = await createModule(new WebAssembly.Memory({ initial: 1 }), new Uint8Array());
 
-		expect(result.buffer).toBeTypeOf('function');
-		expect(() => result.buffer()).not.toThrow();
+		expect(result.entry).toBeTypeOf('function');
+		expect(() => result.entry()).not.toThrow();
 	});
 });

--- a/packages/editor/packages/runtime-audio-worklet/src/createModule.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/createModule.ts
@@ -5,10 +5,10 @@ const noop = () => {
 export default async function createModule(
 	memoryRef: WebAssembly.Memory,
 	codeBuffer: Uint8Array,
-	entryName = 'buffer'
+	bufferExportName = 'buffer'
 ): Promise<{
 	memoryBuffer: Float32Array;
-	entry: CallableFunction;
+	buffer: CallableFunction;
 	initDefaults: CallableFunction;
 }> {
 	const memoryBuffer = new Float32Array(memoryRef.buffer);
@@ -19,9 +19,9 @@ export default async function createModule(
 		},
 	})) as unknown as { instance: WebAssembly.Instance; module: WebAssembly.Module };
 
-	const exportedEntry = instance.exports[entryName];
-	const entry = typeof exportedEntry === 'function' ? exportedEntry : noop;
+	const exportedBuffer = instance.exports[bufferExportName];
+	const buffer = typeof exportedBuffer === 'function' ? exportedBuffer : noop;
 	const initDefaults = instance.exports.initDefaults as CallableFunction;
 
-	return { memoryBuffer, entry, initDefaults };
+	return { memoryBuffer, buffer, initDefaults };
 }

--- a/packages/editor/packages/runtime-audio-worklet/src/createModule.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/createModule.ts
@@ -4,12 +4,12 @@ const noop = () => {
 
 export default async function createModule(
 	memoryRef: WebAssembly.Memory,
-	codeBuffer: Uint8Array
+	codeBuffer: Uint8Array,
+	entryName = 'buffer'
 ): Promise<{
 	memoryBuffer: Float32Array;
-	main: CallableFunction;
+	entry: CallableFunction;
 	initDefaults: CallableFunction;
-	buffer: CallableFunction;
 }> {
 	const memoryBuffer = new Float32Array(memoryRef.buffer);
 
@@ -19,9 +19,9 @@ export default async function createModule(
 		},
 	})) as unknown as { instance: WebAssembly.Instance; module: WebAssembly.Module };
 
-	const main = instance.exports.main as CallableFunction;
-	const buffer = typeof instance.exports.buffer === 'function' ? instance.exports.buffer : noop;
+	const exportedEntry = instance.exports[entryName];
+	const entry = typeof exportedEntry === 'function' ? exportedEntry : noop;
 	const initDefaults = instance.exports.initDefaults as CallableFunction;
 
-	return { memoryBuffer, main, buffer, initDefaults };
+	return { memoryBuffer, entry, initDefaults };
 }

--- a/packages/editor/packages/runtime-audio-worklet/src/index.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/index.ts
@@ -7,7 +7,7 @@ class Main extends AudioWorkletProcessor {
 		this.port.onmessage = async event => {
 			if (event.data.type === 'dispose') {
 				this.disposed = true;
-				this.buffer = () => {};
+				this.entry = () => {};
 				this.memoryBuffer = new Float32Array(0);
 				this.port.close();
 				return;
@@ -16,6 +16,7 @@ class Main extends AudioWorkletProcessor {
 				this.init(
 					event.data.memoryRef,
 					event.data.codeBuffer,
+					event.data.entry,
 					event.data.audioOutputBuffers,
 					event.data.audioInputBuffers
 				);
@@ -26,10 +27,11 @@ class Main extends AudioWorkletProcessor {
 	async init(
 		memoryRef: WebAssembly.Memory,
 		codeBuffer: Uint8Array,
+		entryName: string,
 		audioOutputBuffers: { channel: number; output: number; audioBufferWordAddress: number }[],
 		audioInputBuffers: { channel: number; input: number; audioBufferWordAddress: number }[]
 	) {
-		const { memoryBuffer, buffer } = await createModule(memoryRef, codeBuffer);
+		const { memoryBuffer, entry } = await createModule(memoryRef, codeBuffer, entryName);
 		if (this.disposed) {
 			return;
 		}
@@ -37,7 +39,7 @@ class Main extends AudioWorkletProcessor {
 		this.audioOutputBuffers = audioOutputBuffers;
 		this.audioInputBuffers = audioInputBuffers;
 
-		this.buffer = buffer;
+		this.entry = entry;
 		this.memoryBuffer = memoryBuffer;
 
 		this.port.postMessage({
@@ -48,7 +50,7 @@ class Main extends AudioWorkletProcessor {
 		});
 	}
 
-	buffer: CallableFunction = () => {
+	entry: CallableFunction = () => {
 		return;
 	};
 	private disposed = false;
@@ -100,7 +102,7 @@ class Main extends AudioWorkletProcessor {
 			}
 		}
 
-		this.buffer();
+		this.entry();
 
 		for (let i = 0; i < this.audioOutputBuffers.length; i++) {
 			const output = outputs[this.audioOutputBuffers[i].output];

--- a/packages/editor/packages/runtime-audio-worklet/src/index.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/index.ts
@@ -7,7 +7,7 @@ class Main extends AudioWorkletProcessor {
 		this.port.onmessage = async event => {
 			if (event.data.type === 'dispose') {
 				this.disposed = true;
-				this.entry = () => {};
+				this.buffer = () => {};
 				this.memoryBuffer = new Float32Array(0);
 				this.port.close();
 				return;
@@ -16,7 +16,7 @@ class Main extends AudioWorkletProcessor {
 				this.init(
 					event.data.memoryRef,
 					event.data.codeBuffer,
-					event.data.entry,
+					event.data.bufferExportName,
 					event.data.audioOutputBuffers,
 					event.data.audioInputBuffers
 				);
@@ -27,11 +27,11 @@ class Main extends AudioWorkletProcessor {
 	async init(
 		memoryRef: WebAssembly.Memory,
 		codeBuffer: Uint8Array,
-		entryName: string,
+		bufferExportName: string,
 		audioOutputBuffers: { channel: number; output: number; audioBufferWordAddress: number }[],
 		audioInputBuffers: { channel: number; input: number; audioBufferWordAddress: number }[]
 	) {
-		const { memoryBuffer, entry } = await createModule(memoryRef, codeBuffer, entryName);
+		const { memoryBuffer, buffer } = await createModule(memoryRef, codeBuffer, bufferExportName);
 		if (this.disposed) {
 			return;
 		}
@@ -39,7 +39,7 @@ class Main extends AudioWorkletProcessor {
 		this.audioOutputBuffers = audioOutputBuffers;
 		this.audioInputBuffers = audioInputBuffers;
 
-		this.entry = entry;
+		this.buffer = buffer;
 		this.memoryBuffer = memoryBuffer;
 
 		this.port.postMessage({
@@ -50,7 +50,7 @@ class Main extends AudioWorkletProcessor {
 		});
 	}
 
-	entry: CallableFunction = () => {
+	buffer: CallableFunction = () => {
 		return;
 	};
 	private disposed = false;
@@ -102,7 +102,7 @@ class Main extends AudioWorkletProcessor {
 			}
 		}
 
-		this.entry();
+		this.buffer();
 
 		for (let i = 0; i < this.audioOutputBuffers.length; i++) {
 			const output = outputs[this.audioOutputBuffers[i].output];

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
@@ -97,9 +97,11 @@ describe('AudioWorklet context lifetime', () => {
 		vi.restoreAllMocks();
 	});
 
-	function mount(sharedAudioContext?: MockContext, sampleRate = 48000, input = false) {
+	function mount(sharedAudioContext?: MockContext, sampleRate = 48000, input = false, entry?: string) {
 		const state = {
-			editorConfig: { audioRuntime: { sampleRate, ...(input ? { audioInBufferLAddress: 0 } : {}) } },
+			editorConfig: {
+				audioRuntime: { sampleRate, ...(input ? { audioInBufferLAddress: 0 } : {}), ...(entry ? { entry } : {}) },
+			},
 			compiler: { isCompiling: false },
 		} as unknown as State;
 		const store = createStateManager(state);
@@ -255,6 +257,23 @@ describe('AudioWorklet context lifetime', () => {
 		expect(shared.audioWorklet.addModule).toHaveBeenCalledTimes(2);
 		expect(shared.close).not.toHaveBeenCalled();
 	});
+
+	it.each([
+		[undefined, 'buffer'],
+		['alternate', 'alternate'],
+	])('initializes the worklet with configured entry %s', async (configuredEntry, expectedEntry) => {
+		const shared = new MockContext();
+		const editor = mount(shared, 48000, false, configuredEntry);
+
+		await editor.allow();
+
+		expect(worklets[0].port.postMessage).toHaveBeenCalledWith(
+			expect.objectContaining({
+				type: 'init',
+				entry: expectedEntry,
+			})
+		);
+	});
 });
 
 describe('AudioWorklet runtime config', () => {
@@ -330,14 +349,16 @@ describe('AudioWorklet runtime config', () => {
 		} as State;
 	}
 
-	it('contributes audio buffer address config fields', () => {
+	it('contributes the default entry and audio buffer address config fields', () => {
 		const runtimeDef = createAudioWorkletRuntimeDef(
 			() => new Uint8Array(),
 			() => null,
 			'worklet.js'
 		);
 
+		expect(runtimeDef.editorConfigSchema?.defaults).toMatchObject({ entry: 'buffer' });
 		expect(runtimeDef.editorConfigSchema?.schema.properties).toMatchObject({
+			entry: { type: 'string' },
 			sampleRate: { type: 'number', minimum: 1 },
 			audioOutBufferLAddress: {
 				format: 'memory-address',

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.test.ts
@@ -270,7 +270,7 @@ describe('AudioWorklet context lifetime', () => {
 		expect(worklets[0].port.postMessage).toHaveBeenCalledWith(
 			expect.objectContaining({
 				type: 'init',
-				entry: expectedEntry,
+				bufferExportName: expectedEntry,
 			})
 		);
 	});

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
@@ -57,11 +57,13 @@ const AUDIO_BUFFER_ADDRESS_SCHEMA = {
 const AUDIO_WORKLET_EDITOR_CONFIG: EditorConfigSchemaContribution = {
 	root: 'audioRuntime',
 	defaults: {
+		entry: 'buffer',
 		sampleRate: 48000,
 	},
 	schema: {
 		type: 'object',
 		properties: {
+			entry: { type: 'string' },
 			sampleRate: { type: 'number', minimum: 1 },
 			audioOutBufferLAddress: AUDIO_BUFFER_ADDRESS_SCHEMA,
 			audioOutBufferRAddress: AUDIO_BUFFER_ADDRESS_SCHEMA,
@@ -72,6 +74,7 @@ const AUDIO_WORKLET_EDITOR_CONFIG: EditorConfigSchemaContribution = {
 };
 
 interface AudioWorkletRuntimeConfig {
+	entry: string;
 	sampleRate: number;
 	audioOutBufferLAddress?: number;
 	audioOutBufferRAddress?: number;
@@ -99,6 +102,7 @@ function getAudioWorkletRuntimeConfig(state: State): AudioWorkletRuntimeConfig {
 	>;
 
 	return {
+		entry: typeof config.entry === 'string' && config.entry ? config.entry : 'buffer',
 		sampleRate: typeof config.sampleRate === 'number' ? config.sampleRate : 48000,
 		audioOutBufferLAddress: getAudioBufferConfigValue(config, 'audioOutBufferLAddress'),
 		audioOutBufferRAddress: getAudioBufferConfigValue(config, 'audioOutBufferRAddress'),
@@ -208,10 +212,12 @@ export function audioWorkletRuntimeFactory(
 		}
 
 		if (audioWorklet) {
+			const config = getAudioWorkletRuntimeConfig(state);
 			audioWorklet.port.postMessage({
 				type: 'init',
 				memoryRef: memory,
 				codeBuffer: getCodeBuffer(),
+				entry: config.entry,
 				audioOutputBuffers: getAudioOutputBuffers(state),
 				audioInputBuffers: getAudioInputBuffers(state),
 			});

--- a/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
+++ b/packages/editor/packages/runtime-audio-worklet/src/runtimeDef.ts
@@ -217,7 +217,7 @@ export function audioWorkletRuntimeFactory(
 				type: 'init',
 				memoryRef: memory,
 				codeBuffer: getCodeBuffer(),
-				entry: config.entry,
+				bufferExportName: config.entry,
 				audioOutputBuffers: getAudioOutputBuffers(state),
 				audioInputBuffers: getAudioInputBuffers(state),
 			});

--- a/packages/editor/packages/runtime-web-worker/src/createModule.test.ts
+++ b/packages/editor/packages/runtime-web-worker/src/createModule.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import createModule from './createModule';
+
+function mockInstantiation(exports: WebAssembly.Exports) {
+	vi.spyOn(WebAssembly, 'instantiate').mockResolvedValue({
+		instance: { exports } as WebAssembly.Instance,
+		module: {} as WebAssembly.Module,
+	} as WebAssembly.WebAssemblyInstantiatedSource);
+}
+
+describe('createModule', () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it.each([
+		[undefined, 'main'],
+		['alternate', 'alternate'],
+	])('selects the configured entry export %s', async (configuredEntry, expectedExport) => {
+		const main = vi.fn();
+		const alternate = vi.fn();
+		mockInstantiation({ main, alternate, initDefaults: vi.fn(), buffer: vi.fn() });
+
+		const result = await createModule(new WebAssembly.Memory({ initial: 1 }), new Uint8Array(), configuredEntry);
+
+		expect(result.entry).toBe(expectedExport === 'main' ? main : alternate);
+	});
+});

--- a/packages/editor/packages/runtime-web-worker/src/createModule.ts
+++ b/packages/editor/packages/runtime-web-worker/src/createModule.ts
@@ -1,9 +1,10 @@
 export default async function createModule(
 	memoryRef: WebAssembly.Memory,
-	codeBuffer: Uint8Array
+	codeBuffer: Uint8Array,
+	entryName = 'main'
 ): Promise<{
 	memoryBuffer: Int32Array;
-	main: CallableFunction;
+	entry: CallableFunction;
 	initDefaults: CallableFunction;
 	buffer: CallableFunction;
 }> {
@@ -15,9 +16,9 @@ export default async function createModule(
 		},
 	})) as unknown as { instance: WebAssembly.Instance; module: WebAssembly.Module };
 
-	const main = instance.exports.main as CallableFunction;
+	const entry = instance.exports[entryName] as CallableFunction;
 	const buffer = instance.exports.buffer as CallableFunction;
 	const initDefaults = instance.exports.initDefaults as CallableFunction;
 
-	return { memoryBuffer, main, buffer, initDefaults };
+	return { memoryBuffer, entry, buffer, initDefaults };
 }

--- a/packages/editor/packages/runtime-web-worker/src/index.ts
+++ b/packages/editor/packages/runtime-web-worker/src/index.ts
@@ -6,9 +6,9 @@ let timeToExecuteLoopMs: number;
 let lastIntervalTime: number;
 let timerDriftMs: number;
 
-async function init(memoryRef: WebAssembly.Memory, sampleRate: number, codeBuffer: Uint8Array) {
+async function init(memoryRef: WebAssembly.Memory, sampleRate: number, codeBuffer: Uint8Array, entryName: string) {
 	try {
-		const wasmApp = await createModule(memoryRef, codeBuffer);
+		const wasmApp = await createModule(memoryRef, codeBuffer, entryName);
 
 		const intervalTime = Math.floor(1000 / sampleRate);
 
@@ -20,7 +20,7 @@ async function init(memoryRef: WebAssembly.Memory, sampleRate: number, codeBuffe
 			const startTime = performance.now();
 			timerDriftMs = startTime - lastIntervalTime - intervalTime;
 			lastIntervalTime = startTime;
-			wasmApp.main();
+			wasmApp.entry();
 			const endTime = performance.now();
 			timeToExecuteLoopMs = endTime - startTime;
 		}, intervalTime);
@@ -55,7 +55,12 @@ async function init(memoryRef: WebAssembly.Memory, sampleRate: number, codeBuffe
 self.onmessage = event => {
 	switch (event.data.type) {
 		case 'init':
-			init(event.data.payload.memoryRef, event.data.payload.sampleRate, event.data.payload.codeBuffer);
+			init(
+				event.data.payload.memoryRef,
+				event.data.payload.sampleRate,
+				event.data.payload.codeBuffer,
+				event.data.payload.entry
+			);
 			break;
 	}
 };

--- a/packages/editor/packages/runtime-web-worker/src/runtimeDef.test.ts
+++ b/packages/editor/packages/runtime-web-worker/src/runtimeDef.test.ts
@@ -1,17 +1,69 @@
-import { describe, expect, it } from 'vitest';
+import type { EventDispatcher, State } from '@8f4e/editor-core';
+import createStateManager from '@8f4e/state-manager';
+import { describe, expect, it, vi } from 'vitest';
 
-import { createWebWorkerRuntimeDef } from './runtimeDef';
+import { createWebWorkerRuntimeDef, webWorkerRuntimeFactory } from './runtimeDef';
 
 describe('WebWorker runtime config', () => {
-	it('requires a positive sample rate', () => {
+	it('defaults to the main entry and requires a positive sample rate', () => {
 		const runtimeDef = createWebWorkerRuntimeDef(
 			() => new Uint8Array(),
 			() => null,
 			class {} as unknown as new () => Worker
 		);
 
+		expect(runtimeDef.editorConfigSchema?.defaults).toMatchObject({ entry: 'main' });
 		expect(runtimeDef.editorConfigSchema?.schema.properties).toMatchObject({
+			entry: { type: 'string' },
 			sampleRate: { type: 'number', minimum: 1 },
 		});
+	});
+
+	it.each([
+		[undefined, 'main'],
+		['alternate', 'alternate'],
+	])('initializes the worker with configured entry %s', (configuredEntry, expectedEntry) => {
+		const workers: MockWorker[] = [];
+		class MockWorker {
+			postMessage = vi.fn();
+			addEventListener = vi.fn();
+			removeEventListener = vi.fn();
+			terminate = vi.fn();
+
+			constructor() {
+				workers.push(this);
+			}
+		}
+
+		const state = {
+			editorConfig: {
+				workerRuntime: {
+					sampleRate: 25,
+					...(configuredEntry ? { entry: configuredEntry } : {}),
+				},
+			},
+			compiler: { isCompiling: false },
+			info: {},
+		} as unknown as State;
+		const cleanup = webWorkerRuntimeFactory(
+			createStateManager(state),
+			{ dispatch: vi.fn() } as unknown as EventDispatcher,
+			() => new Uint8Array([1, 2, 3]),
+			() => new WebAssembly.Memory({ initial: 1 }),
+			MockWorker as unknown as new () => Worker
+		);
+		const [worker] = workers;
+
+		expect(worker.postMessage).toHaveBeenCalledWith({
+			type: 'init',
+			payload: {
+				memoryRef: expect.any(WebAssembly.Memory),
+				entry: expectedEntry,
+				sampleRate: 25,
+				codeBuffer: new Uint8Array([1, 2, 3]),
+			},
+		});
+
+		cleanup();
 	});
 });

--- a/packages/editor/packages/runtime-web-worker/src/runtimeDef.ts
+++ b/packages/editor/packages/runtime-web-worker/src/runtimeDef.ts
@@ -14,21 +14,31 @@ import type { StateManager } from '@8f4e/state-manager';
 const WEB_WORKER_EDITOR_CONFIG: EditorConfigSchemaContribution = {
 	root: 'workerRuntime',
 	defaults: {
+		entry: 'main',
 		sampleRate: 50,
 	},
 	schema: {
 		type: 'object',
 		properties: {
+			entry: { type: 'string' },
 			sampleRate: { type: 'number', minimum: 1 },
 		},
 		additionalProperties: false,
 	},
 };
 
-function getSampleRate(editorConfig: EditorConfig): number {
+interface WebWorkerRuntimeConfig {
+	entry: string;
+	sampleRate: number;
+}
+
+function getWebWorkerRuntimeConfig(editorConfig: EditorConfig): WebWorkerRuntimeConfig {
 	const config = resolveSchemaConfigRoot(WEB_WORKER_EDITOR_CONFIG, editorConfig);
 
-	return typeof config.sampleRate === 'number' ? config.sampleRate : 50;
+	return {
+		entry: typeof config.entry === 'string' && config.entry ? config.entry : 'main',
+		sampleRate: typeof config.sampleRate === 'number' ? config.sampleRate : 50,
+	};
 }
 
 // WebWorker Runtime Factory
@@ -68,11 +78,13 @@ export function webWorkerRuntimeFactory(
 			console.warn('[Runtime] Memory not yet created, skipping runtime init');
 			return;
 		}
+		const config = getWebWorkerRuntimeConfig(state.editorConfig);
 		worker.postMessage({
 			type: 'init',
 			payload: {
 				memoryRef: memory,
-				sampleRate: getSampleRate(state.editorConfig),
+				entry: config.entry,
+				sampleRate: config.sampleRate,
 				codeBuffer: getCodeBuffer(),
 			},
 		});
@@ -109,7 +121,7 @@ export function createWebWorkerRuntimeDef(
 	return {
 		id: 'WebWorkerRuntime',
 		editorConfigSchema: WEB_WORKER_EDITOR_CONFIG,
-		getEnvConstants: editorConfig => [`const SAMPLE_RATE ${getSampleRate(editorConfig)}`],
+		getEnvConstants: editorConfig => [`const SAMPLE_RATE ${getWebWorkerRuntimeConfig(editorConfig).sampleRate}`],
 		factory: (store: StateManager<State>, events: EventDispatcher) => {
 			return webWorkerRuntimeFactory(store, events, getCodeBuffer, getMemory, WorkerConstructor);
 		},


### PR DESCRIPTION
## Summary

- add workerRuntime.entry with main as its default
- add audioRuntime.entry with buffer as its default
- pass the configured export name through runtime initialization and call that WebAssembly export
- document the new settings and cover defaults plus custom entry names

## Rationale

Projects with multiple exported entries can now choose which function each runtime invokes while existing projects keep their current behavior.

## Runtime protocol notes

The worker and audio-worklet initialization messages now include the selected entry name. The audio worklet resolves the export during module initialization and keeps the real-time processing path to a direct stored function call.

## Tests

- npx nx run @8f4e/runtime-web-worker:test
- npx nx run @8f4e/runtime-audio-worklet:test
- npx nx run-many --target=typecheck --projects=@8f4e/runtime-web-worker,@8f4e/runtime-audio-worklet
- npx nx run @8f4e/editor-default:build
- pre-commit affected type checks